### PR TITLE
8252887: Zero VM is broken after JDK-8252661

### DIFF
--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -106,7 +106,7 @@
     {                                                                             \
        /* zap freed handles rather than GC'ing them */                            \
        HandleMarkCleaner __hmc(THREAD);                                           \
-       CALL_VM(SafepointMechanism::block_if_requested(THREAD), handle_exception); \
+       CALL_VM(SafepointMechanism::process_if_requested(THREAD), handle_exception); \
     }
 
 /*


### PR DESCRIPTION
Hi all,

JBS: https://bugs.openjdk.java.net/browse/JDK-8252887

Zero VM is broken due to 'block_if_requested' is not a member of 'SafepointMechanism'.
The reason is that 'block_if_requested' has been replaced by 'process_if_requested' after JDK-8252661.

The fix just replaces 'block_if_requested' with 'process_if_requested'.

Thanks.
Best regards,
Jie

/issue add DK-8252887
/cc hotspot-runtime
/test
/summary
8252887: Zero VM is broken after JDK-8252661
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252887](https://bugs.openjdk.java.net/browse/JDK-8252887): Zero VM is broken after JDK-8252661


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/64/head:pull/64`
`$ git checkout pull/64`
