### PR TITLE
8252778: remove jdk.test.lib.FileInstaller action from compiler/c2/stemmer test

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/stemmer/Stemmer.java
+++ b/test/hotspot/jtreg/compiler/c2/stemmer/Stemmer.java
@@ -5,8 +5,7 @@
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  *
- * @run driver jdk.test.lib.FileInstaller words words
- * @run main/othervm -Xbatch compiler.c2.stemmer.Stemmer words
+ * @run main/othervm -Xbatch compiler.c2.stemmer.Stemmer ${test.src}/words
  */
 
 /*


### PR DESCRIPTION
pre-Skara RFR [thread](https://mail.openjdk.java.net/pipermail/hotspot-compiler-dev/2020-September/039878.html)

Hi all,

could you please review this small and trivial cleanup?

from [JBS](https://bugs.openjdk.java.net/browse/JDK-8252778):
> `compiler/c2/stemmer` test uses `jdk.test.lib.FileInstaller` to copy "words" file from the test source directory to the current working directory, `compiler.c2.stemmer.Stemmer` can read this file. yet, `c.c.s.Stemmer` class treats its 1st argument as a path to the file, given this isn't needed and we can pass "${test.src}/words" instead of "words"

testing: compiler/c2/stemmer on {linux,windows,macos}-x64
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252778](https://bugs.openjdk.java.net/browse/JDK-8252778): remove jdk.test.lib.FileInstaller action from compiler/c2/stemmer test


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * epavlova - Committer ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/33/head:pull/33`
`$ git checkout pull/33`
