### PR TITLE
8252715: Problem list java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java on Linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -207,6 +207,7 @@ java/awt/event/KeyEvent/KeyChar/KeyCharTest.java 8169474,8224055 macosx-all,wind
 java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_3.java 6854300 generic-all
 java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java 8129778 generic-all
 java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java 8129778 generic-all
+java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java 8252713 linux-all
 java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java 8129778 generic-all
 
 java/awt/dnd/URIListToFileListBetweenJVMsTest/URIListToFileListBetweenJVMsTest.java 8194947 generic-all


### PR DESCRIPTION
Bug :https://bugs.openjdk.java.net/browse/JDK-8252715

We've opened a bug to track some xserver issues  running this test that cause all subsequent tests to fail
because they can't connect even though the server is still running.
Possibly it is a system configuration issue or perhaps an Xserver bug,
but it has been seen on more than one Ubuntu system running 19.10 and 20.04 and
I think we should problem list it to see if that cures/hides it  .. or moves it .. as this happens
so frequently we can't wait for an investigation to complete.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252715](https://bugs.openjdk.java.net/browse/JDK-8252715): Problem list java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java on Linux


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/23/head:pull/23`
`$ git checkout pull/23`
