### PR TITLE
8251496: Fix doclint warnings in jdk.net.httpserver

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
@@ -65,7 +65,7 @@ public abstract class Authenticator {
          * Creates a {@code Failure} instance with given response code.
          *
          * @param responseCode The response code to associate with this
-         *                     {@code Failure} instance.
+         *                     {@code Failure} instance
          */
         public Failure (int responseCode) {
             this.responseCode = responseCode;
@@ -74,7 +74,7 @@ public abstract class Authenticator {
         /**
          * returns the response code to send to the client
          *
-         * @return The response code associated with this {@code Failure} instance.
+         * @return The response code associated with this {@code Failure} instance
          */
         public int getResponseCode() {
             return responseCode;
@@ -90,9 +90,9 @@ public abstract class Authenticator {
         private HttpPrincipal principal;
 
         /**
-         * Creates a {@code Success} instance with given Principal.
+         * Creates a {@code Success} instance with given {@code Principal}.
          *
-         * @param p The authenticated user you wish to set as Principal.
+         * @param p The authenticated user you wish to set as Principal
          */
         public Success (HttpPrincipal p) {
             principal = p;
@@ -100,7 +100,7 @@ public abstract class Authenticator {
         /**
          * returns the authenticated user Principal
          *
-         * @return The {@code Principal} instance associated with the authenticated user.
+         * @return The {@code Principal} instance associated with the authenticated user
          *
          */
         public HttpPrincipal getPrincipal() {
@@ -123,7 +123,7 @@ public abstract class Authenticator {
          * Creates a {@code Retry} instance with given response code.
          *
          * @param responseCode The response code to associate with this
-         *                     {@code Retry} instance.
+         *                     {@code Retry} instance
          */
         public Retry (int responseCode) {
             this.responseCode = responseCode;
@@ -132,7 +132,7 @@ public abstract class Authenticator {
         /**
          * returns the response code to send to the client
          *
-         * @return The response code associated with this {@code Retry} instance.
+         * @return The response code associated with this {@code Retry} instance
          */
         public int getResponseCode() {
             return responseCode;
@@ -155,8 +155,8 @@ public abstract class Authenticator {
      * given HttpExchange. The response code to be returned must be provided
      * in the Retry object. Retry may occur multiple times.
      *
-     * @param exch The HttpExchange upon which authenticate is called.
-     * @return The result.
+     * @param exch The HttpExchange upon which authenticate is called
+     * @return The result
      */
     public abstract Result authenticate (HttpExchange exch);
 }

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,6 @@
  */
 
 package com.sun.net.httpserver;
-import java.net.*;
-import java.io.*;
-import java.util.*;
 
 /**
  * Authenticator represents an implementation of an HTTP authentication
@@ -39,9 +36,22 @@ import java.util.*;
 public abstract class Authenticator {
 
     /**
+     * Constructor for subclasses to call.
+     */
+    protected Authenticator () { }
+
+    /**
      * Base class for return type from authenticate() method
      */
-    public abstract static class Result {}
+    public abstract static class Result {
+
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected Result () {}
+    }
+
+
 
     /**
      * Indicates an authentication failure. The authentication
@@ -51,12 +61,20 @@ public abstract class Authenticator {
 
         private int responseCode;
 
+        /**
+         * Creates a {@code Failure} instance with given response code.
+         *
+         * @param responseCode The response code to associate with this
+         *                     {@code Failure} instance.
+         */
         public Failure (int responseCode) {
             this.responseCode = responseCode;
         }
 
         /**
          * returns the response code to send to the client
+         *
+         * @return The response code associated with this {@code Failure} instance.
          */
         public int getResponseCode() {
             return responseCode;
@@ -71,11 +89,19 @@ public abstract class Authenticator {
     public static class Success extends Result {
         private HttpPrincipal principal;
 
+        /**
+         * Creates a {@code Success} instance with given Principal.
+         *
+         * @param p The authenticated user you wish to set as Principal.
+         */
         public Success (HttpPrincipal p) {
             principal = p;
         }
         /**
          * returns the authenticated user Principal
+         *
+         * @return The {@code Principal} instance associated with the authenticated user.
+         *
          */
         public HttpPrincipal getPrincipal() {
             return principal;
@@ -93,12 +119,20 @@ public abstract class Authenticator {
 
         private int responseCode;
 
+        /**
+         * Creates a {@code Retry} instance with given response code.
+         *
+         * @param responseCode The response code to associate with this
+         *                     {@code Retry} instance.
+         */
         public Retry (int responseCode) {
             this.responseCode = responseCode;
         }
 
         /**
          * returns the response code to send to the client
+         *
+         * @return The response code associated with this {@code Retry} instance.
          */
         public int getResponseCode() {
             return responseCode;
@@ -120,6 +154,9 @@ public abstract class Authenticator {
      * headers needing to be sent back to the client are set in the
      * given HttpExchange. The response code to be returned must be provided
      * in the Retry object. Retry may occur multiple times.
+     *
+     * @param exch The HttpExchange upon which authenticate is called.
+     * @return The result.
      */
     public abstract Result authenticate (HttpExchange exch);
 }

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
@@ -39,6 +39,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public abstract class BasicAuthenticator extends Authenticator {
 
+    /** The HTTP Basic authentication realm. */
     protected final String realm;
     private final Charset charset;
     private final boolean isUTF8;

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Filter.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Filter.java
@@ -42,7 +42,7 @@ import java.util.*;
 public abstract class Filter {
 
     /**
-     * Creates a Filter.
+     * Constructor for subclasses to call.
      */
     protected Filter () {}
 
@@ -61,9 +61,9 @@ public abstract class Filter {
         /**
          * Creates a {@code Chain} instance with given filters and handler.
          *
-         * @param filters The filters that make up the Chain.
+         * @param filters The filters that make up the Chain
          * @param handler The HttpHandler that will be invoked after the final
-         *                Filter has finished.
+         *                Filter has finished
          */
         public Chain (List<Filter> filters, HttpHandler handler) {
             iter = filters.listIterator();

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Filter.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Filter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,9 @@ import java.util.*;
  */
 public abstract class Filter {
 
+    /**
+     * Creates a Filter.
+     */
     protected Filter () {}
 
     /**
@@ -55,6 +58,13 @@ public abstract class Filter {
         private ListIterator<Filter> iter;
         private HttpHandler handler;
 
+        /**
+         * Creates a {@code Chain} instance with given filters and handler.
+         *
+         * @param filters The filters that make up the Chain.
+         * @param handler The HttpHandler that will be invoked after the final
+         *                Filter has finished.
+         */
         public Chain (List<Filter> filters, HttpHandler handler) {
             iter = filters.listIterator();
             this.handler = handler;

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Headers.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Headers.java
@@ -65,6 +65,9 @@ public class Headers implements Map<String,List<String>> {
 
         HashMap<String,List<String>> map;
 
+        /**
+        * Creates an empty instance of Headers.
+        */
         public Headers () {map = new HashMap<String,List<String>>(32);}
 
         /* Normalize the key by converting to following form.

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Headers.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Headers.java
@@ -65,7 +65,7 @@ public class Headers implements Map<String,List<String>> {
 
         HashMap<String,List<String>> map;
 
-        /**
+       /**
         * Creates an empty instance of Headers.
         */
         public Headers () {map = new HashMap<String,List<String>>(32);}

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpContext.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,8 @@
  */
 
 package com.sun.net.httpserver;
-import java.net.*;
-import java.io.*;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 
 /**
  * HttpContext represents a mapping between the root URI path of an application
@@ -42,6 +41,9 @@ import java.util.*;
  */
 public abstract class HttpContext {
 
+    /**
+     * Creates a HttpContext.
+     */
     protected HttpContext () {
     }
 
@@ -78,6 +80,8 @@ public abstract class HttpContext {
      * <p>
      * Every attribute stored in this Map will be visible to
      * every HttpExchange processed by this context
+     *
+     * @return a map containing the attributes of this context.
      */
     public abstract Map<String,Object> getAttributes() ;
 

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpContext.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpContext.java
@@ -42,7 +42,7 @@ import java.util.Map;
 public abstract class HttpContext {
 
     /**
-     * Creates a HttpContext.
+     * Constructor for subclasses to call.
      */
     protected HttpContext () {
     }
@@ -81,7 +81,7 @@ public abstract class HttpContext {
      * Every attribute stored in this Map will be visible to
      * every HttpExchange processed by this context
      *
-     * @return a map containing the attributes of this context.
+     * @return a map containing the attributes of this context
      */
     public abstract Map<String,Object> getAttributes() ;
 

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -188,8 +188,6 @@ public abstract class HttpExchange implements AutoCloseable {
      *        and an arbitrary number of bytes may be written.
      *        if {@literal <= -1}, then no response body length is specified and
      *        no response body may be written.
-     * @throws IOException An IOException will be thrown if an error occurs during
-     *         the sending of response headers, or if headers have already been sent
      * @see HttpExchange#getResponseBody()
      */
     public abstract void sendResponseHeaders (int rCode, long responseLength) throws IOException ;

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,11 @@
 
 package com.sun.net.httpserver;
 
-import java.io.*;
-import java.nio.*;
-import java.nio.channels.*;
-import java.net.*;
-import javax.net.ssl.*;
-import java.util.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
 
 /**
  * This class encapsulates a HTTP request received and a
@@ -66,6 +65,9 @@ import java.util.*;
 
 public abstract class HttpExchange implements AutoCloseable {
 
+    /**
+     * Creates a HttpExchange.
+     */
     protected HttpExchange () {
     }
 
@@ -186,6 +188,8 @@ public abstract class HttpExchange implements AutoCloseable {
      *        and an arbitrary number of bytes may be written.
      *        if {@literal <= -1}, then no response body length is specified and
      *        no response body may be written.
+     * @throws IOException An IOException will be thrown if an error occurs during
+     *         the sending of response headers, or if headers have already been sent.
      * @see HttpExchange#getResponseBody()
      */
     public abstract void sendResponseHeaders (int rCode, long responseLength) throws IOException ;

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -66,7 +66,7 @@ import java.net.URI;
 public abstract class HttpExchange implements AutoCloseable {
 
     /**
-     * Creates a HttpExchange.
+     * Constructor for subclasses to call.
      */
     protected HttpExchange () {
     }
@@ -189,7 +189,7 @@ public abstract class HttpExchange implements AutoCloseable {
      *        if {@literal <= -1}, then no response body length is specified and
      *        no response body may be written.
      * @throws IOException An IOException will be thrown if an error occurs during
-     *         the sending of response headers, or if headers have already been sent.
+     *         the sending of response headers, or if headers have already been sent
      * @see HttpExchange#getResponseBody()
      */
     public abstract void sendResponseHeaders (int rCode, long responseLength) throws IOException ;

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpPrincipal.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpPrincipal.java
@@ -73,7 +73,7 @@ public class HttpPrincipal implements Principal {
     /**
      * returns the username this object was created with.
      *
-     * @returns The name of the user assoicated with this object.
+     * @return The name of the user assoicated with this object
      */
     public String getUsername() {
         return username;
@@ -82,7 +82,7 @@ public class HttpPrincipal implements Principal {
     /**
      * returns the realm this object was created with.
      *
-     * @returns The realm associated with this object.
+     * @return The realm associated with this object
      */
     public String getRealm() {
         return realm;

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpPrincipal.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,6 @@
  */
 
 package com.sun.net.httpserver;
-import java.net.*;
-import java.io.*;
-import java.util.*;
 import java.security.Principal;
 
 /**
@@ -75,6 +72,8 @@ public class HttpPrincipal implements Principal {
 
     /**
      * returns the username this object was created with.
+     *
+     * @returns The name of the user assoicated with this object.
      */
     public String getUsername() {
         return username;
@@ -82,6 +81,8 @@ public class HttpPrincipal implements Principal {
 
     /**
      * returns the realm this object was created with.
+     *
+     * @returns The realm associated with this object.
      */
     public String getRealm() {
         return realm;

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpServer.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpServer.java
@@ -105,7 +105,7 @@ public abstract class HttpServer {
      * The HttpServer is acquired from the currently installed {@link HttpServerProvider}
      * The server must be bound using {@link #bind(InetSocketAddress,int)} before it can be used.
      *
-     * @throws IOException if I/O error occurs
+     * @throws IOException if an I/O error occurs
      * @return An instance of HttpServer
      */
     public static HttpServer create () throws IOException {
@@ -127,7 +127,7 @@ public abstract class HttpServer {
      *          then a system default value is used.
      * @throws BindException if the server cannot bind to the requested address,
      *          or if the server is already bound.
-     * @throws IOException if I/O error occurs.
+     * @throws IOException if an I/O error occurs
      * @return An instance of HttpServer
      */
 
@@ -241,7 +241,7 @@ public abstract class HttpServer {
      * @throws IllegalArgumentException if path is invalid, or if a context
      *          already exists for this path
      * @throws NullPointerException if path is <code>null</code>
-     * @return An instance of HttpContext.
+     * @return An instance of HttpContext
      */
     public abstract HttpContext createContext (String path) ;
 

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpServer.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,12 @@
 
 package com.sun.net.httpserver;
 
-import java.net.*;
-import java.io.*;
-import java.nio.*;
-import java.security.*;
-import java.nio.channels.*;
-import java.util.*;
-import java.util.concurrent.*;
-import javax.net.ssl.*;
 import com.sun.net.httpserver.spi.HttpServerProvider;
+
+import java.io.IOException;
+import java.net.BindException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.Executor;
 
 /**
  * This class implements a simple HTTP server. A HttpServer is bound to an IP address
@@ -98,6 +95,7 @@ import com.sun.net.httpserver.spi.HttpServerProvider;
 public abstract class HttpServer {
 
     /**
+     * Constructor for subclasses to call.
      */
     protected HttpServer () {
     }
@@ -106,7 +104,9 @@ public abstract class HttpServer {
      * creates a HttpServer instance which is initially not bound to any local address/port.
      * The HttpServer is acquired from the currently installed {@link HttpServerProvider}
      * The server must be bound using {@link #bind(InetSocketAddress,int)} before it can be used.
-     * @throws IOException
+     *
+     * @throws IOException if I/O error occurs
+     * @return An instance of HttpServer
      */
     public static HttpServer create () throws IOException {
         return create (null, 0);
@@ -127,7 +127,8 @@ public abstract class HttpServer {
      *          then a system default value is used.
      * @throws BindException if the server cannot bind to the requested address,
      *          or if the server is already bound.
-     * @throws IOException
+     * @throws IOException if I/O error occurs.
+     * @return An instance of HttpServer
      */
 
     public static HttpServer create (
@@ -215,6 +216,7 @@ public abstract class HttpServer {
      * @throws IllegalArgumentException if path is invalid, or if a context
      *          already exists for this path
      * @throws NullPointerException if either path, or handler are <code>null</code>
+     * @return An instance of HttpContext
      */
     public abstract HttpContext createContext (String path, HttpHandler handler) ;
 
@@ -239,6 +241,7 @@ public abstract class HttpServer {
      * @throws IllegalArgumentException if path is invalid, or if a context
      *          already exists for this path
      * @throws NullPointerException if path is <code>null</code>
+     * @return An instance of HttpContext.
      */
     public abstract HttpContext createContext (String path) ;
 

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpsParameters.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpsParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,10 @@
  */
 
 package com.sun.net.httpserver;
-import java.net.InetSocketAddress;
-//BEGIN_TIGER_EXCLUDE
 import javax.net.ssl.SSLParameters;
+import java.net.InetSocketAddress;
+
+//BEGIN_TIGER_EXCLUDE
 //END_TIGER_EXCLUDE
 
 /**
@@ -56,16 +57,23 @@ public abstract class HttpsParameters {
     private boolean wantClientAuth;
     private boolean needClientAuth;
 
+    /**
+     * Creates a HttpsParameters.
+     */
     protected HttpsParameters() {}
 
     /**
      * Returns the HttpsConfigurator for this HttpsParameters.
+     *
+     * @returns HttpsConfigurator for this instance of HttpsParameters.
      */
     public abstract HttpsConfigurator getHttpsConfigurator();
 
     /**
      * Returns the address of the remote client initiating the
      * connection.
+     *
+     * @returns Address of the remote client initiating the connection.
      */
     public abstract InetSocketAddress getClientAddress();
 

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpsParameters.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpsParameters.java
@@ -24,10 +24,11 @@
  */
 
 package com.sun.net.httpserver;
-import javax.net.ssl.SSLParameters;
+
 import java.net.InetSocketAddress;
 
 //BEGIN_TIGER_EXCLUDE
+import javax.net.ssl.SSLParameters;
 //END_TIGER_EXCLUDE
 
 /**
@@ -58,14 +59,14 @@ public abstract class HttpsParameters {
     private boolean needClientAuth;
 
     /**
-     * Creates a HttpsParameters.
+     * Constructor for subclasses to call.
      */
     protected HttpsParameters() {}
 
     /**
      * Returns the HttpsConfigurator for this HttpsParameters.
      *
-     * @returns HttpsConfigurator for this instance of HttpsParameters.
+     * @return HttpsConfigurator for this instance of HttpsParameters
      */
     public abstract HttpsConfigurator getHttpsConfigurator();
 
@@ -73,7 +74,7 @@ public abstract class HttpsParameters {
      * Returns the address of the remote client initiating the
      * connection.
      *
-     * @returns Address of the remote client initiating the connection.
+     * @return Address of the remote client initiating the connection
      */
     public abstract InetSocketAddress getClientAddress();
 

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/spi/HttpServerProvider.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/spi/HttpServerProvider.java
@@ -52,7 +52,7 @@ public abstract class HttpServerProvider {
      *
      * @param  backlog
      *         the socket backlog. A value of {@code zero} means the systems default
-     * @throws IOException if I/O error occurs.
+     * @throws IOException if an I/O error occurs
      * @return An instance of HttpServer
      */
     public abstract HttpServer createHttpServer(InetSocketAddress addr,
@@ -67,7 +67,7 @@ public abstract class HttpServerProvider {
      *
      * @param  backlog
      *         the socket backlog. A value of {@code zero} means the systems default
-     * @throws IOException if I/O error occurs.
+     * @throws IOException if an I/O error occurs
      * @return An instance of HttpServer
      */
     public abstract HttpsServer createHttpsServer(InetSocketAddress addr,

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/spi/HttpServerProvider.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/spi/HttpServerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,16 @@
 
 package com.sun.net.httpserver.spi;
 
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpsServer;
+
 import java.io.IOException;
-import java.net.*;
+import java.net.InetSocketAddress;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Iterator;
-import java.util.ServiceLoader;
 import java.util.ServiceConfigurationError;
-import com.sun.net.httpserver.*;
+import java.util.ServiceLoader;
 
 /**
  * Service provider class for HttpServer.
@@ -50,6 +52,8 @@ public abstract class HttpServerProvider {
      *
      * @param  backlog
      *         the socket backlog. A value of {@code zero} means the systems default
+     * @throws IOException if I/O error occurs.
+     * @return An instance of HttpServer
      */
     public abstract HttpServer createHttpServer(InetSocketAddress addr,
                                                 int backlog)
@@ -63,6 +67,8 @@ public abstract class HttpServerProvider {
      *
      * @param  backlog
      *         the socket backlog. A value of {@code zero} means the systems default
+     * @throws IOException if I/O error occurs.
+     * @return An instance of HttpServer
      */
     public abstract HttpsServer createHttpsServer(InetSocketAddress addr,
                                                   int backlog)

--- a/test/jdk/com/sun/net/httpserver/AuthenticatorTest
+++ b/test/jdk/com/sun/net/httpserver/AuthenticatorTest
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8251496
+ * @summary Tests for methods in Authenticator
+ * @run testng/othervm AuthenticatorTest
+ */
+
+import com.sun.net.httpserver.Authenticator;
+import com.sun.net.httpserver.BasicAuthenticator;
+import com.sun.net.httpserver.HttpPrincipal;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class AuthenticatorTest {
+    @Test
+    public void testFailure() {
+        var failureResult = new Authenticator.Failure(666);
+        assertEquals(failureResult.getResponseCode(), 666);
+    }
+
+    @Test
+    public void testRetry() {
+        var retryResult = new Authenticator.Retry(333);
+        assertEquals(retryResult.getResponseCode(), 333);
+    }
+
+    @Test
+    public void TestSuccess() {
+        var principal = new HttpPrincipal("test", "123");
+        var successResult = new Authenticator.Success(principal);
+        assertEquals(successResult.getPrincipal(), principal);
+        assertEquals("test", principal.getName());
+        assertEquals("123", principal.getRealm());
+    }
+}

--- a/test/jdk/com/sun/net/httpserver/CreateHttpServerTest.java
+++ b/test/jdk/com/sun/net/httpserver/CreateHttpServerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8251496
+ * @summary summary
+ * @run testng/othervm CreateHttpServerTest
+ */
+
+import com.sun.net.httpserver.HttpServer;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import static org.testng.Assert.assertTrue;
+
+public class CreateHttpServerTest {
+    @Test
+    public void TestCreate() throws IOException {
+        var server = HttpServer.create();
+        assertTrue(server instanceof HttpServer);
+    }
+    @Test
+    public void TestCreateWithParameters() throws IOException {
+        var addr = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        var server = HttpServer.create(addr, 123);
+        assertTrue(server instanceof HttpServer);
+    }
+}

--- a/test/jdk/com/sun/net/httpserver/HeadersTest.java
+++ b/test/jdk/com/sun/net/httpserver/HeadersTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8251496
+ * @summary Tests for methods in Headers class
+ * @run testng/othervm HeadersTest
+ */
+
+import com.sun.net.httpserver.Headers;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+public class HeadersTest {
+
+    @Test
+    public void TestDefaultConstructor() {
+        var headers = new Headers();
+        assertTrue(headers.isEmpty());
+    }
+}

--- a/test/jdk/com/sun/net/httpserver/HttpPrincipalTest.java
+++ b/test/jdk/com/sun/net/httpserver/HttpPrincipalTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8251496
+ * @summary Tests for methods in HttpPrincipal
+ * @run testng/othervm HttpPrincipalTest
+ */
+
+import com.sun.net.httpserver.HttpPrincipal;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class HttpPrincipalTest {
+
+    @Test
+    public void TestGetters() {
+        var principal = new HttpPrincipal("test", "123");
+        assertEquals(principal.getUsername(), "test");
+        assertEquals(principal.getRealm(), "123");
+    }
+}


### PR DESCRIPTION
Hi,

Could someone please review my doc-only fix for JDK-8251496 - ‘Fix doclint warnings in jdk.net.httpserver’ ?

This fix addresses the warnings generated by `javadoc -Xdoclint` due to missing/incomplete API documentation for several classes within `jdk.net.httpserver`. 

Kind regards,
Patrick
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251496](https://bugs.openjdk.java.net/browse/JDK-8251496): Fix doclint warnings in jdk.net.httpserver


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/81/head:pull/81`
`$ git checkout pull/81`
