### PR TITLE
8252859: Inconsistent use of alpha in class AbsSeq

### DIFF
--- a/src/hotspot/share/gc/g1/g1IHOPControl.cpp
+++ b/src/hotspot/share/gc/g1/g1IHOPControl.cpp
@@ -91,8 +91,8 @@ G1AdaptiveIHOPControl::G1AdaptiveIHOPControl(double ihop_percent,
   _heap_reserve_percent(heap_reserve_percent),
   _heap_waste_percent(heap_waste_percent),
   _predictor(predictor),
-  _marking_times_s(10, 0.95),
-  _allocation_rate_s(10, 0.95),
+  _marking_times_s(10, 0.05),
+  _allocation_rate_s(10, 0.05),
   _last_unrestrained_young_size(0)
 {
 }

--- a/src/hotspot/share/gc/z/zStat.cpp
+++ b/src/hotspot/share/gc/z/zStat.cpp
@@ -1029,7 +1029,7 @@ public:
 uint64_t  ZStatCycle::_nwarmup_cycles = 0;
 Ticks     ZStatCycle::_start_of_last;
 Ticks     ZStatCycle::_end_of_last;
-NumberSeq ZStatCycle::_normalized_duration(0.3 /* alpha */);
+NumberSeq ZStatCycle::_normalized_duration(0.7 /* alpha */);
 
 void ZStatCycle::at_start() {
   _start_of_last = Ticks::now();

--- a/src/hotspot/share/utilities/numberSeq.cpp
+++ b/src/hotspot/share/utilities/numberSeq.cpp
@@ -47,11 +47,10 @@ void AbsSeq::add(double val) {
     // mean := mean + incr
     // variance := (1 - alpha) * (variance + diff * incr)
     // PDF available at https://fanf2.user.srcf.net/hermes/doc/antiforgery/stats.pdf
-    // Note: alpha is actually (1.0 - _alpha) in our code
     double diff = val - _davg;
-    double incr = (1.0 - _alpha) * diff;
+    double incr = _alpha * diff;
     _davg += incr;
-    _dvariance = _alpha * (_dvariance + diff * incr);
+    _dvariance = (1.0 - _alpha) * (_dvariance + diff * incr);
   }
 }
 

--- a/src/hotspot/share/utilities/numberSeq.hpp
+++ b/src/hotspot/share/utilities/numberSeq.hpp
@@ -40,7 +40,7 @@
  **      of the sequence and calculates avg, max, and sd only over them
  **/
 
-#define DEFAULT_ALPHA_VALUE 0.7
+#define DEFAULT_ALPHA_VALUE 0.3
 
 class AbsSeq: public CHeapObj<mtInternal> {
 private:


### PR DESCRIPTION
Invert the meaning of `_alpha`, from `alpha` to `1-alpha`.

Test: I instrumented the constructor of `AbsSeq` with `printf("%f\n", _alpha)` onto master and `printf("%f\n", 1.0 - _alpha)` after the patch, and checked the output of `java <useXgc> --version` (G1, Parallel, Shenandoah, and Z) are the same before and after.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252859](https://bugs.openjdk.java.net/browse/JDK-8252859): Inconsistent use of alpha in class AbsSeq


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/47/head:pull/47`
`$ git checkout pull/47`
