### PR TITLE
8252500: ZGC on aarch64: Unable to allocate heap for certain Linux kernel configurations

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.cpp
@@ -25,6 +25,7 @@
 #include "gc/shared/gcLogPrecious.hpp"
 #include "gc/z/zGlobals.hpp"
 #include "runtime/globals.hpp"
+#include "runtime/os.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/powerOfTwo.hpp"
 
@@ -187,7 +188,7 @@ static size_t probe_valid_max_address_bit() {
       munmap(result_addr, page_size);
     }
   }
-  log_info_p(gc, init)("Probing address space for the highest valid bit: %zu", max_address_bit);
+  log_info_p(gc, init)("Probing address space for the highest valid bit: " SIZE_FORMAT, max_address_bit);
   if (max_address_bit < MINIMUM_MAX_ADDRESS_BIT) {
     return MINIMUM_MAX_ADDRESS_BIT;
   }

--- a/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.cpp
@@ -161,15 +161,15 @@ static size_t probe_valid_max_address_bit() {
       // Some error occured. This should never happen, but msync
       // has some undefined behavior, hence ignore this bit.
 #ifdef ASSERT
-      fatal("Received %s while probing the address space for the highest valid bit", os::errno_name(errno));
+      fatal("Received '%s' while probing the address space for the highest valid bit", os::errno_name(errno));
 #else // ASSERT
-      log_warning_p(gc)("Received %s while probing the address space for the highest valid bit", os::errno_name(errno));
+      log_warning_p(gc)("Received '%s' while probing the address space for the highest valid bit", os::errno_name(errno));
 #endif // ASSERT
       continue;
     }
     // Since msync failed with ENOMEM, the page might not be mapped.
     // Try to map it, to see if the address is valid.
-    void* result_addr = mmap((void*) base_addr, page_size, PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE, -1, 0);
+    void* const result_addr = mmap((void*) base_addr, page_size, PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE, -1, 0);
     if (result_addr != MAP_FAILED) {
       munmap(result_addr, page_size);
     }
@@ -181,8 +181,8 @@ static size_t probe_valid_max_address_bit() {
   }
   if (max_address_bit == 0) {
     // probing failed, allocate a very high page and take that bit as the maximum
-    uintptr_t high_addr = ((uintptr_t) 1U) << DEFAULT_MAX_ADDRESS_BIT;
-    void* result_addr = mmap((void*) high_addr, page_size, PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE, -1, 0);
+    const uintptr_t high_addr = ((uintptr_t) 1U) << DEFAULT_MAX_ADDRESS_BIT;
+    void* const result_addr = mmap((void*) high_addr, page_size, PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE, -1, 0);
     if (result_addr != MAP_FAILED) {
       max_address_bit = BitsPerSize_t - count_leading_zeros((size_t) result_addr) - 1;
       munmap(result_addr, page_size);

--- a/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.cpp
@@ -139,15 +139,15 @@
 //
 
 // Default value if probing is not implemented for a certain platform: 128TB
-#define DEFAULT_MAX_ADDRESS_BIT 47
+static const size_t DEFAULT_MAX_ADDRESS_BIT = 47;
 // Minimum value returned, if probing fails: 64GB
-#define MINIMUM_MAX_ADDRESS_BIT 36
+static const size_t MINIMUM_MAX_ADDRESS_BIT = 36;
 
 static size_t probe_valid_max_address_bit() {
 #ifdef LINUX
   size_t max_address_bit = 0;
   const size_t page_size = os::vm_page_size();
-  for (int i = DEFAULT_MAX_ADDRESS_BIT; i > MINIMUM_MAX_ADDRESS_BIT && max_address_bit == 0; --i) {
+  for (size_t i = DEFAULT_MAX_ADDRESS_BIT; i > MINIMUM_MAX_ADDRESS_BIT; --i) {
     const uintptr_t base_addr = ((uintptr_t) 1U) << i;
     if (msync((void*)base_addr, page_size, MS_ASYNC) == 0) {
       // msync suceeded, the address is valid, and maybe even already mapped.
@@ -160,19 +160,20 @@ static size_t probe_valid_max_address_bit() {
 #ifdef ASSERT
       fatal("Received %s while probing the address space for the highest valid bit", os::errno_name(errno));
 #else // ASSERT
-      log_warning(gc)("Received %s while probing the address space for the highest valid bit", os::errno_name(errno));
+      log_warning_p(gc)("Received %s while probing the address space for the highest valid bit", os::errno_name(errno));
 #endif // ASSERT
       continue;
     }
     // Since msync failed with ENOMEM, the page might not be mapped.
     // Try to map it, to see if the address is valid.
     void* result_addr = mmap((void*) base_addr, page_size, PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE, -1, 0);
+    if (result_addr != MAP_FAILED) {
+      munmap(result_addr, page_size);
+    }
     if ((uintptr_t) result_addr == base_addr) {
       // address is valid
       max_address_bit = i;
-    }
-    if (result_addr != MAP_FAILED) {
-      munmap(result_addr, page_size);
+      break;
     }
   }
   if (max_address_bit == 0) {
@@ -195,8 +196,8 @@ static size_t probe_valid_max_address_bit() {
 }
 
 size_t ZPlatformAddressOffsetBits() {
-  const static size_t valid_max_address_bit = probe_valid_max_address_bit();
-  const size_t max_address_offset_bits = valid_max_address_bit - 3;
+  const static size_t valid_max_address_offset_bits = probe_valid_max_address_bit() + 1;
+  const size_t max_address_offset_bits = valid_max_address_offset_bits - 3;
   const size_t min_address_offset_bits = max_address_offset_bits - 2;
   const size_t address_offset = round_up_power_of_2(MaxHeapSize * ZVirtualToPhysicalRatio);
   const size_t address_offset_bits = log2_intptr(address_offset);

--- a/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.cpp
@@ -28,7 +28,9 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/powerOfTwo.hpp"
 
+#ifdef LINUX
 #include <sys/mman.h>
+#endif // LINUX
 
 //
 // The heap can have three different layouts, depending on the max heap size.

--- a/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zGlobals_aarch64.cpp
@@ -189,10 +189,7 @@ static size_t probe_valid_max_address_bit() {
     }
   }
   log_info_p(gc, init)("Probing address space for the highest valid bit: " SIZE_FORMAT, max_address_bit);
-  if (max_address_bit < MINIMUM_MAX_ADDRESS_BIT) {
-    return MINIMUM_MAX_ADDRESS_BIT;
-  }
-  return max_address_bit;
+  return MAX2(max_address_bit, MINIMUM_MAX_ADDRESS_BIT);
 #else // LINUX
   return DEFAULT_MAX_ADDRESS_BIT;
 #endif // LINUX


### PR DESCRIPTION
The patch introduces a new function to probe for the highest valid bit in the virtual address space for userspace programs on Linux.

I guarded the whole implementation to only probe on Linux, other platforms will remain unaffected. Possibly, it would be nicer to move the probing code into an OS+ARCH specific source file. But since this is only a single function, I thought it would be better to put it right next to the caller and guard it with an #ifdef LINUX.

The probing mechanism uses a combination of msync + mmap, to first check if the address is valid using msync (if msync succeeds, the address was valid). If msync fails, mmap is used to check if msync failed because the memory wasn't mapped, or if it failed because the address is invalid. Due to some undefined behavior (documented in the msync man page), I also use a single mmap at the end, if the msync approach failed before.

I tested msync with different combinations of mappings, and also with sbrk, and it always succeeded, or failed with ENOMEM. I never got back any other error code.

The specified minimum value has been chosen "randomly". The JVM terminates (unable to allocate heap), if this minimum value is smaller than the requested Java Heap size, so it might be better to make the minimum dependent on the MaxHeapSize and not a compile time constant? I didn't want to make the minimum too big, since for aarch64 on Linux, the documented minimum would be 38 (see [1]). 

I avoided MAP_FIXED_NOREPLACE, because according to the man page, it has been added in Linux 4.17. There are still plenty of stable kernel versions around which will not have that feature, which means we need to implement a workaround for it. Some of my test devices also have a kernel version lower than that.

I executed the HotSpot tier1 JTreg tests on two different aarch64 devices. One with 4KB pages and 3 page levels and the other with 4KB pages and 4 page levels. Tests passed on both devices.

[1] https://www.kernel.org/doc/Documentation/arm64/memory.txt
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252500](https://bugs.openjdk.java.net/browse/JDK-8252500): ZGC on aarch64: Unable to allocate heap for certain Linux kernel configurations


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to 70efdd8b04d80a1c4fc1316b020a623a713c215a
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to 70efdd8b04d80a1c4fc1316b020a623a713c215a
 * [Per Lidén](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/40/head:pull/40`
`$ git checkout pull/40`
