### PR TITLE
8250563: Add KVHashtable::add_if_absent

### DIFF
--- a/src/hotspot/share/memory/archiveBuilder.cpp
+++ b/src/hotspot/share/memory/archiveBuilder.cpp
@@ -333,14 +333,12 @@ bool ArchiveBuilder::gather_one_source_obj(MetaspaceClosure::Ref* enclosing_ref,
 
   FollowMode follow_mode = get_follow_mode(ref);
   SourceObjInfo src_info(ref, read_only, follow_mode);
-  bool created = false;
-  SourceObjInfo* p = _src_obj_table.lookup(src_obj);
-  if (p == NULL) {
-    p = _src_obj_table.add(src_obj, src_info);
+  bool created;
+  SourceObjInfo* p = _src_obj_table.add_if_absent(src_obj, src_info, &created);
+  if (created) {
     if (_src_obj_table.maybe_grow(MAX_TABLE_SIZE)) {
       log_info(cds, hashtables)("Expanded _src_obj_table table to %d", _src_obj_table.table_size());
     }
-    created = true;
   }
 
   assert(p->read_only() == src_info.read_only(), "must be");

--- a/src/hotspot/share/memory/metaspaceClosure.cpp
+++ b/src/hotspot/share/memory/metaspaceClosure.cpp
@@ -94,12 +94,11 @@ MetaspaceClosure::~MetaspaceClosure() {
 }
 
 bool UniqueMetaspaceClosure::do_ref(MetaspaceClosure::Ref* ref, bool read_only) {
-  bool* found = _has_been_visited.lookup(ref->obj());
-  if (found != NULL) {
-    assert(*found == read_only, "must be");
+  bool created;
+  _has_been_visited.add_if_absent(ref->obj(), read_only, &created);
+  if (!created) {
     return false; // Already visited: no need to iterate embedded pointers.
   } else {
-    _has_been_visited.add(ref->obj(), read_only);
     if (_has_been_visited.maybe_grow(MAX_TABLE_SIZE)) {
       log_info(cds, hashtables)("Expanded _has_been_visited table to %d", _has_been_visited.table_size());
     }

--- a/src/hotspot/share/utilities/hashtable.hpp
+++ b/src/hotspot/share/utilities/hashtable.hpp
@@ -312,7 +312,7 @@ public:
     unsigned int hash = HASH(key);
     int index = BasicHashtable<F>::hash_to_index(hash);
     for (KVHashtableEntry* e = bucket(index); e != NULL; e = e->next()) {
-      if (e->hash() == hash && e->_key == key) {
+      if (e->hash() == hash && EQUALS(e->_key, key)) {
         return &(e->_value);
       }
     }
@@ -324,11 +324,11 @@ public:
   // If no entry for the key exists, create a new entry from key and value and return a
   //  pointer to the value.
   // *p_created is true if entry was created, false if entry pre-existed.
-  V* add_if_absent(K const& key, V const& value, bool* p_created) {
+  V* add_if_absent(K key, V value, bool* p_created) {
     unsigned int hash = HASH(key);
     int index = BasicHashtable<F>::hash_to_index(hash);
     for (KVHashtableEntry* e = bucket(index); e != NULL; e = e->next()) {
-      if (e->hash() == hash && e->_key == key) {
+      if (e->hash() == hash && EQUALS(e->_key, key)) {
         *p_created = false;
         return &(e->_value);
       }

--- a/src/hotspot/share/utilities/hashtable.hpp
+++ b/src/hotspot/share/utilities/hashtable.hpp
@@ -319,6 +319,27 @@ public:
     return NULL;
   }
 
+  // Look up the key.
+  // If an entry for the key exists, leave map unchanged and return a pointer to its value.
+  // If no entry for the key exists, create a new entry from key and value and return a
+  //  pointer to the value.
+  // *p_created is true if entry was created, false if entry pre-existed.
+  V* add_if_absent(K const& key, V const& value, bool* p_created) {
+    unsigned int hash = HASH(key);
+    int index = BasicHashtable<F>::hash_to_index(hash);
+    for (KVHashtableEntry* e = bucket(index); e != NULL; e = e->next()) {
+      if (e->hash() == hash && e->_key == key) {
+        *p_created = false;
+        return &(e->_value);
+      }
+    }
+
+    KVHashtableEntry* entry = new_entry(hash, key, value);
+    BasicHashtable<F>::add_entry(BasicHashtable<F>::hash_to_index(hash), entry);
+    *p_created = true;
+    return &(entry->_value);
+  }
+
   int table_size() const {
     return BasicHashtable<F>::table_size();
   }

--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,7 +133,7 @@ class ResourceHashtable : public ResourceObj {
   // If an entry for the key exists, leave map unchanged and return a pointer to its value.
   // If no entry for the key exists, create a new entry from key and a default-created value
   //  and return a pointer to the value.
-  // *p_created is new if entry was created, false if entry pre-existed.
+  // *p_created is true if entry was created, false if entry pre-existed.
   V* put_if_absent(K const& key, bool* p_created) {
     unsigned hv = HASH(key);
     Node** ptr = lookup_node(hv, key);
@@ -150,7 +150,7 @@ class ResourceHashtable : public ResourceObj {
   // If an entry for the key exists, leave map unchanged and return a pointer to its value.
   // If no entry for the key exists, create a new entry from key and value and return a
   //  pointer to the value.
-  // *p_created is new if entry was created, false if entry pre-existed.
+  // *p_created is true if entry was created, false if entry pre-existed.
   V* put_if_absent(K const& key, V const& value, bool* p_created) {
     unsigned hv = HASH(key);
     Node** ptr = lookup_node(hv, key);


### PR DESCRIPTION
Please review this XS change. I added a new **KVHashtable::add_if_absent** function (modeled after ResourceHashtable::put_if_absent from JDK-8244733).

- I used "add" instead of "put" to be consistent with the naming convention in utility/hashtable.hpp
- I also fixed a type in the comments in resourceHashtable.hpp

Running mach5 tiers1/2.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250563](https://bugs.openjdk.java.net/browse/JDK-8250563): Add KVHashtable::add_if_absent


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/66/head:pull/66`
`$ git checkout pull/66`
