### PR TITLE
8252661: Change SafepointMechanism terminology to talk less about "blocking"

### DIFF
--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -419,7 +419,7 @@ int ZeroInterpreter::native_entry(Method* method, intptr_t UNUSED, TRAPS) {
 
   // Handle safepoint operations, pending suspend requests,
   // and pending asynchronous exceptions.
-  if (SafepointMechanism::should_block(thread) ||
+  if (SafepointMechanism::should_process(thread) ||
       thread->has_special_condition_for_native_trans()) {
     JavaThread::check_special_condition_for_native_trans(thread);
     CHECK_UNHANDLED_OOPS_ONLY(thread->clear_unhandled_oops());
@@ -551,7 +551,7 @@ int ZeroInterpreter::accessor_entry(Method* method, intptr_t UNUSED, TRAPS) {
   intptr_t *locals = stack->sp();
 
   // Drop into the slow path if we need a safepoint check
-  if (SafepointMechanism::should_block(THREAD)) {
+  if (SafepointMechanism::should_process(THREAD)) {
     return normal_entry(method, 0, THREAD);
   }
 
@@ -683,7 +683,7 @@ int ZeroInterpreter::empty_entry(Method* method, intptr_t UNUSED, TRAPS) {
   ZeroStack *stack = thread->zero_stack();
 
   // Drop into the slow path if we need a safepoint check
-  if (SafepointMechanism::should_block(THREAD)) {
+  if (SafepointMechanism::should_process(THREAD)) {
     return normal_entry(method, 0, THREAD);
   }
 

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -919,7 +919,7 @@ JVMCI::CodeInstallResult CodeInstaller::initialize_buffer(CodeBuffer& buffer, bo
     last_pc_offset = pc_offset;
 
     JavaThread* thread = JavaThread::current();
-    if (SafepointMechanism::should_block(thread)) {
+    if (SafepointMechanism::should_process(thread)) {
       // this is a hacky way to force a safepoint check but nothing else was jumping out at me.
       ThreadToNativeFromVM ttnfv(thread);
     }

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -361,7 +361,7 @@ bool Handshake::execute_direct(HandshakeClosure* thread_cl, JavaThread* target) 
     hsy.add_result(pr);
     // Check for pending handshakes to avoid possible deadlocks where our
     // target is trying to handshake us.
-    if (SafepointMechanism::should_block(self)) {
+    if (SafepointMechanism::should_process(self)) {
       ThreadBlockInVM tbivm(self);
     }
     hsy.process();

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -93,7 +93,7 @@ class ThreadStateTransition : public StackObj {
     // Change to transition state and ensure it is seen by the VM thread.
     thread->set_thread_state_fence((JavaThreadState)(from + 1));
 
-    SafepointMechanism::block_if_requested(thread);
+    SafepointMechanism::process_if_requested(thread);
     thread->set_thread_state(to);
   }
 
@@ -114,7 +114,7 @@ class ThreadStateTransition : public StackObj {
     // We never install asynchronous exceptions when coming (back) in
     // to the runtime from native code because the runtime is not set
     // up to handle exceptions floating around at arbitrary points.
-    if (SafepointMechanism::should_block(thread) || thread->is_suspend_after_native()) {
+    if (SafepointMechanism::should_process(thread) || thread->is_suspend_after_native()) {
       JavaThread::check_safepoint_and_suspend_for_native_trans(thread);
     }
 
@@ -135,7 +135,7 @@ class ThreadInVMForHandshake : public ThreadStateTransition {
     // Change to transition state and ensure it is seen by the VM thread.
     _thread->set_thread_state_fence(_thread_in_vm_trans);
 
-    SafepointMechanism::block_if_requested(_thread);
+    SafepointMechanism::process_if_requested(_thread);
 
     _thread->set_thread_state(_original_state);
 
@@ -290,9 +290,9 @@ class ThreadBlockInVMWithDeadlockCheck : public ThreadStateTransition {
     // Change to transition state and ensure it is seen by the VM thread.
     _thread->set_thread_state_fence((JavaThreadState)(_thread_blocked_trans));
 
-    if (SafepointMechanism::should_block(_thread)) {
+    if (SafepointMechanism::should_process(_thread)) {
       release_mutex();
-      SafepointMechanism::block_if_requested(_thread);
+      SafepointMechanism::process_if_requested(_thread);
     }
 
     _thread->set_thread_state(_thread_in_vm);

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1783,7 +1783,7 @@ int ObjectMonitor::TrySpin(Thread * Self) {
     // This is in keeping with the "no loitering in runtime" rule.
     // We periodically check to see if there's a safepoint pending.
     if ((ctr & 0xFF) == 0) {
-      if (SafepointMechanism::should_block(Self)) {
+      if (SafepointMechanism::should_process(Self)) {
         goto Abort;           // abrupt spin egress
       }
       SpinPause();

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -774,7 +774,7 @@ void SafepointSynchronize::block(JavaThread *thread) {
       !thread->is_at_poll_safepoint() && (state != _thread_in_native_trans));
   }
 
-  // cross_modify_fence is done by SafepointMechanism::block_if_requested_slow
+  // cross_modify_fence is done by SafepointMechanism::process_operation_if_requested_slow
   // which is the only caller here.
 }
 
@@ -924,7 +924,7 @@ void ThreadSafepointState::print_on(outputStream *st) const {
 
 // ---------------------------------------------------------------------------------------------------------------------
 
-// Block the thread at poll or poll return for safepoint/handshake.
+// Process pending operation.
 void ThreadSafepointState::handle_polling_page_exception() {
 
   // Step 1: Find the nmethod from the return address
@@ -963,8 +963,8 @@ void ThreadSafepointState::handle_polling_page_exception() {
       assert(Universe::heap()->is_in_or_null(result), "must be heap pointer");
     }
 
-    // Block the thread
-    SafepointMechanism::block_if_requested(thread());
+    // Process pending operation
+    SafepointMechanism::process_if_requested(thread());
 
     // restore oop result, if any
     if (return_oop) {
@@ -979,8 +979,8 @@ void ThreadSafepointState::handle_polling_page_exception() {
     // verify the blob built the "return address" correctly
     assert(real_return_addr == caller_fr.pc(), "must match");
 
-    // Block the thread
-    SafepointMechanism::block_if_requested(thread());
+    // Process pending operation
+    SafepointMechanism::process_if_requested(thread());
     set_at_poll_safepoint(false);
 
     // If we have a pending async exception deoptimize the frame

--- a/src/hotspot/share/runtime/safepointMechanism.cpp
+++ b/src/hotspot/share/runtime/safepointMechanism.cpp
@@ -71,7 +71,7 @@ void SafepointMechanism::default_initialize() {
   _poll_disarmed_value = reinterpret_cast<void*>(poll_disarmed_value);
 }
 
-void SafepointMechanism::block_or_handshake(JavaThread *thread) {
+void SafepointMechanism::process(JavaThread *thread) {
   if (global_poll()) {
     // Any load in ::block must not pass the global poll load.
     // Otherwise we might load an old safepoint counter (for example).
@@ -83,12 +83,12 @@ void SafepointMechanism::block_or_handshake(JavaThread *thread) {
   }
 }
 
-void SafepointMechanism::block_if_requested_slow(JavaThread *thread) {
+void SafepointMechanism::process_if_requested_slow(JavaThread *thread) {
   // Read global poll and has_handshake after local poll
   OrderAccess::loadload();
 
   // local poll already checked, if used.
-  block_or_handshake(thread);
+  process(thread);
 
   OrderAccess::loadload();
 

--- a/src/hotspot/share/runtime/safepointMechanism.hpp
+++ b/src/hotspot/share/runtime/safepointMechanism.hpp
@@ -47,8 +47,8 @@ class SafepointMechanism : public AllStatic {
   static inline bool local_poll(Thread* thread);
   static inline bool global_poll();
 
-  static void block_or_handshake(JavaThread *thread);
-  static void block_if_requested_slow(JavaThread *thread);
+  static void process(JavaThread *thread);
+  static void process_if_requested_slow(JavaThread *thread);
 
   static void default_initialize();
 
@@ -64,10 +64,10 @@ public:
   static bool    is_poll_address(address addr)  { return addr >= _polling_page && addr < (_polling_page + os::vm_page_size()); }
 
   // Call this method to see if this thread should block for a safepoint or process handshake.
-  static inline bool should_block(Thread* thread);
+  static inline bool should_process(Thread* thread);
 
-  // Blocks a thread until safepoint/handshake is completed.
-  static inline void block_if_requested(JavaThread* thread);
+  // Processes a pending requested operation.
+  static inline void process_if_requested(JavaThread* thread);
 
   // Caller is responsible for using a memory barrier if needed.
   static inline void arm_local_poll(JavaThread* thread);

--- a/src/hotspot/share/runtime/safepointMechanism.inline.hpp
+++ b/src/hotspot/share/runtime/safepointMechanism.inline.hpp
@@ -47,15 +47,15 @@ bool SafepointMechanism::local_poll(Thread* thread) {
   }
 }
 
-bool SafepointMechanism::should_block(Thread* thread) {
+bool SafepointMechanism::should_process(Thread* thread) {
   return local_poll(thread);
 }
 
-void SafepointMechanism::block_if_requested(JavaThread *thread) {
+void SafepointMechanism::process_if_requested(JavaThread *thread) {
   if (!local_poll_armed(thread)) {
     return;
   }
-  block_if_requested_slow(thread);
+  process_if_requested_slow(thread);
 }
 
 void SafepointMechanism::arm_local_poll(JavaThread* thread) {

--- a/src/hotspot/share/runtime/sweeper.cpp
+++ b/src/hotspot/share/runtime/sweeper.cpp
@@ -267,7 +267,7 @@ void NMethodSweeper::force_sweep() {
  */
 void NMethodSweeper::handle_safepoint_request() {
   JavaThread* thread = JavaThread::current();
-  if (SafepointMechanism::should_block(thread)) {
+  if (SafepointMechanism::should_process(thread)) {
     if (PrintMethodFlushing && Verbose) {
       tty->print_cr("### Sweep at %d out of %d, yielding to safepoint", _seen, CodeCache::nmethod_count());
     }

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -2313,7 +2313,7 @@ int ObjectSynchronizer::deflate_monitor_list_using_JT(ObjectMonitor** list_p,
       mid = next;  // mid keeps non-NULL next's locked state
       next = next_next;
 
-      if (SafepointMechanism::should_block(self) &&
+      if (SafepointMechanism::should_process(self) &&
           // Acquire semantics are not needed on this list load since
           // it is not dependent on the following load which does have
           // acquire semantics.
@@ -2507,7 +2507,7 @@ void ObjectSynchronizer::deflate_common_idle_monitors_using_JT(bool is_global, J
         } else {
           log_debug(monitorinflation)("jt=" INTPTR_FORMAT ": pausing deflation of per-thread idle monitors for a safepoint.", p2i(target));
         }
-        assert(SafepointMechanism::should_block(self), "sanity check");
+        assert(SafepointMechanism::should_process(self), "sanity check");
         ThreadBlockInVM blocker(self);
       }
       // Prepare for another loop after the safepoint.

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -2628,7 +2628,7 @@ void JavaThread::java_suspend_self_with_safepoint_check() {
   // we must manually emit the instruction barrier after leaving a safe state.
   OrderAccess::cross_modify_fence();
   if (state != _thread_in_native) {
-    SafepointMechanism::block_if_requested(this);
+    SafepointMechanism::process_if_requested(this);
   }
 }
 
@@ -2658,7 +2658,7 @@ void JavaThread::check_safepoint_and_suspend_for_native_trans(JavaThread *thread
   if (thread->is_external_suspend()) {
     thread->java_suspend_self_with_safepoint_check();
   } else {
-    SafepointMechanism::block_if_requested(thread);
+    SafepointMechanism::process_if_requested(thread);
   }
 
   JFR_ONLY(SUSPEND_THREAD_CONDITIONAL(thread);)


### PR DESCRIPTION
Migrating this review from the mailing list into a pull request. So far, the favourite terminology is to talk about "process", but without "operation".
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252661](https://bugs.openjdk.java.net/browse/JDK-8252661): Change SafepointMechanism terminology to talk less about "blocking"


### Reviewers
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * dholmes - **Reviewer** ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/54/head:pull/54`
`$ git checkout pull/54`
