### PR TITLE
8252658: G1: Do not consider G1HeapWastePercent during region selection within a gc

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1332,22 +1332,6 @@ void G1Policy::calculate_old_collection_set_regions(G1CollectionSetCandidates* c
       break;
     }
 
-    // Stop adding regions if the remaining reclaimable space is
-    // not above G1HeapWastePercent.
-    size_t reclaimable_bytes = candidates->remaining_reclaimable_bytes();
-    double reclaimable_percent = reclaimable_bytes_percent(reclaimable_bytes);
-    double threshold = (double) G1HeapWastePercent;
-    if (reclaimable_percent <= threshold) {
-      // We've added enough old regions that the amount of uncollected
-      // reclaimable space is at or below the waste threshold. Stop
-      // adding old regions to the CSet.
-      log_debug(gc, ergo, cset)("Finish adding old regions to collection set (Reclaimable percentage below threshold). "
-                                "Reclaimable: " SIZE_FORMAT "%s (%1.2f%%) threshold: " UINTX_FORMAT "%%",
-                                byte_size_in_proper_unit(reclaimable_bytes), proper_unit_for_byte_size(reclaimable_bytes),
-                                reclaimable_percent, G1HeapWastePercent);
-      break;
-    }
-
     double predicted_time_ms = predict_region_total_time_ms(hr, false);
     time_remaining_ms = MAX2(time_remaining_ms - predicted_time_ms, 0.0);
     // Add regions to old set until we reach the minimum amount


### PR DESCRIPTION
"We agreed in an internal discussion to remove that check from region selection completely - the rationale is that when we already started a (mixed) gc, we should evacuate as much as possible. So that check may at least moved out of the loop or completely removed."
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252658](https://bugs.openjdk.java.net/browse/JDK-8252658): G1: Do not consider G1HeapWastePercent during region selection within a gc


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/62/head:pull/62`
`$ git checkout pull/62`
