### PR TITLE
8252695: Shenandoah: clean up Graal enabled/disabled filter in tests

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatilesShenandoah.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatilesShenandoah.java
@@ -29,7 +29,7 @@
  * @modules java.base/jdk.internal.misc
  *
  * @requires os.arch=="aarch64" & vm.debug == true &
- *           vm.flavor == "server" & !vm.graal.enabled &
+ *           vm.flavor == "server" &
  *           vm.gc.Shenandoah
  *
  * @build compiler.c2.aarch64.TestVolatiles

--- a/test/hotspot/jtreg/gc/shenandoah/TestAllocHumongousFragment.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestAllocHumongousFragment.java
@@ -82,7 +82,7 @@
  * @test TestAllocHumongousFragment
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xmx1g -Xms1g -Xlog:gc -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:ShenandoahTargetNumRegions=2048
@@ -99,7 +99,7 @@
  * @test TestAllocHumongousFragment
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xmx1g -Xms1g -Xlog:gc -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:ShenandoahTargetNumRegions=2048
@@ -111,7 +111,7 @@
  * @test TestAllocHumongousFragment
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xmx1g -Xms1g -Xlog:gc -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:ShenandoahTargetNumRegions=2048
@@ -151,7 +151,7 @@
  * @test TestAllocHumongousFragment
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xlog:gc -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g -XX:ShenandoahTargetNumRegions=2048

--- a/test/hotspot/jtreg/gc/shenandoah/TestAllocIntArrays.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestAllocIntArrays.java
@@ -86,7 +86,7 @@
  * @test TestAllocIntArrays
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
@@ -103,7 +103,7 @@
  * @test TestAllocIntArrays
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
@@ -115,7 +115,7 @@
  * @test TestAllocIntArrays
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
@@ -127,7 +127,7 @@
  * @test TestAllocIntArrays
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
@@ -172,7 +172,7 @@
  * @test TestAllocIntArrays
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g

--- a/test/hotspot/jtreg/gc/shenandoah/TestAllocObjectArrays.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestAllocObjectArrays.java
@@ -86,7 +86,7 @@
  * @test TestAllocObjectArrays
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
@@ -103,7 +103,7 @@
  * @test TestAllocObjectArrays
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
@@ -115,7 +115,7 @@
  * @test TestAllocObjectArrays
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
@@ -127,7 +127,7 @@
  * @test TestAllocObjectArrays
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
@@ -172,7 +172,7 @@
  * @test TestAllocObjectArrays
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g

--- a/test/hotspot/jtreg/gc/shenandoah/TestAllocObjects.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestAllocObjects.java
@@ -87,7 +87,7 @@
 /*
  * @test TestAllocObjects
  * @summary Acceptance tests: collector can withstand allocation
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
@@ -107,7 +107,7 @@
 /*
  * @test TestAllocObjects
  * @summary Acceptance tests: collector can withstand allocation
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=static
@@ -122,7 +122,7 @@
 /*
  * @test TestAllocObjects
  * @summary Acceptance tests: collector can withstand allocation
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact
@@ -167,7 +167,7 @@
 /*
  * @test TestAllocObjects
  * @summary Acceptance tests: collector can withstand allocation
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu

--- a/test/hotspot/jtreg/gc/shenandoah/TestDynamicSoftMaxHeapSize.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestDynamicSoftMaxHeapSize.java
@@ -24,7 +24,7 @@
 
 /*
  * @test TestDynamicSoftMaxHeapSize
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -42,7 +42,7 @@
 
 /*
  * @test TestDynamicSoftMaxHeapSize
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -53,7 +53,7 @@
 
 /*
  * @test TestDynamicSoftMaxHeapSize
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -64,7 +64,7 @@
 
 /*
  * @test TestDynamicSoftMaxHeapSize
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -75,7 +75,7 @@
 
 /*
  * @test TestDynamicSoftMaxHeapSize
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -86,7 +86,7 @@
 
 /*
  * @test TestDynamicSoftMaxHeapSize
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -97,7 +97,7 @@
 
 /*
  * @test TestDynamicSoftMaxHeapSize
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xms16m -Xmx512m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions

--- a/test/hotspot/jtreg/gc/shenandoah/TestLotsOfCycles.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestLotsOfCycles.java
@@ -63,7 +63,7 @@
 
 /*
  * @test TestLotsOfCycles
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
@@ -73,7 +73,7 @@
 
 /*
  * @test TestLotsOfCycles
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=static
@@ -83,7 +83,7 @@
 
 /*
  * @test TestLotsOfCycles
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact
@@ -115,7 +115,7 @@
 
 /*
  * @test TestLotsOfCycles
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu

--- a/test/hotspot/jtreg/gc/shenandoah/TestRegionSampling.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestRegionSampling.java
@@ -48,7 +48,7 @@
 
 /*
  * @test TestRegionSampling
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahRegionSampling
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=static
@@ -57,7 +57,7 @@
 
 /*
  * @test TestRegionSampling
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahRegionSampling
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact
@@ -66,7 +66,7 @@
 
 /*
  * @test TestRegionSampling
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahRegionSampling
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
@@ -84,7 +84,7 @@
 
 /*
  * @test TestRegionSampling
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahRegionSampling
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu

--- a/test/hotspot/jtreg/gc/shenandoah/TestRetainObjects.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestRetainObjects.java
@@ -71,7 +71,7 @@
 /*
  * @test TestRetainObjects
  * @summary Acceptance tests: collector can deal with retained objects
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
@@ -86,7 +86,7 @@
 /*
  * @test TestRetainObjects
  * @summary Acceptance tests: collector can deal with retained objects
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=static
@@ -96,7 +96,7 @@
 /*
  * @test TestRetainObjects
  * @summary Acceptance tests: collector can deal with retained objects
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact
@@ -106,7 +106,7 @@
 /*
  * @test TestRetainObjects
  * @summary Acceptance tests: collector can deal with retained objects
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC
@@ -137,7 +137,7 @@
 /*
  * @test TestRetainObjects
  * @summary Acceptance tests: collector can deal with retained objects
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu

--- a/test/hotspot/jtreg/gc/shenandoah/TestSieveObjects.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestSieveObjects.java
@@ -76,7 +76,7 @@
  * @test TestSieveObjects
  * @summary Acceptance tests: collector can deal with retained objects
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -94,7 +94,7 @@
  * @test TestSieveObjects
  * @summary Acceptance tests: collector can deal with retained objects
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -106,7 +106,7 @@
  * @test TestSieveObjects
  * @summary Acceptance tests: collector can deal with retained objects
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -118,7 +118,7 @@
  * @test TestSieveObjects
  * @summary Acceptance tests: collector can deal with retained objects
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm/timeout=240 -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -153,7 +153,7 @@
  * @test TestSieveObjects
  * @summary Acceptance tests: collector can deal with retained objects
  * @key randomness
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLoadPinnedAfterCall.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLoadPinnedAfterCall.java
@@ -26,7 +26,7 @@
  * @bug 8251527
  * @summary CTW: C2 (Shenandoah) compilation fails with SEGV due to unhandled catchproj == NUL
  * @requires vm.flavor == "server"
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UseShenandoahGC -XX:CompileOnly=TestLoadPinnedAfterCall.test -XX:CompileCommand=dontinline,TestLoadPinnedAfterCall.not_inlined -XX:-TieredCompilation -XX:-BackgroundCompilation TestLoadPinnedAfterCall
  *

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestChurnNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestChurnNotifications.java
@@ -52,7 +52,7 @@
 /*
  * @test TestChurnNotifications
  * @summary Check that MX notifications are reported for all cycles
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
@@ -63,7 +63,7 @@
 /*
  * @test TestChurnNotifications
  * @summary Check that MX notifications are reported for all cycles
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=static
@@ -74,7 +74,7 @@
 /*
  * @test TestChurnNotifications
  * @summary Check that MX notifications are reported for all cycles
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
@@ -51,7 +51,7 @@
 /*
  * @test TestPauseNotifications
  * @summary Check that MX notifications are reported for all cycles
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
@@ -61,7 +61,7 @@
 /*
  * @test TestPauseNotifications
  * @summary Check that MX notifications are reported for all cycles
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=static
@@ -71,7 +71,7 @@
 /*
  * @test TestPauseNotifications
  * @summary Check that MX notifications are reported for all cycles
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestSoftMaxHeapSize.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestSoftMaxHeapSize.java
@@ -25,7 +25,7 @@
 /*
  * @test TestSoftMaxHeapSize
  * @summary Test that Shenandoah checks SoftMaxHeapSize
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithShenandoah.java
@@ -91,7 +91,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled & vm.opt.ClassUnloading != false
+ * @requires vm.flavor == "server" & !vm.emulatedClient & vm.opt.ClassUnloading != false
  * @summary Stress Shenandoah GC with nmethod barrier forced deoptimization enabled.
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -212,7 +212,7 @@ import java.io.IOException;
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
- * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled & vm.opt.ClassUnloading != false
+ * @requires vm.flavor == "server" & !vm.emulatedClient & vm.opt.ClassUnloading != false
  * @summary Stress Shenandoah GC with nmethod barrier forced deoptimization enabled.
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info,nmethod+barrier=trace -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions

--- a/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithShenandoah.java
@@ -43,7 +43,7 @@ package gc.stress.gclocker;
 /*
  * @test TestGCLockerWithShenandoah
  * @library /
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @summary Stress Shenandoah's JNI handling by calling GetPrimitiveArrayCritical while concurrently filling up old gen.
  *
  * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithShenandoah.java
@@ -77,7 +77,7 @@ package gc.stress.gcold;
  * @test TestGCOldWithShenandoah
  * @key stress randomness
  * @library / /test/lib
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @summary Stress the GC by trying to make old objects more likely to be garbage than young objects.
  *
  * @run main/othervm/timeout=600 -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -94,7 +94,7 @@ package gc.stress.gcold;
  * @test TestGCOldWithShenandoah
  * @key stress randomness
  * @library / /test/lib
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @summary Stress the GC by trying to make old objects more likely to be garbage than young objects.
  *
  * @run main/othervm -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -128,7 +128,7 @@ package gc.stress.gcold;
  * @test TestGCOldWithShenandoah
  * @key stress randomness
  * @library / /test/lib
- * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
  * @summary Stress the GC by trying to make old objects more likely to be garbage than young objects.
  *
  * @run main/othervm/timeout=600 -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions


### PR DESCRIPTION
Drop `!vm.graal.enabled` since it is not required after JDK-8249000.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252695](https://bugs.openjdk.java.net/browse/JDK-8252695): Shenandoah: clean up Graal enabled/disabled filter in tests


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/51/head:pull/51`
`$ git checkout pull/51`
