### PR TITLE
8252721: Nested classes in Swing APIs rely on default constructors

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -1335,7 +1335,7 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
 
     NSTextInputContext *curContxt = [NSTextInputContext currentInputContext];
     kbdLayout = curContxt.selectedKeyboardInputSource;
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [[NSNotificationCenter defaultCenter] addObserver:[AWTView class]
                                            selector:@selector(keyboardInputSourceChanged:)
                                                name:NSTextInputContextKeyboardSelectionDidChangeNotification
                                              object:nil];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -1335,7 +1335,7 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
 
     NSTextInputContext *curContxt = [NSTextInputContext currentInputContext];
     kbdLayout = curContxt.selectedKeyboardInputSource;
-    [[NSNotificationCenter defaultCenter] addObserver:[AWTView class]
+    [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(keyboardInputSourceChanged:)
                                                name:NSTextInputContextKeyboardSelectionDidChangeNotification
                                              object:nil];

--- a/src/java.desktop/share/classes/javax/swing/AbstractButton.java
+++ b/src/java.desktop/share/classes/javax/swing/AbstractButton.java
@@ -2357,6 +2357,11 @@ public abstract class AbstractButton extends JComponent implements ItemSelectabl
         AccessibleValue, AccessibleText, AccessibleExtendedComponent {
 
         /**
+         * Constructor for subclasses to call.
+         */
+        protected AccessibleAbstractButton() {}
+
+        /**
          * Returns the accessible name of this object.
          *
          * @return the localized name of the object -- can be

--- a/src/java.desktop/share/classes/javax/swing/Box.java
+++ b/src/java.desktop/share/classes/javax/swing/Box.java
@@ -384,9 +384,9 @@ public class Box extends JComponent implements Accessible {
         @SuppressWarnings("serial")
         protected class AccessibleBoxFiller extends AccessibleAWTComponent {
             /**
-             * Constructs a {@code AccessibleBoxFiller}.
+             * Constructor for subclasses to call.
              */
-            public AccessibleBoxFiller() {}
+            protected AccessibleBoxFiller() {}
 
             // AccessibleContext methods
             //
@@ -431,9 +431,9 @@ public class Box extends JComponent implements Accessible {
     @SuppressWarnings("serial")
     protected class AccessibleBox extends AccessibleAWTContainer {
         /**
-         * Constructs a {@code AccessibleBox}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleBox() {}
+        protected AccessibleBox() {}
 
         // AccessibleContext methods
         //

--- a/src/java.desktop/share/classes/javax/swing/Box.java
+++ b/src/java.desktop/share/classes/javax/swing/Box.java
@@ -383,6 +383,11 @@ public class Box extends JComponent implements Accessible {
          */
         @SuppressWarnings("serial")
         protected class AccessibleBoxFiller extends AccessibleAWTComponent {
+            /**
+             * Constructs a {@code AccessibleBoxFiller}.
+             */
+            public AccessibleBoxFiller() {}
+
             // AccessibleContext methods
             //
             /**
@@ -425,6 +430,11 @@ public class Box extends JComponent implements Accessible {
      */
     @SuppressWarnings("serial")
     protected class AccessibleBox extends AccessibleAWTContainer {
+        /**
+         * Constructs a {@code AccessibleBox}.
+         */
+        public AccessibleBox() {}
+
         // AccessibleContext methods
         //
         /**

--- a/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
+++ b/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
@@ -244,6 +244,11 @@ public class CellRendererPane extends Container implements Accessible
      * <code>CellRendererPane</code> class.
      */
     protected class AccessibleCellRendererPane extends AccessibleAWTContainer {
+        /**
+         * Constructs a {@code AccessibleCellRendererPane}.
+         */
+        public AccessibleCellRendererPane() {}
+
         // AccessibleContext methods
         //
         /**

--- a/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
+++ b/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
@@ -245,9 +245,9 @@ public class CellRendererPane extends Container implements Accessible
      */
     protected class AccessibleCellRendererPane extends AccessibleAWTContainer {
         /**
-         * Constructs a {@code AccessibleCellRendererPane}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleCellRendererPane() {}
+        protected AccessibleCellRendererPane() {}
 
         // AccessibleContext methods
         //

--- a/src/java.desktop/share/classes/javax/swing/DefaultCellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultCellEditor.java
@@ -303,6 +303,11 @@ public class DefaultCellEditor extends AbstractCellEditor
         /**  The value of this cell. */
         protected Object value;
 
+        /**
+         * Constructs a {@code EditorDelegate}.
+         */
+        public EditorDelegate() {}
+
        /**
         * Returns the value of this cell.
         * @return the value of this cell

--- a/src/java.desktop/share/classes/javax/swing/DefaultCellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultCellEditor.java
@@ -304,9 +304,9 @@ public class DefaultCellEditor extends AbstractCellEditor
         protected Object value;
 
         /**
-         * Constructs a {@code EditorDelegate}.
+         * Constructor for subclasses to call.
          */
-        public EditorDelegate() {}
+        protected EditorDelegate() {}
 
        /**
         * Returns the value of this cell.

--- a/src/java.desktop/share/classes/javax/swing/ImageIcon.java
+++ b/src/java.desktop/share/classes/javax/swing/ImageIcon.java
@@ -596,6 +596,11 @@ public class ImageIcon implements Icon, Serializable, Accessible {
     protected class AccessibleImageIcon extends AccessibleContext
         implements AccessibleIcon, Serializable {
 
+        /**
+         * Constructs a {@code AccessibleImageIcon}.
+         */
+        public AccessibleImageIcon() {}
+
         /*
          * AccessibleContest implementation -----------------
          */

--- a/src/java.desktop/share/classes/javax/swing/ImageIcon.java
+++ b/src/java.desktop/share/classes/javax/swing/ImageIcon.java
@@ -597,9 +597,9 @@ public class ImageIcon implements Icon, Serializable, Accessible {
         implements AccessibleIcon, Serializable {
 
         /**
-         * Constructs a {@code AccessibleImageIcon}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleImageIcon() {}
+        protected AccessibleImageIcon() {}
 
         /*
          * AccessibleContest implementation -----------------

--- a/src/java.desktop/share/classes/javax/swing/JApplet.java
+++ b/src/java.desktop/share/classes/javax/swing/JApplet.java
@@ -566,6 +566,11 @@ public class JApplet extends Applet implements Accessible,
      * <code>JApplet</code> class.
      */
     protected class AccessibleJApplet extends AccessibleApplet {
+        /**
+         * Constructs a {@code AccessibleJApplet}.
+         */
+        public AccessibleJApplet() {}
+
         // everything moved to new parent, AccessibleApplet
     }
 }

--- a/src/java.desktop/share/classes/javax/swing/JApplet.java
+++ b/src/java.desktop/share/classes/javax/swing/JApplet.java
@@ -567,9 +567,9 @@ public class JApplet extends Applet implements Accessible,
      */
     protected class AccessibleJApplet extends AccessibleApplet {
         /**
-         * Constructs a {@code AccessibleJApplet}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJApplet() {}
+        protected AccessibleJApplet() {}
 
         // everything moved to new parent, AccessibleApplet
     }

--- a/src/java.desktop/share/classes/javax/swing/JButton.java
+++ b/src/java.desktop/share/classes/javax/swing/JButton.java
@@ -302,6 +302,11 @@ public class JButton extends AbstractButton implements Accessible {
     protected class AccessibleJButton extends AccessibleAbstractButton {
 
         /**
+         * Constructs a {@code AccessibleJButton}.
+         */
+        public AccessibleJButton() {}
+
+        /**
          * Get the role of this object.
          *
          * @return an instance of AccessibleRole describing the role of the

--- a/src/java.desktop/share/classes/javax/swing/JButton.java
+++ b/src/java.desktop/share/classes/javax/swing/JButton.java
@@ -302,9 +302,9 @@ public class JButton extends AbstractButton implements Accessible {
     protected class AccessibleJButton extends AccessibleAbstractButton {
 
         /**
-         * Constructs a {@code AccessibleJButton}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJButton() {}
+        protected AccessibleJButton() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JCheckBox.java
+++ b/src/java.desktop/share/classes/javax/swing/JCheckBox.java
@@ -333,6 +333,11 @@ public class JCheckBox extends JToggleButton implements Accessible {
     protected class AccessibleJCheckBox extends AccessibleJToggleButton {
 
         /**
+         * Constructs a {@code AccessibleJCheckBox}.
+         */
+        public AccessibleJCheckBox() {}
+
+        /**
          * Get the role of this object.
          *
          * @return an instance of AccessibleRole describing the role of the object

--- a/src/java.desktop/share/classes/javax/swing/JCheckBox.java
+++ b/src/java.desktop/share/classes/javax/swing/JCheckBox.java
@@ -333,9 +333,9 @@ public class JCheckBox extends JToggleButton implements Accessible {
     protected class AccessibleJCheckBox extends AccessibleJToggleButton {
 
         /**
-         * Constructs a {@code AccessibleJCheckBox}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJCheckBox() {}
+        protected AccessibleJCheckBox() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JCheckBoxMenuItem.java
+++ b/src/java.desktop/share/classes/javax/swing/JCheckBoxMenuItem.java
@@ -305,9 +305,9 @@ public class JCheckBoxMenuItem extends JMenuItem implements SwingConstants,
     @SuppressWarnings("serial") // Same-version serialization only
     protected class AccessibleJCheckBoxMenuItem extends AccessibleJMenuItem {
         /**
-         * Constructs a {@code AccessibleJCheckBoxMenuItem}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJCheckBoxMenuItem() {}
+        protected AccessibleJCheckBoxMenuItem() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JCheckBoxMenuItem.java
+++ b/src/java.desktop/share/classes/javax/swing/JCheckBoxMenuItem.java
@@ -305,6 +305,11 @@ public class JCheckBoxMenuItem extends JMenuItem implements SwingConstants,
     @SuppressWarnings("serial") // Same-version serialization only
     protected class AccessibleJCheckBoxMenuItem extends AccessibleJMenuItem {
         /**
+         * Constructs a {@code AccessibleJCheckBoxMenuItem}.
+         */
+        public AccessibleJCheckBoxMenuItem() {}
+
+        /**
          * Get the role of this object.
          *
          * @return an instance of AccessibleRole describing the role of the

--- a/src/java.desktop/share/classes/javax/swing/JColorChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JColorChooser.java
@@ -600,9 +600,9 @@ public class JColorChooser extends JComponent implements Accessible {
     protected class AccessibleJColorChooser extends AccessibleJComponent {
 
         /**
-         * Constructs a {@code AccessibleJColorChooser}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJColorChooser() {}
+        protected AccessibleJColorChooser() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JColorChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JColorChooser.java
@@ -600,6 +600,11 @@ public class JColorChooser extends JComponent implements Accessible {
     protected class AccessibleJColorChooser extends AccessibleJComponent {
 
         /**
+         * Constructs a {@code AccessibleJColorChooser}.
+         */
+        public AccessibleJColorChooser() {}
+
+        /**
          * Get the role of this object.
          *
          * @return an instance of AccessibleRole describing the role of the

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -3710,6 +3710,10 @@ public abstract class JComponent extends Container implements Serializable,
          */
         protected class AccessibleContainerHandler
             implements ContainerListener {
+            /**
+             * Constructs a {@code AccessibleContainerHandler}.
+             */
+            public AccessibleContainerHandler() {}
             public void componentAdded(ContainerEvent e) {
                 Component c = e.getChild();
                 if (c != null && c instanceof Accessible) {
@@ -3738,6 +3742,10 @@ public abstract class JComponent extends Container implements Serializable,
          */
         @Deprecated
         protected class AccessibleFocusHandler implements FocusListener {
+           /**
+            * Constructs a {@code AccessibleFocusHandler}.
+            */
+           public AccessibleFocusHandler() {}
            public void focusGained(FocusEvent event) {
                if (accessibleContext != null) {
                     accessibleContext.firePropertyChange(

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -3711,9 +3711,9 @@ public abstract class JComponent extends Container implements Serializable,
         protected class AccessibleContainerHandler
             implements ContainerListener {
             /**
-             * Constructs a {@code AccessibleContainerHandler}.
+             * Constructor for subclasses to call.
              */
-            public AccessibleContainerHandler() {}
+            protected AccessibleContainerHandler() {}
             public void componentAdded(ContainerEvent e) {
                 Component c = e.getChild();
                 if (c != null && c instanceof Accessible) {
@@ -3743,9 +3743,9 @@ public abstract class JComponent extends Container implements Serializable,
         @Deprecated
         protected class AccessibleFocusHandler implements FocusListener {
            /**
-            * Constructs a {@code AccessibleFocusHandler}.
+            * Constructor for subclasses to call.
             */
-           public AccessibleFocusHandler() {}
+           protected AccessibleFocusHandler() {}
            public void focusGained(FocusEvent event) {
                if (accessibleContext != null) {
                     accessibleContext.firePropertyChange(

--- a/src/java.desktop/share/classes/javax/swing/JDesktopPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JDesktopPane.java
@@ -628,9 +628,9 @@ public class JDesktopPane extends JLayeredPane implements Accessible
     protected class AccessibleJDesktopPane extends AccessibleJComponent {
 
         /**
-         * Constructs a {@code AccessibleJDesktopPane}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJDesktopPane() {}
+        protected AccessibleJDesktopPane() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JDesktopPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JDesktopPane.java
@@ -628,6 +628,11 @@ public class JDesktopPane extends JLayeredPane implements Accessible
     protected class AccessibleJDesktopPane extends AccessibleJComponent {
 
         /**
+         * Constructs a {@code AccessibleJDesktopPane}.
+         */
+        public AccessibleJDesktopPane() {}
+
+        /**
          * Get the role of this object.
          *
          * @return an instance of AccessibleRole describing the role of the

--- a/src/java.desktop/share/classes/javax/swing/JDialog.java
+++ b/src/java.desktop/share/classes/javax/swing/JDialog.java
@@ -1239,9 +1239,9 @@ public class JDialog extends Dialog implements WindowConstants,
     protected class AccessibleJDialog extends AccessibleAWTDialog {
 
         /**
-         * Constructs a {@code AccessibleJDialog}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJDialog() {}
+        protected AccessibleJDialog() {}
 
         // AccessibleContext methods
         //

--- a/src/java.desktop/share/classes/javax/swing/JDialog.java
+++ b/src/java.desktop/share/classes/javax/swing/JDialog.java
@@ -1238,6 +1238,11 @@ public class JDialog extends Dialog implements WindowConstants,
      */
     protected class AccessibleJDialog extends AccessibleAWTDialog {
 
+        /**
+         * Constructs a {@code AccessibleJDialog}.
+         */
+        public AccessibleJDialog() {}
+
         // AccessibleContext methods
         //
         /**

--- a/src/java.desktop/share/classes/javax/swing/JEditorPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JEditorPane.java
@@ -1660,9 +1660,9 @@ public class JEditorPane extends JTextComponent {
     protected class AccessibleJEditorPane extends AccessibleJTextComponent {
 
         /**
-         * Constructs a {@code AccessibleJEditorPane}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJEditorPane() {}
+        protected AccessibleJEditorPane() {}
 
         /**
          * Gets the accessibleDescription property of this object.  If this

--- a/src/java.desktop/share/classes/javax/swing/JEditorPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JEditorPane.java
@@ -1660,6 +1660,11 @@ public class JEditorPane extends JTextComponent {
     protected class AccessibleJEditorPane extends AccessibleJTextComponent {
 
         /**
+         * Constructs a {@code AccessibleJEditorPane}.
+         */
+        public AccessibleJEditorPane() {}
+
+        /**
          * Gets the accessibleDescription property of this object.  If this
          * property isn't set, returns the content type of this
          * <code>JEditorPane</code> instead (e.g. "plain/text", "html/text").

--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -2042,9 +2042,9 @@ public class JFileChooser extends JComponent implements Accessible {
     protected class AccessibleJFileChooser extends AccessibleJComponent {
 
         /**
-         * Constructs a {@code AccessibleJFileChooser}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJFileChooser() {}
+        protected AccessibleJFileChooser() {}
 
         /**
          * Gets the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -2042,6 +2042,11 @@ public class JFileChooser extends JComponent implements Accessible {
     protected class AccessibleJFileChooser extends AccessibleJComponent {
 
         /**
+         * Constructs a {@code AccessibleJFileChooser}.
+         */
+        public AccessibleJFileChooser() {}
+
+        /**
          * Gets the role of this object.
          *
          * @return an instance of AccessibleRole describing the role of the

--- a/src/java.desktop/share/classes/javax/swing/JFrame.java
+++ b/src/java.desktop/share/classes/javax/swing/JFrame.java
@@ -882,6 +882,11 @@ public class JFrame  extends Frame implements WindowConstants,
      */
     protected class AccessibleJFrame extends AccessibleAWTFrame {
 
+        /**
+         * Constructs a {@code AccessibleJFrame}.
+         */
+        public AccessibleJFrame() {}
+
         // AccessibleContext methods
         /**
          * Get the accessible name of this object.

--- a/src/java.desktop/share/classes/javax/swing/JFrame.java
+++ b/src/java.desktop/share/classes/javax/swing/JFrame.java
@@ -883,9 +883,9 @@ public class JFrame  extends Frame implements WindowConstants,
     protected class AccessibleJFrame extends AccessibleAWTFrame {
 
         /**
-         * Constructs a {@code AccessibleJFrame}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJFrame() {}
+        protected AccessibleJFrame() {}
 
         // AccessibleContext methods
         /**

--- a/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
+++ b/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
@@ -2012,9 +2012,9 @@ public class JInternalFrame extends JComponent implements
         implements AccessibleValue {
 
         /**
-         * Constructs a {@code AccessibleJInternalFrame}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJInternalFrame() {}
+        protected AccessibleJInternalFrame() {}
 
         /**
          * Get the accessible name of this object.
@@ -2308,9 +2308,9 @@ public class JInternalFrame extends JComponent implements
             implements AccessibleValue {
 
             /**
-             * Constructs a {@code AccessibleJDesktopIcon}.
+             * Constructor for subclasses to call.
              */
-            public AccessibleJDesktopIcon() {}
+            protected AccessibleJDesktopIcon() {}
 
             /**
              * Gets the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
+++ b/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
@@ -2012,6 +2012,11 @@ public class JInternalFrame extends JComponent implements
         implements AccessibleValue {
 
         /**
+         * Constructs a {@code AccessibleJInternalFrame}.
+         */
+        public AccessibleJInternalFrame() {}
+
+        /**
          * Get the accessible name of this object.
          *
          * @return the localized name of the object -- can be <code>null</code> if this
@@ -2301,6 +2306,11 @@ public class JInternalFrame extends JComponent implements
         @SuppressWarnings("serial") // Same-version serialization only
         protected class AccessibleJDesktopIcon extends AccessibleJComponent
             implements AccessibleValue {
+
+            /**
+             * Constructs a {@code AccessibleJDesktopIcon}.
+             */
+            public AccessibleJDesktopIcon() {}
 
             /**
              * Gets the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JLabel.java
+++ b/src/java.desktop/share/classes/javax/swing/JLabel.java
@@ -1044,6 +1044,11 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
         implements AccessibleText, AccessibleExtendedComponent {
 
         /**
+         * Constructs a {@code AccessibleJLabel}.
+         */
+        public AccessibleJLabel() {}
+
+        /**
          * Get the accessible name of this object.
          *
          * @return the localized name of the object -- can be null if this

--- a/src/java.desktop/share/classes/javax/swing/JLabel.java
+++ b/src/java.desktop/share/classes/javax/swing/JLabel.java
@@ -1044,9 +1044,9 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
         implements AccessibleText, AccessibleExtendedComponent {
 
         /**
-         * Constructs a {@code AccessibleJLabel}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJLabel() {}
+        protected AccessibleJLabel() {}
 
         /**
          * Get the accessible name of this object.

--- a/src/java.desktop/share/classes/javax/swing/JLayeredPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JLayeredPane.java
@@ -767,6 +767,11 @@ public class JLayeredPane extends JComponent implements Accessible {
     protected class AccessibleJLayeredPane extends AccessibleJComponent {
 
         /**
+         * Constructs a {@code AccessibleJLayeredPane}.
+         */
+        public AccessibleJLayeredPane() {}
+
+        /**
          * Get the role of this object.
          *
          * @return an instance of AccessibleRole describing the role of the

--- a/src/java.desktop/share/classes/javax/swing/JLayeredPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JLayeredPane.java
@@ -767,9 +767,9 @@ public class JLayeredPane extends JComponent implements Accessible {
     protected class AccessibleJLayeredPane extends AccessibleJComponent {
 
         /**
-         * Constructs a {@code AccessibleJLayeredPane}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJLayeredPane() {}
+        protected AccessibleJLayeredPane() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenu.java
@@ -1396,9 +1396,9 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
         implements AccessibleSelection {
 
         /**
-         * Constructs a {@code AccessibleJMenu}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJMenu() {}
+        protected AccessibleJMenu() {}
 
         /**
          * Returns the number of accessible children in the object.  If all

--- a/src/java.desktop/share/classes/javax/swing/JMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenu.java
@@ -1396,6 +1396,11 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
         implements AccessibleSelection {
 
         /**
+         * Constructs a {@code AccessibleJMenu}.
+         */
+        public AccessibleJMenu() {}
+
+        /**
          * Returns the number of accessible children in the object.  If all
          * of the children of this object implement Accessible, than this
          * method should return the number of children of this object.

--- a/src/java.desktop/share/classes/javax/swing/JMenuBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenuBar.java
@@ -511,9 +511,9 @@ public class JMenuBar extends JComponent implements Accessible,MenuElement
         implements AccessibleSelection {
 
         /**
-         * Constructs a {@code AccessibleJMenuBar}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJMenuBar() {}
+        protected AccessibleJMenuBar() {}
 
         /**
          * Get the accessible state set of this object.

--- a/src/java.desktop/share/classes/javax/swing/JMenuBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenuBar.java
@@ -511,6 +511,11 @@ public class JMenuBar extends JComponent implements Accessible,MenuElement
         implements AccessibleSelection {
 
         /**
+         * Constructs a {@code AccessibleJMenuBar}.
+         */
+        public AccessibleJMenuBar() {}
+
+        /**
          * Get the accessible state set of this object.
          *
          * @return an instance of AccessibleState containing the current state

--- a/src/java.desktop/share/classes/javax/swing/JOptionPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JOptionPane.java
@@ -2548,9 +2548,9 @@ public class JOptionPane extends JComponent implements Accessible
     protected class AccessibleJOptionPane extends AccessibleJComponent {
 
         /**
-         * Constructs a {@code AccessibleJOptionPane}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJOptionPane() {}
+        protected AccessibleJOptionPane() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JOptionPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JOptionPane.java
@@ -2548,6 +2548,11 @@ public class JOptionPane extends JComponent implements Accessible
     protected class AccessibleJOptionPane extends AccessibleJComponent {
 
         /**
+         * Constructs a {@code AccessibleJOptionPane}.
+         */
+        public AccessibleJOptionPane() {}
+
+        /**
          * Get the role of this object.
          *
          * @return an instance of AccessibleRole describing the role of the object

--- a/src/java.desktop/share/classes/javax/swing/JPanel.java
+++ b/src/java.desktop/share/classes/javax/swing/JPanel.java
@@ -232,6 +232,10 @@ public class JPanel extends JComponent implements Accessible
      */
     @SuppressWarnings("serial") // Same-version serialization only
     protected class AccessibleJPanel extends AccessibleJComponent {
+        /**
+         * Constructs a {@code AccessibleJPanel}.
+         */
+        public AccessibleJPanel() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JPanel.java
+++ b/src/java.desktop/share/classes/javax/swing/JPanel.java
@@ -233,9 +233,9 @@ public class JPanel extends JComponent implements Accessible
     @SuppressWarnings("serial") // Same-version serialization only
     protected class AccessibleJPanel extends AccessibleJComponent {
         /**
-         * Constructs a {@code AccessibleJPanel}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJPanel() {}
+        protected AccessibleJPanel() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JPasswordField.java
+++ b/src/java.desktop/share/classes/javax/swing/JPasswordField.java
@@ -407,9 +407,9 @@ public class JPasswordField extends JTextField {
     protected class AccessibleJPasswordField extends AccessibleJTextField {
 
         /**
-         * Constructs a {@code AccessibleJPasswordField}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJPasswordField() {}
+        protected AccessibleJPasswordField() {}
 
         /**
          * Gets the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JPasswordField.java
+++ b/src/java.desktop/share/classes/javax/swing/JPasswordField.java
@@ -407,6 +407,11 @@ public class JPasswordField extends JTextField {
     protected class AccessibleJPasswordField extends AccessibleJTextField {
 
         /**
+         * Constructs a {@code AccessibleJPasswordField}.
+         */
+        public AccessibleJPasswordField() {}
+
+        /**
          * Gets the role of this object.
          *
          * @return an instance of AccessibleRole describing the role of the

--- a/src/java.desktop/share/classes/javax/swing/JProgressBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JProgressBar.java
@@ -1012,9 +1012,9 @@ public class JProgressBar extends JComponent implements SwingConstants, Accessib
         implements AccessibleValue {
 
         /**
-         * Constructs a {@code AccessibleJProgressBar}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJProgressBar() {}
+        protected AccessibleJProgressBar() {}
 
         /**
          * Gets the state set of this object.

--- a/src/java.desktop/share/classes/javax/swing/JProgressBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JProgressBar.java
@@ -1012,6 +1012,11 @@ public class JProgressBar extends JComponent implements SwingConstants, Accessib
         implements AccessibleValue {
 
         /**
+         * Constructs a {@code AccessibleJProgressBar}.
+         */
+        public AccessibleJProgressBar() {}
+
+        /**
          * Gets the state set of this object.
          *
          * @return an instance of AccessibleState containing the current state

--- a/src/java.desktop/share/classes/javax/swing/JRadioButton.java
+++ b/src/java.desktop/share/classes/javax/swing/JRadioButton.java
@@ -286,9 +286,9 @@ public class JRadioButton extends JToggleButton implements Accessible {
     protected class AccessibleJRadioButton extends AccessibleJToggleButton {
 
         /**
-         * Constructs a {@code AccessibleJRadioButton}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJRadioButton() {}
+        protected AccessibleJRadioButton() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JRadioButton.java
+++ b/src/java.desktop/share/classes/javax/swing/JRadioButton.java
@@ -286,6 +286,11 @@ public class JRadioButton extends JToggleButton implements Accessible {
     protected class AccessibleJRadioButton extends AccessibleJToggleButton {
 
         /**
+         * Constructs a {@code AccessibleJRadioButton}.
+         */
+        public AccessibleJRadioButton() {}
+
+        /**
          * Get the role of this object.
          *
          * @return an instance of AccessibleRole describing the role of the object

--- a/src/java.desktop/share/classes/javax/swing/JRadioButtonMenuItem.java
+++ b/src/java.desktop/share/classes/javax/swing/JRadioButtonMenuItem.java
@@ -279,6 +279,11 @@ public class JRadioButtonMenuItem extends JMenuItem implements Accessible {
     @SuppressWarnings("serial") // Same-version serialization only
     protected class AccessibleJRadioButtonMenuItem extends AccessibleJMenuItem {
         /**
+         * Constructs a {@code AccessibleJRadioButtonMenuItem}.
+         */
+        public AccessibleJRadioButtonMenuItem() {}
+
+        /**
          * Get the role of this object.
          *
          * @return an instance of AccessibleRole describing the role of the

--- a/src/java.desktop/share/classes/javax/swing/JRadioButtonMenuItem.java
+++ b/src/java.desktop/share/classes/javax/swing/JRadioButtonMenuItem.java
@@ -279,9 +279,9 @@ public class JRadioButtonMenuItem extends JMenuItem implements Accessible {
     @SuppressWarnings("serial") // Same-version serialization only
     protected class AccessibleJRadioButtonMenuItem extends AccessibleJMenuItem {
         /**
-         * Constructs a {@code AccessibleJRadioButtonMenuItem}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJRadioButtonMenuItem() {}
+        protected AccessibleJRadioButtonMenuItem() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JRootPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JRootPane.java
@@ -848,9 +848,9 @@ public class JRootPane extends JComponent implements Accessible {
     protected class RootLayout implements LayoutManager2, Serializable
     {
         /**
-         * Constructs a {@code RootLayout}.
+         * Constructor for subclasses to call.
          */
-        public RootLayout() {}
+        protected RootLayout() {}
 
         /**
          * Returns the amount of space the layout would like to have.
@@ -1018,9 +1018,9 @@ public class JRootPane extends JComponent implements Accessible {
     @SuppressWarnings("serial")
     protected class AccessibleJRootPane extends AccessibleJComponent {
         /**
-         * Constructs a {@code AccessibleJRootPane}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJRootPane() {}
+        protected AccessibleJRootPane() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JRootPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JRootPane.java
@@ -848,6 +848,11 @@ public class JRootPane extends JComponent implements Accessible {
     protected class RootLayout implements LayoutManager2, Serializable
     {
         /**
+         * Constructs a {@code RootLayout}.
+         */
+        public RootLayout() {}
+
+        /**
          * Returns the amount of space the layout would like to have.
          *
          * @param parent the Container for which this layout manager
@@ -1012,6 +1017,11 @@ public class JRootPane extends JComponent implements Accessible {
      */
     @SuppressWarnings("serial")
     protected class AccessibleJRootPane extends AccessibleJComponent {
+        /**
+         * Constructs a {@code AccessibleJRootPane}.
+         */
+        public AccessibleJRootPane() {}
+
         /**
          * Get the role of this object.
          *

--- a/src/java.desktop/share/classes/javax/swing/JScrollBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JScrollBar.java
@@ -856,9 +856,9 @@ public class JScrollBar extends JComponent implements Adjustable, Accessible
         implements AccessibleValue {
 
         /**
-         * Constructs a {@code AccessibleJScrollBar}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJScrollBar() {}
+        protected AccessibleJScrollBar() {}
 
         /**
          * Get the state set of this object.

--- a/src/java.desktop/share/classes/javax/swing/JScrollBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JScrollBar.java
@@ -856,6 +856,11 @@ public class JScrollBar extends JComponent implements Adjustable, Accessible
         implements AccessibleValue {
 
         /**
+         * Constructs a {@code AccessibleJScrollBar}.
+         */
+        public AccessibleJScrollBar() {}
+
+        /**
          * Get the state set of this object.
          *
          * @return an instance of AccessibleState containing the current state

--- a/src/java.desktop/share/classes/javax/swing/JSeparator.java
+++ b/src/java.desktop/share/classes/javax/swing/JSeparator.java
@@ -278,6 +278,11 @@ public class JSeparator extends JComponent implements SwingConstants, Accessible
     protected class AccessibleJSeparator extends AccessibleJComponent {
 
         /**
+         * Constructs a {@code AccessibleJSeparator}.
+         */
+        public AccessibleJSeparator() {}
+
+        /**
          * Get the role of this object.
          *
          * @return an instance of AccessibleRole describing the role of the

--- a/src/java.desktop/share/classes/javax/swing/JSeparator.java
+++ b/src/java.desktop/share/classes/javax/swing/JSeparator.java
@@ -278,9 +278,9 @@ public class JSeparator extends JComponent implements SwingConstants, Accessible
     protected class AccessibleJSeparator extends AccessibleJComponent {
 
         /**
-         * Constructs a {@code AccessibleJSeparator}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJSeparator() {}
+        protected AccessibleJSeparator() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -1136,6 +1136,11 @@ public class JSplitPane extends JComponent implements Accessible
     protected class AccessibleJSplitPane extends AccessibleJComponent
         implements AccessibleValue {
         /**
+         * Constructs a {@code AccessibleJSplitPane}.
+         */
+        public AccessibleJSplitPane() {}
+
+        /**
          * Gets the state set of this object.
          *
          * @return an instance of AccessibleState containing the current state

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -1136,9 +1136,9 @@ public class JSplitPane extends JComponent implements Accessible
     protected class AccessibleJSplitPane extends AccessibleJComponent
         implements AccessibleValue {
         /**
-         * Constructs a {@code AccessibleJSplitPane}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJSplitPane() {}
+        protected AccessibleJSplitPane() {}
 
         /**
          * Gets the state set of this object.

--- a/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
@@ -289,6 +289,11 @@ public class JTabbedPane extends JComponent
      * the tabbedpane (instead of the model itself) as the event source.
      */
     protected class ModelListener implements ChangeListener, Serializable {
+        /**
+         * Constructs a {@code ModelListener}.
+         */
+        public ModelListener() {}
+
         public void stateChanged(ChangeEvent e) {
             fireStateChanged();
         }

--- a/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
@@ -290,9 +290,9 @@ public class JTabbedPane extends JComponent
      */
     protected class ModelListener implements ChangeListener, Serializable {
         /**
-         * Constructs a {@code ModelListener}.
+         * Constructor for subclasses to call.
          */
-        public ModelListener() {}
+        protected ModelListener() {}
 
         public void stateChanged(ChangeEvent e) {
             fireStateChanged();

--- a/src/java.desktop/share/classes/javax/swing/JTextArea.java
+++ b/src/java.desktop/share/classes/javax/swing/JTextArea.java
@@ -784,9 +784,9 @@ public class JTextArea extends JTextComponent {
     protected class AccessibleJTextArea extends AccessibleJTextComponent {
 
         /**
-         * Constructs a {@code AccessibleJTextArea}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJTextArea() {}
+        protected AccessibleJTextArea() {}
 
         /**
          * Gets the state set of this object.

--- a/src/java.desktop/share/classes/javax/swing/JTextArea.java
+++ b/src/java.desktop/share/classes/javax/swing/JTextArea.java
@@ -784,6 +784,11 @@ public class JTextArea extends JTextComponent {
     protected class AccessibleJTextArea extends AccessibleJTextComponent {
 
         /**
+         * Constructs a {@code AccessibleJTextArea}.
+         */
+        public AccessibleJTextArea() {}
+
+        /**
          * Gets the state set of this object.
          *
          * @return an instance of AccessibleStateSet describing the states

--- a/src/java.desktop/share/classes/javax/swing/JTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JTextField.java
@@ -951,9 +951,9 @@ public class JTextField extends JTextComponent implements SwingConstants {
     protected class AccessibleJTextField extends AccessibleJTextComponent {
 
         /**
-         * Constructs a {@code AccessibleJTextField}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJTextField() {}
+        protected AccessibleJTextField() {}
 
         /**
          * Gets the state set of this object.

--- a/src/java.desktop/share/classes/javax/swing/JTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JTextField.java
@@ -951,6 +951,11 @@ public class JTextField extends JTextComponent implements SwingConstants {
     protected class AccessibleJTextField extends AccessibleJTextComponent {
 
         /**
+         * Constructs a {@code AccessibleJTextField}.
+         */
+        public AccessibleJTextField() {}
+
+        /**
          * Gets the state set of this object.
          *
          * @return an instance of AccessibleStateSet describing the states

--- a/src/java.desktop/share/classes/javax/swing/JToolBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JToolBar.java
@@ -832,9 +832,9 @@ public class JToolBar extends JComponent implements SwingConstants, Accessible
     protected class AccessibleJToolBar extends AccessibleJComponent {
 
         /**
-         * Constructs a {@code AccessibleJToolBar}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJToolBar() {}
+        protected AccessibleJToolBar() {}
 
         /**
          * Get the state of this object.

--- a/src/java.desktop/share/classes/javax/swing/JToolBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JToolBar.java
@@ -832,6 +832,11 @@ public class JToolBar extends JComponent implements SwingConstants, Accessible
     protected class AccessibleJToolBar extends AccessibleJComponent {
 
         /**
+         * Constructs a {@code AccessibleJToolBar}.
+         */
+        public AccessibleJToolBar() {}
+
+        /**
          * Get the state of this object.
          *
          * @return an instance of AccessibleStateSet containing the current

--- a/src/java.desktop/share/classes/javax/swing/JToolTip.java
+++ b/src/java.desktop/share/classes/javax/swing/JToolTip.java
@@ -262,9 +262,9 @@ public class JToolTip extends JComponent implements Accessible {
     protected class AccessibleJToolTip extends AccessibleJComponent {
 
         /**
-         * Constructs a {@code AccessibleJToolTip}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJToolTip() {}
+        protected AccessibleJToolTip() {}
 
         /**
          * Get the accessible description of this object.

--- a/src/java.desktop/share/classes/javax/swing/JToolTip.java
+++ b/src/java.desktop/share/classes/javax/swing/JToolTip.java
@@ -262,6 +262,11 @@ public class JToolTip extends JComponent implements Accessible {
     protected class AccessibleJToolTip extends AccessibleJComponent {
 
         /**
+         * Constructs a {@code AccessibleJToolTip}.
+         */
+        public AccessibleJToolTip() {}
+
+        /**
          * Get the accessible description of this object.
          *
          * @return a localized String describing this object.

--- a/src/java.desktop/share/classes/javax/swing/JTree.java
+++ b/src/java.desktop/share/classes/javax/swing/JTree.java
@@ -3321,6 +3321,11 @@ public class JTree extends JComponent implements Scrollable, Accessible
               DefaultTreeSelectionModel
     {
         /**
+         * Constructs a {@code EmptySelectionModel}.
+         */
+        public EmptySelectionModel() {}
+
+        /**
          * The single instance of {@code EmptySelectionModel}.
          */
         protected static final EmptySelectionModel sharedInstance =
@@ -3442,6 +3447,11 @@ public class JTree extends JComponent implements Scrollable, Accessible
     protected class TreeSelectionRedirector implements Serializable,
                     TreeSelectionListener
     {
+        /**
+         * Constructs a {@code TreeSelectionRedirector}.
+         */
+        public TreeSelectionRedirector() {}
+
         /**
          * Invoked by the <code>TreeSelectionModel</code> when the
          * selection changes.
@@ -3863,6 +3873,11 @@ public class JTree extends JComponent implements Scrollable, Accessible
       * accordingly when nodes are removed, or changed.
       */
     protected class TreeModelHandler implements TreeModelListener {
+         /**
+          * Constructs a {@code TreeModelHandler}.
+          */
+         public TreeModelHandler() {}
+
         public void treeNodesChanged(TreeModelEvent e) { }
 
         public void treeNodesInserted(TreeModelEvent e) { }

--- a/src/java.desktop/share/classes/javax/swing/JTree.java
+++ b/src/java.desktop/share/classes/javax/swing/JTree.java
@@ -3321,9 +3321,9 @@ public class JTree extends JComponent implements Scrollable, Accessible
               DefaultTreeSelectionModel
     {
         /**
-         * Constructs a {@code EmptySelectionModel}.
+         * Constructor for subclasses to call.
          */
-        public EmptySelectionModel() {}
+        protected EmptySelectionModel() {}
 
         /**
          * The single instance of {@code EmptySelectionModel}.
@@ -3448,9 +3448,9 @@ public class JTree extends JComponent implements Scrollable, Accessible
                     TreeSelectionListener
     {
         /**
-         * Constructs a {@code TreeSelectionRedirector}.
+         * Constructor for subclasses to call.
          */
-        public TreeSelectionRedirector() {}
+        protected TreeSelectionRedirector() {}
 
         /**
          * Invoked by the <code>TreeSelectionModel</code> when the
@@ -3874,9 +3874,9 @@ public class JTree extends JComponent implements Scrollable, Accessible
       */
     protected class TreeModelHandler implements TreeModelListener {
          /**
-          * Constructs a {@code TreeModelHandler}.
+          * Constructor for subclasses to call.
           */
-         public TreeModelHandler() {}
+         protected TreeModelHandler() {}
 
         public void treeNodesChanged(TreeModelEvent e) { }
 

--- a/src/java.desktop/share/classes/javax/swing/JViewport.java
+++ b/src/java.desktop/share/classes/javax/swing/JViewport.java
@@ -1406,9 +1406,9 @@ public class JViewport extends JComponent implements Accessible
     protected class ViewListener extends ComponentAdapter implements Serializable
     {
         /**
-         * Constructs a {@code ViewListener}.
+         * Constructor for subclasses to call.
          */
-        public ViewListener() {}
+        protected ViewListener() {}
 
         public void componentResized(ComponentEvent e) {
             fireStateChanged();
@@ -1882,9 +1882,9 @@ public class JViewport extends JComponent implements Accessible
     protected class AccessibleJViewport extends AccessibleJComponent {
 
         /**
-         * Constructs a {@code AccessibleJViewport}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJViewport() {}
+        protected AccessibleJViewport() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/JViewport.java
+++ b/src/java.desktop/share/classes/javax/swing/JViewport.java
@@ -1405,6 +1405,11 @@ public class JViewport extends JComponent implements Accessible
     @SuppressWarnings("serial") // Same-version serialization only
     protected class ViewListener extends ComponentAdapter implements Serializable
     {
+        /**
+         * Constructs a {@code ViewListener}.
+         */
+        public ViewListener() {}
+
         public void componentResized(ComponentEvent e) {
             fireStateChanged();
             revalidate();
@@ -1875,6 +1880,12 @@ public class JViewport extends JComponent implements Accessible
      */
     @SuppressWarnings("serial") // Same-version serialization only
     protected class AccessibleJViewport extends AccessibleJComponent {
+
+        /**
+         * Constructs a {@code AccessibleJViewport}.
+         */
+        public AccessibleJViewport() {}
+
         /**
          * Get the role of this object.
          *

--- a/src/java.desktop/share/classes/javax/swing/JWindow.java
+++ b/src/java.desktop/share/classes/javax/swing/JWindow.java
@@ -655,9 +655,9 @@ public class JWindow extends Window implements Accessible,
     protected class AccessibleJWindow extends AccessibleAWTWindow {
         // everything is in the new parent, AccessibleAWTWindow
         /**
-         * Constructs a {@code AccessibleJWindow}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJWindow() {}
+        protected AccessibleJWindow() {}
     }
 
 }

--- a/src/java.desktop/share/classes/javax/swing/JWindow.java
+++ b/src/java.desktop/share/classes/javax/swing/JWindow.java
@@ -654,6 +654,10 @@ public class JWindow extends Window implements Accessible,
     @SuppressWarnings("serial")
     protected class AccessibleJWindow extends AccessibleAWTWindow {
         // everything is in the new parent, AccessibleAWTWindow
+        /**
+         * Constructs a {@code AccessibleJWindow}.
+         */
+        public AccessibleJWindow() {}
     }
 
 }

--- a/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
+++ b/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
@@ -678,9 +678,9 @@ public class ToolTipManager extends MouseAdapter implements MouseMotionListener 
      */
     protected class insideTimerAction implements ActionListener {
         /**
-         * Constructs a {@code insideTimerAction}.
+         * Constructor for subclasses to call.
          */
-        public insideTimerAction() {}
+        protected insideTimerAction() {}
 
         /**
          * {@inheritDoc}
@@ -713,9 +713,9 @@ public class ToolTipManager extends MouseAdapter implements MouseMotionListener 
      */
     protected class outsideTimerAction implements ActionListener {
         /**
-         * Constructs a {@code outsideTimerAction}.
+         * Constructor for subclasses to call.
          */
-        public outsideTimerAction() {}
+        protected outsideTimerAction() {}
 
         /**
          * {@inheritDoc}
@@ -730,9 +730,9 @@ public class ToolTipManager extends MouseAdapter implements MouseMotionListener 
      */
     protected class stillInsideTimerAction implements ActionListener {
         /**
-         * Constructs a {@code stillInsideTimerAction}.
+         * Constructor for subclasses to call.
          */
-        public stillInsideTimerAction() {}
+        protected stillInsideTimerAction() {}
 
         /**
          * {@inheritDoc}

--- a/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
+++ b/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
@@ -678,6 +678,11 @@ public class ToolTipManager extends MouseAdapter implements MouseMotionListener 
      */
     protected class insideTimerAction implements ActionListener {
         /**
+         * Constructs a {@code insideTimerAction}.
+         */
+        public insideTimerAction() {}
+
+        /**
          * {@inheritDoc}
          */
         public void actionPerformed(ActionEvent e) {
@@ -708,6 +713,11 @@ public class ToolTipManager extends MouseAdapter implements MouseMotionListener 
      */
     protected class outsideTimerAction implements ActionListener {
         /**
+         * Constructs a {@code outsideTimerAction}.
+         */
+        public outsideTimerAction() {}
+
+        /**
          * {@inheritDoc}
          */
         public void actionPerformed(ActionEvent e) {
@@ -719,6 +729,11 @@ public class ToolTipManager extends MouseAdapter implements MouseMotionListener 
      * Still inside timer action.
      */
     protected class stillInsideTimerAction implements ActionListener {
+        /**
+         * Constructs a {@code stillInsideTimerAction}.
+         */
+        public stillInsideTimerAction() {}
+
         /**
          * {@inheritDoc}
          */

--- a/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
+++ b/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
@@ -809,6 +809,11 @@ public class JTableHeader extends JComponent implements TableColumnModelListener
     protected class AccessibleJTableHeader extends AccessibleJComponent {
 
         /**
+         * Constructs a {@code AccessibleJTableHeader}.
+         */
+        public AccessibleJTableHeader() {}
+
+        /**
          * Get the role of this object.
          *
          * @return an instance of AccessibleRole describing the role of the

--- a/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
+++ b/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
@@ -809,9 +809,9 @@ public class JTableHeader extends JComponent implements TableColumnModelListener
     protected class AccessibleJTableHeader extends AccessibleJComponent {
 
         /**
-         * Constructs a {@code AccessibleJTableHeader}.
+         * Constructor for subclasses to call.
          */
-        public AccessibleJTableHeader() {}
+        protected AccessibleJTableHeader() {}
 
         /**
          * Get the role of this object.

--- a/src/java.desktop/share/classes/javax/swing/text/html/FormView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/FormView.java
@@ -552,6 +552,11 @@ public class FormView extends ComponentView implements ActionListener {
      */
     protected class MouseEventListener extends MouseAdapter {
 
+        /**
+         * Constructs a {@code MouseEventListener}.
+         */
+        public MouseEventListener() {}
+
         public void mouseReleased(MouseEvent evt) {
             String imageData = getImageData(evt.getPoint());
             imageSubmit(imageData);

--- a/src/java.desktop/share/classes/javax/swing/text/html/FormView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/FormView.java
@@ -553,9 +553,9 @@ public class FormView extends ComponentView implements ActionListener {
     protected class MouseEventListener extends MouseAdapter {
 
         /**
-         * Constructs a {@code MouseEventListener}.
+         * Constructor for subclasses to call.
          */
-        public MouseEventListener() {}
+        protected MouseEventListener() {}
 
         public void mouseReleased(MouseEvent evt) {
             String imageData = getImageData(evt.getPoint());


### PR DESCRIPTION
Please review a fix for issue where it was seen that several 
nested classes rely on default constructors as part of their public API.

It's to be noted that "A no-arg public constructor is generated by the compiler for a class if it does not declare an explicit constructor. While convenient, this is inappropriate for many kinds of formal classes, both because the constructor will have no javadoc and because the constructor may be unintended."

For the JDK, classes intended to be used outside of the JDK, public classes in exported packages, should not rely on default constructors.

Proposed fix is to add explicit public no-arg constructors for public classes and protected no-arg constructor for public abstract classes for javax.swing module (as one part of overalll java.desktop change) 

CSR: https://bugs.openjdk.java.net/browse/JDK-8252908
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252721](https://bugs.openjdk.java.net/browse/JDK-8252721): Nested classes in Swing APIs rely on default constructors


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/72/head:pull/72`
`$ git checkout pull/72`
