### PR TITLE
8251193: bin/idea.sh is generating wrong folder definitions for JVMCI modules

### DIFF
--- a/bin/idea.sh
+++ b/bin/idea.sh
@@ -184,7 +184,18 @@ for root in $MODULE_ROOTS; do
     elif [ "x$WSL_DISTRO_NAME" != "x" ]; then
       root=`wslpath -am $root`
     fi
-    SOURCES=$SOURCES" $SOURCE_PREFIX""$root""$SOURCE_POSTFIX"
+
+    VM_CI="jdk.internal.vm.ci/share/classes"
+    VM_COMPILER="src/jdk.internal.vm.compiler/share/classes"
+    if test "${root#*$VM_CI}" != "$root" || test "${root#*$VM_COMPILER}" != "$root"; then
+        for subdir in "$root"/*; do
+            if [ -d "$subdir" ]; then
+                SOURCES=$SOURCES" $SOURCE_PREFIX""$subdir"/src"$SOURCE_POSTFIX"
+            fi
+        done
+    else
+        SOURCES=$SOURCES" $SOURCE_PREFIX""$root""$SOURCE_POSTFIX"
+    fi
 done
 
 add_replacement "###SOURCE_ROOTS###" "$SOURCES"


### PR DESCRIPTION
Reviewed-by: mcimadamore
Contributed-by: Galder Zamarreno <galder@redhat.com>
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251193](https://bugs.openjdk.java.net/browse/JDK-8251193): bin/idea.sh is generating wrong folder definitions for JVMCI modules


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Contributors
 * Galder Zamarreno `<galder@redhat.com>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/63/head:pull/63`
`$ git checkout pull/63`
