### PR TITLE
8251152: ARM32: jtreg c2 Test8202414 test crash

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/Test8202414.java
+++ b/test/hotspot/jtreg/compiler/c2/Test8202414.java
@@ -25,6 +25,8 @@
  * @test
  * @bug 8202414
  * @summary Unsafe write after primitive array creation may result in array length change
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
  * @run main/othervm compiler.c2.Test8202414
  */
 
@@ -34,10 +36,18 @@ import sun.misc.Unsafe;
 import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import jtreg.SkippedException;
 
 public class Test8202414 {
 
     public static void main(String[] args) {
+        // Some CPUs (for example, ARM) does not support unaligned
+        // memory accesses. This test may cause JVM crash due to
+        // alignment check failure on such CPUs.
+        if (!jdk.internal.misc.Unsafe.getUnsafe().unalignedAccess()) {
+          throw new SkippedException(
+            "Platform is missing unaligned memory accesses support.");
+        }
         System.err.close();
         int count = 0;
         while (count++ < 120000) {

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeUnalignedAccess.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeUnalignedAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8158260
  * @summary Test unaligned Unsafe accesses
  * @modules java.base/jdk.internal.misc:+open
- *
+ * @library /test/lib
  * @run main/othervm -Diters=20000 -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
  *      compiler.unsafe.JdkInternalMiscUnsafeUnalignedAccess
  * @author volker.simonis@gmail.com
@@ -38,6 +38,7 @@ import jdk.internal.misc.Unsafe;
 
 import java.lang.reflect.Field;
 import java.nio.ByteOrder;
+import jtreg.SkippedException;
 
 public class JdkInternalMiscUnsafeUnalignedAccess {
     static final int ITERS = Integer.getInteger("iters", 20_000);
@@ -131,8 +132,7 @@ public class JdkInternalMiscUnsafeUnalignedAccess {
     public static void main(String[] args) throws Exception {
 
         if (!UNSAFE.unalignedAccess()) {
-            System.out.println("Platform is not supporting unaligned access - nothing to test.");
-            return;
+            throw new SkippedException("Platform is not supporting unaligned access - nothing to test.");
         }
 
         memory = UNSAFE.allocateMemory(SIZE);


### PR DESCRIPTION
Some CPUs (like ARM32) does not support unaligned memory accesses. To avoid JVM crashes tests that perform such accesses should be skipped on corresponding platforms.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251152](https://bugs.openjdk.java.net/browse/JDK-8251152): ARM32: jtreg c2 Test8202414 test crash


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)
 * clanger - **Reviewer** ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/48/head:pull/48`
`$ git checkout pull/48`
