### PR TITLE
8253768: Deleting unused pipe_class definitions in adl-file (x86_64.ad).

### DIFF
--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -4258,16 +4258,6 @@ pipe_class ialu_reg_fat(rRegI dst)
     ALU    : S3;        // any alu
 %}
 
-// Long ALU reg operation using big decoder
-pipe_class ialu_reg_long_fat(rRegL dst)
-%{
-    instruction_count(2);
-    dst    : S4(write);
-    dst    : S3(read);
-    D0     : S0(2);     // big decoder only; twice
-    ALU    : S3(2);     // any 2 alus
-%}
-
 // Integer ALU reg-reg operation
 pipe_class ialu_reg_reg(rRegI dst, rRegI src)
 %{
@@ -4278,16 +4268,6 @@ pipe_class ialu_reg_reg(rRegI dst, rRegI src)
     ALU    : S3;        // any alu
 %}
 
-// Long ALU reg-reg operation
-pipe_class ialu_reg_reg_long(rRegL dst, rRegL src)
-%{
-    instruction_count(2);
-    dst    : S4(write);
-    src    : S3(read);
-    DECODE : S0(2);     // any 2 decoders
-    ALU    : S3(2);     // both alus
-%}
-
 // Integer ALU reg-reg operation
 pipe_class ialu_reg_reg_fat(rRegI dst, memory src)
 %{
@@ -4296,16 +4276,6 @@ pipe_class ialu_reg_reg_fat(rRegI dst, memory src)
     src    : S3(read);
     D0     : S0;        // big decoder only
     ALU    : S3;        // any alu
-%}
-
-// Long ALU reg-reg operation
-pipe_class ialu_reg_reg_long_fat(rRegL dst, rRegL src)
-%{
-    instruction_count(2);
-    dst    : S4(write);
-    src    : S3(read);
-    D0     : S0(2);     // big decoder only; twice
-    ALU    : S3(2);     // both alus
 %}
 
 // Integer ALU reg-mem operation


### PR DESCRIPTION
/issue create hotspot/compiler

This is just removing some dead/unused code. More importantly, this is a test of the new "issue create" support in Skara.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253768](https://bugs.openjdk.java.net/browse/JDK-8253768): Deleting unused pipe_class definitions in adl-file (x86_64.ad).


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/74/head:pull/74`
`$ git checkout pull/74`
