### PR TITLE
8258422: Cleanup unnecessary null comparison before instanceof check in java.base

### DIFF
--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -2190,8 +2190,8 @@ public class File
      *          {@code false} otherwise
      */
     public boolean equals(Object obj) {
-        if (obj instanceof File) {
-            return compareTo((File)obj) == 0;
+        if (obj instanceof File file) {
+            return compareTo(file) == 0;
         }
         return false;
     }

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -2190,7 +2190,7 @@ public class File
      *          {@code false} otherwise
      */
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof File)) {
+        if (obj instanceof File) {
             return compareTo((File)obj) == 0;
         }
         return false;

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -308,7 +308,7 @@ public final class Constructor<T> extends Executable {
      * same formal parameter types.
      */
     public boolean equals(Object obj) {
-        if (obj != null && obj instanceof Constructor) {
+        if (obj instanceof Constructor) {
             Constructor<?> other = (Constructor<?>)obj;
             if (getDeclaringClass() == other.getDeclaringClass()) {
                 return equalParamTypes(parameterTypes, other.parameterTypes);

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -308,8 +308,7 @@ public final class Constructor<T> extends Executable {
      * same formal parameter types.
      */
     public boolean equals(Object obj) {
-        if (obj instanceof Constructor) {
-            Constructor<?> other = (Constructor<?>)obj;
+        if (obj instanceof Constructor<?> other) {
             if (getDeclaringClass() == other.getDeclaringClass()) {
                 return equalParamTypes(parameterTypes, other.parameterTypes);
             }

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -279,7 +279,7 @@ class Field extends AccessibleObject implements Member {
      * and type.
      */
     public boolean equals(Object obj) {
-        if (obj != null && obj instanceof Field) {
+        if (obj instanceof Field) {
             Field other = (Field)obj;
             return (getDeclaringClass() == other.getDeclaringClass())
                 && (getName() == other.getName())

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -279,8 +279,7 @@ class Field extends AccessibleObject implements Member {
      * and type.
      */
     public boolean equals(Object obj) {
-        if (obj instanceof Field) {
-            Field other = (Field)obj;
+        if (obj instanceof Field other) {
             return (getDeclaringClass() == other.getDeclaringClass())
                 && (getName() == other.getName())
                 && (getType() == other.getType());

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -358,8 +358,7 @@ public final class Method extends Executable {
      * and formal parameter types and return type.
      */
     public boolean equals(Object obj) {
-        if (obj instanceof Method) {
-            Method other = (Method)obj;
+        if (obj instanceof Method other) {
             if ((getDeclaringClass() == other.getDeclaringClass())
                 && (getName() == other.getName())) {
                 if (!returnType.equals(other.getReturnType()))

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -358,7 +358,7 @@ public final class Method extends Executable {
      * and formal parameter types and return type.
      */
     public boolean equals(Object obj) {
-        if (obj != null && obj instanceof Method) {
+        if (obj instanceof Method) {
             Method other = (Method)obj;
             if ((getDeclaringClass() == other.getDeclaringClass())
                 && (getName() == other.getName())) {

--- a/src/java.base/share/classes/java/net/AbstractPlainDatagramSocketImpl.java
+++ b/src/java.base/share/classes/java/net/AbstractPlainDatagramSocketImpl.java
@@ -235,9 +235,9 @@ abstract class AbstractPlainDatagramSocketImpl extends DatagramSocketImpl
 
     protected void joinGroup(SocketAddress mcastaddr, NetworkInterface netIf)
         throws IOException {
-        if (!(mcastaddr instanceof InetSocketAddress))
+        if (!(mcastaddr instanceof InetSocketAddress addr))
             throw new IllegalArgumentException("Unsupported address type");
-        join(((InetSocketAddress)mcastaddr).getAddress(), netIf);
+        join(addr.getAddress(), netIf);
     }
 
     protected abstract void join(InetAddress inetaddr, NetworkInterface netIf)
@@ -253,9 +253,9 @@ abstract class AbstractPlainDatagramSocketImpl extends DatagramSocketImpl
      */
     protected void leaveGroup(SocketAddress mcastaddr, NetworkInterface netIf)
         throws IOException {
-        if (!(mcastaddr instanceof InetSocketAddress))
+        if (!(mcastaddr instanceof InetSocketAddress addr))
             throw new IllegalArgumentException("Unsupported address type");
-        leave(((InetSocketAddress)mcastaddr).getAddress(), netIf);
+        leave(addr.getAddress(), netIf);
     }
 
     protected abstract void leave(InetAddress inetaddr, NetworkInterface netIf)

--- a/src/java.base/share/classes/java/net/AbstractPlainDatagramSocketImpl.java
+++ b/src/java.base/share/classes/java/net/AbstractPlainDatagramSocketImpl.java
@@ -235,7 +235,7 @@ abstract class AbstractPlainDatagramSocketImpl extends DatagramSocketImpl
 
     protected void joinGroup(SocketAddress mcastaddr, NetworkInterface netIf)
         throws IOException {
-        if (mcastaddr == null || !(mcastaddr instanceof InetSocketAddress))
+        if (!(mcastaddr instanceof InetSocketAddress))
             throw new IllegalArgumentException("Unsupported address type");
         join(((InetSocketAddress)mcastaddr).getAddress(), netIf);
     }
@@ -253,7 +253,7 @@ abstract class AbstractPlainDatagramSocketImpl extends DatagramSocketImpl
      */
     protected void leaveGroup(SocketAddress mcastaddr, NetworkInterface netIf)
         throws IOException {
-        if (mcastaddr == null || !(mcastaddr instanceof InetSocketAddress))
+        if (!(mcastaddr instanceof InetSocketAddress))
             throw new IllegalArgumentException("Unsupported address type");
         leave(((InetSocketAddress)mcastaddr).getAddress(), netIf);
     }
@@ -292,7 +292,7 @@ abstract class AbstractPlainDatagramSocketImpl extends DatagramSocketImpl
              * PlainSocketImpl.setOption().
              */
          case SO_TIMEOUT:
-             if (o == null || !(o instanceof Integer)) {
+             if (!(o instanceof Integer)) {
                  throw new SocketException("bad argument for SO_TIMEOUT");
              }
              int tmp = ((Integer) o).intValue();
@@ -301,18 +301,18 @@ abstract class AbstractPlainDatagramSocketImpl extends DatagramSocketImpl
              timeout = tmp;
              return;
          case IP_TOS:
-             if (o == null || !(o instanceof Integer)) {
+             if (!(o instanceof Integer)) {
                  throw new SocketException("bad argument for IP_TOS");
              }
              trafficClass = ((Integer)o).intValue();
              break;
          case SO_REUSEADDR:
-             if (o == null || !(o instanceof Boolean)) {
+             if (!(o instanceof Boolean)) {
                  throw new SocketException("bad argument for SO_REUSEADDR");
              }
              break;
          case SO_BROADCAST:
-             if (o == null || !(o instanceof Boolean)) {
+             if (!(o instanceof Boolean)) {
                  throw new SocketException("bad argument for SO_BROADCAST");
              }
              break;
@@ -320,26 +320,26 @@ abstract class AbstractPlainDatagramSocketImpl extends DatagramSocketImpl
              throw new SocketException("Cannot re-bind Socket");
          case SO_RCVBUF:
          case SO_SNDBUF:
-             if (o == null || !(o instanceof Integer) ||
+             if (!(o instanceof Integer) ||
                  ((Integer)o).intValue() < 0) {
                  throw new SocketException("bad argument for SO_SNDBUF or " +
                                            "SO_RCVBUF");
              }
              break;
          case IP_MULTICAST_IF:
-             if (o == null || !(o instanceof InetAddress))
+             if (!(o instanceof InetAddress))
                  throw new SocketException("bad argument for IP_MULTICAST_IF");
              break;
          case IP_MULTICAST_IF2:
-             if (o == null || !(o instanceof NetworkInterface))
+             if (!(o instanceof NetworkInterface))
                  throw new SocketException("bad argument for IP_MULTICAST_IF2");
              break;
          case IP_MULTICAST_LOOP:
-             if (o == null || !(o instanceof Boolean))
+             if (!(o instanceof Boolean))
                  throw new SocketException("bad argument for IP_MULTICAST_LOOP");
              break;
          case SO_REUSEPORT:
-             if (o == null || !(o instanceof Boolean)) {
+             if (!(o instanceof Boolean)) {
                  throw new SocketException("bad argument for SO_REUSEPORT");
              }
              if (!supportedOptions().contains(StandardSocketOptions.SO_REUSEPORT)) {

--- a/src/java.base/share/classes/java/net/AbstractPlainSocketImpl.java
+++ b/src/java.base/share/classes/java/net/AbstractPlainSocketImpl.java
@@ -213,7 +213,7 @@ abstract class AbstractPlainSocketImpl extends SocketImpl implements PlatformSoc
             throws IOException {
         boolean connected = false;
         try {
-            if (address == null || !(address instanceof InetSocketAddress))
+            if (!(address instanceof InetSocketAddress))
                 throw new IllegalArgumentException("unsupported address type");
             InetSocketAddress addr = (InetSocketAddress) address;
             if (addr.isUnresolved())
@@ -259,7 +259,7 @@ abstract class AbstractPlainSocketImpl extends SocketImpl implements PlatformSoc
              * PlainSocketImpl.setOption().
              */
         case SO_LINGER:
-            if (val == null || (!(val instanceof Integer) && !(val instanceof Boolean)))
+            if (!(val instanceof Integer) && !(val instanceof Boolean))
                 throw new SocketException("Bad parameter for option");
             if (val instanceof Boolean) {
                 /* true only if disabling - enabling should be Integer */
@@ -267,7 +267,7 @@ abstract class AbstractPlainSocketImpl extends SocketImpl implements PlatformSoc
             }
             break;
         case SO_TIMEOUT:
-            if (val == null || (!(val instanceof Integer)))
+            if (!(val instanceof Integer))
                 throw new SocketException("Bad parameter for SO_TIMEOUT");
             int tmp = ((Integer) val).intValue();
             if (tmp < 0)
@@ -275,7 +275,7 @@ abstract class AbstractPlainSocketImpl extends SocketImpl implements PlatformSoc
             timeout = tmp;
             break;
         case IP_TOS:
-             if (val == null || !(val instanceof Integer)) {
+             if (!(val instanceof Integer)) {
                  throw new SocketException("bad argument for IP_TOS");
              }
              trafficClass = ((Integer)val).intValue();
@@ -283,35 +283,35 @@ abstract class AbstractPlainSocketImpl extends SocketImpl implements PlatformSoc
         case SO_BINDADDR:
             throw new SocketException("Cannot re-bind socket");
         case TCP_NODELAY:
-            if (val == null || !(val instanceof Boolean))
+            if (!(val instanceof Boolean))
                 throw new SocketException("bad parameter for TCP_NODELAY");
             on = ((Boolean)val).booleanValue();
             break;
         case SO_SNDBUF:
         case SO_RCVBUF:
-            if (val == null || !(val instanceof Integer) ||
+            if (!(val instanceof Integer) ||
                 !(((Integer)val).intValue() > 0)) {
                 throw new SocketException("bad parameter for SO_SNDBUF " +
                                           "or SO_RCVBUF");
             }
             break;
         case SO_KEEPALIVE:
-            if (val == null || !(val instanceof Boolean))
+            if (!(val instanceof Boolean))
                 throw new SocketException("bad parameter for SO_KEEPALIVE");
             on = ((Boolean)val).booleanValue();
             break;
         case SO_OOBINLINE:
-            if (val == null || !(val instanceof Boolean))
+            if (!(val instanceof Boolean))
                 throw new SocketException("bad parameter for SO_OOBINLINE");
             on = ((Boolean)val).booleanValue();
             break;
         case SO_REUSEADDR:
-            if (val == null || !(val instanceof Boolean))
+            if (!(val instanceof Boolean))
                 throw new SocketException("bad parameter for SO_REUSEADDR");
             on = ((Boolean)val).booleanValue();
             break;
         case SO_REUSEPORT:
-            if (val == null || !(val instanceof Boolean))
+            if (!(val instanceof Boolean))
                 throw new SocketException("bad parameter for SO_REUSEPORT");
             if (!supportedOptions().contains(StandardSocketOptions.SO_REUSEPORT))
                 throw new UnsupportedOperationException("unsupported option");

--- a/src/java.base/share/classes/java/net/AbstractPlainSocketImpl.java
+++ b/src/java.base/share/classes/java/net/AbstractPlainSocketImpl.java
@@ -213,9 +213,8 @@ abstract class AbstractPlainSocketImpl extends SocketImpl implements PlatformSoc
             throws IOException {
         boolean connected = false;
         try {
-            if (!(address instanceof InetSocketAddress))
+            if (!(address instanceof InetSocketAddress addr))
                 throw new IllegalArgumentException("unsupported address type");
-            InetSocketAddress addr = (InetSocketAddress) address;
             if (addr.isUnresolved())
                 throw new UnknownHostException(addr.getHostName());
             // recording this.address as supplied by caller before calling connect

--- a/src/java.base/share/classes/java/net/DatagramPacket.java
+++ b/src/java.base/share/classes/java/net/DatagramPacket.java
@@ -352,9 +352,8 @@ class DatagramPacket {
      * @since   1.4
      */
     public synchronized void setSocketAddress(SocketAddress address) {
-        if (!(address instanceof InetSocketAddress))
+        if (!(address instanceof InetSocketAddress addr))
             throw new IllegalArgumentException("unsupported address type");
-        InetSocketAddress addr = (InetSocketAddress) address;
         if (addr.isUnresolved())
             throw new IllegalArgumentException("unresolved address");
         setAddress(addr.getAddress());

--- a/src/java.base/share/classes/java/net/DatagramPacket.java
+++ b/src/java.base/share/classes/java/net/DatagramPacket.java
@@ -352,7 +352,7 @@ class DatagramPacket {
      * @since   1.4
      */
     public synchronized void setSocketAddress(SocketAddress address) {
-        if (address == null || !(address instanceof InetSocketAddress))
+        if (!(address instanceof InetSocketAddress))
             throw new IllegalArgumentException("unsupported address type");
         InetSocketAddress addr = (InetSocketAddress) address;
         if (addr.isUnresolved())

--- a/src/java.base/share/classes/java/net/HttpConnectSocketImpl.java
+++ b/src/java.base/share/classes/java/net/HttpConnectSocketImpl.java
@@ -102,7 +102,7 @@ import java.util.Set;
     protected void connect(SocketAddress endpoint, int timeout)
         throws IOException
     {
-        if (endpoint == null || !(endpoint instanceof InetSocketAddress))
+        if (!(endpoint instanceof InetSocketAddress))
             throw new IllegalArgumentException("Unsupported address type");
         final InetSocketAddress epoint = (InetSocketAddress)endpoint;
         String destHost = epoint.isUnresolved() ? epoint.getHostName()

--- a/src/java.base/share/classes/java/net/HttpConnectSocketImpl.java
+++ b/src/java.base/share/classes/java/net/HttpConnectSocketImpl.java
@@ -102,9 +102,8 @@ import java.util.Set;
     protected void connect(SocketAddress endpoint, int timeout)
         throws IOException
     {
-        if (!(endpoint instanceof InetSocketAddress))
+        if (!(endpoint instanceof InetSocketAddress epoint))
             throw new IllegalArgumentException("Unsupported address type");
-        final InetSocketAddress epoint = (InetSocketAddress)endpoint;
         String destHost = epoint.isUnresolved() ? epoint.getHostName()
                                                 : epoint.getAddress().getHostAddress();
         final int destPort = epoint.getPort();

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -352,8 +352,8 @@ class Inet4Address extends InetAddress {
      * @see     java.net.InetAddress#getAddress()
      */
     public boolean equals(Object obj) {
-        return (obj instanceof Inet4Address) &&
-            (((InetAddress)obj).holder().getAddress() == holder().getAddress());
+        return (obj instanceof Inet4Address inet4Address) &&
+            inet4Address.holder().getAddress() == holder().getAddress();
     }
 
     // Utilities

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -352,7 +352,7 @@ class Inet4Address extends InetAddress {
      * @see     java.net.InetAddress#getAddress()
      */
     public boolean equals(Object obj) {
-        return (obj != null) && (obj instanceof Inet4Address) &&
+        return (obj instanceof Inet4Address) &&
             (((InetAddress)obj).holder().getAddress() == holder().getAddress());
     }
 

--- a/src/java.base/share/classes/java/net/Inet6Address.java
+++ b/src/java.base/share/classes/java/net/Inet6Address.java
@@ -878,12 +878,10 @@ class Inet6Address extends InetAddress {
      */
     @Override
     public boolean equals(Object obj) {
-        if (!(obj instanceof Inet6Address))
-            return false;
-
-        Inet6Address inetAddr = (Inet6Address)obj;
-
-        return holder6.equals(inetAddr.holder6);
+        if (obj instanceof Inet6Address inetAddr) {
+            return holder6.equals(inetAddr.holder6);
+        }
+        return false;
     }
 
     /**

--- a/src/java.base/share/classes/java/net/Inet6Address.java
+++ b/src/java.base/share/classes/java/net/Inet6Address.java
@@ -878,7 +878,7 @@ class Inet6Address extends InetAddress {
      */
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof Inet6Address))
+        if (!(obj instanceof Inet6Address))
             return false;
 
         Inet6Address inetAddr = (Inet6Address)obj;

--- a/src/java.base/share/classes/java/net/InetSocketAddress.java
+++ b/src/java.base/share/classes/java/net/InetSocketAddress.java
@@ -119,7 +119,7 @@ public class InetSocketAddress
 
         @Override
         public final boolean equals(Object obj) {
-            if (obj == null || !(obj instanceof InetSocketAddressHolder))
+            if (!(obj instanceof InetSocketAddressHolder))
                 return false;
             InetSocketAddressHolder that = (InetSocketAddressHolder)obj;
             boolean sameIP;
@@ -409,7 +409,7 @@ public class InetSocketAddress
      */
     @Override
     public final boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof InetSocketAddress))
+        if (!(obj instanceof InetSocketAddress))
             return false;
         return holder.equals(((InetSocketAddress) obj).holder);
     }

--- a/src/java.base/share/classes/java/net/InetSocketAddress.java
+++ b/src/java.base/share/classes/java/net/InetSocketAddress.java
@@ -119,9 +119,8 @@ public class InetSocketAddress
 
         @Override
         public final boolean equals(Object obj) {
-            if (!(obj instanceof InetSocketAddressHolder))
+            if (!(obj instanceof InetSocketAddressHolder that))
                 return false;
-            InetSocketAddressHolder that = (InetSocketAddressHolder)obj;
             boolean sameIP;
             if (addr != null)
                 sameIP = addr.equals(that.addr);
@@ -409,9 +408,10 @@ public class InetSocketAddress
      */
     @Override
     public final boolean equals(Object obj) {
-        if (!(obj instanceof InetSocketAddress))
-            return false;
-        return holder.equals(((InetSocketAddress) obj).holder);
+        if (obj instanceof InetSocketAddress addr) {
+            return holder.equals(addr.holder);
+        }
+        return false;
     }
 
     /**

--- a/src/java.base/share/classes/java/net/NetMulticastSocket.java
+++ b/src/java.base/share/classes/java/net/NetMulticastSocket.java
@@ -801,19 +801,19 @@ final class NetMulticastSocket extends MulticastSocket {
         if (isClosed())
             throw new SocketException("Socket is closed");
 
-        if (!(mcastaddr instanceof InetSocketAddress))
+        if (!(mcastaddr instanceof InetSocketAddress addr))
             throw new IllegalArgumentException("Unsupported address type");
 
         if (oldImpl)
             throw new UnsupportedOperationException();
 
-        checkAddress(((InetSocketAddress)mcastaddr).getAddress(), "joinGroup");
+        checkAddress(addr.getAddress(), "joinGroup");
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
-            security.checkMulticast(((InetSocketAddress)mcastaddr).getAddress());
+            security.checkMulticast(addr.getAddress());
         }
 
-        if (!((InetSocketAddress)mcastaddr).getAddress().isMulticastAddress()) {
+        if (!addr.getAddress().isMulticastAddress()) {
             throw new SocketException("Not a multicast address");
         }
 
@@ -826,19 +826,19 @@ final class NetMulticastSocket extends MulticastSocket {
         if (isClosed())
             throw new SocketException("Socket is closed");
 
-        if (!(mcastaddr instanceof InetSocketAddress))
+        if (!(mcastaddr instanceof InetSocketAddress addr))
             throw new IllegalArgumentException("Unsupported address type");
 
         if (oldImpl)
             throw new UnsupportedOperationException();
 
-        checkAddress(((InetSocketAddress)mcastaddr).getAddress(), "leaveGroup");
+        checkAddress(addr.getAddress(), "leaveGroup");
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
-            security.checkMulticast(((InetSocketAddress)mcastaddr).getAddress());
+            security.checkMulticast(addr.getAddress());
         }
 
-        if (!((InetSocketAddress)mcastaddr).getAddress().isMulticastAddress()) {
+        if (!addr.getAddress().isMulticastAddress()) {
             throw new SocketException("Not a multicast address");
         }
 

--- a/src/java.base/share/classes/java/net/NetMulticastSocket.java
+++ b/src/java.base/share/classes/java/net/NetMulticastSocket.java
@@ -801,7 +801,7 @@ final class NetMulticastSocket extends MulticastSocket {
         if (isClosed())
             throw new SocketException("Socket is closed");
 
-        if (mcastaddr == null || !(mcastaddr instanceof InetSocketAddress))
+        if (!(mcastaddr instanceof InetSocketAddress))
             throw new IllegalArgumentException("Unsupported address type");
 
         if (oldImpl)
@@ -826,7 +826,7 @@ final class NetMulticastSocket extends MulticastSocket {
         if (isClosed())
             throw new SocketException("Socket is closed");
 
-        if (mcastaddr == null || !(mcastaddr instanceof InetSocketAddress))
+        if (!(mcastaddr instanceof InetSocketAddress))
             throw new IllegalArgumentException("Unsupported address type");
 
         if (oldImpl)

--- a/src/java.base/share/classes/java/net/Proxy.java
+++ b/src/java.base/share/classes/java/net/Proxy.java
@@ -146,7 +146,7 @@ public class Proxy {
      * @see java.net.InetSocketAddress#equals(java.lang.Object)
      */
     public final boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof Proxy))
+        if (!(obj instanceof Proxy))
             return false;
         Proxy p = (Proxy) obj;
         if (p.type() == type()) {

--- a/src/java.base/share/classes/java/net/Proxy.java
+++ b/src/java.base/share/classes/java/net/Proxy.java
@@ -146,9 +146,8 @@ public class Proxy {
      * @see java.net.InetSocketAddress#equals(java.lang.Object)
      */
     public final boolean equals(Object obj) {
-        if (!(obj instanceof Proxy))
+        if (!(obj instanceof Proxy p))
             return false;
-        Proxy p = (Proxy) obj;
         if (p.type() == type()) {
             if (address() == null) {
                 return (p.address() == null);

--- a/src/java.base/share/classes/java/net/SocksSocketImpl.java
+++ b/src/java.base/share/classes/java/net/SocksSocketImpl.java
@@ -272,9 +272,8 @@ class SocksSocketImpl extends DelegatingSocketImpl implements SocksConsts {
         }
 
         SecurityManager security = System.getSecurityManager();
-        if (!(endpoint instanceof InetSocketAddress))
+        if (!(endpoint instanceof InetSocketAddress epoint))
             throw new IllegalArgumentException("Unsupported address type");
-        InetSocketAddress epoint = (InetSocketAddress) endpoint;
         if (security != null) {
             if (epoint.isUnresolved())
                 security.checkConnect(epoint.getHostName(),

--- a/src/java.base/share/classes/java/net/SocksSocketImpl.java
+++ b/src/java.base/share/classes/java/net/SocksSocketImpl.java
@@ -272,7 +272,7 @@ class SocksSocketImpl extends DelegatingSocketImpl implements SocksConsts {
         }
 
         SecurityManager security = System.getSecurityManager();
-        if (endpoint == null || !(endpoint instanceof InetSocketAddress))
+        if (!(endpoint instanceof InetSocketAddress))
             throw new IllegalArgumentException("Unsupported address type");
         InetSocketAddress epoint = (InetSocketAddress) endpoint;
         if (security != null) {

--- a/src/java.base/share/classes/java/nio/file/attribute/AclEntry.java
+++ b/src/java.base/share/classes/java/nio/file/attribute/AclEntry.java
@@ -342,7 +342,7 @@ public final class AclEntry {
     public boolean equals(Object ob) {
         if (ob == this)
             return true;
-        if (ob == null || !(ob instanceof AclEntry))
+        if (!(ob instanceof AclEntry))
             return false;
         AclEntry other = (AclEntry)ob;
         if (this.type != other.type)

--- a/src/java.base/share/classes/java/nio/file/attribute/AclEntry.java
+++ b/src/java.base/share/classes/java/nio/file/attribute/AclEntry.java
@@ -342,9 +342,8 @@ public final class AclEntry {
     public boolean equals(Object ob) {
         if (ob == this)
             return true;
-        if (!(ob instanceof AclEntry))
+        if (!(ob instanceof AclEntry other))
             return false;
-        AclEntry other = (AclEntry)ob;
         if (this.type != other.type)
             return false;
         if (!this.who.equals(other.who))

--- a/src/java.base/share/classes/jdk/internal/misc/Signal.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Signal.java
@@ -102,7 +102,7 @@ public final class Signal {
         if (this == other) {
             return true;
         }
-        if (other == null || !(other instanceof Signal)) {
+        if (!(other instanceof Signal)) {
             return false;
         }
         Signal other1 = (Signal)other;

--- a/src/java.base/share/classes/jdk/internal/misc/Signal.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Signal.java
@@ -95,7 +95,7 @@ public final class Signal {
     /**
      * Compares the equality of two <code>Signal</code> objects.
      *
-     * @param other the object to compare with.
+     * @param oth the object to compare with.
      * @return whether two <code>Signal</code> objects are equal.
      */
     public boolean equals(Object oth) {

--- a/src/java.base/share/classes/jdk/internal/misc/Signal.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Signal.java
@@ -98,12 +98,12 @@ public final class Signal {
      * @param other the object to compare with.
      * @return whether two <code>Signal</code> objects are equal.
      */
-    public boolean equals(Object other) {
-        if (this == other) {
+    public boolean equals(Object oth) {
+        if (this == oth) {
             return true;
         }
-        if (other instanceof Signal other1) {
-            return name.equals(other1.name) && (number == other1.number);
+        if (oth instanceof Signal other) {
+            return name.equals(other.name) && (number == other.number);
         }
         return false;
     }

--- a/src/java.base/share/classes/jdk/internal/misc/Signal.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Signal.java
@@ -102,11 +102,10 @@ public final class Signal {
         if (this == other) {
             return true;
         }
-        if (!(other instanceof Signal)) {
-            return false;
+        if (other instanceof Signal other1) {
+            return name.equals(other1.name) && (number == other1.number);
         }
-        Signal other1 = (Signal)other;
-        return name.equals(other1.name) && (number == other1.number);
+        return false;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/misc/Signal.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Signal.java
@@ -95,14 +95,14 @@ public final class Signal {
     /**
      * Compares the equality of two <code>Signal</code> objects.
      *
-     * @param oth the object to compare with.
+     * @param obj the object to compare with.
      * @return whether two <code>Signal</code> objects are equal.
      */
-    public boolean equals(Object oth) {
-        if (this == oth) {
+    public boolean equals(Object obj) {
+        if (this == obj) {
             return true;
         }
-        if (oth instanceof Signal other) {
+        if (obj instanceof Signal other) {
             return name.equals(other.name) && (number == other.number);
         }
         return false;

--- a/src/java.base/share/classes/sun/net/www/protocol/http/Negotiator.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/Negotiator.java
@@ -66,7 +66,7 @@ public abstract class Negotiator {
         } catch (ReflectiveOperationException roe) {
             finest(roe);
             Throwable t = roe.getCause();
-            if (t != null && t instanceof Exception)
+            if (t instanceof Exception)
                 finest((Exception)t);
             return null;
         }

--- a/src/java.base/share/classes/sun/net/www/protocol/http/Negotiator.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/Negotiator.java
@@ -66,8 +66,8 @@ public abstract class Negotiator {
         } catch (ReflectiveOperationException roe) {
             finest(roe);
             Throwable t = roe.getCause();
-            if (t instanceof Exception)
-                finest((Exception)t);
+            if (t instanceof Exception exception)
+                finest(exception);
             return null;
         }
     }

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -426,7 +426,7 @@ final class HttpsClient extends HttpClient
             // unconnected sockets have not been implemented.
             //
             Throwable t = se.getCause();
-            if (t != null && t instanceof UnsupportedOperationException) {
+            if (t instanceof UnsupportedOperationException) {
                 return super.createSocket();
             } else {
                 throw se;

--- a/src/java.base/share/classes/sun/nio/ch/DatagramSocketAdaptor.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramSocketAdaptor.java
@@ -504,7 +504,7 @@ public class DatagramSocketAdaptor
      * @throws SocketException if group is not a multicast address
      */
     private static InetAddress checkGroup(SocketAddress mcastaddr) throws SocketException {
-        if (mcastaddr == null || !(mcastaddr instanceof InetSocketAddress))
+        if (!(mcastaddr instanceof InetSocketAddress))
             throw new IllegalArgumentException("Unsupported address type");
         InetAddress group = ((InetSocketAddress) mcastaddr).getAddress();
         if (group == null)

--- a/src/java.base/share/classes/sun/nio/ch/DatagramSocketAdaptor.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramSocketAdaptor.java
@@ -504,9 +504,9 @@ public class DatagramSocketAdaptor
      * @throws SocketException if group is not a multicast address
      */
     private static InetAddress checkGroup(SocketAddress mcastaddr) throws SocketException {
-        if (!(mcastaddr instanceof InetSocketAddress))
+        if (!(mcastaddr instanceof InetSocketAddress addr))
             throw new IllegalArgumentException("Unsupported address type");
-        InetAddress group = ((InetSocketAddress) mcastaddr).getAddress();
+        InetAddress group = addr.getAddress();
         if (group == null)
             throw new IllegalArgumentException("Unresolved address");
         if (!group.isMulticastAddress())

--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -149,8 +149,8 @@ class PollingWatchService
                 });
         } catch (PrivilegedActionException pae) {
             Throwable cause = pae.getCause();
-            if (cause instanceof IOException)
-                throw (IOException)cause;
+            if (cause instanceof IOException ioe)
+                throw ioe;
             throw new AssertionError(pae);
         }
     }

--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -149,7 +149,7 @@ class PollingWatchService
                 });
         } catch (PrivilegedActionException pae) {
             Throwable cause = pae.getCause();
-            if (cause != null && cause instanceof IOException)
+            if (cause instanceof IOException)
                 throw (IOException)cause;
             throw new AssertionError(pae);
         }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -762,8 +762,8 @@ class UnixPath implements Path {
 
     @Override
     public boolean equals(Object ob) {
-        if ((ob != null) && (ob instanceof UnixPath)) {
-            return compareTo((Path)ob) == 0;
+        if (ob instanceof UnixPath path) {
+            return compareTo(path) == 0;
         }
         return false;
     }

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
@@ -798,8 +798,8 @@ class WindowsPath implements Path {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof WindowsPath) {
-            return compareTo((Path)obj) == 0;
+        if (obj instanceof WindowsPath path) {
+            return compareTo(path) == 0;
         }
         return false;
     }

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
@@ -798,7 +798,7 @@ class WindowsPath implements Path {
 
     @Override
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof WindowsPath)) {
+        if (obj instanceof WindowsPath) {
             return compareTo((Path)obj) == 0;
         }
         return false;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258422](https://bugs.openjdk.java.net/browse/JDK-8258422): Cleanup unnecessary null comparison before instanceof check in java.base


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to f5727ca95bdab10cf060454ecd7df498c6165779
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer) ⚠️ Review applies to f5727ca95bdab10cf060454ecd7df498c6165779


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/20/head:pull/20`
`$ git checkout pull/20`
