### PR TITLE
8252844: Update check configuration to Skara format

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,2 +1,30 @@
+[general]
 project=jdk
-bugids=dup
+jbs=JDK
+
+[checks]
+error=blacklist.author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace
+
+[repository]
+tags=(?:jdk-(?:[1-9]([0-9]*)(?:\\.(?:0|[1-9][0-9]*)){0,4})(?:\\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\\d{1,3})?-(?:(?:b\\d{2,3})|(?:ga)))|(?:hs\\d\\d(?:\\.\\d{1,2})?-b\\d\\d)
+branches=
+
+[census]
+version=0
+domain=openjdk.org
+
+[checks "whitespace"]
+files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java
+
+[checks "merge"]
+message=Merge
+
+[checks "reviewers"]
+reviewers=1
+ignore=duke
+
+[checks "committer"]
+role=contributor
+
+[checks "issues"]
+pattern=^([124-8][0-9]{6}): (\S.*)$

--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@ reviewers=1
 ignore=duke
 
 [checks "committer"]
-role=contributor
+role=committer
 
 [checks "issues"]
 pattern=^([124-8][0-9]{6}): (\S.*)$


### PR DESCRIPTION
Now that the JDK main-line repository is using the Skara tooling, the jcheck configuration file should be updated to the new format.

Best regards,
Robin
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252844](https://bugs.openjdk.java.net/browse/JDK-8252844): Update check configuration to Skara format


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/39/head:pull/39`
`$ git checkout pull/39`
