### PR TITLE
8252868: Clean up unused function from G1MMUTracker

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -80,7 +80,7 @@ public:
 double G1ConcurrentMarkThread::mmu_delay_end(G1Policy* g1_policy, bool remark) {
   // There are 3 reasons to use SuspendibleThreadSetJoiner.
   // 1. To avoid concurrency problem.
-  //    - G1MMUTracker::add_pause(), when_sec() and its variation(when_ms() etc..) can be called
+  //    - G1MMUTracker::add_pause(), when_sec() and when_max_gc_sec() can be called
   //      concurrently from ConcurrentMarkThread and VMThread.
   // 2. If currently a gc is running, but it has not yet updated the MMU,
   //    we will not forget to consider that pause in the MMU calculation.

--- a/src/hotspot/share/gc/g1/g1MMUTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1MMUTracker.hpp
@@ -62,22 +62,8 @@ public:
     return _max_gc_time;
   }
 
-  inline bool now_max_gc(double current_time) {
-    return when_sec(current_time, max_gc_time()) < 0.00001;
-  }
-
   inline double when_max_gc_sec(double current_time) {
     return when_sec(current_time, max_gc_time());
-  }
-
-  inline jlong when_max_gc_ms(double current_time) {
-    double when = when_max_gc_sec(current_time);
-    return (jlong) (when * 1000.0);
-  }
-
-  inline jlong when_ms(double current_time, double pause_time) {
-    double when = when_sec(current_time, pause_time);
-    return (jlong) (when * 1000.0);
   }
 };
 


### PR DESCRIPTION
Please review this cleanup to remove a few unused functions from the G1MMUTracker interface.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252868](https://bugs.openjdk.java.net/browse/JDK-8252868): Clean up unused function from G1MMUTracker


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/58/head:pull/58`
`$ git checkout pull/58`
