### PR TITLE
8027545: Improve object array chunking test in G1's copy_to_survivor_space

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -230,7 +230,7 @@ void G1ParScanThreadState::do_partial_array(PartialArrayScanTask task) {
                               step._index + _partial_objarray_chunk_size);
 }
 
-void G1ParScanThreadState::start_partial_objArray(G1HeapRegionAttr dest_attr,
+void G1ParScanThreadState::start_partial_objarray(G1HeapRegionAttr dest_attr,
                                                   oop from_obj,
                                                   oop to_obj) {
   assert(from_obj->is_objArray(), "precondition");
@@ -485,7 +485,7 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
     // checking for each array category for each object.
     if (klass->is_array_klass()) {
       if (klass->is_objArray_klass()) {
-        start_partial_objArray(dest_attr, old, obj);
+        start_partial_objarray(dest_attr, old, obj);
       } else {
         // Nothing needs to be done for typeArrays.  Body doesn't contain
         // any oops to scan, and the type in the klass will already be handled
@@ -495,7 +495,7 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
       return obj;
     }
 
-    if (G1StringDedup::is_enabled() && (klass == SystemDictionary::String_klass())) {
+    if (G1StringDedup::is_enabled()) {
       const bool is_from_young = region_attr.is_young();
       const bool is_to_young = dest_attr.is_young();
       assert(is_from_young == from_region->is_young(),

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -60,6 +60,8 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
     _surviving_young_words(NULL),
     _surviving_words_length(young_cset_length + 1),
     _old_gen_is_full(false),
+    _objarray_scan_chunk_size(ParGCArrayScanChunk),
+    _objarray_length_offset_in_bytes(arrayOopDesc::length_offset_in_bytes()),
     _num_optional_regions(optional_cset_length),
     _numa(g1h->numa()),
     _obj_alloc_stat(NULL)
@@ -199,48 +201,76 @@ void G1ParScanThreadState::do_partial_array(PartialArrayScanTask task) {
 
   assert(_g1h->is_in_reserved(from_obj), "must be in heap.");
   assert(from_obj->is_objArray(), "must be obj array");
-  objArrayOop from_obj_array = objArrayOop(from_obj);
-  // The from-space object contains the real length.
-  int length                 = from_obj_array->length();
-
   assert(from_obj->is_forwarded(), "must be forwarded");
-  oop to_obj                 = from_obj->forwardee();
+
+  oop to_obj = from_obj->forwardee();
   assert(from_obj != to_obj, "should not be chunking self-forwarded objects");
-  objArrayOop to_obj_array   = objArrayOop(to_obj);
-  // We keep track of the next start index in the length field of the
-  // to-space object.
-  int next_index             = to_obj_array->length();
-  assert(0 <= next_index && next_index < length,
-         "invariant, next index: %d, length: %d", next_index, length);
+  assert(to_obj->is_objArray(), "must be obj array");
+  objArrayOop to_array = objArrayOop(to_obj);
 
-  int start                  = next_index;
-  int end                    = length;
-  int remainder              = end - start;
-  // We'll try not to push a range that's smaller than ParGCArrayScanChunk.
-  if (remainder > 2 * ParGCArrayScanChunk) {
-    end = start + ParGCArrayScanChunk;
-    to_obj_array->set_length(end);
-    // Push the remainder before we process the range in case another
-    // worker has run out of things to do and can steal it.
-    push_on_queue(ScannerTask(PartialArrayScanTask(from_obj)));
-  } else {
-    assert(length == end, "sanity");
-    // We'll process the final range for this object. Restore the length
-    // so that the heap remains parsable in case of evacuation failure.
-    to_obj_array->set_length(end);
-  }
+  // The next chunk index is in the length field of the to-space object.
+  // Atomically increment by the chunk size to claim the associated chunk.
+  char* to_addr = cast_from_oop<char*>(to_array);
+  char* length_addr_raw = (to_addr + _objarray_length_offset_in_bytes);
+  volatile int* length_addr = reinterpret_cast<int*>(length_addr_raw);
+  int end = Atomic::add(length_addr, _objarray_scan_chunk_size, memory_order_relaxed);
+#ifdef ASSERT
+  // The from-space object contains the real length.
+  int length = objArrayOop(from_obj)->length();
+  assert(end <= length, "invariant: end %d, length %d", end, length);
+  assert(((length - end) % _objarray_scan_chunk_size) == 0,
+         "invariant: end %d, length %d, chunk size %d",
+         end, length, _objarray_scan_chunk_size);
+#endif // ASSERT
 
-  HeapRegion* hr = _g1h->heap_region_containing(to_obj);
+  HeapRegion* hr = _g1h->heap_region_containing(to_array);
   G1ScanInYoungSetter x(&_scanner, hr->is_young());
-  // Process indexes [start,end). It will also process the header
-  // along with the first chunk (i.e., the chunk with start == 0).
-  // Note that at this point the length field of to_obj_array is not
-  // correct given that we are using it to keep track of the next
-  // start index. oop_iterate_range() (thankfully!) ignores the length
-  // field and only relies on the start / end parameters.  It does
-  // however return the size of the object which will be incorrect. So
-  // we have to ignore it even if we wanted to use it.
-  to_obj_array->oop_iterate_range(&_scanner, start, end);
+  // Process claimed chunk.  Note that the length field of
+  // to_obj_array is not correct.  Fortunately, the iteration ignores
+  // the length and just relies on start / end.  However, it does
+  // return the (incorrect) length, but we ignore it.
+  to_array->oop_iterate_range(&_scanner, end - _objarray_scan_chunk_size, end);
+}
+
+oop G1ParScanThreadState::start_partial_objArray(G1HeapRegionAttr dest_attr,
+                                                 oop from_obj,
+                                                 oop to_obj) {
+  assert(from_obj->is_objArray(), "precondition");
+  assert(from_obj->is_forwarded(), "precondition");
+  assert(from_obj->forwardee() == to_obj, "precondition");
+  assert(from_obj != to_obj, "should not be scanning self-forwarded objects");
+  assert(to_obj->is_objArray(), "precondition");
+
+  objArrayOop to_array = objArrayOop(to_obj);
+
+  int length = objArrayOop(from_obj)->length();
+  int chunks = length / _objarray_scan_chunk_size;
+  int end = length % _objarray_scan_chunk_size;
+  assert(end <= length, "invariant");
+  assert(((length - end) % _objarray_scan_chunk_size) == 0, "invariant");
+  // The value of end can be 0, either because of a 0-length array or
+  // because length is a multiple of the chunk size.  Both of those
+  // are rare and handled in the normal course of the iteration, so
+  // not worth doing anything special about here.
+
+  // Set to's length to end of initial chunk.  Partial tasks use that
+  // length field as the start of the next chunk to process.  Must be
+  // done before enqueuing partial scan tasks, in case other threads
+  // steal any of those tasks.
+  to_array->set_length(end);
+  // Push partial scan tasks for all but the initial chunk.  Pushed
+  // before processing the initial chunk to allow other workers to
+  // steal while we're processing.
+  for (int i = 0; i < chunks; ++i) {
+    push_on_queue(ScannerTask(PartialArrayScanTask(from_obj)));
+  }
+  G1ScanInYoungSetter x(&_scanner, dest_attr.is_young());
+  // Process the initial chunk.  No need to process the type in the
+  // klass, as it will already be handled by processing the built-in
+  // module. The length of to_array is not correct, but fortunately
+  // the iteration ignores that length field and relies on start/end.
+  to_array->oop_iterate_range(&_scanner, 0, end);
+  return to_array;
 }
 
 void G1ParScanThreadState::dispatch_task(ScannerTask task) {
@@ -394,7 +424,10 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
   assert(region_attr.is_in_cset(),
          "Unexpected region attr type: %s", region_attr.get_type_str());
 
-  const size_t word_sz = old->size();
+  // Get the klass once.  We'll need it again later, and this avoids
+  // re-decoding when it's compressed.
+  Klass* klass = old->klass();
+  const size_t word_sz = old->size_given_klass(klass);
 
   uint age = 0;
   G1HeapRegionAttr dest_attr = next_region_attr(region_attr, old_mark, age);
@@ -461,7 +494,22 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
       obj->set_mark_raw(old_mark);
     }
 
-    if (G1StringDedup::is_enabled()) {
+    // Most objects are not arrays, so do one array check rather than both
+    // typeArray and objArray checks for each object.
+    if (klass->is_array_klass()) {
+      if (klass->is_typeArray_klass()) {
+        // Nothing needs to be done for typeArrays.  Body doesn't contain
+        // any oops to scan, and the type in the klass will already be handled
+        // by processing the built-in module.
+        return obj;
+      } else if (klass->is_objArray_klass()) {
+        // Do special handling for objArray.
+        return start_partial_objArray(dest_attr, old, obj);
+      }
+      // Not a special array, so fall through to generic handling.
+    }
+
+    if (G1StringDedup::is_enabled() && (klass == SystemDictionary::String_klass())) {
       const bool is_from_young = region_attr.is_young();
       const bool is_to_young = dest_attr.is_young();
       assert(is_from_young == from_region->is_young(),
@@ -474,17 +522,10 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
                                              obj);
     }
 
-    if (obj->is_objArray() && arrayOop(obj)->length() >= ParGCArrayScanChunk) {
-      // We keep track of the next start index in the length field of
-      // the to-space object. The actual length can be found in the
-      // length field of the from-space object.
-      arrayOop(obj)->set_length(0);
-      do_partial_array(PartialArrayScanTask(old));
-    } else {
-      G1ScanInYoungSetter x(&_scanner, dest_attr.is_young());
-      obj->oop_iterate_backwards(&_scanner);
-    }
+    G1ScanInYoungSetter x(&_scanner, dest_attr.is_young());
+    obj->oop_iterate_backwards(&_scanner);
     return obj;
+
   } else {
     _plab_allocator->undo_allocation(dest_attr, obj_ptr, word_sz, node_index);
     return forward_ptr;

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -162,7 +162,7 @@ public:
 
 private:
   inline void do_partial_array(PartialArrayScanTask task);
-  inline void start_partial_objArray(G1HeapRegionAttr dest_dir, oop from, oop to);
+  inline void start_partial_objarray(G1HeapRegionAttr dest_dir, oop from, oop to);
 
   HeapWord* allocate_copy_slow(G1HeapRegionAttr* dest_attr,
                                oop old,

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -32,6 +32,7 @@
 #include "gc/g1/g1RemSet.hpp"
 #include "gc/g1/heapRegionRemSet.hpp"
 #include "gc/shared/ageTable.hpp"
+#include "gc/shared/partialArrayTaskStepper.hpp"
 #include "gc/shared/taskqueue.hpp"
 #include "memory/allocation.hpp"
 #include "oops/oop.hpp"
@@ -79,9 +80,9 @@ class G1ParScanThreadState : public CHeapObj<mtGC> {
   // Indicates whether in the last generation (old) there is no more space
   // available for allocation.
   bool _old_gen_is_full;
-
-  int _objarray_scan_chunk_size;
-  int _objarray_length_offset_in_bytes;
+  // Size (in elements) of a partial objArray task chunk.
+  int _partial_objarray_chunk_size;
+  PartialArrayTaskStepper _partial_array_stepper;
 
   G1RedirtyCardsQueue& redirty_cards_queue()     { return _rdcq; }
   G1CardTable* ct()                              { return _ct; }
@@ -108,6 +109,7 @@ public:
   G1ParScanThreadState(G1CollectedHeap* g1h,
                        G1RedirtyCardsQueueSet* rdcqs,
                        uint worker_id,
+                       uint n_workers,
                        size_t young_cset_length,
                        size_t optional_cset_length);
   virtual ~G1ParScanThreadState();
@@ -160,7 +162,7 @@ public:
 
 private:
   inline void do_partial_array(PartialArrayScanTask task);
-  inline oop start_partial_objArray(G1HeapRegionAttr dest_dir, oop from, oop to);
+  inline void start_partial_objArray(G1HeapRegionAttr dest_dir, oop from, oop to);
 
   HeapWord* allocate_copy_slow(G1HeapRegionAttr* dest_attr,
                                oop old,
@@ -253,9 +255,6 @@ class G1ParScanThreadStateSet : public StackObj {
   G1ParScanThreadState* state_for_worker(uint worker_id);
 
   const size_t* surviving_young_words() const;
-
- private:
-  G1ParScanThreadState* new_par_scan_state(uint worker_id, size_t young_cset_length);
 };
 
 #endif // SHARE_GC_G1_G1PARSCANTHREADSTATE_HPP

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -80,6 +80,9 @@ class G1ParScanThreadState : public CHeapObj<mtGC> {
   // available for allocation.
   bool _old_gen_is_full;
 
+  int _objarray_scan_chunk_size;
+  int _objarray_length_offset_in_bytes;
+
   G1RedirtyCardsQueue& redirty_cards_queue()     { return _rdcq; }
   G1CardTable* ct()                              { return _ct; }
 
@@ -157,6 +160,7 @@ public:
 
 private:
   inline void do_partial_array(PartialArrayScanTask task);
+  inline oop start_partial_objArray(G1HeapRegionAttr dest_dir, oop from, oop to);
 
   HeapWord* allocate_copy_slow(G1HeapRegionAttr* dest_attr,
                                oop old,

--- a/src/hotspot/share/gc/shared/partialArrayTaskStepper.cpp
+++ b/src/hotspot/share/gc/shared/partialArrayTaskStepper.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "gc/shared/partialArrayTaskStepper.hpp"
+#include "oops/arrayOop.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+static uint compute_task_limit(uint n_workers) {
+  // Don't need more than n_workers tasks at a time.  But allowing up to
+  // that maximizes available parallelism.
+  return n_workers;
+}
+
+static uint compute_task_fannout(uint task_limit) {
+  assert(task_limit > 0, "precondition");
+  // There is a tradeoff between providing parallelism more quickly and
+  // number of enqueued tasks.  A constant fannout may be too slow when
+  // parallelism (and so task_limit) is large.  A constant fraction might
+  // be overly eager.  Using log2 attempts to balance between those.
+  uint result = log2_uint(task_limit);
+  // result must be > 0.  result should be > 1 if task_limit > 1, to
+  // provide some potentially parallel tasks.  But don't just +1 to
+  // avoid otherwise increasing rate of task generation.
+  if (result < 2) ++result;
+  return result;
+}
+
+PartialArrayTaskStepper::PartialArrayTaskStepper(uint n_workers) :
+  _task_limit(compute_task_limit(n_workers)),
+  _task_fannout(compute_task_fannout(_task_limit))
+{}

--- a/src/hotspot/share/gc/shared/partialArrayTaskStepper.cpp
+++ b/src/hotspot/share/gc/shared/partialArrayTaskStepper.cpp
@@ -33,10 +33,10 @@ static uint compute_task_limit(uint n_workers) {
   return n_workers;
 }
 
-static uint compute_task_fannout(uint task_limit) {
+static uint compute_task_fanout(uint task_limit) {
   assert(task_limit > 0, "precondition");
   // There is a tradeoff between providing parallelism more quickly and
-  // number of enqueued tasks.  A constant fannout may be too slow when
+  // number of enqueued tasks.  A constant fanout may be too slow when
   // parallelism (and so task_limit) is large.  A constant fraction might
   // be overly eager.  Using log2 attempts to balance between those.
   uint result = log2_uint(task_limit);
@@ -49,5 +49,5 @@ static uint compute_task_fannout(uint task_limit) {
 
 PartialArrayTaskStepper::PartialArrayTaskStepper(uint n_workers) :
   _task_limit(compute_task_limit(n_workers)),
-  _task_fannout(compute_task_fannout(_task_limit))
+  _task_fanout(compute_task_fanout(_task_limit))
 {}

--- a/src/hotspot/share/gc/shared/partialArrayTaskStepper.hpp
+++ b/src/hotspot/share/gc/shared/partialArrayTaskStepper.hpp
@@ -43,11 +43,6 @@
 // to process, or equals the actual length when there are no more chunks to
 // be processed.
 class PartialArrayTaskStepper {
-  // Limit on the number of partial array tasks to create for a given array.
-  uint _task_limit;
-  // Maximum number of new tasks to create when processing an existing task.
-  uint _task_fannout;
-
 public:
   PartialArrayTaskStepper(uint n_workers);
 
@@ -60,13 +55,28 @@ public:
   // the first partial task if the array is large enough to need splitting.
   // Returns a Step with _index being that index and _ncreate being the
   // initial number of partial tasks to enqueue.
-  inline Step start(arrayOop from, arrayOop to, int chunk_size);
+  inline Step start(arrayOop from, arrayOop to, int chunk_size) const;
 
   // Increment to's length by chunk_size to claim the next chunk.  Returns a
   // Step with _index being the starting index of the claimed chunk and
   // _ncreate being the number of additional partial tasks to enqueue.
   // precondition: chunk_size must be the same as used to start the task sequence.
-  inline Step next(arrayOop from, arrayOop to, int chunk_size);
+  inline Step next(arrayOop from, arrayOop to, int chunk_size) const;
+
+  class TestSupport;            // For unit tests
+
+private:
+  // Limit on the number of partial array tasks to create for a given array.
+  uint _task_limit;
+  // Maximum number of new tasks to create when processing an existing task.
+  uint _task_fannout;
+
+  // Split start/next into public part dealing with oops and private
+  // impl dealing with lengths and pointers to lengths, for unit testing.
+  // length is the actual length obtained from the from-space object.
+  // to_length_addr is the address of the to-space object's length value.
+  inline Step start_impl(int length, int* to_length_addr, int chunk_size) const;
+  inline Step next_impl(int length, int* to_length_addr, int chunk_size) const;
 };
 
 #endif // SHARE_GC_SHARED_PARTIALARRAYTASKSTEPPER_HPP

--- a/src/hotspot/share/gc/shared/partialArrayTaskStepper.hpp
+++ b/src/hotspot/share/gc/shared/partialArrayTaskStepper.hpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_SHARED_PARTIALARRAYTASKSTEPPER_HPP
+#define SHARE_GC_SHARED_PARTIALARRAYTASKSTEPPER_HPP
+
+#include "oops/arrayOop.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+// Helper for handling PartialArrayTasks.
+//
+// When an array is large, we want to split it up into chunks that can be
+// processed in parallel.  Each task (implicitly) represents such a chunk.
+// We can enqueue multiple tasks at the same time.  We want to enqueue
+// enough tasks to benefit from the available parallelism, while not so many
+// as to substantially expand the task queues.
+//
+// A task directly refers to the from-space array.  The from-space array's
+// forwarding pointer refers to the associated to-space array, and its
+// length is the actual length. The to-space array's length field is used to
+// indicate processing progress.  It is the starting index of the next chunk
+// to process, or equals the actual length when there are no more chunks to
+// be processed.
+class PartialArrayTaskStepper {
+  // Limit on the number of partial array tasks to create for a given array.
+  uint _task_limit;
+  // Maximum number of new tasks to create when processing an existing task.
+  uint _task_fannout;
+
+public:
+  PartialArrayTaskStepper(uint n_workers);
+
+  struct Step {
+    int _index;                 // Array index for the step.
+    uint _ncreate;              // Number of new tasks to create.
+  };
+
+  // Set to's length to the end of the initial chunk, which is the start of
+  // the first partial task if the array is large enough to need splitting.
+  // Returns a Step with _index being that index and _ncreate being the
+  // initial number of partial tasks to enqueue.
+  inline Step start(arrayOop from, arrayOop to, int chunk_size);
+
+  // Increment to's length by chunk_size to claim the next chunk.  Returns a
+  // Step with _index being the starting index of the claimed chunk and
+  // _ncreate being the number of additional partial tasks to enqueue.
+  // precondition: chunk_size must be the same as used to start the task sequence.
+  inline Step next(arrayOop from, arrayOop to, int chunk_size);
+};
+
+#endif // SHARE_GC_SHARED_PARTIALARRAYTASKSTEPPER_HPP

--- a/src/hotspot/share/gc/shared/partialArrayTaskStepper.hpp
+++ b/src/hotspot/share/gc/shared/partialArrayTaskStepper.hpp
@@ -69,7 +69,7 @@ private:
   // Limit on the number of partial array tasks to create for a given array.
   uint _task_limit;
   // Maximum number of new tasks to create when processing an existing task.
-  uint _task_fannout;
+  uint _task_fanout;
 
   // Split start/next into public part dealing with oops and private
   // impl dealing with lengths and pointers to lengths, for unit testing.

--- a/src/hotspot/share/gc/shared/partialArrayTaskStepper.inline.hpp
+++ b/src/hotspot/share/gc/shared/partialArrayTaskStepper.inline.hpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_SHARED_PARTIALARRAYTASKSTEPPER_INLINE_HPP
+#define SHARE_GC_SHARED_PARTIALARRAYTASKSTEPPER_INLINE_HPP
+
+#include "gc/shared/partialArrayTaskStepper.hpp"
+#include "oops/arrayOop.hpp"
+#include "runtime/atomic.hpp"
+
+PartialArrayTaskStepper::Step
+PartialArrayTaskStepper::start(arrayOop from, arrayOop to, int chunk_size) {
+  assert(chunk_size > 0, "precondition");
+
+  int length = from->length();
+  int end = length % chunk_size; // End of initial chunk.
+  // Set to's length to end of initial chunk.  Partial tasks use that length
+  // field as the start of the next chunk to process.  Must be done before
+  // enqueuing partial scan tasks, in case other threads steal any of those
+  // tasks.
+  //
+  // The value of end can be 0, either because of a 0-length array or
+  // because length is a multiple of the chunk size.  Both of those are
+  // relatively rare and handled in the normal course of the iteration, so
+  // not worth doing anything special about here.
+  to->set_length(end);
+
+  // If the initial chunk is the complete array, then don't need any partial
+  // tasks.  Otherwise, start with just one partial task; see new task
+  // calculation in next().
+  Step result = { end, (length > end) ? 1u : 0u };
+  return result;
+}
+
+PartialArrayTaskStepper::Step
+PartialArrayTaskStepper::next(arrayOop from, arrayOop to, int chunk_size) {
+  assert(chunk_size > 0, "precondition");
+
+  // The start of the next task is in the length field of the to-space object.
+  // Atomically increment by the chunk size to claim the associated chunk.
+  // Because we limit the number of enqueued tasks to being no more than the
+  // number of remaining chunks to process, we can use an atomic add for the
+  // claim, rather than a CAS loop.
+  int start = Atomic::fetch_and_add(to->length_addr(),
+                                    chunk_size,
+                                    memory_order_relaxed);
+
+  // The from-space object contains the real length.
+  int length = from->length();
+  assert(start < length, "invariant: start %d, length %d", start, length);
+  assert(((length - start) % chunk_size) == 0,
+         "invariant: start %d, length %d, chunk size %d",
+         start, length, chunk_size);
+
+  // Determine the number of new tasks to create.
+  // Zero-based index for this partial task.  The initial task isn't counted.
+  uint task_num = (start / chunk_size);
+  // Number of tasks left to process, including this one.
+  uint remaining_tasks = (length - start) / chunk_size;
+  assert(remaining_tasks > 0, "invariant");
+  // Compute number of pending tasks, including this one.  The maximum number
+  // of tasks is a function of task_num (N) and _task_fannout (F).
+  //   1    : current task
+  //   N    : number of preceeding tasks
+  //   F*N  : maximum created for preceeding tasks
+  // => F*N - N + 1 : maximum number of tasks
+  // => (F-1)*N + 1
+  assert(_task_limit > 0, "precondition");
+  assert(_task_fannout > 0, "precondition");
+  uint max_pending = (_task_fannout - 1) * task_num + 1;
+
+  // The actual pending may be less than that.  Bound by remaining_tasks to
+  // not overrun.  Also bound by _task_limit to avoid spawning an excessive
+  // number of tasks for a large array.  The +1 is to replace the current
+  // task with a new task when _task_limit limited.  The pending value may
+  // not be what's actually in the queues, because of concurrent task
+  // processing.  That's okay; we just need to determine the correct number
+  // of tasks to add for this task.
+  uint pending = MIN3(max_pending, remaining_tasks, _task_limit);
+  uint ncreate = MIN2(_task_fannout, MIN2(remaining_tasks, _task_limit + 1) - pending);
+  Step result = { start, ncreate };
+  return result;
+}
+
+#endif // SHARE_GC_SHARED_PARTIALARRAYTASKSTEPPER_INLINE_HPP

--- a/src/hotspot/share/gc/shared/partialArrayTaskStepper.inline.hpp
+++ b/src/hotspot/share/gc/shared/partialArrayTaskStepper.inline.hpp
@@ -86,15 +86,15 @@ PartialArrayTaskStepper::next_impl(int length,
   uint remaining_tasks = (length - start) / chunk_size;
   assert(remaining_tasks > 0, "invariant");
   // Compute number of pending tasks, including this one.  The maximum number
-  // of tasks is a function of task_num (N) and _task_fannout (F).
+  // of tasks is a function of task_num (N) and _task_fanout (F).
   //   1    : current task
   //   N    : number of preceeding tasks
   //   F*N  : maximum created for preceeding tasks
   // => F*N - N + 1 : maximum number of tasks
   // => (F-1)*N + 1
   assert(_task_limit > 0, "precondition");
-  assert(_task_fannout > 0, "precondition");
-  uint max_pending = (_task_fannout - 1) * task_num + 1;
+  assert(_task_fanout > 0, "precondition");
+  uint max_pending = (_task_fanout - 1) * task_num + 1;
 
   // The actual pending may be less than that.  Bound by remaining_tasks to
   // not overrun.  Also bound by _task_limit to avoid spawning an excessive
@@ -104,7 +104,7 @@ PartialArrayTaskStepper::next_impl(int length,
   // processing.  That's okay; we just need to determine the correct number
   // of tasks to add for this task.
   uint pending = MIN3(max_pending, remaining_tasks, _task_limit);
-  uint ncreate = MIN2(_task_fannout, MIN2(remaining_tasks, _task_limit + 1) - pending);
+  uint ncreate = MIN2(_task_fanout, MIN2(remaining_tasks, _task_limit + 1) - pending);
   Step result = { start, ncreate };
   return result;
 }

--- a/src/hotspot/share/oops/arrayOop.hpp
+++ b/src/hotspot/share/oops/arrayOop.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,12 +104,19 @@ class arrayOopDesc : public oopDesc {
 
   // Accessors for instance variable which is not a C++ declared nonstatic
   // field.
-  int length() const {
-    return *(int*)(((intptr_t)this) + length_offset_in_bytes());
+  int length() const { return *length_addr(); }
+  void set_length(int length) { *length_addr() = length; }
+
+  int* length_addr() {
+    char* base = reinterpret_cast<char*>(this);
+    char* addr = base +  length_offset_in_bytes();
+    return reinterpret_cast<int*>(addr);
   }
-  void set_length(int length) {
-    set_length((HeapWord*)this, length);
+
+  const int* length_addr() const {
+    return const_cast<arrayOopDesc*>(this)->length_addr();
   }
+
   static void set_length(HeapWord* mem, int length) {
     *(int*)(((char*)mem) + length_offset_in_bytes()) = length;
   }

--- a/src/hotspot/share/oops/objArrayOop.hpp
+++ b/src/hotspot/share/oops/objArrayOop.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ class objArrayOopDesc : public arrayOopDesc {
   friend class Runtime1;
   friend class psPromotionManager;
   friend class CSetMarkWordClosure;
-  friend class G1ParScanPartialArrayClosure;
 
   template <class T> T* obj_at_addr(int index) const;
   template <class T> T* obj_at_addr_raw(int index) const;

--- a/test/hotspot/gtest/gc/shared/test_partialArrayTaskStepper.cpp
+++ b/test/hotspot/gtest/gc/shared/test_partialArrayTaskStepper.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "gc/shared/partialArrayTaskStepper.inline.hpp"
+#include "memory/allStatic.hpp"
+#include "unittest.hpp"
+
+using Step = PartialArrayTaskStepper::Step;
+using Stepper = PartialArrayTaskStepper;
+
+class PartialArrayTaskStepper::TestSupport : AllStatic {
+public:
+  static Step start(const Stepper* stepper,
+                    int length,
+                    int* to_length_addr,
+                    uint chunk_size) {
+    return stepper->start_impl(length, to_length_addr, chunk_size);
+  }
+
+  static Step next(const Stepper* stepper,
+                   int length,
+                   int* to_length_addr,
+                   uint chunk_size) {
+    return stepper->next_impl(length, to_length_addr, chunk_size);
+  }
+};
+
+using StepperSupport = PartialArrayTaskStepper::TestSupport;
+
+static int simulate(const Stepper* stepper,
+                     int length,
+                     int* to_length_addr,
+                     uint chunk_size) {
+  Step init = StepperSupport::start(stepper, length, to_length_addr, chunk_size);
+  uint queue_count = init._ncreate;
+  int task = 0;
+  for ( ; queue_count > 0; ++task) {
+    --queue_count;
+    Step step = StepperSupport::next(stepper, length, to_length_addr, chunk_size);
+    queue_count += step._ncreate;
+  }
+  return task;
+}
+
+static void run_test(int length, int chunk_size, uint n_workers) {
+  const PartialArrayTaskStepper stepper(n_workers);
+  int to_length;
+  int tasks = simulate(&stepper, length, &to_length, chunk_size);
+  ASSERT_EQ(length, to_length);
+  ASSERT_EQ(tasks, length / chunk_size);
+}
+
+TEST(PartialArrayTaskStepperTest, doit) {
+  for (int chunk_size = 50; chunk_size <= 500; chunk_size += 50) {
+    for (uint n_workers = 1; n_workers <= 256; n_workers = (n_workers * 3 / 2 + 1)) {
+      for (int length = 0; length <= 1000000; length = (length * 2 + 1)) {
+        run_test(length, chunk_size, n_workers);
+      }
+      // Ensure we hit boundary cases for length % chunk_size == 0.
+      for (uint i = 0; i < 2 * n_workers; ++i) {
+        run_test(i * chunk_size, chunk_size, n_workers);
+      }
+    }
+  }
+}

--- a/test/hotspot/gtest/gc/shared/test_partialArrayTaskStepper.cpp
+++ b/test/hotspot/gtest/gc/shared/test_partialArrayTaskStepper.cpp
@@ -50,9 +50,9 @@ public:
 using StepperSupport = PartialArrayTaskStepper::TestSupport;
 
 static int simulate(const Stepper* stepper,
-                     int length,
-                     int* to_length_addr,
-                     uint chunk_size) {
+                    int length,
+                    int* to_length_addr,
+                    uint chunk_size) {
   Step init = StepperSupport::start(stepper, length, to_length_addr, chunk_size);
   uint queue_count = init._ncreate;
   int task = 0;


### PR DESCRIPTION
/issue add JDK-8158045
/issue add JDK-8027761
/issue add JDK-8027545

This is rework of initial change from before the transition to git.
The initial RFR email is attached below.

The primary change is to limit the number of partial array tasks in
the queues for any given array.  The original change just split up an
array into N tasks that were all enqueued at once.  But for a large
array this could be a lot of tasks, leading to significant and
unnecessary queue expansion.  Instead we now limit the number of tasks
for a given array based on the number of workers, and only gradually
add tasks up to that limit.  This gives other threads an opportunity
to steal such tasks, while still keeping queue growth under control.

Most of the calculation for this is handled by a new helper class, so
this can later be shared with ParallelGC.

The dispatch on array klass type for has also been changed.  It now
affirmatively breaks Project Valhalla, rather than quietly doing
something that probably isn't what is actually wanted.  I'll discuss
with them so there is a plan for dealing with it when they take this
update.

Ran tier1-6 in mach5 and some local stress tests.

Performance testing was unchanged from previous, except I wasn't able
to reproduce the small specjbb2015 critical-jops improvement
previously seen on one platform.  My suspicion is that improvement was
a statistical abberation.

--- Initial RFR email ---

RFR: 8158045: Improve large object handling during evacuation
RFR: 8027761: Investigate fast-path for scanning only objects with references during gc
RFR: 8027545: Improve object array chunking test in G1's copy_to_survivor_space

Please review this change to type dispatching and handling in G1's
evacuation copying, in order to improve the hot paths and improve array
handling. This change addresses several closely co-located enhancement
requests; it seemed difficult to split them up in a sensible way.

do_copy_to_survivor_space now gets the klass of the object being copied
once, up front, for use in multiple places. This avoids fetching (including
re-decoding when compressed) the klass multiple times. This addresses part
of JDK-8027545.

Moved check for and handling of string deduplication later, only applying it
after the special array cases have been dealt with, since strings are not
arrays.  (They are header objects pointing to an array of character values.)

Special case typeArray, doing nothing other than the copy, since they
contain no oops that need to be processed.  This addresses JDK-8027761.

Changed handling of objArray, pushing all of the partial array tasks up
front, rather than processing the current chunk after pushing a single task
for the remaining work.  This addresses JDK-8158045.

As part of these, cached some more frequently accessed values in
G1ParScanThreadState member variables. This addresses part of part of
JDK-8027545.

While both the old and new code will work for Project Valhalla, the handling
of arrays should be updated for that project, which introduces new array
types.

Deleted a lingering reference to G1ParScanPartialArrayClosure that was
deleted long ago (JDK-8035330, JDK 9).

CR:
https://bugs.openjdk.java.net/browse/JDK-8158045
https://bugs.openjdk.java.net/browse/JDK-8027761
https://bugs.openjdk.java.net/browse/JDK-8027545

Webrev:
https://cr.openjdk.java.net/~kbarrett/8158045/open.00/

Testing:
tier1-3

performance testing - seems to be at worst performance neutral, with a
statistically significant 3% improvement in specjbb2015 critical-jops seen
on one platform.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8027545](https://bugs.openjdk.java.net/browse/JDK-8027545): Improve object array chunking test in G1's copy_to_survivor_space
 * [JDK-8158045](https://bugs.openjdk.java.net/browse/JDK-8158045): Improve large object handling during evacuation
 * [JDK-8027761](https://bugs.openjdk.java.net/browse/JDK-8027761): Investigate fast-path for scanning only objects with references during gc


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 1981c392b36e81c1113d926f188b2d5ac1cc8ca7
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author) ⚠️ Review applies to 1981c392b36e81c1113d926f188b2d5ac1cc8ca7
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 1981c392b36e81c1113d926f188b2d5ac1cc8ca7


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/90/head:pull/90`
`$ git checkout pull/90`
