### PR TITLE
8252916: Newline in object field values list of ScopeDesc should be removed

### DIFF
--- a/src/hotspot/share/code/debugInfo.cpp
+++ b/src/hotspot/share/code/debugInfo.cpp
@@ -276,7 +276,7 @@ void ConstantOopReadValue::print_on(outputStream* st) const {
   if (value()() != NULL) {
     value()()->print_value_on(st);
   } else {
-    st->print_cr("NULL");
+    st->print("NULL");
   }
 }
 


### PR DESCRIPTION
Given the following test:

```
public class Test {

    static class MyClass {
        Object o1 = null;
        Object o2 = new Integer(42);
    }

    static Object test(boolean trap) {
        MyClass obj = new MyClass();
        if (trap) { }
        return obj.o1;
    }

    public static void main(String[] args) {
        for (int i = 0; i < 100_000; ++i) {
            test(false);
        }
    }
}
```

The ScopeDesc for the uncommon trap in C2 compiled 'test' is printed like this:

```
ScopeDesc(pc=0x00007f52a5160144 offset=84):
   Test::test@9 (line 11) reexecute=true
   Locals
    - l0: empty
    - l1: obj[52]
   Expression stack
    - @0: reg rbp [10],int
   Objects
    - 52: Test$MyClass NULL
, stack[0],oop
```

There should be no newline after "NULL".

This is a regression from [JDK-8202171](https://bugs.openjdk.java.net/browse/JDK-8202171) in JDK 12. The fix is to no print a new line in to be consistent with 'print_value_on'.

Thanks,
Tobias
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252916](https://bugs.openjdk.java.net/browse/JDK-8252916): Newline in object field values list of ScopeDesc should be removed


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/75/head:pull/75`
`$ git checkout pull/75`
