### PR TITLE
8235229: Compilation against a modular, multi-release JAR erroneous with --release

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/platform/JDKPlatformProvider.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/platform/JDKPlatformProvider.java
@@ -67,6 +67,7 @@ import com.sun.tools.javac.code.Source.Feature;
 import com.sun.tools.javac.file.CacheFSInfo;
 import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.jvm.Target;
+import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.StringUtils;
@@ -245,6 +246,8 @@ public class JDKPlatformProvider implements PlatformProvider {
                 }
 
             };
+
+            fm.handleOption(Option.MULTIRELEASE, sourceVersion);
 
             Path file = findCtSym();
             // file == ${jdk.home}/lib/ct.sym


### PR DESCRIPTION
A combination of a multi-release modular jar and --release option does not work well, because the appropriate file manager does not have a multi-release option set. The proposal is to set the multi-release option to the file manager.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8235229](https://bugs.openjdk.java.net/browse/JDK-8235229): Compilation against a modular, multi-release JAR erroneous with --release


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/43/head:pull/43`
`$ git checkout pull/43`
