### PR TITLE
8251495: Remove the implNote in the DOM package description added by JDK-8249643

### DIFF
--- a/src/java.xml/share/classes/org/w3c/dom/package-info.java
+++ b/src/java.xml/share/classes/org/w3c/dom/package-info.java
@@ -42,31 +42,6 @@
  * {@link org.w3c.dom.Node#setTextContent(String) setTextContent} shared the same
  * content that defined the TextContent property itself.
  *
- * @implNote
- * The JDK implementation of {@link org.w3c.dom.ls.LSSerializer LSSerializer}
- * follows the <a href="https://www.w3.org/TR/xml/#charsets">Characters</a> section
- * of the XML Specification in handling characters output. In particular, the
- * specification defined a character range that excluded the surrogate blocks.
- * As a result, the JDK LSSerializer writes characters in the surrogate blocks
- * as Character References. Character {@code 0xf0 0x9f 0x9a 0xa9}
- * (Unicode code point U+1F6A9) for example will be written as {@code &#128681;}.
- *
- * <p>
- * This behavior is different from what was in the class description of
- * {@link org.w3c.dom.ls.LSSerializer LSSerializer}. The relevant section is quoted
- * below:
- *
- * <p>
- * {@code Within the character data of a document (outside of markup), any characters
- * that cannot be represented directly are replaced with character references...
- * Any characters that cannot be represented directly in the output character encoding
- * are serialized as numeric character references }
- *
- * <p>
- * The JDK implementation does not follow this definition because it is not consistent
- * with the XML Specification that defined an explicit character range with no
- * association to the setting of the output character encoding.
- *
  *
  * @since 1.4
  */


### PR DESCRIPTION
Revert changes made by JDK-8249643, removing the implNote.

/issue add 8251495
/csr needed
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251495](https://bugs.openjdk.java.net/browse/JDK-8251495): Remove the implNote in the DOM package description added by JDK-8249643


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/100/head:pull/100`
`$ git checkout pull/100`
