### PR TITLE
8252853: AArch64: gc/shenandoah/TestVerifyJCStress.java fails intermittently with C1

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -302,16 +302,9 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier_native(MacroAssembler
 
 void ShenandoahBarrierSetAssembler::storeval_barrier(MacroAssembler* masm, Register dst, Register tmp) {
   if (ShenandoahStoreValEnqueueBarrier) {
-    // Save possibly live regs.
-    RegSet live_regs = RegSet::range(r0, r4) - dst;
-    __ push(live_regs, sp);
-    __ strd(v0, __ pre(sp, 2 * -wordSize));
-
+    __ push_call_clobbered_registers();
     satb_write_barrier_pre(masm, noreg, dst, rthread, tmp, true, false);
-
-    // Restore possibly live regs.
-    __ ldrd(v0, __ post(sp, 2 * wordSize));
-    __ pop(live_regs, sp);
+    __ pop_call_clobbered_registers();
   }
 }
 

--- a/test/hotspot/jtreg/gc/shenandoah/TestVerifyJCStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestVerifyJCStress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2020, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,11 @@
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
  *      -XX:+ShenandoahVerify -XX:+IgnoreUnrecognizedVMOptions -XX:+ShenandoahVerifyOptoBarriers
+ *      TestVerifyJCStress
+ *
+ * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
+ *      -XX:+ShenandoahVerify -XX:+IgnoreUnrecognizedVMOptions -XX:TieredStopAtLevel=1
  *      TestVerifyJCStress
  */
 


### PR DESCRIPTION
This test fails occasionally when run with -XX:TieredStopAtLevel=1 on
AArch64 with the error

```
  java.util.concurrent.ExecutionException: java.lang.NullPointerException: Cannot assign field "prev" because "node" is null
      at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
      at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
      at TestVerifyJCStress.main(TestVerifyJCStress.java:109)
      [..snip..]
  Caused by: java.lang.NullPointerException: Cannot assign field "prev" because "node" is null
      at java.base/java.util.concurrent.locks.StampedLock.acquireWrite(StampedLock.java:1221)
      at java.base/java.util.concurrent.locks.StampedLock.writeLockInterruptibly(StampedLock.java:536)
      at TestVerifyJCStress$Test.WLI_Us(TestVerifyJCStress.java:133)
```

The particular configuration that fails is -XX:ShenandoahGCMode=iu. In
this mode the Shenandoah C1 CAS implementation calls into
ShenandoahBarrierSetAssembler::storeval_barrier() which performs a VM
leaf call in the slow path (via satb_write_barrier_pre()) but only saves
R0-R4 and V0 (for the interpreter, I guess). Instead it needs to
preserve all the caller saved registers as some of these might hold live
values over the CAS in the C1 generated code.

Tested jtreg hotspot_all_no_apps, jdk_core, plus jcstress with -jvmArgs
'-XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:TieredStopAtLevel=1'
which would also fail in the same way.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252853](https://bugs.openjdk.java.net/browse/JDK-8252853): AArch64: gc/shenandoah/TestVerifyJCStress.java fails intermittently with C1


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/68/head:pull/68`
`$ git checkout pull/68`
