### PR TITLE
8252830: Correct missing javadoc comments in java.rmi module

### DIFF
--- a/src/java.rmi/share/classes/java/rmi/activation/ActivationGroupDesc.java
+++ b/src/java.rmi/share/classes/java/rmi/activation/ActivationGroupDesc.java
@@ -90,6 +90,7 @@ public final class ActivationGroupDesc implements Serializable {
     private Properties props;
 
     /** indicate compatibility with the Java 2 SDK v1.2 version of class */
+    @java.io.Serial
     private static final long serialVersionUID = -4936225423168276595L;
 
     /**
@@ -204,6 +205,7 @@ public final class ActivationGroupDesc implements Serializable {
      * @since 1.2
      */
     public static class CommandEnvironment implements Serializable {
+        @java.io.Serial
         private static final long serialVersionUID = 6165754737887770191L;
 
         /**
@@ -318,6 +320,7 @@ public final class ActivationGroupDesc implements Serializable {
          * @throws ClassNotFoundException if a serialized class cannot be loaded
          *
          */
+        @java.io.Serial
         private void readObject(ObjectInputStream in)
             throws IOException, ClassNotFoundException
         {

--- a/src/java.rmi/share/classes/java/rmi/activation/ActivationGroupDesc.java
+++ b/src/java.rmi/share/classes/java/rmi/activation/ActivationGroupDesc.java
@@ -308,11 +308,15 @@ public final class ActivationGroupDesc implements Serializable {
          *
          * <p>This method reads this object's serialized form for this
          * class as follows:
-         *
          * <p>This method first invokes <code>defaultReadObject</code> on
          * the specified object input stream, and if <code>options</code>
          * is <code>null</code>, then <code>options</code> is set to a
          * zero-length array of <code>String</code>.
+         *
+         * @param  in the {@code ObjectInputStream} from which data is read
+         * @throws IOException if an I/O error occurs
+         * @throws ClassNotFoundException if a serialized class cannot be loaded
+         *
          */
         private void readObject(ObjectInputStream in)
             throws IOException, ClassNotFoundException

--- a/src/java.rmi/share/classes/java/rmi/activation/ActivationID.java
+++ b/src/java.rmi/share/classes/java/rmi/activation/ActivationID.java
@@ -90,6 +90,7 @@ public class ActivationID implements Serializable {
     private transient UID uid = new UID();
 
     /** indicate compatibility with the Java 2 SDK v1.2 version of class */
+    @java.io.Serial
     private static final long serialVersionUID = -4608673054848209235L;
 
     /** an AccessControlContext with no permissions */
@@ -296,6 +297,7 @@ public class ActivationID implements Serializable {
      * @throws ClassNotFoundException if a serialized class cannot be loaded
      *
      */
+    @java.io.Serial
     private void readObject(ObjectInputStream in)
         throws IOException, ClassNotFoundException
     {

--- a/src/java.rmi/share/classes/java/rmi/activation/ActivationID.java
+++ b/src/java.rmi/share/classes/java/rmi/activation/ActivationID.java
@@ -233,6 +233,7 @@ public class ActivationID implements Serializable {
      * @param  out the {@code ObjectOutputStream} to which data is written
      * @throws IOException if an I/O error occurs
      **/
+    @java.io.Serial
     private void writeObject(ObjectOutputStream out)
         throws IOException
     {

--- a/src/java.rmi/share/classes/java/rmi/activation/ActivationID.java
+++ b/src/java.rmi/share/classes/java/rmi/activation/ActivationID.java
@@ -228,6 +228,9 @@ public class ActivationID implements Serializable {
      * java.rmi.server.RemoteObject RemoteObject}
      * <code>writeObject</code> method <b>serialData</b>
      * specification.
+     *
+     * @param  out the {@code ObjectOutputStream} to which data is written
+     * @throws IOException if an I/O error occurs
      **/
     private void writeObject(ObjectOutputStream out)
         throws IOException
@@ -287,6 +290,11 @@ public class ActivationID implements Serializable {
      * class corresponding to that external ref type name, in which
      * case the <code>RemoteRef</code> will be an instance of
      * that implementation-specific class.
+     *
+     * @param  in the {@code ObjectInputStream} from which data is read
+     * @throws IOException if an I/O error occurs
+     * @throws ClassNotFoundException if a serialized class cannot be loaded
+     *
      */
     private void readObject(ObjectInputStream in)
         throws IOException, ClassNotFoundException

--- a/src/java.rmi/share/classes/java/rmi/server/RemoteObject.java
+++ b/src/java.rmi/share/classes/java/rmi/server/RemoteObject.java
@@ -48,6 +48,7 @@ public abstract class RemoteObject implements Remote, java.io.Serializable {
     transient protected RemoteRef ref;
 
     /** indicate compatibility with JDK 1.1.x version of class */
+    @java.io.Serial
     private static final long serialVersionUID = -3215090123894869218L;
 
     /**
@@ -362,6 +363,7 @@ public abstract class RemoteObject implements Remote, java.io.Serializable {
      * @param  out the {@code ObjectOutputStream} to which data is written
      * @throws IOException if an I/O error occurs
      */
+    @java.io.Serial
     private void writeObject(java.io.ObjectOutputStream out)
         throws java.io.IOException
     {
@@ -427,6 +429,7 @@ public abstract class RemoteObject implements Remote, java.io.Serializable {
      * @throws IOException if an I/O error occurs
      * @throws ClassNotFoundException if a serialized class cannot be loaded
      */
+    @java.io.Serial
     private void readObject(java.io.ObjectInputStream in)
         throws java.io.IOException, java.lang.ClassNotFoundException
     {

--- a/src/java.rmi/share/classes/java/rmi/server/RemoteObject.java
+++ b/src/java.rmi/share/classes/java/rmi/server/RemoteObject.java
@@ -25,6 +25,7 @@
 
 package java.rmi.server;
 
+import java.io.IOException;
 import java.rmi.Remote;
 import java.rmi.NoSuchObjectException;
 import java.lang.reflect.Proxy;
@@ -357,6 +358,9 @@ public abstract class RemoteObject implements Remote, java.io.Serializable {
      * <code>"UnicastServerRef2"</code>, no data is written by the
      * <code>writeExternal</code> method or read by the
      * <code>readExternal</code> method.
+     *
+     * @param  out the {@code ObjectOutputStream} to which data is written
+     * @throws IOException if an I/O error occurs
      */
     private void writeObject(java.io.ObjectOutputStream out)
         throws java.io.IOException
@@ -418,6 +422,10 @@ public abstract class RemoteObject implements Remote, java.io.Serializable {
      * class corresponding to that external ref type name, in which
      * case this object's <code>ref</code> field will be set to an
      * instance of that implementation-specific class.
+     *
+     * @param  in the {@code ObjectInputStream} from which data is read
+     * @throws IOException if an I/O error occurs
+     * @throws ClassNotFoundException if a serialized class cannot be loaded
      */
     private void readObject(java.io.ObjectInputStream in)
         throws java.io.IOException, java.lang.ClassNotFoundException

--- a/src/java.rmi/share/classes/java/rmi/server/UnicastRemoteObject.java
+++ b/src/java.rmi/share/classes/java/rmi/server/UnicastRemoteObject.java
@@ -24,6 +24,7 @@
  */
 package java.rmi.server;
 
+import java.io.IOException;
 import java.io.ObjectInputFilter;
 import java.rmi.*;
 import sun.rmi.server.UnicastServerRef;
@@ -259,6 +260,11 @@ public class UnicastRemoteObject extends RemoteServer {
 
     /**
      * Re-export the remote object when it is deserialized.
+     *
+     * @param  in the {@code ObjectInputStream} from which data is read
+     * @throws IOException if an I/O error occurs
+     * @throws ClassNotFoundException if a serialized class cannot be loaded
+     *
      */
     private void readObject(java.io.ObjectInputStream in)
         throws java.io.IOException, java.lang.ClassNotFoundException

--- a/src/java.rmi/share/classes/java/rmi/server/UnicastRemoteObject.java
+++ b/src/java.rmi/share/classes/java/rmi/server/UnicastRemoteObject.java
@@ -196,6 +196,7 @@ public class UnicastRemoteObject extends RemoteServer {
     private RMIServerSocketFactory ssf = null;
 
     /* indicate compatibility with JDK 1.1.x version of class */
+    @java.io.Serial
     private static final long serialVersionUID = 4974527148936298033L;
 
     /**
@@ -266,6 +267,7 @@ public class UnicastRemoteObject extends RemoteServer {
      * @throws ClassNotFoundException if a serialized class cannot be loaded
      *
      */
+    @java.io.Serial
     private void readObject(java.io.ObjectInputStream in)
         throws java.io.IOException, java.lang.ClassNotFoundException
     {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252830](https://bugs.openjdk.java.net/browse/JDK-8252830): Correct missing javadoc comments in java.rmi module


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/79/head:pull/79`
`$ git checkout pull/79`
