### PR TITLE
8248532: Every time I change keyboard language at my MacBook, Java crashes

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -1335,7 +1335,7 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
 
     NSTextInputContext *curContxt = [NSTextInputContext currentInputContext];
     kbdLayout = curContxt.selectedKeyboardInputSource;
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [[NSNotificationCenter defaultCenter] addObserver:[AWTView class]
                                            selector:@selector(keyboardInputSourceChanged:)
                                                name:NSTextInputContextKeyboardSelectionDidChangeNotification
                                              object:nil];


### PR DESCRIPTION
It seems the observer either needs to be removed when it is dealloced/destroyed (Otherwise Notification Centre would send the notification to the destroyed object resulting in crash.)

and we need to do the below in dealloc, which solves the crash in my system.

NSNotificationCenter *nc = [NSNotificationCenter defaultCenter]; [nc removeObserver:self]

But it is not done for LWCToolkit, so I changed the observer as is being done there, to make existing @implementation class as observer
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248532](https://bugs.openjdk.java.net/browse/JDK-8248532): Every time I change keyboard language at my MacBook, Java crashes


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/28/head:pull/28`
`$ git checkout pull/28`
