### PR TITLE
8252679: Two windows specific FileDIalog tests may fail on some Windows_Server_2016_Standard

### DIFF
--- a/test/jdk/java/awt/FileDialog/8003399/bug8003399.java
+++ b/test/jdk/java/awt/FileDialog/8003399/bug8003399.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 
 /* @test
+   @key headful
    @bug 8003399
    @summary JFileChooser gives wrong path to selected file when saving to Libraries folder on Windows 7
    @author Semyon Sadetsky
@@ -50,6 +51,9 @@ public class bug8003399 {
                             String path = file1.getPath();
                             if(path.startsWith("::{") &&
                                     path.toLowerCase().endsWith(".library-ms")) {
+                                System.err.println("file = " + file);
+                                System.err.println("file1 = " + file1);
+                                System.err.println("path = " + path);
                                 throw new RuntimeException("Unconverted library link found");
                             }
                         }

--- a/test/jdk/java/awt/FileDialog/8017487/bug8017487.java
+++ b/test/jdk/java/awt/FileDialog/8017487/bug8017487.java
@@ -22,6 +22,7 @@
  */
 
 /* @test
+   @key headful
    @bug 8017487 8167988
    @summary filechooser in Windows-Libraries folder: columns are mixed up
    @author Semyon Sadetsky


### PR DESCRIPTION
These seemingly simple checks are needed on Windows because on windows we allow navigating in the special folders(Libraries). To map the LIbrary such as Music/Video we call the native win32 API. If this API fails to convert the Library to the path, we will show this library to the user in the FileChooser without an ability to navigate it.

I have checked that the test fails on the systems where the native API sometimes cannot map the Library to the path, so even the native applications cannot navigate it.

We run these tests, as a service on the headless windows system, so this could be a reason.

For now, I would like to move these tests to the headful group where we know the desktop session exists. If they continue to fail we probably will need to relax the checks in the tests.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252679](https://bugs.openjdk.java.net/browse/JDK-8252679): Two windows specific FileDIalog tests may fail on some Windows_Server_2016_Standard 


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/24/head:pull/24`
`$ git checkout pull/24`
