### PR TITLE
8166554: Avoid compilation blocking in OverloadCompileQueueTest.java

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/stress/OverloadCompileQueueTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/OverloadCompileQueueTest.java
@@ -30,6 +30,7 @@
  *          java.management
  *
  * @build sun.hotspot.WhiteBox
+ *        compiler.codecache.stress.TestCaseImpl
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
@@ -52,8 +53,33 @@ import java.lang.reflect.Method;
 import java.util.stream.IntStream;
 import java.util.Random;
 
-public class OverloadCompileQueueTest implements Runnable {
+class LockUnlockThread extends Thread {
     private static final int MAX_SLEEP = 10000;
+    private static final int DELAY_BETWEEN_LOCKS = 100;
+    private final Random rng = Utils.getRandomInstance();
+
+    public volatile boolean isActive = true;
+
+    @Override
+    public void run() {
+        try {
+            while (isActive) {
+                int timeInLockedState = rng.nextInt(MAX_SLEEP);
+                Helper.WHITE_BOX.lockCompilation();
+                Thread.sleep(timeInLockedState);
+                Helper.WHITE_BOX.unlockCompilation();
+                Thread.sleep(DELAY_BETWEEN_LOCKS);
+            }
+        } catch (InterruptedException e) {
+            throw new Error("TESTBUG: lockUnlocker thread was unexpectedly interrupted", e);
+        } finally {
+            Helper.WHITE_BOX.unlockCompilation();
+        }
+    }
+}
+
+public class OverloadCompileQueueTest implements Runnable {
+    private static final LockUnlockThread lockUnlockThread = new LockUnlockThread();
     private static final String METHOD_TO_ENQUEUE = "method";
     private static final int LEVEL_SIMPLE = 1;
     private static final int LEVEL_FULL_OPTIMIZATION = 4;
@@ -62,7 +88,6 @@ public class OverloadCompileQueueTest implements Runnable {
     private static final int TIERED_STOP_AT_LEVEL
             = Helper.WHITE_BOX.getIntxVMFlag("TieredStopAtLevel").intValue();
     private static final int[] AVAILABLE_LEVELS;
-    private final Random rng = Utils.getRandomInstance();
     static {
         if (TIERED_COMPILATION) {
             AVAILABLE_LEVELS = IntStream
@@ -77,15 +102,16 @@ public class OverloadCompileQueueTest implements Runnable {
         }
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws InterruptedException {
+        lockUnlockThread.start();
+
         if (Platform.isInt()) {
             throw new Error("TESTBUG: test can not be run in interpreter");
         }
         new CodeCacheStressRunner(new OverloadCompileQueueTest()).runTest();
-    }
 
-    public OverloadCompileQueueTest() {
-        Helper.startInfiniteLoopThread(this::lockUnlock, 100L);
+        lockUnlockThread.isActive = false;
+        lockUnlockThread.join();
     }
 
     @Override
@@ -102,18 +128,6 @@ public class OverloadCompileQueueTest implements Runnable {
         }
         for (int compLevel : AVAILABLE_LEVELS) {
             Helper.WHITE_BOX.enqueueMethodForCompilation(mEnqueue, compLevel);
-        }
-    }
-
-    private void lockUnlock() {
-        try {
-            int sleep = rng.nextInt(MAX_SLEEP);
-            Helper.WHITE_BOX.lockCompilation();
-            Thread.sleep(sleep);
-        } catch (InterruptedException e) {
-            throw new Error("TESTBUG: lockUnlocker thread was unexpectedly interrupted", e);
-        } finally {
-            Helper.WHITE_BOX.unlockCompilation();
         }
     }
 

--- a/test/hotspot/jtreg/compiler/codecache/stress/OverloadCompileQueueTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/OverloadCompileQueueTest.java
@@ -71,7 +71,9 @@ class LockUnlockThread extends Thread {
                 Thread.sleep(DELAY_BETWEEN_LOCKS);
             }
         } catch (InterruptedException e) {
-            throw new Error("TESTBUG: lockUnlocker thread was unexpectedly interrupted", e);
+            if (isActive) {
+                throw new Error("TESTBUG: LockUnlockThread was unexpectedly interrupted", e);
+            }
         } finally {
             Helper.WHITE_BOX.unlockCompilation();
         }
@@ -79,7 +81,6 @@ class LockUnlockThread extends Thread {
 }
 
 public class OverloadCompileQueueTest implements Runnable {
-    private static final LockUnlockThread lockUnlockThread = new LockUnlockThread();
     private static final String METHOD_TO_ENQUEUE = "method";
     private static final int LEVEL_SIMPLE = 1;
     private static final int LEVEL_FULL_OPTIMIZATION = 4;
@@ -103,6 +104,7 @@ public class OverloadCompileQueueTest implements Runnable {
     }
 
     public static void main(String[] args) throws InterruptedException {
+        LockUnlockThread lockUnlockThread = new LockUnlockThread();
         lockUnlockThread.start();
 
         if (Platform.isInt()) {
@@ -111,6 +113,7 @@ public class OverloadCompileQueueTest implements Runnable {
         new CodeCacheStressRunner(new OverloadCompileQueueTest()).runTest();
 
         lockUnlockThread.isActive = false;
+        lockUnlockThread.interrupt();
         lockUnlockThread.join();
     }
 


### PR DESCRIPTION
**Problem explanation**

1. The stress test [uses 0.8 of allowed running time](https://hg.openjdk.java.net/jdk/jdk/file/e10f558e1df5/test/hotspot/jtreg/compiler/codecache/stress/CodeCacheStressRunner.java#l40) + 10 seconds, thus exceeding the limit;
2. 10 additional seconds are [given by the VM](https://hg.openjdk.java.net/jdk/jdk/file/6db0cb3893c5/src/hotspot/share/runtime/vmOperations.cpp#l388) for stuck compiler threads to finish;
3. Compiler threads aren't progressing due to the compilation being blocked;
4. Compilation is blocked via WhiteBox by the test, its lockUnlock thread;
5. The lockUnlock thread doesn't unblock the compilation because [it is a daemon](https://hg.openjdk.java.net/jdk/jdk/file/e10f558e1df5/test/hotspot/jtreg/compiler/codecache/stress/Helper.java#l59), it is stopped in the middle of the sleep.

**Solution**

Since the 'lockUnlock' is started via InfiniteLoop, it's not possible to un-daemon it. So I just turned the lockUnlock method into a Thread descendant, which got joined in the end.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8166554](https://bugs.openjdk.java.net/browse/JDK-8166554): Avoid compilation blocking in OverloadCompileQueueTest.java


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/46/head:pull/46`
`$ git checkout pull/46`
