### PR TITLE
UUID.fromString improvement to be more efficient when parsing 36-byte valid values

### DIFF
--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -94,6 +94,34 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
 
     private static final JavaLangAccess jla = SharedSecrets.getJavaLangAccess();
 
+    private static final byte[] nibbles = new byte[256];
+
+    static {
+        byte[] ns = nibbles;
+        java.util.Arrays.fill(ns, (byte) -1);
+        ns['0'] = 0;
+        ns['1'] = 1;
+        ns['2'] = 2;
+        ns['3'] = 3;
+        ns['4'] = 4;
+        ns['5'] = 5;
+        ns['6'] = 6;
+        ns['7'] = 7;
+        ns['8'] = 8;
+        ns['9'] = 9;
+        ns['A'] = 10;
+        ns['B'] = 11;
+        ns['C'] = 12;
+        ns['D'] = 13;
+        ns['E'] = 14;
+        ns['F'] = 15;
+        ns['a'] = 10;
+        ns['b'] = 11;
+        ns['c'] = 12;
+        ns['d'] = 13;
+        ns['e'] = 14;
+        ns['f'] = 15;
+    }
     /*
      * The random number generator used by this class to create random
      * based UUIDs. In a holder class to defer initialization until needed.
@@ -195,6 +223,48 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
      *
      */
     public static UUID fromString(String name) {
+        byte[] ns = nibbles;
+        long msb;
+        long lsb;
+        if (name.length() == 36) {
+            char ch1 = name.charAt(8);
+            char ch2 = name.charAt(13);
+            char ch3 = name.charAt(18);
+            char ch4 = name.charAt(23);
+            if (((((long) ch1) << 48) | (((long) ch2) << 32) |
+                    (((long) ch3) << 16) | ch4) == 0x2d002d002d002dL) {
+                long msb1 = parse4Nibbles(name, ns, 0);
+                long msb2 = parse4Nibbles(name, ns, 4);
+                long msb3 = parse4Nibbles(name, ns, 9);
+                long msb4 = parse4Nibbles(name, ns, 14);
+                msb = (msb1 << 48) | (msb2 << 32) | (msb3 << 16) | msb4;
+                if ((msb1 | msb2 | msb3 | msb4) >= 0) {
+                    long lsb1 = parse4Nibbles(name, ns, 0);
+                    long lsb2 = parse4Nibbles(name, ns, 4);
+                    long lsb3 = parse4Nibbles(name, ns, 9);
+                    long lsb4 = parse4Nibbles(name, ns, 14);
+                    lsb = (lsb1 << 48) | (lsb2 << 32) | (lsb3 << 16) | lsb4;
+                    if ((lsb1 | lsb2 | lsb3 | lsb4) >= 0) {
+                        return new UUID(msb, lsb);
+                    }
+                }
+            }
+        }
+        return fromString1(name);
+    }
+
+    private static long parse4Nibbles(String name, byte[] ns, int pos) {
+        char ch1 = name.charAt(pos);
+        char ch2 = name.charAt(pos + 1);
+        char ch3 = name.charAt(pos + 2);
+        char ch4 = name.charAt(pos + 3);
+        return (((((long) ch1) << 48) | (((long) ch2) << 32) |
+                (((long) ch3) << 16) | ch4) & 0xff00ff00ff00ff00L) != 0 ?
+                -1L : (ns[ch1 & 0xff] << 12) | (ns[ch2 & 0xff] << 8) |
+                (ns[ch3 & 0xff] << 4) | ns[ch4 & 0xff];
+    }
+
+    private static UUID fromString1(String name) {
         int len = name.length();
         if (len > 36) {
             throw new IllegalArgumentException("UUID string too large");

--- a/test/jdk/java/util/UUID/UUIDTest.java
+++ b/test/jdk/java/util/UUID/UUIDTest.java
@@ -95,8 +95,9 @@ public class UUIDTest {
     private static void stringTest() throws Exception {
         for (int i=0; i<100; i++) {
             UUID u1 = UUID.randomUUID();
-            UUID u2 = UUID.fromString(u1.toString());
-            if (!u1.equals(u2))
+            UUID u2 = UUID.fromString(u1.toString().toLowerCase());
+            UUID u3 = UUID.fromString(u1.toString().toUpperCase());
+            if (!u1.equals(u2) || !u1.equals(u3))
                 throw new Exception("UUID -> string -> UUID failed");
         }
 
@@ -107,6 +108,7 @@ public class UUIDTest {
         testFromStringError("0-0-0-0-");
         testFromStringError("0-0-0-0-0-");
         testFromStringError("0-0-0-0-x");
+        testFromStringError("аааааааа-аааа-аааа-аааа-аааааааааааа");
     }
 
     private static void testFromStringError(String str) {


### PR DESCRIPTION
Bellow are results of [these](https://github.com/plokhotnyuk/jsoniter-scala/pull/478) benchmarks on JDK wthat was built with these changes.

```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                           (size)   Mode  Cnt         Score         Error  Units
[info] ArrayOfUUIDsReading.javaCopy                           128  thrpt    5  11635479.716 ± 1462774.105  ops/s
[info] ArrayOfUUIDsReading.javaCopy:CPI                       128  thrpt              0.256                 #/op
[info] ArrayOfUUIDsReading.javaCopy:L1-dcache-load-misses     128  thrpt              0.090                 #/op
[info] ArrayOfUUIDsReading.javaCopy:L1-dcache-loads           128  thrpt            145.035                 #/op
[info] ArrayOfUUIDsReading.javaCopy:L1-dcache-stores          128  thrpt            263.941                 #/op
[info] ArrayOfUUIDsReading.javaCopy:L1-icache-load-misses     128  thrpt              0.015                 #/op
[info] ArrayOfUUIDsReading.javaCopy:LLC-load-misses           128  thrpt              0.022                 #/op
[info] ArrayOfUUIDsReading.javaCopy:LLC-loads                 128  thrpt              0.026                 #/op
[info] ArrayOfUUIDsReading.javaCopy:LLC-store-misses          128  thrpt              0.001                 #/op
[info] ArrayOfUUIDsReading.javaCopy:LLC-stores                128  thrpt              0.005                 #/op
[info] ArrayOfUUIDsReading.javaCopy:branch-misses             128  thrpt              0.207                 #/op
[info] ArrayOfUUIDsReading.javaCopy:branches                  128  thrpt             44.966                 #/op
[info] ArrayOfUUIDsReading.javaCopy:cycles                    128  thrpt            294.216                 #/op
[info] ArrayOfUUIDsReading.javaCopy:dTLB-load-misses          128  thrpt             ≈ 10⁻³                 #/op
[info] ArrayOfUUIDsReading.javaCopy:dTLB-loads                128  thrpt            145.620                 #/op
[info] ArrayOfUUIDsReading.javaCopy:dTLB-store-misses         128  thrpt             ≈ 10⁻⁴                 #/op
[info] ArrayOfUUIDsReading.javaCopy:dTLB-stores               128  thrpt            261.805                 #/op
[info] ArrayOfUUIDsReading.javaCopy:iTLB-load-misses          128  thrpt             ≈ 10⁻³                 #/op
[info] ArrayOfUUIDsReading.javaCopy:iTLB-loads                128  thrpt              0.001                 #/op
[info] ArrayOfUUIDsReading.javaCopy:instructions              128  thrpt           1149.567                 #/op
[info] ArrayOfUUIDsReading.javaFast                           128  thrpt    5    151876.374 ±     928.733  ops/s
[info] ArrayOfUUIDsReading.javaFast:CPI                       128  thrpt              0.277                 #/op
[info] ArrayOfUUIDsReading.javaFast:L1-dcache-load-misses     128  thrpt             75.746                 #/op
[info] ArrayOfUUIDsReading.javaFast:L1-dcache-loads           128  thrpt          18552.905                 #/op
[info] ArrayOfUUIDsReading.javaFast:L1-dcache-stores          128  thrpt           6365.694                 #/op
[info] ArrayOfUUIDsReading.javaFast:L1-icache-load-misses     128  thrpt              1.868                 #/op
[info] ArrayOfUUIDsReading.javaFast:LLC-load-misses           128  thrpt              3.212                 #/op
[info] ArrayOfUUIDsReading.javaFast:LLC-loads                 128  thrpt              4.720                 #/op
[info] ArrayOfUUIDsReading.javaFast:LLC-store-misses          128  thrpt              2.287                 #/op
[info] ArrayOfUUIDsReading.javaFast:LLC-stores                128  thrpt              7.618                 #/op
[info] ArrayOfUUIDsReading.javaFast:branch-misses             128  thrpt              1.925                 #/op
[info] ArrayOfUUIDsReading.javaFast:branches                  128  thrpt          11792.118                 #/op
[info] ArrayOfUUIDsReading.javaFast:cycles                    128  thrpt          22661.394                 #/op
[info] ArrayOfUUIDsReading.javaFast:dTLB-load-misses          128  thrpt              1.121                 #/op
[info] ArrayOfUUIDsReading.javaFast:dTLB-loads                128  thrpt          18449.733                 #/op
[info] ArrayOfUUIDsReading.javaFast:dTLB-store-misses         128  thrpt              0.010                 #/op
[info] ArrayOfUUIDsReading.javaFast:dTLB-stores               128  thrpt           6379.309                 #/op
[info] ArrayOfUUIDsReading.javaFast:iTLB-load-misses          128  thrpt              0.022                 #/op
[info] ArrayOfUUIDsReading.javaFast:iTLB-loads                128  thrpt              0.011                 #/op
[info] ArrayOfUUIDsReading.javaFast:instructions              128  thrpt          81934.987                 #/op
[info] ArrayOfUUIDsReading.javaOrig                           128  thrpt    5    211373.721 ±    1387.862  ops/s
[info] ArrayOfUUIDsReading.javaOrig:CPI                       128  thrpt              0.302                 #/op
[info] ArrayOfUUIDsReading.javaOrig:L1-dcache-load-misses     128  thrpt             75.717                 #/op
[info] ArrayOfUUIDsReading.javaOrig:L1-dcache-loads           128  thrpt          12154.735                 #/op
[info] ArrayOfUUIDsReading.javaOrig:L1-dcache-stores          128  thrpt           4275.815                 #/op
[info] ArrayOfUUIDsReading.javaOrig:L1-icache-load-misses     128  thrpt              1.674                 #/op
[info] ArrayOfUUIDsReading.javaOrig:LLC-load-misses           128  thrpt              1.932                 #/op
[info] ArrayOfUUIDsReading.javaOrig:LLC-loads                 128  thrpt              2.998                 #/op
[info] ArrayOfUUIDsReading.javaOrig:LLC-store-misses          128  thrpt              2.871                 #/op
[info] ArrayOfUUIDsReading.javaOrig:LLC-stores                128  thrpt              7.016                 #/op
[info] ArrayOfUUIDsReading.javaOrig:branch-misses             128  thrpt              1.590                 #/op
[info] ArrayOfUUIDsReading.javaOrig:branches                  128  thrpt           5209.724                 #/op
[info] ArrayOfUUIDsReading.javaOrig:cycles                    128  thrpt          16313.407                 #/op
[info] ArrayOfUUIDsReading.javaOrig:dTLB-load-misses          128  thrpt              1.026                 #/op
[info] ArrayOfUUIDsReading.javaOrig:dTLB-loads                128  thrpt          12197.325                 #/op
[info] ArrayOfUUIDsReading.javaOrig:dTLB-store-misses         128  thrpt              0.005                 #/op
[info] ArrayOfUUIDsReading.javaOrig:dTLB-stores               128  thrpt           4322.943                 #/op
[info] ArrayOfUUIDsReading.javaOrig:iTLB-load-misses          128  thrpt              0.035                 #/op
[info] ArrayOfUUIDsReading.javaOrig:iTLB-loads                128  thrpt              0.082                 #/op
[info] ArrayOfUUIDsReading.javaOrig:instructions              128  thrpt          53996.443                 #/op
```