### PR TITLE
8252919: JDK built with --enable-cds=no fails with NoClassDefFoundError

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/GenerateJLIClassesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/GenerateJLIClassesPlugin.java
@@ -141,6 +141,9 @@ public final class GenerateJLIClassesPlugin implements Plugin {
         initialize(in);
         // Copy all but DMH_ENTRY to out
         in.transformAndCopy(entry -> {
+                // No trace file given.  Copy all entries.
+                if (traceFileStream == null) return entry;
+
                 // filter out placeholder entries
                 String path = entry.path();
                 if (path.equals(DIRECT_METHOD_HOLDER_ENTRY) ||

--- a/test/jdk/tools/jlink/plugins/GenerateJLIClassesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/GenerateJLIClassesPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,12 @@ import tests.JImageGenerator;
 import tests.JImageValidator;
 import tests.Result;
 
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
  /*
  * @test
+ * @bug 8252919
  * @library ../../lib
  * @summary Test --generate-jli-classes plugin
  * @modules java.base/jdk.internal.jimage
@@ -45,21 +49,24 @@ import tests.Result;
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.*
- * @run main/othervm GenerateJLIClassesPluginTest
+ * @run testng/othervm GenerateJLIClassesPluginTest
  */
 public class GenerateJLIClassesPluginTest {
 
     private static Helper helper;
 
-    public static void main(String[] args) throws Exception {
+    @BeforeTest
+    public static void setup() throws Exception {
         helper = Helper.newHelper();
         if (helper == null) {
             System.err.println("Test not run");
             return;
         }
-
         helper.generateDefaultModules();
+    }
 
+    @Test
+    public static void testSpecies()  throws IOException {
         // Check that --generate-jli-classes=@file works as intended
         Path baseFile = Files.createTempFile("base", "trace");
         String species = "LLLLLLLLLLLLLLLLLLL";
@@ -73,33 +80,55 @@ public class GenerateJLIClassesPluginTest {
                 .call();
 
         Path image = result.assertSuccess();
-
+        validateHolderClasses(image);
         JImageValidator.validate(image.resolve("lib").resolve("modules"),
                 classFilesForSpecies(List.of(species)), // species should be in the image
                 classFilesForSpecies(List.of(species.substring(1)))); // but not it's immediate parent
+    }
 
+    @Test
+    public static void testInvalidSignatures() throws IOException {
         // Check that --generate-jli-classes=@file fails as intended on shapes that can't be generated
-        ensureInvalidSignaturesFail(
+        String[] args = new String[] {
                 "[LF_RESOLVE] java.lang.invoke.DirectMethodHandle$Holder invokeVirtual L_L (success)\n",
                 "[LF_RESOLVE] java.lang.invoke.DirectMethodHandle$Holder invokeInterface L_L (success)\n",
                 "[LF_RESOLVE] java.lang.invoke.DirectMethodHandle$Holder invokeStatic I_L (success)\n"
-        );
-    }
-
-    private static void ensureInvalidSignaturesFail(String ... args) throws IOException {
+        };
         for (String fileString : args) {
             Path failFile = Files.createTempFile("fail", "trace");
             fileString = "[LF_RESOLVE] java.lang.invoke.DirectMethodHandle$Holder invokeVirtual L_L (success)\n";
             Files.write(failFile, fileString.getBytes(Charset.defaultCharset()));
             Result result = JImageGenerator.getJLinkTask()
                     .modulePath(helper.defaultModulePath())
-                    .output(helper.createNewImageDir("generate-jli-file"))
+                    .output(helper.createNewImageDir("invalid-signature"))
                     .option("--generate-jli-classes=@" + failFile.toString())
                     .addMods("java.base")
                     .call();
 
             result.assertFailure();
         }
+    }
+
+    @Test
+    public static void nonExistentTraceFile() throws IOException {
+        Result result = JImageGenerator.getJLinkTask()
+                .modulePath(helper.defaultModulePath())
+                .output(helper.createNewImageDir("non-existent-tracefile"))
+                .option("--generate-jli-classes=@NON_EXISTENT_FILE")
+                .addMods("java.base")
+                .call();
+
+        Path image = result.assertSuccess();
+        validateHolderClasses(image);
+    }
+
+    private static void validateHolderClasses(Path image) throws IOException {
+        JImageValidator.validate(image.resolve("lib").resolve("modules"),
+                List.of("/java.base/java/lang/invoke/DirectMethodHandle$Holder.class",
+                        "/java.base/java/lang/invoke/DelegatingMethodHandle$Holder.class",
+                        "/java.base/java/lang/invoke/LambdaForm$Holder.class",
+                        "/java.base/java/lang/invoke/Invokers$Holder.class"),
+                List.of());
     }
 
     private static List<String> classFilesForSpecies(Collection<String> species) {


### PR DESCRIPTION
`jlink --generate-jli-classes` plugin should retain the original holder classes if the default_jli_trace.txt
file does not exist.  

Before JDK-8252725, `JavaLangInvokeAccess::generateXXXHolderClassesBytes` methods are invoked
unconditionally and therefore the holder classes are "regenerated" when default_jli_trace.txt
does not exist.  JDK-8252725 does not handle this case properly and results in an image missing
the holder classes when the specified trace file does not exist.

The fix is very simple.  Retains the original holder classes when the file does not exist.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252919](https://bugs.openjdk.java.net/browse/JDK-8252919): JDK built with --enable-cds=no fails with NoClassDefFoundError: DirectMethodHandle$Holder ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/96/head:pull/96`
`$ git checkout pull/96`
