### PR TITLE
8249625: cleanup unused SkippedException in the tests under cds/appcds/dynamicArchive/methodHandles

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/CDSMHTest_generate.sh
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/CDSMHTest_generate.sh
@@ -80,10 +80,6 @@ import org.junit.Test;
 
 import java.io.File;
 
-import jtreg.SkippedException;
-
-import sun.hotspot.gc.GC;
-
 public class $i extends DynamicArchiveTestBase {
     @Test
     public void test() throws Exception {
@@ -96,7 +92,6 @@ public class $i extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "$i";
-    private static final String skippedException = "jtreg.SkippedException: Unable to map shared archive: test did not complete";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesAsCollectorTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesAsCollectorTest.java
@@ -48,10 +48,6 @@ import org.junit.Test;
 
 import java.io.File;
 
-import jtreg.SkippedException;
-
-import sun.hotspot.gc.GC;
-
 public class MethodHandlesAsCollectorTest extends DynamicArchiveTestBase {
     @Test
     public void test() throws Exception {
@@ -64,7 +60,6 @@ public class MethodHandlesAsCollectorTest extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "MethodHandlesAsCollectorTest";
-    private static final String skippedException = "jtreg.SkippedException: Unable to map shared archive: test did not complete";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesCastFailureTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesCastFailureTest.java
@@ -48,10 +48,6 @@ import org.junit.Test;
 
 import java.io.File;
 
-import jtreg.SkippedException;
-
-import sun.hotspot.gc.GC;
-
 public class MethodHandlesCastFailureTest extends DynamicArchiveTestBase {
     @Test
     public void test() throws Exception {
@@ -64,7 +60,6 @@ public class MethodHandlesCastFailureTest extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "MethodHandlesCastFailureTest";
-    private static final String skippedException = "jtreg.SkippedException: Unable to map shared archive: test did not complete";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesGeneralTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesGeneralTest.java
@@ -48,10 +48,6 @@ import org.junit.Test;
 
 import java.io.File;
 
-import jtreg.SkippedException;
-
-import sun.hotspot.gc.GC;
-
 public class MethodHandlesGeneralTest extends DynamicArchiveTestBase {
     @Test
     public void test() throws Exception {
@@ -64,7 +60,6 @@ public class MethodHandlesGeneralTest extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "MethodHandlesGeneralTest";
-    private static final String skippedException = "jtreg.SkippedException: Unable to map shared archive: test did not complete";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesInvokersTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesInvokersTest.java
@@ -48,10 +48,6 @@ import org.junit.Test;
 
 import java.io.File;
 
-import jtreg.SkippedException;
-
-import sun.hotspot.gc.GC;
-
 public class MethodHandlesInvokersTest extends DynamicArchiveTestBase {
     @Test
     public void test() throws Exception {
@@ -64,7 +60,6 @@ public class MethodHandlesInvokersTest extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "MethodHandlesInvokersTest";
-    private static final String skippedException = "jtreg.SkippedException: Unable to map shared archive: test did not complete";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesPermuteArgumentsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesPermuteArgumentsTest.java
@@ -48,10 +48,6 @@ import org.junit.Test;
 
 import java.io.File;
 
-import jtreg.SkippedException;
-
-import sun.hotspot.gc.GC;
-
 public class MethodHandlesPermuteArgumentsTest extends DynamicArchiveTestBase {
     @Test
     public void test() throws Exception {
@@ -64,7 +60,6 @@ public class MethodHandlesPermuteArgumentsTest extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "MethodHandlesPermuteArgumentsTest";
-    private static final String skippedException = "jtreg.SkippedException: Unable to map shared archive: test did not complete";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesSpreadArgumentsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesSpreadArgumentsTest.java
@@ -48,10 +48,6 @@ import org.junit.Test;
 
 import java.io.File;
 
-import jtreg.SkippedException;
-
-import sun.hotspot.gc.GC;
-
 public class MethodHandlesSpreadArgumentsTest extends DynamicArchiveTestBase {
     @Test
     public void test() throws Exception {
@@ -64,7 +60,6 @@ public class MethodHandlesSpreadArgumentsTest extends DynamicArchiveTestBase {
     private static final String ps = System.getProperty("path.separator");
     private static final String testPackageName = "test.java.lang.invoke";
     private static final String testClassName = "MethodHandlesSpreadArgumentsTest";
-    private static final String skippedException = "jtreg.SkippedException: Unable to map shared archive: test did not complete";
 
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();


### PR DESCRIPTION
A simple fix to remove two unused import statements and a line of unneeded code from the tests in appcds/dynamicArchive/methodHandles.

Tested locally on linux-x64.
Running mach5 tiers 1 and 2 tests.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249625](https://bugs.openjdk.java.net/browse/JDK-8249625): cleanup unused SkippedException in the tests under cds/appcds/dynamicArchive/methodHandles


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/83/head:pull/83`
`$ git checkout pull/83`
