### PR TITLE
8171303: sun/java2d/pipe/InterpolationQualityTest.java fails on Windows & Linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -272,7 +272,6 @@ sun/java2d/SunGraphics2D/PolyVertTest.java 6986565 generic-all
 sun/java2d/SunGraphics2D/SimplePrimQuality.java 6992007 generic-all
 sun/java2d/SunGraphics2D/SourceClippingBlitTest/SourceClippingBlitTest.java 8196185 generic-all
 
-sun/java2d/pipe/InterpolationQualityTest.java 8171303 windows-all,linux-all,macosx-all
 sun/java2d/X11SurfaceData/SharedMemoryPixmapsTest/SharedMemoryPixmapsTest.sh 8221451 linux-all
 java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java 8169469 windows-all
 java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8197796 generic-all

--- a/test/jdk/sun/java2d/pipe/InterpolationQualityTest.java
+++ b/test/jdk/sun/java2d/pipe/InterpolationQualityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,11 +29,11 @@
  * image via rendering hints for default, xrender and opengl pipelines.
  *
  * @author Vadim.Pakhnushev@oracle.com
- * @run main/othervm -Dsun.java2d.xrender=false InterpolationQualityTest
- * @run main/othervm -Dsun.java2d.xrender=True InterpolationQualityTest
- * @run main/othervm -Dsun.java2d.d3d=false InterpolationQualityTest
- * @run main/othervm -Dsun.java2d.d3d=True InterpolationQualityTest
- * @run main/othervm InterpolationQualityTest
+ * @run main/othervm -Dsun.java2d.uiScale=1 -Dsun.java2d.xrender=false InterpolationQualityTest
+ * @run main/othervm -Dsun.java2d.uiScale=1 -Dsun.java2d.xrender=True InterpolationQualityTest
+ * @run main/othervm -Dsun.java2d.uiScale=1 -Dsun.java2d.d3d=false InterpolationQualityTest
+ * @run main/othervm -Dsun.java2d.uiScale=1 -Dsun.java2d.d3d=True InterpolationQualityTest
+ * @run main/othervm -Dsun.java2d.uiScale=1 InterpolationQualityTest
  */
 
 import java.awt.*;

--- a/test/jdk/sun/java2d/pipe/InterpolationQualityTest.java
+++ b/test/jdk/sun/java2d/pipe/InterpolationQualityTest.java
@@ -28,7 +28,6 @@
  * @summary Tests each of the 3 possible methods for rendering an upscaled
  * image via rendering hints for default, xrender and opengl pipelines.
  *
- * @author Vadim.Pakhnushev@oracle.com
  * @run main/othervm -Dsun.java2d.uiScale=1 -Dsun.java2d.xrender=false InterpolationQualityTest
  * @run main/othervm -Dsun.java2d.uiScale=1 -Dsun.java2d.xrender=True InterpolationQualityTest
  * @run main/othervm -Dsun.java2d.uiScale=1 -Dsun.java2d.d3d=false InterpolationQualityTest


### PR DESCRIPTION
This the only test which was created to check different types of interpolation.
It checks the rendering to the VolatileImage and uses BufferedImage as a gold image.
But it does not take into account that rendering to the VolatileImage might be affected
by the HiDPI support.

Old review request:
https://mail.openjdk.java.net/pipermail/2d-dev/2020-August/010982.html
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8171303](https://bugs.openjdk.java.net/browse/JDK-8171303): sun/java2d/pipe/InterpolationQualityTest.java fails on Windows & Linux


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to 2e6a02518b79017fd839a17319e4344c1f66adab
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to 2e6a02518b79017fd839a17319e4344c1f66adab
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - no project role)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/86/head:pull/86`
`$ git checkout pull/86`
