### PR TITLE
use gappinfo instead of gvfs for detecting actions

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk2_interface.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk2_interface.h
@@ -51,7 +51,7 @@ typedef enum
 
 /* We define all structure pointers to be void* */
 typedef void GMainContext;
-typedef void GVfs;
+typedef void GAppInfo;
 
 typedef void GdkColormap;
 typedef void GdkDrawable;

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
@@ -135,9 +135,7 @@ do {                                                                           \
 
 
 static void update_supported_actions(JNIEnv *env) {
-    GVfs * (*fp_g_vfs_get_default) (void);
-    const gchar * const * (*fp_g_vfs_get_supported_uri_schemes) (GVfs * vfs);
-    const gchar * const * schemes = NULL;
+    GAppInfo * (*fp_g_app_info_get_default_for_uri_scheme) (const gchar *);
 
     jclass cls_action = (*env)->FindClass(env, "java/awt/Desktop$Action");
     CHECK_NULL(cls_action);
@@ -163,39 +161,17 @@ static void update_supported_actions(JNIEnv *env) {
 
     ADD_SUPPORTED_ACTION("OPEN");
 
-    /**
-     * gtk_show_uri() documentation says:
-     *
-     * > you need to install gvfs to get support for uri schemes such as http://
-     * > or ftp://, as only local files are handled by GIO itself.
-     *
-     * So OPEN action was safely added here.
-     * However, it looks like Solaris 11 have gvfs support only for 32-bit
-     * applications only by default.
-     */
-
-    fp_g_vfs_get_default = dl_symbol("g_vfs_get_default");
-    fp_g_vfs_get_supported_uri_schemes =
-                           dl_symbol("g_vfs_get_supported_uri_schemes");
+    fp_g_app_info_get_default_for_uri_scheme = dl_symbol("g_app_info_get_default_for_uri_scheme");
     dlerror();
 
-    if (fp_g_vfs_get_default && fp_g_vfs_get_supported_uri_schemes) {
-        GVfs * vfs = fp_g_vfs_get_default();
-        schemes = vfs ? fp_g_vfs_get_supported_uri_schemes(vfs) : NULL;
-        if (schemes) {
-            int i = 0;
-            while (schemes[i]) {
-                if (strcmp(schemes[i], "http") == 0) {
-                    ADD_SUPPORTED_ACTION("BROWSE");
-                    ADD_SUPPORTED_ACTION("MAIL");
-                    break;
-                }
-                i++;
-            }
+    if (fp_g_app_info_get_default_for_uri_scheme) {
+        if (fp_g_app_info_get_default_for_uri_scheme("http")) {
+            ADD_SUPPORTED_ACTION("BROWSE");
+            ADD_SUPPORTED_ACTION("MAIL");
         }
     } else {
 #ifdef DEBUG
-        fprintf(stderr, "Cannot load g_vfs_get_supported_uri_schemes\n");
+        fprintf(stderr, "Cannot load g_app_info_get_default_for_uri_scheme\n");
 #endif /* DEBUG */
     }
 

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
@@ -177,7 +177,7 @@ typedef enum _cairo_status {
 /* We define all structure pointers to be void* */
 typedef void GdkPixbuf;
 typedef void GMainContext;
-typedef void GVfs;
+typedef void GAppInfo;
 
 typedef void GdkColormap;
 typedef void GdkDrawable;


### PR DESCRIPTION
gtk_show_uri uses gappinfo, not gvfs. see https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/2359

this fixes Desktop.browse for systems without gvfs installed. this
doesn't accurately reflect systems which use libgnome gnome_url_show,
but gtk_show_uri should be used on all modern GNOME systems anyways.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/84/head:pull/84`
`$ git checkout pull/84`
