### PR TITLE
fix comment: unit of cpu_quota and share is microsecond

### DIFF
--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -203,11 +203,11 @@ char * CgroupV1Subsystem::cpu_cpuset_memory_nodes() {
 
 /* cpu_quota
  *
- * Return the number of milliseconds per period
+ * Return the number of microseconds per period
  * process is guaranteed to run.
  *
  * return:
- *    quota time in milliseconds
+ *    quota time in microseconds
  *    -1 for no quota
  *    OSCONTAINER_ERROR for not supported
  */


### PR DESCRIPTION
Unit of `cpu.cfs_quota_us` and `cpu.cfs_period_us` is microsecond.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/89/head:pull/89`
`$ git checkout pull/89`
