### PR TITLE
Make "can write" check work on Windows

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
@@ -611,14 +611,14 @@ class JdepsTask {
     }
 
     private GenDotFile genDotFile(Path dir) throws BadArgs {
-        if (Files.exists(dir) && (!Files.isDirectory(dir) || !Files.isWritable(dir))) {
+        if (Files.exists(dir) && (!Files.isDirectory(dir) || !dir.toFile().canWrite())) {
             throw new BadArgs("err.invalid.path", dir.toString());
         }
         return new GenDotFile(dir);
     }
 
     private GenModuleInfo genModuleInfo(Path dir, boolean openModule) throws BadArgs {
-        if (Files.exists(dir) && (!Files.isDirectory(dir) || !Files.isWritable(dir))) {
+        if (Files.exists(dir) && (!Files.isDirectory(dir) || !dir.toFile().canWrite())) {
             throw new BadArgs("err.invalid.path", dir.toString());
         }
         return new GenModuleInfo(dir, openModule);


### PR DESCRIPTION
Prior to this commit, an existing and writable directory was considered invalid, as `Files.isWritable(dir)` returns `false` on Windows. Using `dir.toFile().canWrite()` yields the correct result, which in turn permits valid directories to passed to the tool.

Resolves https://bugs.openjdk.java.net/browse/JDK-8232092