### PR TITLE
8252627: Make it safe for JFR thread to read threadObj

### DIFF
--- a/src/hotspot/share/gc/z/zObjectAllocator.cpp
+++ b/src/hotspot/share/gc/z/zObjectAllocator.cpp
@@ -146,8 +146,7 @@ uintptr_t ZObjectAllocator::alloc_medium_object(size_t size, ZAllocationFlags fl
 }
 
 uintptr_t ZObjectAllocator::alloc_small_object_from_nonworker(size_t size, ZAllocationFlags flags) {
-  assert(ZThread::is_java() || ZThread::is_vm() || ZThread::is_runtime_worker(),
-         "Should be a Java, VM or Runtime worker thread");
+  assert(!ZThread::is_worker(), "Should not be a worker thread");
 
   // Non-worker small page allocation can never use the reserve
   flags.set_no_reserve();
@@ -208,9 +207,6 @@ uintptr_t ZObjectAllocator::alloc_object(size_t size) {
 }
 
 uintptr_t ZObjectAllocator::alloc_object_for_relocation(size_t size) {
-  assert(ZThread::is_java() || ZThread::is_vm() || ZThread::is_worker() || ZThread::is_runtime_worker(),
-         "Unknown thread");
-
   ZAllocationFlags flags;
   flags.set_relocation();
   flags.set_non_blocking();

--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -119,6 +119,7 @@ class OSThreadSampler : public os::SuspendedThreadTask {
                   JfrStackFrame *frames,
                   u4 max_frames) : os::SuspendedThreadTask((Thread*)thread),
     _success(false),
+    _thread_oop(thread->threadObj()),
     _stacktrace(frames, max_frames),
     _closure(closure),
     _suspend_time() {}
@@ -131,6 +132,7 @@ class OSThreadSampler : public os::SuspendedThreadTask {
 
  private:
   bool _success;
+  oop _thread_oop;
   JfrStackTrace _stacktrace;
   JfrThreadSampleClosure& _closure;
   JfrTicks _suspend_time;
@@ -190,7 +192,7 @@ void OSThreadSampler::protected_task(const os::SuspendedThreadTaskContext& conte
       ev->set_starttime(_suspend_time);
       ev->set_endtime(_suspend_time); // fake to not take an end time
       ev->set_sampledThread(JFR_THREAD_ID(jth));
-      ev->set_state(java_lang_Thread::get_thread_status(jth->threadObj()));
+      ev->set_state(java_lang_Thread::get_thread_status(_thread_oop));
     }
   }
 }
@@ -202,7 +204,7 @@ void OSThreadSampler::take_sample() {
 class JfrNativeSamplerCallback : public os::CrashProtectionCallback {
  public:
   JfrNativeSamplerCallback(JfrThreadSampleClosure& closure, JavaThread* jt, JfrStackFrame* frames, u4 max_frames) :
-    _closure(closure), _jt(jt), _stacktrace(frames, max_frames), _success(false) {
+    _closure(closure), _jt(jt), _thread_oop(jt->threadObj()), _stacktrace(frames, max_frames), _success(false) {
   }
   virtual void call();
   bool success() { return _success; }
@@ -211,15 +213,16 @@ class JfrNativeSamplerCallback : public os::CrashProtectionCallback {
  private:
   JfrThreadSampleClosure& _closure;
   JavaThread* _jt;
+  oop _thread_oop;
   JfrStackTrace _stacktrace;
   bool _success;
 };
 
-static void write_native_event(JfrThreadSampleClosure& closure, JavaThread* jt) {
+static void write_native_event(JfrThreadSampleClosure& closure, JavaThread* jt, oop thread_oop) {
   EventNativeMethodSample *ev = closure.next_event_native();
   ev->set_starttime(JfrTicks::now());
   ev->set_sampledThread(JFR_THREAD_ID(jt));
-  ev->set_state(java_lang_Thread::get_thread_status(jt->threadObj()));
+  ev->set_state(java_lang_Thread::get_thread_status(thread_oop));
 }
 
 void JfrNativeSamplerCallback::call() {
@@ -241,7 +244,7 @@ void JfrNativeSamplerCallback::call() {
   topframe = first_java_frame;
   _success = _stacktrace.record_thread(*_jt, topframe);
   if (_success) {
-    write_native_event(_closure, _jt);
+    write_native_event(_closure, _jt, _thread_oop);
   }
 }
 


### PR DESCRIPTION
Migrating this review from the mailing list to a PR so I can integrate it. Already reviewed really.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252627](https://bugs.openjdk.java.net/browse/JDK-8252627): Make it safe for JFR thread to read threadObj


### Reviewers
 * dholmes - **Reviewer** ⚠️ Added manually
 * mgronlun - **Reviewer** ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/59/head:pull/59`
`$ git checkout pull/59`
