### PR TITLE
8252871: fatal error: must own lock JvmtiThreadState_lock

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
@@ -230,17 +230,6 @@ void JvmtiEnvThreadState::clear_frame_pop(int frame_number) {
 }
 
 
-void JvmtiEnvThreadState::clear_to_frame_pop(int frame_number)  {
-#ifdef ASSERT
-  Thread *current = Thread::current();
-#endif
-  assert(get_thread() == current || current == get_thread()->active_handshaker(),
-         "frame pop data only accessible from same thread or direct handshake");
-  JvmtiFramePop fpop(frame_number);
-  JvmtiEventController::clear_to_frame_pop(this, fpop);
-}
-
-
 bool JvmtiEnvThreadState::is_frame_pop(int cur_frame_number) {
 #ifdef ASSERT
   Thread *current = Thread::current();

--- a/src/hotspot/share/prims/jvmtiEnvThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvThreadState.hpp
@@ -178,7 +178,6 @@ public:
 
   void set_frame_pop(int frame_number);
   void clear_frame_pop(int frame_number);
-  void clear_to_frame_pop(int frame_number);
 
 };
 

--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -979,27 +979,16 @@ JvmtiEventController::set_extension_event_callback(JvmtiEnvBase *env,
   }
 }
 
-
-
-
 void
 JvmtiEventController::set_frame_pop(JvmtiEnvThreadState *ets, JvmtiFramePop fpop) {
-  assert_lock_strong(JvmtiThreadState_lock);
+  assert(JvmtiThreadState_lock->is_locked(), "Must be locked.");
   JvmtiEventControllerPrivate::set_frame_pop(ets, fpop);
 }
 
-
 void
 JvmtiEventController::clear_frame_pop(JvmtiEnvThreadState *ets, JvmtiFramePop fpop) {
-  assert_lock_strong(JvmtiThreadState_lock);
+  assert(JvmtiThreadState_lock->is_locked(), "Must be locked.");
   JvmtiEventControllerPrivate::clear_frame_pop(ets, fpop);
-}
-
-
-void
-JvmtiEventController::clear_to_frame_pop(JvmtiEnvThreadState *ets, JvmtiFramePop fpop) {
-  assert_lock_strong(JvmtiThreadState_lock);
-  JvmtiEventControllerPrivate::clear_to_frame_pop(ets, fpop);
 }
 
 void

--- a/src/hotspot/share/prims/jvmtiEventController.hpp
+++ b/src/hotspot/share/prims/jvmtiEventController.hpp
@@ -226,7 +226,6 @@ public:
 
   static void set_frame_pop(JvmtiEnvThreadState *env_thread, JvmtiFramePop fpop);
   static void clear_frame_pop(JvmtiEnvThreadState *env_thread, JvmtiFramePop fpop);
-  static void clear_to_frame_pop(JvmtiEnvThreadState *env_thread, JvmtiFramePop fpop);
 
   static void change_field_watch(jvmtiEvent event_type, bool added);
 


### PR DESCRIPTION
When these two methods (set_frame_pop/clear_frame_pop) are called in a handshake the requesting thread will have lock the JvmtiThreadState_lock.
But the thread executing one of these in the handshake may not be the owner.
So we only check that JvmtiThreadState_lock is locked.

When verifying the callers to these methods I notice "clear_to_frame_pop" was unused, so instead of fixing it I remove it.

Passes testing locally, still running T3 and T7.

Now passed!
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8252871](https://bugs.openjdk.java.net/browse/JDK-8252871): fatal error: must own lock JvmtiThreadState_lock
 * [JDK-8252816](https://bugs.openjdk.java.net/browse/JDK-8252816): JvmtiEnvThreadState::clear_to_frame_pop() is not used


### Reviewers
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/60/head:pull/60`
`$ git checkout pull/60`
