### PR TITLE
8252114: Windows-AArch64: Enable and test ZGC and ShenandoahGC

### DIFF
--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -395,8 +395,14 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_ZGC],
         AC_MSG_RESULT([no, $OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU])
         AVAILABLE=false
       fi
-    elif test "x$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" = "xlinux-aarch64"; then
-      AC_MSG_RESULT([yes])
+    elif test "$OPENJDK_TARGET_CPU" = "aarch64"; then
+      if test "x$OPENJDK_TARGET_OS" = "xlinux" || \
+          test "x$OPENJDK_TARGET_OS" = "xwindows"; then
+        AC_MSG_RESULT([yes])
+      else
+        AC_MSG_RESULT([no, $OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU])
+        AVAILABLE=false
+      fi
     else
       AC_MSG_RESULT([no, $OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU])
       AVAILABLE=false

--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -395,7 +395,7 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_ZGC],
         AC_MSG_RESULT([no, $OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU])
         AVAILABLE=false
       fi
-    elif test "$OPENJDK_TARGET_CPU" = "aarch64"; then
+    elif test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
       if test "x$OPENJDK_TARGET_OS" = "xlinux" || \
           test "x$OPENJDK_TARGET_OS" = "xwindows"; then
         AC_MSG_RESULT([yes])


### PR DESCRIPTION
ZGC and ShenandoahGC are two low latency GCs in OpenJDK HotSpot. We will enable and run microbenchmarks and scaling tests for both.
After enabling, I ran JTRegs, a few micros, and SPECJBB2015 (heap and multi-JVM) scaling tests for both the GCs.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252114](https://bugs.openjdk.java.net/browse/JDK-8252114): Windows-AArch64: Enable and test ZGC and ShenandoahGC


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/97/head:pull/97`
`$ git checkout pull/97`
