### PR TITLE
8244505: G1 pause time ratio calculation does not consider Remark/Cleanup pauses

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,2 +1,30 @@
+[general]
 project=jdk
-bugids=dup
+jbs=JDK
+
+[checks]
+error=blacklist.author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace
+
+[repository]
+tags=(?:jdk-(?:[1-9]([0-9]*)(?:\\.(?:0|[1-9][0-9]*)){0,4})(?:\\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\\d{1,3})?-(?:(?:b\\d{2,3})|(?:ga)))|(?:hs\\d\\d(?:\\.\\d{1,2})?-b\\d\\d)
+branches=
+
+[census]
+version=0
+domain=openjdk.org
+
+[checks "whitespace"]
+files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java
+
+[checks "merge"]
+message=Merge
+
+[checks "reviewers"]
+reviewers=1
+ignore=duke
+
+[checks "committer"]
+role=committer
+
+[checks "issues"]
+pattern=^([124-8][0-9]{6}): (\S.*)$

--- a/src/hotspot/share/gc/g1/g1Analytics.cpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.cpp
@@ -98,8 +98,9 @@ G1Analytics::G1Analytics(const G1Predictions* predictor) :
     _short_term_pause_time_ratio(0.0) {
 
   // Seed sequences with initial values.
-  _recent_prev_end_times_for_all_gcs_sec->add(os::elapsedTime());
-  _prev_collection_pause_end_ms = os::elapsedTime() * 1000.0;
+  double time_sec = os::elapsedTime();
+  _recent_prev_end_times_for_all_gcs_sec->add(time_sec);
+  _prev_collection_pause_end_ms = time_sec * 1000.0;
 
   int index = MIN2(ParallelGCThreads - 1, 7u);
 
@@ -150,11 +151,19 @@ void G1Analytics::report_alloc_rate_ms(double alloc_rate) {
 }
 
 void G1Analytics::compute_pause_time_ratios(double end_time_sec, double pause_time_ms) {
+  // consider the most recent Remark and/or Cleanup pause time.
+  // look at append_prev_collection_pause_end_ms() for clues on why we use
+  // _prev_collection_pause_end_ms to determine the pause time
+  double most_recent_gc_end_ms =  most_recent_gc_end_time_sec() * 1000.0;
+  assert(_prev_collection_pause_end_ms >= most_recent_gc_end_ms, "should be");
+  double remark_cleanup_pause_ms = _prev_collection_pause_end_ms - most_recent_gc_end_ms;
+  pause_time_ms += remark_cleanup_pause_ms;
+
   double long_interval_ms = (end_time_sec - oldest_known_gc_end_time_sec()) * 1000.0;
-  _long_term_pause_time_ratio = _recent_gc_times_ms->sum() / long_interval_ms;
+  _long_term_pause_time_ratio = (_recent_gc_times_ms->sum() + pause_time_ms) / long_interval_ms;
   _long_term_pause_time_ratio = clamp(_long_term_pause_time_ratio, 0.0, 1.0);
 
-  double short_interval_ms = (end_time_sec - most_recent_gc_end_time_sec()) * 1000.0;
+  double short_interval_ms = (end_time_sec * 1000.0) - most_recent_gc_end_ms;
   _short_term_pause_time_ratio = pause_time_ms / short_interval_ms;
   _short_term_pause_time_ratio = clamp(_short_term_pause_time_ratio, 0.0, 1.0);
 }
@@ -317,6 +326,18 @@ double G1Analytics::most_recent_gc_end_time_sec() const {
 
 void G1Analytics::update_recent_gc_times(double end_time_sec,
                                          double pause_time_ms) {
+  // If a Remark and/or Cleanup pause happened leading up to this pause,
+  // piggy-back the Remark or Cleanup pause time onto this pause.
+  // Reason why we do not update_recent_gc_times at the end of Remark/Cleanup is
+  // that allocation rates are computed using recent_gc_times as checkpoints.
+  // Updating on Remark/Cleanup would introduce check points that didn't do any
+  // collections.
+  double most_recent_gc_end_ms =  most_recent_gc_end_time_sec() * 1000.0;
+  assert(_prev_collection_pause_end_ms >= most_recent_gc_end_time_ms, "should be");
+  double remark_cleanup_pause_ms = _prev_collection_pause_end_ms - most_recent_gc_end_ms;
+
+  pause_time_ms += remark_cleanup_pause_ms;
+
   _recent_gc_times_ms->add(pause_time_ms);
   _recent_prev_end_times_for_all_gcs_sec->add(end_time_sec);
   _prev_collection_pause_end_ms = end_time_sec * 1000.0;

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -415,7 +415,7 @@ void G1Policy::revise_young_list_target_length_if_necessary(size_t rs_length) {
 
   if (rs_length > _rs_length_prediction) {
     // add 10% to avoid having to recalculate often
-    size_t rs_length_prediction = rs_length * 1100 / 1000;
+    size_t rs_length_prediction = rs_length * 110 / 100;
     update_rs_length_prediction(rs_length_prediction);
 
     update_young_list_max_and_target_length(rs_length_prediction);
@@ -445,10 +445,7 @@ void G1Policy::record_full_collection_end() {
   // Consider this like a collection pause for the purposes of allocation
   // since last pause.
   double end_sec = os::elapsedTime();
-  double full_gc_time_sec = end_sec - _full_collection_start_sec;
-  double full_gc_time_ms = full_gc_time_sec * 1000.0;
-
-  _analytics->update_recent_gc_times(end_sec, full_gc_time_ms);
+  update_pause_time_stats(_full_collection_start_sec, end_sec);
 
   collector_state()->set_in_full_gc(false);
 
@@ -551,7 +548,7 @@ void G1Policy::record_collection_pause_start(double start_time_sec) {
   assert(_g1h->collection_set()->verify_young_ages(), "region age verification failed");
 }
 
-void G1Policy::record_concurrent_mark_init_end(double mark_init_elapsed_time_ms) {
+void G1Policy::record_concurrent_mark_init_end() {
   assert(!collector_state()->initiate_conc_mark_if_possible(), "we should have cleared it by now");
   collector_state()->set_in_concurrent_start_gc(false);
 }
@@ -640,20 +637,21 @@ void G1Policy::record_collection_pause_end(double pause_time_ms) {
   G1GCPhaseTimes* p = phase_times();
 
   double end_time_sec = os::elapsedTime();
+  double start_time_sec = phase_times()->cur_collection_start_sec();
 
   PauseKind this_pause = young_gc_pause_kind();
 
   bool update_stats = !_g1h->evacuation_failed();
 
-  record_pause(this_pause, end_time_sec - pause_time_ms / 1000.0, end_time_sec);
+  record_pause(this_pause, start_time_sec, end_time_sec);
 
   if (is_concurrent_start_pause(this_pause)) {
-    record_concurrent_mark_init_end(0.0);
+    record_concurrent_mark_init_end();
   } else {
     maybe_start_marking();
   }
 
-  double app_time_ms = (phase_times()->cur_collection_start_sec() * 1000.0 - _analytics->prev_collection_pause_end_ms());
+  double app_time_ms = (start_time_sec * 1000.0 - _analytics->prev_collection_pause_end_ms());
   if (app_time_ms < MIN_TIMER_GRANULARITY) {
     // This usually happens due to the timer not having the required
     // granularity. Some Linuxes are the usual culprits.
@@ -674,8 +672,7 @@ void G1Policy::record_collection_pause_end(double pause_time_ms) {
     double alloc_rate_ms = (double) regions_allocated / app_time_ms;
     _analytics->report_alloc_rate_ms(alloc_rate_ms);
 
-    _analytics->compute_pause_time_ratios(end_time_sec, pause_time_ms);
-    _analytics->update_recent_gc_times(end_time_sec, pause_time_ms);
+    update_pause_time_stats(start_time_sec, end_time_sec);
   }
 
   if (is_last_young_pause(this_pause)) {
@@ -1201,6 +1198,14 @@ G1Policy::PauseKind G1Policy::young_gc_pause_kind() const {
   }
 }
 
+void G1Policy::update_pause_time_stats(double start_time_sec, double end_time_sec){
+  double pause_time_sec = start_time_sec - end_time_sec;
+  double pause_time_ms = pause_time_sec * 1000.0;
+
+  _analytics->compute_pause_time_ratios(end_time_sec, pause_time_ms);
+  _analytics->update_recent_gc_times(end_time_sec, pause_time_ms);
+}
+
 void G1Policy::record_pause(PauseKind kind, double start, double end) {
   // Manage the MMU tracker. For some reason it ignores Full GCs.
   if (kind != FullGC) {
@@ -1270,11 +1275,9 @@ uint G1Policy::calc_min_old_cset_length() const {
 
   const size_t region_num = _collection_set->candidates()->num_regions();
   const size_t gc_num = (size_t) MAX2(G1MixedGCCountTarget, (uintx) 1);
-  size_t result = region_num / gc_num;
+
   // emulate ceiling
-  if (result * gc_num < region_num) {
-    result += 1;
-  }
+  size_t result = (region_num + gc_num -1) / gc_num;
   return (uint) result;
 }
 
@@ -1287,11 +1290,9 @@ uint G1Policy::calc_max_old_cset_length() const {
   const G1CollectedHeap* g1h = G1CollectedHeap::heap();
   const size_t region_num = g1h->num_regions();
   const size_t perc = (size_t) G1OldCSetRegionThresholdPercent;
-  size_t result = region_num * perc / 100;
+
   // emulate ceiling
-  if (100 * result < region_num * perc) {
-    result += 1;
-  }
+  size_t result = ((region_num * perc) + 99) / 100;
   return (uint) result;
 }
 

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -325,7 +325,7 @@ public:
   virtual void record_full_collection_end();
 
   // Must currently be called while the world is stopped.
-  void record_concurrent_mark_init_end(double mark_init_elapsed_time_ms);
+  void record_concurrent_mark_init_end();
 
   // Record start and end of remark.
   void record_concurrent_mark_remark_start();
@@ -439,6 +439,8 @@ public:
   void update_max_gc_locker_expansion();
 
   void update_survivors_policy();
+
+  void update_pause_time_stats(double start_sec, double end_sec);
 
   virtual bool force_upgrade_to_full() {
     return false;


### PR DESCRIPTION
The computation for long and short term pause time ratios does not include Remark/Cleanup pause times. The solution proposed is to piggy-back  Remark/Cleanup pause times to the collection pause which happens immediately after the Remark and/or Cleanup pause. Reason why we do not update_recent_gc_times at the end of Remark/Cleanup is that allocation rates are computed using recent_gc_times as checkpoints. With the assumption that collections have happened at these checkpoints. Updating on Remark/Cleanup would introduce check points that didn't do any collections.

Additionally, I also included refactoring clean up of the G1Policy class.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8244505](https://bugs.openjdk.java.net/browse/JDK-8244505): G1 pause time ratio calculation does not consider Remark/Cleanup pauses


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/76/head:pull/76`
`$ git checkout pull/76`
