### PR TITLE
8252889: Obsolete -XX:+InsertMemBarAfterArraycopy

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -384,9 +384,6 @@
   product(bool, UseOnlyInlinedBimorphic, true,                              \
           "Don't use BimorphicInlining if can't inline a second method")    \
                                                                             \
-  product(bool, InsertMemBarAfterArraycopy, true,                           \
-          "Insert memory barrier after arraycopy call")                     \
-                                                                            \
   develop(bool, SubsumeLoads, true,                                         \
           "Attempt to compile while subsuming loads into machine "          \
           "instructions.")                                                  \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -553,6 +553,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "UseNewFieldLayout",             JDK_Version::jdk(15), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "UseSemaphoreGCThreadsSynchronization", JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "ForceNUMA",                     JDK_Version::jdk(15), JDK_Version::jdk(16), JDK_Version::jdk(17) },
+  { "InsertMemBarAfterArraycopy",    JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
 
 #ifdef TEST_VERIFY_SPECIAL_JVM_FLAGS
   // These entries will generate build errors.  Their purpose is to test the macros.


### PR DESCRIPTION
The InsertMemBarAfterArraycopy product flag (enabled by default) is broken. I propose to simply remove it.
The corresponding CSR (JDK-8252890) is still waiting for approval.

Thanks,
Tobias
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252889](https://bugs.openjdk.java.net/browse/JDK-8252889): Obsolete -XX:+InsertMemBarAfterArraycopy


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Aditya Mandaleeka](https://openjdk.java.net/census#adityam) (@adityamandaleeka - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/69/head:pull/69`
`$ git checkout pull/69`
