### PR TITLE
8252825: Add automated test for fix done in JDK-8218479

### DIFF
--- a/test/jdk/javax/swing/JTextPane/TestJTextPaneBackgroundColor.java
+++ b/test/jdk/javax/swing/JTextPane/TestJTextPaneBackgroundColor.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires (os.family == "linux")
+ * @key headful
+ * @bug 8218479
+ * @summary Tests JTextPane background color
+ * @run main TestJTextPaneBackgroundColor
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTextPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+
+public class TestJTextPaneBackgroundColor {
+    private static JFrame frame;
+    private static JTextPane textPane;
+    private static Point point;
+    private static Rectangle rect;
+    private static Robot robot;
+    private static final String GTK_LAF_CLASS = "GTKLookAndFeel";
+
+    private static void blockTillDisplayed(Component comp) {
+        Point p = null;
+        while (p == null) {
+            try {
+                p = comp.getLocationOnScreen();
+            } catch (IllegalStateException e) {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException ie) {
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (!System.getProperty("os.name").startsWith("Linux")) {
+            System.out.println("This test is meant for Linux platform only");
+            return;
+        }
+
+        for (UIManager.LookAndFeelInfo lookAndFeelInfo :
+                UIManager.getInstalledLookAndFeels()) {
+            if (lookAndFeelInfo.getClassName().contains(GTK_LAF_CLASS)) {
+                try {
+                    UIManager.setLookAndFeel(lookAndFeelInfo.getClassName());
+                } catch (final UnsupportedLookAndFeelException ignored) {
+                    System.out.println("GTK L&F could not be set, so this " +
+                            "test can not be run in this scenario ");
+                    return;
+                }
+            }
+        }
+
+        robot = new Robot();
+        robot.setAutoDelay(100);
+
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    JPanel panel = new JPanel();
+                    textPane = new JTextPane();
+                    textPane.setText("             ");
+                    panel.add(textPane, BorderLayout.CENTER);
+                    frame = new JFrame("TestJTextPaneBackgroundColor");
+                    frame.add(panel);
+                    frame.setSize(200, 200);
+                    frame.setAlwaysOnTop(true);
+                    frame.setLocationRelativeTo(null);
+                    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                    frame.setVisible(true);
+                }
+            });
+
+            robot.waitForIdle();
+            robot.delay(500);
+
+            blockTillDisplayed(textPane);
+            SwingUtilities.invokeAndWait(() -> {
+                point = textPane.getLocationOnScreen();
+                rect = textPane.getBounds();
+            });
+            robot.waitForIdle();
+            robot.delay(500);
+
+            Color textpaneBackgroundColor = robot
+                    .getPixelColor(point.x+rect.width/2, point.y+rect.height/2);
+            robot.waitForIdle();
+            robot.delay(500);
+
+            Color panelColor = robot
+                    .getPixelColor(point.x-rect.width/2, point.y+rect.height/2);
+            robot.waitForIdle();
+            robot.delay(500);
+
+            System.out.println(textpaneBackgroundColor);
+            System.out.println(panelColor);
+            if (textpaneBackgroundColor.equals(panelColor)) {
+                throw new RuntimeException("The expected background color for " +
+                        "TextPane was not found");
+            }
+        } finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Under JDK-8218479, fix was made to correct the rendering of JTextPane as the background color of JTextPane was similar to Panel color, so it looked like the JTextPane has transparent background. No automated test was written to verify the results. Current bug is to write the automated tests for the same.

The test fails without the fix done in JDK-8218479 and pass with the fix. I have run the tests multiple times in mach5. Links in JBS.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252825](https://bugs.openjdk.java.net/browse/JDK-8252825): Add automated test for fix done in JDK-8218479


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/30/head:pull/30`
`$ git checkout pull/30`
