### PR TITLE
8252767: URLConnection.setRequestProperty throws IllegalAccessError

### DIFF
--- a/src/java.base/share/classes/sun/net/www/URLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/URLConnection.java
@@ -71,7 +71,7 @@ public abstract class URLConnection extends java.net.URLConnection {
 
     public void setRequestProperty(String key, String value) {
         if(connected)
-            throw new IllegalAccessError("Already connected");
+            throw new IllegalStateException("Already connected");
         if (key == null)
             throw new NullPointerException ("key cannot be null");
         properties.set(key, value);

--- a/test/jdk/java/net/URLConnection/RequestProperties.java
+++ b/test/jdk/java/net/URLConnection/RequestProperties.java
@@ -42,6 +42,9 @@ import java.util.List;
 
 public class RequestProperties {
 
+    private static final Class NPE = NullPointerException.class;
+    private static final Class ISE = IllegalStateException.class;
+
     @DataProvider(name = "urls")
     private Object[][] urls() {
         final List<String> urls = new ArrayList<>();
@@ -66,14 +69,7 @@ public class RequestProperties {
     @Test(dataProvider = "urls")
     public void testSetRequestPropertyNullPointerException(final String url) throws Exception {
         final URLConnection conn = new URL(url).openConnection();
-        try {
-            conn.setRequestProperty(null, "bar");
-            Assert.fail("setRequestProperty on " + conn.getClass().getName()
-                    + " for " + conn.getURL() + " was expected to throw"
-                    + " NullPointerException, but didn't");
-        } catch (NullPointerException npe) {
-            // expected
-        }
+        Assert.assertThrows(NPE, () -> conn.setRequestProperty(null, "bar"));
         // expected to pass
         conn.setRequestProperty("key", null);
     }
@@ -85,14 +81,7 @@ public class RequestProperties {
     @Test(dataProvider = "urls")
     public void testAddRequestPropertyNullPointerException(final String url) throws Exception {
         final URLConnection conn = new URL(url).openConnection();
-        try {
-            conn.addRequestProperty(null, "hello");
-            Assert.fail("addRequestProperty on " + conn.getClass().getName()
-                    + " for " + conn.getURL() + " was expected to throw"
-                    + " NullPointerException, but didn't");
-        } catch (NullPointerException npe) {
-            // expected
-        }
+        Assert.assertThrows(NPE, () -> conn.addRequestProperty(null, "hello"));
         // expected to pass
         conn.addRequestProperty("key", null);
     }
@@ -116,12 +105,7 @@ public class RequestProperties {
     public void testSetRequestPropertyIllegalStateException() throws Exception {
         final URLConnection conn = createAndConnectURLConnection();
         try {
-            conn.setRequestProperty("foo", "bar");
-            Assert.fail("setRequestProperty on " + conn.getClass().getName()
-                    + " for " + conn.getURL() + " was expected to throw"
-                    + " IllegalStateException, but didn't");
-        } catch (IllegalStateException ise) {
-            // expected
+            Assert.assertThrows(ISE, () -> conn.setRequestProperty("foo", "bar"));
         } finally {
             safeClose(conn);
         }
@@ -135,12 +119,7 @@ public class RequestProperties {
     public void testAddRequestPropertyIllegalStateException() throws Exception {
         final URLConnection conn = createAndConnectURLConnection();
         try {
-            conn.addRequestProperty("foo", "bar");
-            Assert.fail("addRequestProperty on " + conn.getClass().getName()
-                    + " for " + conn.getURL() + " was expected to throw"
-                    + " IllegalStateException, but didn't");
-        } catch (IllegalStateException ise) {
-            // expected
+            Assert.assertThrows(ISE, () -> conn.addRequestProperty("foo", "bar"));
         } finally {
             safeClose(conn);
         }
@@ -154,12 +133,7 @@ public class RequestProperties {
     public void testGetRequestPropertyIllegalStateException() throws Exception {
         final URLConnection conn = createAndConnectURLConnection();
         try {
-            conn.getRequestProperty("hello");
-            Assert.fail("getRequestProperty on " + conn.getClass().getName()
-                    + " for " + conn.getURL() + " was expected to throw"
-                    + " IllegalStateException, but didn't");
-        } catch (IllegalStateException ise) {
-            // expected
+            Assert.assertThrows(ISE, () -> conn.getRequestProperty("hello"));
         } finally {
             safeClose(conn);
         }
@@ -173,12 +147,7 @@ public class RequestProperties {
     public void testGetRequestPropertiesIllegalStateException() throws Exception {
         final URLConnection conn = createAndConnectURLConnection();
         try {
-            conn.getRequestProperties();
-            Assert.fail("getRequestProperties on " + conn.getClass().getName()
-                    + " for " + conn.getURL() + " was expected to throw"
-                    + " IllegalStateException, but didn't");
-        } catch (IllegalStateException ise) {
-            // expected
+            Assert.assertThrows(ISE, () -> conn.getRequestProperties());
         } finally {
             safeClose(conn);
         }


### PR DESCRIPTION
Can I please get a review and a sponsor for a fix for the issue reported at https://bugs.openjdk.java.net/browse/JDK-8252767?

As noted in that issue, the `sun.net.www.URLConnection#setRequestProperty` is throwing a `IllegalAccessError` instead of a `IllegalStateException`. The commit here fixes that and includes a test which reproduces the issue and verifies the fix.

Would a CSR be needed for this change?
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252767](https://bugs.openjdk.java.net/browse/JDK-8252767): URLConnection.setRequestProperty throws IllegalAccessError


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**) ⚠️ Review applies to 9b8539a1a4d0d6826bce654903fabdb6394c4ad6
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/26/head:pull/26`
`$ git checkout pull/26`
