### PR TITLE
8250961: Move Universe::update_heap_info_at_gc to CollectedHeap

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2676,7 +2676,7 @@ void G1CollectedHeap::gc_epilogue(bool full) {
   MemoryService::track_memory_usage();
   // We have just completed a GC. Update the soft reference
   // policy with the new heap occupancy
-  Universe::heap()->update_heap_info_at_gc();
+  Universe::heap()->update_capacity_and_used_at_gc();
 
   // Print NUMA statistics.
   _numa->print_statistics();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2676,7 +2676,7 @@ void G1CollectedHeap::gc_epilogue(bool full) {
   MemoryService::track_memory_usage();
   // We have just completed a GC. Update the soft reference
   // policy with the new heap occupancy
-  Universe::update_heap_info_at_gc();
+  Universe::heap()->update_heap_info_at_gc();
 
   // Print NUMA statistics.
   _numa->print_statistics();

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1280,7 +1280,7 @@ void G1ConcurrentMark::compute_new_sizes() {
 
   // Cleanup will have freed any regions completely full of garbage.
   // Update the soft reference policy with the new heap occupancy.
-  Universe::update_heap_info_at_gc();
+  Universe::heap()->update_heap_info_at_gc();
 
   // We reclaimed old regions so we should calculate the sizes to make
   // sure we update the old gen/space data.

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1280,7 +1280,7 @@ void G1ConcurrentMark::compute_new_sizes() {
 
   // Cleanup will have freed any regions completely full of garbage.
   // Update the soft reference policy with the new heap occupancy.
-  Universe::heap()->update_heap_info_at_gc();
+  Universe::heap()->update_capacity_and_used_at_gc();
 
   // We reclaimed old regions so we should calculate the sizes to make
   // sure we update the old gen/space data.

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1043,7 +1043,7 @@ void PSParallelCompact::post_compact()
 
   // Update heap occupancy information which is used as input to the soft ref
   // clearing policy at the next gc.
-  Universe::update_heap_info_at_gc();
+  Universe::heap()->update_heap_info_at_gc();
 
   bool young_gen_empty = eden_empty && from_space->is_empty() &&
     to_space->is_empty();

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1043,7 +1043,7 @@ void PSParallelCompact::post_compact()
 
   // Update heap occupancy information which is used as input to the soft ref
   // clearing policy at the next gc.
-  Universe::heap()->update_heap_info_at_gc();
+  Universe::heap()->update_capacity_and_used_at_gc();
 
   bool young_gen_empty = eden_empty && from_space->is_empty() &&
     to_space->is_empty();

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -135,7 +135,7 @@ void GenMarkSweep::invoke_at_safepoint(ReferenceProcessor* rp, bool clear_all_so
 
   // Update heap occupancy information which is used as
   // input to soft ref clearing policy at the next gc.
-  Universe::heap()->update_heap_info_at_gc();
+  Universe::heap()->update_capacity_and_used_at_gc();
 
   // Signal that we have completed a visit to all live objects.
   Universe::heap()->record_whole_heap_examined_timestamp();

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -135,7 +135,7 @@ void GenMarkSweep::invoke_at_safepoint(ReferenceProcessor* rp, bool clear_all_so
 
   // Update heap occupancy information which is used as
   // input to soft ref clearing policy at the next gc.
-  Universe::update_heap_info_at_gc();
+  Universe::heap()->update_heap_info_at_gc();
 
   // Signal that we have completed a visit to all live objects.
   Universe::heap()->record_whole_heap_examined_timestamp();

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -190,6 +190,8 @@ bool CollectedHeap::is_oop(oop object) const {
 
 
 CollectedHeap::CollectedHeap() :
+  _capacity_at_last_gc(0),
+  _used_at_last_gc(0),
   _is_gc_active(false),
   _last_whole_heap_examined_time_ns(os::javaTimeNanos()),
   _total_collections(0),
@@ -593,7 +595,7 @@ uint32_t CollectedHeap::hash_oop(oop obj) const {
 
 // It's the caller's responsibility to ensure glitch-freedom
 // (if required).
-void CollectedHeap::update_heap_info_at_gc() {
-  _heap_capacity_at_last_gc = capacity();
-  _heap_used_at_last_gc     = used();
+void CollectedHeap::update_capacity_and_used_at_gc() {
+  _capacity_at_last_gc = capacity();
+  _used_at_last_gc     = used();
 }

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -590,3 +590,10 @@ uint32_t CollectedHeap::hash_oop(oop obj) const {
   const uintptr_t addr = cast_from_oop<uintptr_t>(obj);
   return static_cast<uint32_t>(addr >> LogMinObjAlignment);
 }
+
+// It's the caller's responsibility to ensure glitch-freedom
+// (if required).
+void CollectedHeap::update_heap_info_at_gc() {
+  _heap_capacity_at_last_gc = capacity();
+  _heap_used_at_last_gc     = used();
+}

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -244,8 +244,8 @@ class CollectedHeap : public CHeapObj<mtInternal> {
   virtual size_t unused() const;
 
   // Historic gc information
-  size_t free_at_last_gc()    { return _capacity_at_last_gc - _used_at_last_gc; }
-  size_t used_at_last_gc()    { return _used_at_last_gc; }
+  size_t free_at_last_gc() const { return _capacity_at_last_gc - _used_at_last_gc; }
+  size_t used_at_last_gc() const { return _used_at_last_gc; }
   void update_capacity_and_used_at_gc();
 
   // Return "true" if the part of the heap that allocates Java

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -110,6 +110,10 @@ class CollectedHeap : public CHeapObj<mtInternal> {
  private:
   GCHeapLog* _gc_heap_log;
 
+  // Historic gc information
+  size_t _capacity_at_last_gc;
+  size_t _used_at_last_gc;
+
  protected:
   // Not used by all GCs
   MemRegion _reserved;
@@ -238,6 +242,11 @@ class CollectedHeap : public CHeapObj<mtInternal> {
 
   // Returns unused capacity.
   virtual size_t unused() const;
+
+  // Historic gc information
+  size_t free_at_last_gc()    { return _capacity_at_last_gc - _used_at_last_gc; }
+  size_t used_at_last_gc()    { return _used_at_last_gc; }
+  void update_capacity_and_used_at_gc();
 
   // Return "true" if the part of the heap that allocates Java
   // objects has reached the maximal committed limit that it can
@@ -437,10 +446,6 @@ class CollectedHeap : public CHeapObj<mtInternal> {
 
   virtual void initialize_serviceability() = 0;
 
-  // Historic gc information
-  size_t _heap_capacity_at_last_gc;
-  size_t _heap_used_at_last_gc;
-
  public:
   void pre_full_gc_dump(GCTimer* timer);
   void post_full_gc_dump(GCTimer* timer);
@@ -516,11 +521,6 @@ class CollectedHeap : public CHeapObj<mtInternal> {
   virtual void deduplicate_string(oop str);
 
   virtual bool is_oop(oop object) const;
-
-  // Historic gc information
-  size_t get_heap_free_at_last_gc()    { return _heap_capacity_at_last_gc - _heap_used_at_last_gc; }
-  size_t get_heap_used_at_last_gc()    { return _heap_used_at_last_gc; }
-  void update_heap_info_at_gc();
 
   // Non product verification and debugging.
 #ifndef PRODUCT

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -437,6 +437,10 @@ class CollectedHeap : public CHeapObj<mtInternal> {
 
   virtual void initialize_serviceability() = 0;
 
+  // Historic gc information
+  size_t _heap_capacity_at_last_gc;
+  size_t _heap_used_at_last_gc;
+
  public:
   void pre_full_gc_dump(GCTimer* timer);
   void post_full_gc_dump(GCTimer* timer);
@@ -512,6 +516,11 @@ class CollectedHeap : public CHeapObj<mtInternal> {
   virtual void deduplicate_string(oop str);
 
   virtual bool is_oop(oop object) const;
+
+  // Historic gc information
+  size_t get_heap_free_at_last_gc()    { return _heap_capacity_at_last_gc - _heap_used_at_last_gc; }
+  size_t get_heap_used_at_last_gc()    { return _heap_used_at_last_gc; }
+  void update_heap_info_at_gc();
 
   // Non product verification and debugging.
 #ifndef PRODUCT

--- a/src/hotspot/share/gc/shared/referencePolicy.cpp
+++ b/src/hotspot/share/gc/shared/referencePolicy.cpp
@@ -35,7 +35,7 @@ LRUCurrentHeapPolicy::LRUCurrentHeapPolicy() {
 
 // Capture state (of-the-VM) information needed to evaluate the policy
 void LRUCurrentHeapPolicy::setup() {
-  _max_interval = (Universe::heap()->get_heap_free_at_last_gc() / M) * SoftRefLRUPolicyMSPerMB;
+  _max_interval = (Universe::heap()->free_at_last_gc() / M) * SoftRefLRUPolicyMSPerMB;
   assert(_max_interval >= 0,"Sanity check");
 }
 
@@ -63,7 +63,7 @@ LRUMaxHeapPolicy::LRUMaxHeapPolicy() {
 // Capture state (of-the-VM) information needed to evaluate the policy
 void LRUMaxHeapPolicy::setup() {
   size_t max_heap = MaxHeapSize;
-  max_heap -= Universe::heap()->get_heap_used_at_last_gc();
+  max_heap -= Universe::heap()->used_at_last_gc();
   max_heap /= M;
 
   _max_interval = max_heap * SoftRefLRUPolicyMSPerMB;

--- a/src/hotspot/share/gc/shared/referencePolicy.cpp
+++ b/src/hotspot/share/gc/shared/referencePolicy.cpp
@@ -35,7 +35,7 @@ LRUCurrentHeapPolicy::LRUCurrentHeapPolicy() {
 
 // Capture state (of-the-VM) information needed to evaluate the policy
 void LRUCurrentHeapPolicy::setup() {
-  _max_interval = (Universe::get_heap_free_at_last_gc() / M) * SoftRefLRUPolicyMSPerMB;
+  _max_interval = (Universe::heap()->get_heap_free_at_last_gc() / M) * SoftRefLRUPolicyMSPerMB;
   assert(_max_interval >= 0,"Sanity check");
 }
 
@@ -63,7 +63,7 @@ LRUMaxHeapPolicy::LRUMaxHeapPolicy() {
 // Capture state (of-the-VM) information needed to evaluate the policy
 void LRUMaxHeapPolicy::setup() {
   size_t max_heap = MaxHeapSize;
-  max_heap -= Universe::get_heap_used_at_last_gc();
+  max_heap -= Universe::heap()->get_heap_used_at_last_gc();
   max_heap /= M;
 
   _max_interval = max_heap * SoftRefLRUPolicyMSPerMB;

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -237,7 +237,7 @@ void ShenandoahControlThread::run_service() {
         // Notify Universe about new heap usage. This has implications for
         // global soft refs policy, and we better report it every time heap
         // usage goes down.
-        Universe::heap()->update_heap_info_at_gc();
+        Universe::heap()->update_capacity_and_used_at_gc();
 
         // Signal that we have completed a visit to all live objects.
         Universe::heap()->record_whole_heap_examined_timestamp();

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -237,7 +237,7 @@ void ShenandoahControlThread::run_service() {
         // Notify Universe about new heap usage. This has implications for
         // global soft refs policy, and we better report it every time heap
         // usage goes down.
-        Universe::update_heap_info_at_gc();
+        Universe::heap()->update_heap_info_at_gc();
 
         // Signal that we have completed a visit to all live objects.
         Universe::heap()->record_whole_heap_examined_timestamp();

--- a/src/hotspot/share/gc/z/zDriver.cpp
+++ b/src/hotspot/share/gc/z/zDriver.cpp
@@ -380,7 +380,7 @@ public:
     ZStatCycle::at_end(_gc_cause, boost_factor);
 
     // Update data used by soft reference policy
-    Universe::update_heap_info_at_gc();
+    Universe::heap()->update_heap_info_at_gc();
 
     // Signal that we have completed a visit to all live objects
     Universe::heap()->record_whole_heap_examined_timestamp();

--- a/src/hotspot/share/gc/z/zDriver.cpp
+++ b/src/hotspot/share/gc/z/zDriver.cpp
@@ -380,7 +380,7 @@ public:
     ZStatCycle::at_end(_gc_cause, boost_factor);
 
     // Update data used by soft reference policy
-    Universe::heap()->update_heap_info_at_gc();
+    Universe::heap()->update_capacity_and_used_at_gc();
 
     // Signal that we have completed a visit to all live objects
     Universe::heap()->record_whole_heap_examined_timestamp();

--- a/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
@@ -226,7 +226,7 @@ void ObjectSampler::add(HeapWord* obj, size_t allocated, traceid thread_id, Java
   sample->set_object((oop)obj);
   sample->set_allocated(allocated);
   sample->set_allocation_time(JfrTicks::now());
-  sample->set_heap_used_at_last_gc(Universe::heap()->get_heap_used_at_last_gc());
+  sample->set_heap_used_at_last_gc(Universe::heap()->used_at_last_gc());
   _priority_queue->push(sample);
 }
 

--- a/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
@@ -226,7 +226,7 @@ void ObjectSampler::add(HeapWord* obj, size_t allocated, traceid thread_id, Java
   sample->set_object((oop)obj);
   sample->set_allocated(allocated);
   sample->set_allocation_time(JfrTicks::now());
-  sample->set_heap_used_at_last_gc(Universe::get_heap_used_at_last_gc());
+  sample->set_heap_used_at_last_gc(Universe::heap()->get_heap_used_at_last_gc());
   _priority_queue->push(sample);
 }
 

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -997,7 +997,7 @@ bool universe_post_init() {
   // it's an input to soft ref clearing policy.
   {
     MutexLocker x(THREAD, Heap_lock);
-    Universe::heap()->update_heap_info_at_gc();
+    Universe::heap()->update_capacity_and_used_at_gc();
   }
 
   // ("weak") refs processing infrastructure initialization

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -141,9 +141,6 @@ bool            Universe::_bootstrapping = false;
 bool            Universe::_module_initialized = false;
 bool            Universe::_fully_initialized = false;
 
-size_t          Universe::_heap_capacity_at_last_gc;
-size_t          Universe::_heap_used_at_last_gc = 0;
-
 OopStorage*     Universe::_vm_weak = NULL;
 OopStorage*     Universe::_vm_global = NULL;
 
@@ -865,14 +862,6 @@ ReservedHeapSpace Universe::reserve_heap(size_t heap_size, size_t alignment) {
   return ReservedHeapSpace(0, 0, false);
 }
 
-
-// It's the caller's responsibility to ensure glitch-freedom
-// (if required).
-void Universe::update_heap_info_at_gc() {
-  _heap_capacity_at_last_gc = heap()->capacity();
-  _heap_used_at_last_gc     = heap()->used();
-}
-
 OopStorage* Universe::vm_weak() {
   return Universe::_vm_weak;
 }
@@ -1008,7 +997,7 @@ bool universe_post_init() {
   // it's an input to soft ref clearing policy.
   {
     MutexLocker x(THREAD, Heap_lock);
-    Universe::update_heap_info_at_gc();
+    Universe::heap()->update_heap_info_at_gc();
   }
 
   // ("weak") refs processing infrastructure initialization

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -162,10 +162,6 @@ class Universe: AllStatic {
   // otherwise return the given default error.
   static oop        gen_out_of_memory_error(oop default_err);
 
-  // Historic gc information
-  static size_t _heap_capacity_at_last_gc;
-  static size_t _heap_used_at_last_gc;
-
   static OopStorage* _vm_weak;
   static OopStorage* _vm_global;
 
@@ -308,11 +304,6 @@ class Universe: AllStatic {
 
   // Reserve Java heap and determine CompressedOops mode
   static ReservedHeapSpace reserve_heap(size_t heap_size, size_t alignment);
-
-  // Historic gc information
-  static size_t get_heap_free_at_last_gc()             { return _heap_capacity_at_last_gc - _heap_used_at_last_gc; }
-  static size_t get_heap_used_at_last_gc()             { return _heap_used_at_last_gc; }
-  static void update_heap_info_at_gc();
 
   // Global OopStorages
   static OopStorage* vm_weak();


### PR DESCRIPTION
This is a small refactoring that moves `update_heap_info_at_gc()` and related members to `CollectedHeap`. There should be no behavioral change.

jdk/hotspot tier1 passed

JBS: https://bugs.openjdk.java.net/browse/JDK-8250961
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250961](https://bugs.openjdk.java.net/browse/JDK-8250961): Move Universe::update_heap_info_at_gc to CollectedHeap


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to 64d1c399b5940ccf2be932a994a96ab160b8528e
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/27/head:pull/27`
`$ git checkout pull/27`
