### PR TITLE
8157729: examples in LinkedHashMap and LinkedHashSet class doc use raw types

### DIFF
--- a/src/java.base/share/classes/java/util/LinkedHashMap.java
+++ b/src/java.base/share/classes/java/util/LinkedHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/LinkedHashMap.java
+++ b/src/java.base/share/classes/java/util/LinkedHashMap.java
@@ -47,12 +47,12 @@ import java.io.IOException;
  * without incurring the increased cost associated with {@link TreeMap}.  It
  * can be used to produce a copy of a map that has the same order as the
  * original, regardless of the original map's implementation:
- * <pre>
- *     void foo(Map m) {
- *         Map copy = new LinkedHashMap(m);
+ * <pre>{@code
+ *     void foo(Map<String, Integer> m) {
+ *         Map<String, Integer> copy = new LinkedHashMap<>(m);
  *         ...
  *     }
- * </pre>
+ * }</pre>
  * This technique is particularly useful if a module takes a map on input,
  * copies it, and later returns results whose order is determined by that of
  * the copy.  (Clients generally appreciate having things returned in the same

--- a/src/java.base/share/classes/java/util/LinkedHashSet.java
+++ b/src/java.base/share/classes/java/util/LinkedHashSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/LinkedHashSet.java
+++ b/src/java.base/share/classes/java/util/LinkedHashSet.java
@@ -42,12 +42,12 @@ package java.util;
  * increased cost associated with {@link TreeSet}.  It can be used to
  * produce a copy of a set that has the same order as the original, regardless
  * of the original set's implementation:
- * <pre>
- *     void foo(Set s) {
- *         Set copy = new LinkedHashSet(s);
+ * <pre>{@code
+ *     void foo(Set<String> s) {
+ *         Set<String> copy = new LinkedHashSet<>(s);
  *         ...
  *     }
- * </pre>
+ * }</pre>
  * This technique is particularly useful if a module takes a set on input,
  * copies it, and later returns results whose order is determined by that of
  * the copy.  (Clients generally appreciate having things returned in the same


### PR DESCRIPTION
Add some generics and wrap in `{@code}` to protect angle brackets.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8157729](https://bugs.openjdk.java.net/browse/JDK-8157729): examples in LinkedHashMap and LinkedHashSet class doc use raw types


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to b40485baa74f8be222aa3b6c8291b6e93cfe0f17
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/87/head:pull/87`
`$ git checkout pull/87`
