### PR TITLE
8252957: Wrong comment in CgroupV1Subsystem::cpu_quota

### DIFF
--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -203,11 +203,11 @@ char * CgroupV1Subsystem::cpu_cpuset_memory_nodes() {
 
 /* cpu_quota
  *
- * Return the number of milliseconds per period
+ * Return the number of microseconds per period
  * process is guaranteed to run.
  *
  * return:
- *    quota time in milliseconds
+ *    quota time in microseconds
  *    -1 for no quota
  *    OSCONTAINER_ERROR for not supported
  */

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -74,11 +74,11 @@ int CgroupV2Subsystem::cpu_shares() {
 
 /* cpu_quota
  *
- * Return the number of milliseconds per period
+ * Return the number of microseconds per period
  * process is guaranteed to run.
  *
  * return:
- *    quota time in milliseconds
+ *    quota time in microseconds
  *    -1 for no quota
  *    OSCONTAINER_ERROR for not supported
  */


### PR DESCRIPTION
The comment is wrong. The 'us' in 'cpu.cfs_quota_us' stands for
microseconds, which is read verbatim. Similarly for cgroups v2
all units in 'cpu.max' are in microseconds.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252957](https://bugs.openjdk.java.net/browse/JDK-8252957): Wrong comment in CgroupV1Subsystem::cpu_quota


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/91/head:pull/91`
`$ git checkout pull/91`
