### PR TITLE
8172366: Support SHA-3 based signatures

### DIFF
--- a/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,6 +107,30 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
      */
     public static final MGF1ParameterSpec SHA512_256 =
         new MGF1ParameterSpec("SHA-512/256");
+
+    /**
+     * The MGF1ParameterSpec which uses SHA3-224 message digest
+     */
+    public static final MGF1ParameterSpec SHA3_224 =
+        new MGF1ParameterSpec("SHA3-224");
+
+    /**
+     * The MGF1ParameterSpec which uses SHA3-256 message digest
+     */
+    public static final MGF1ParameterSpec SHA3_256 =
+        new MGF1ParameterSpec("SHA3-256");
+
+    /**
+     * The MGF1ParameterSpec which uses SHA3-384 message digest
+     */
+    public static final MGF1ParameterSpec SHA3_384 =
+        new MGF1ParameterSpec("SHA3-384");
+
+    /**
+     * The MGF1ParameterSpec which uses SHA3-512 message digest
+     */
+    public static final MGF1ParameterSpec SHA3_512 =
+        new MGF1ParameterSpec("SHA3-512");
 
     private String mdName;
 

--- a/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
@@ -110,24 +110,28 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
 
     /**
      * The MGF1ParameterSpec which uses SHA3-224 message digest
+     * @since 16
      */
     public static final MGF1ParameterSpec SHA3_224 =
         new MGF1ParameterSpec("SHA3-224");
 
     /**
      * The MGF1ParameterSpec which uses SHA3-256 message digest
+     * @since 16
      */
     public static final MGF1ParameterSpec SHA3_256 =
         new MGF1ParameterSpec("SHA3-256");
 
     /**
      * The MGF1ParameterSpec which uses SHA3-384 message digest
+     * @since 16
      */
     public static final MGF1ParameterSpec SHA3_384 =
         new MGF1ParameterSpec("SHA3-384");
 
     /**
      * The MGF1ParameterSpec which uses SHA3-512 message digest
+     * @since 16
      */
     public static final MGF1ParameterSpec SHA3_512 =
         new MGF1ParameterSpec("SHA3-512");

--- a/src/java.base/share/classes/sun/security/provider/DSA.java
+++ b/src/java.base/share/classes/sun/security/provider/DSA.java
@@ -57,7 +57,7 @@ import sun.security.jca.JCAUtil;
  * In addition, IEEE P1363 signature format is supported. The
  * corresponding implementation is registered under <sig>inP1363Format,
  * e.g. SHA256withDSAinP1363Format.
- * 
+ *
  * @author Benjamin Renaud
  *
  * @since   1.1
@@ -517,7 +517,7 @@ abstract class DSA extends SignatureSpi {
             super(MessageDigest.getInstance("SHA3-224"));
         }
     }
-    
+
     /**
      * SHA3-224withDSA implementation that uses the IEEE P1363 format.
      */
@@ -535,7 +535,7 @@ abstract class DSA extends SignatureSpi {
             super(MessageDigest.getInstance("SHA3-256"));
         }
     }
-    
+
     /**
      * Standard SHA3-256withDSA implementation that uses the IEEE P1363 format.
      */
@@ -553,7 +553,7 @@ abstract class DSA extends SignatureSpi {
             super(MessageDigest.getInstance("SHA3-384"));
         }
     }
-    
+
     /**
      * Standard SHA3-384withDSA implementation that uses the IEEE P1363 format.
      */
@@ -571,7 +571,7 @@ abstract class DSA extends SignatureSpi {
             super(MessageDigest.getInstance("SHA3-512"));
         }
     }
-    
+
     /**
      * Standard SHA3-512withDSA implementation that uses the IEEE P1363 format.
      */

--- a/src/java.base/share/classes/sun/security/provider/DSA.java
+++ b/src/java.base/share/classes/sun/security/provider/DSA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,9 +49,11 @@ import sun.security.jca.JCAUtil;
  *
  * This file contains both the signature implementation for the
  * commonly used SHA1withDSA (DSS), SHA224withDSA, SHA256withDSA,
- * as well as RawDSA, used by TLS among others. RawDSA expects
- * the 20 byte SHA-1 digest as input via update rather than the
- * original data like other signature implementations.
+ * SHA384withDSA, SHA512withDSA, SHA3-224withDSA, SHA3-256withDSA,
+ * SHA3-384withDSA, SHA3-512withDSA, as well as RawDSA, used by
+ * TLS among others. RawDSA expects the 20 byte SHA-1 digest as
+ * input via update rather than the original data like other signature
+ * implementations.
  *
  * @author Benjamin Renaud
  *
@@ -504,6 +506,50 @@ abstract class DSA extends SignatureSpi {
         return printable;
     }
 
+    public static final class SHA3_224withDSA extends DSA {
+        public SHA3_224withDSA() throws NoSuchAlgorithmException {
+            super(MessageDigest.getInstance("SHA3-224"));
+        }
+    }
+    public static final class SHA3_224withDSAinP1363Format extends DSA {
+        public SHA3_224withDSAinP1363Format() throws NoSuchAlgorithmException {
+            super(MessageDigest.getInstance("SHA3-224"), true);
+        }
+    }
+
+    public static final class SHA3_256withDSA extends DSA {
+        public SHA3_256withDSA() throws NoSuchAlgorithmException {
+            super(MessageDigest.getInstance("SHA3-256"));
+        }
+    }
+    public static final class SHA3_256withDSAinP1363Format extends DSA {
+        public SHA3_256withDSAinP1363Format() throws NoSuchAlgorithmException {
+            super(MessageDigest.getInstance("SHA3-256"), true);
+        }
+    }
+
+    public static final class SHA3_384withDSA extends DSA {
+        public SHA3_384withDSA() throws NoSuchAlgorithmException {
+            super(MessageDigest.getInstance("SHA3-384"));
+        }
+    }
+    public static final class SHA3_384withDSAinP1363Format extends DSA {
+        public SHA3_384withDSAinP1363Format() throws NoSuchAlgorithmException {
+            super(MessageDigest.getInstance("SHA3-384"), true);
+        }
+    }
+
+    public static final class SHA3_512withDSA extends DSA {
+        public SHA3_512withDSA() throws NoSuchAlgorithmException {
+            super(MessageDigest.getInstance("SHA3-512"));
+        }
+    }
+    public static final class SHA3_512withDSAinP1363Format extends DSA {
+        public SHA3_512withDSAinP1363Format() throws NoSuchAlgorithmException {
+            super(MessageDigest.getInstance("SHA3-512"), true);
+        }
+    }
+
     /**
      * Standard SHA224withDSA implementation as defined in FIPS186-3.
      */
@@ -537,6 +583,42 @@ abstract class DSA extends SignatureSpi {
     public static final class SHA256withDSAinP1363Format extends DSA {
         public SHA256withDSAinP1363Format() throws NoSuchAlgorithmException {
             super(MessageDigest.getInstance("SHA-256"), true);
+        }
+    }
+
+    /**
+     * Standard SHA384withDSA implementation as defined in FIPS186-3.
+     */
+    public static final class SHA384withDSA extends DSA {
+        public SHA384withDSA() throws NoSuchAlgorithmException {
+            super(MessageDigest.getInstance("SHA-384"));
+        }
+    }
+
+    /**
+     * SHA384withDSA implementation that uses the IEEE P1363 format.
+     */
+    public static final class SHA384withDSAinP1363Format extends DSA {
+        public SHA384withDSAinP1363Format() throws NoSuchAlgorithmException {
+            super(MessageDigest.getInstance("SHA-384"), true);
+        }
+    }
+
+    /**
+     * Standard SHA512withDSA implementation as defined in FIPS186-3.
+     */
+    public static final class SHA512withDSA extends DSA {
+        public SHA512withDSA() throws NoSuchAlgorithmException {
+            super(MessageDigest.getInstance("SHA-512"));
+        }
+    }
+
+    /**
+     * SHA512withDSA implementation that uses the IEEE P1363 format.
+     */
+    public static final class SHA512withDSAinP1363Format extends DSA {
+        public SHA512withDSAinP1363Format() throws NoSuchAlgorithmException {
+            super(MessageDigest.getInstance("SHA-512"), true);
         }
     }
 

--- a/src/java.base/share/classes/sun/security/provider/DSA.java
+++ b/src/java.base/share/classes/sun/security/provider/DSA.java
@@ -47,14 +47,17 @@ import sun.security.jca.JCAUtil;
  * Standards and Technology (NIST), using SHA digest algorithms
  * from FIPS180-3.
  *
- * This file contains both the signature implementation for the
- * commonly used SHA1withDSA (DSS), SHA224withDSA, SHA256withDSA,
- * SHA384withDSA, SHA512withDSA, SHA3-224withDSA, SHA3-256withDSA,
- * SHA3-384withDSA, SHA3-512withDSA, as well as RawDSA, used by
- * TLS among others. RawDSA expects the 20 byte SHA-1 digest as
- * input via update rather than the original data like other signature
- * implementations.
+ * This file contains the signature implementation for the
+ * SHA1withDSA (DSS), SHA224withDSA, SHA256withDSA, SHA384withDSA,
+ * SHA512withDSA, SHA3-224withDSA, SHA3-256withDSA, SHA3-384withDSA,
+ * SHA3-512withDSA, as well as RawDSA, used by TLS among others.
+ * RawDSA expects the 20 byte SHA-1 digest as input via update rather
+ * than the original data like other signature implementations.
  *
+ * In addition, IEEE P1363 signature format is supported. The
+ * corresponding implementation is registered under <sig>inP1363Format,
+ * e.g. SHA256withDSAinP1363Format.
+ * 
  * @author Benjamin Renaud
  *
  * @since   1.1
@@ -506,44 +509,72 @@ abstract class DSA extends SignatureSpi {
         return printable;
     }
 
+    /**
+     * SHA3-224withDSA implementation.
+     */
     public static final class SHA3_224withDSA extends DSA {
         public SHA3_224withDSA() throws NoSuchAlgorithmException {
             super(MessageDigest.getInstance("SHA3-224"));
         }
     }
+    
+    /**
+     * SHA3-224withDSA implementation that uses the IEEE P1363 format.
+     */
     public static final class SHA3_224withDSAinP1363Format extends DSA {
         public SHA3_224withDSAinP1363Format() throws NoSuchAlgorithmException {
             super(MessageDigest.getInstance("SHA3-224"), true);
         }
     }
 
+    /**
+     * Standard SHA3-256withDSA implementation.
+     */
     public static final class SHA3_256withDSA extends DSA {
         public SHA3_256withDSA() throws NoSuchAlgorithmException {
             super(MessageDigest.getInstance("SHA3-256"));
         }
     }
+    
+    /**
+     * Standard SHA3-256withDSA implementation that uses the IEEE P1363 format.
+     */
     public static final class SHA3_256withDSAinP1363Format extends DSA {
         public SHA3_256withDSAinP1363Format() throws NoSuchAlgorithmException {
             super(MessageDigest.getInstance("SHA3-256"), true);
         }
     }
 
+    /**
+     * Standard SHA3-384withDSA implementation.
+     */
     public static final class SHA3_384withDSA extends DSA {
         public SHA3_384withDSA() throws NoSuchAlgorithmException {
             super(MessageDigest.getInstance("SHA3-384"));
         }
     }
+    
+    /**
+     * Standard SHA3-384withDSA implementation that uses the IEEE P1363 format.
+     */
     public static final class SHA3_384withDSAinP1363Format extends DSA {
         public SHA3_384withDSAinP1363Format() throws NoSuchAlgorithmException {
             super(MessageDigest.getInstance("SHA3-384"), true);
         }
     }
 
+    /**
+     * Standard SHA3-512withDSA implementation.
+     */
     public static final class SHA3_512withDSA extends DSA {
         public SHA3_512withDSA() throws NoSuchAlgorithmException {
             super(MessageDigest.getInstance("SHA3-512"));
         }
     }
+    
+    /**
+     * Standard SHA3-512withDSA implementation that uses the IEEE P1363 format.
+     */
     public static final class SHA3_512withDSAinP1363Format extends DSA {
         public SHA3_512withDSAinP1363Format() throws NoSuchAlgorithmException {
             super(MessageDigest.getInstance("SHA3-512"), true);

--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -54,9 +54,13 @@ import static sun.security.util.SecurityProviderConstants.getAliases;
  *   SHA-2 family of hash functions includes SHA-224, SHA-256, SHA-384,
  *   and SHA-512.
  *
- * - SHA-224withDSA/SHA-256withDSA are the signature schemes
+ * - [SHA-224|SHA-256|SHA-384|SHA-512]withDSA are the signature schemes
  *   described in FIPS 186-3. The associated object identifiers are
- *   "OID.2.16.840.1.101.3.4.3.1", and "OID.2.16.840.1.101.3.4.3.2".
+ *   "OID.2.16.840.1.101.3.4.3.[1|2|3|4]" respectively.
+ *
+ * - [SHA3-224|SHA3-256|SHA3-384|SHA3-512]withDSA are the signature schemes
+ *   using SHA-3 family of digests with DSA. The associated object identifiers
+ *   are "OID.2.16.840.1.101.3.4.3.[5|6|7|8]" respectively.
  *
  * - DSA is the key generation scheme as described in FIPS 186.
  *   Aliases for DSA include the OID strings "OID.1.3.14.3.2.12"
@@ -127,12 +131,29 @@ public final class SunEntries {
         addWithAlias(p, "Signature", "NONEwithDSA",
                 "sun.security.provider.DSA$RawDSA", attrs);
 
-        attrs.put("KeySize", "2048"); // for SHA224 and SHA256 DSA signatures
+        // for DSA signatures with 224/256-bit digests
+        attrs.put("KeySize", "2048");
 
         addWithAlias(p, "Signature", "SHA224withDSA",
                 "sun.security.provider.DSA$SHA224withDSA", attrs);
         addWithAlias(p, "Signature", "SHA256withDSA",
                 "sun.security.provider.DSA$SHA256withDSA", attrs);
+
+        addWithAlias(p, "Signature", "SHA3-224withDSA",
+                "sun.security.provider.DSA$SHA3_224withDSA", attrs);
+        addWithAlias(p, "Signature", "SHA3-256withDSA",
+                "sun.security.provider.DSA$SHA3_256withDSA", attrs);
+
+        attrs.put("KeySize", "3072"); // for DSA sig using 384/512-bit digests
+
+        addWithAlias(p, "Signature", "SHA384withDSA",
+                "sun.security.provider.DSA$SHA384withDSA", attrs);
+        addWithAlias(p, "Signature", "SHA512withDSA",
+                "sun.security.provider.DSA$SHA512withDSA", attrs);
+        addWithAlias(p, "Signature", "SHA3-384withDSA",
+                "sun.security.provider.DSA$SHA3_384withDSA", attrs);
+        addWithAlias(p, "Signature", "SHA3-512withDSA",
+                "sun.security.provider.DSA$SHA3_512withDSA", attrs);
 
         attrs.remove("KeySize");
 
@@ -144,7 +165,18 @@ public final class SunEntries {
                 "sun.security.provider.DSA$SHA224withDSAinP1363Format");
         add(p, "Signature", "SHA256withDSAinP1363Format",
                 "sun.security.provider.DSA$SHA256withDSAinP1363Format");
-
+        add(p, "Signature", "SHA384withDSAinP1363Format",
+                "sun.security.provider.DSA$SHA384withDSAinP1363Format");
+        add(p, "Signature", "SHA512withDSAinP1363Format",
+                "sun.security.provider.DSA$SHA512withDSAinP1363Format");
+        add(p, "Signature", "SHA3-224withDSAinP1363Format",
+                "sun.security.provider.DSA$SHA3_224withDSAinP1363Format");
+        add(p, "Signature", "SHA3-256withDSAinP1363Format",
+                "sun.security.provider.DSA$SHA3_256withDSAinP1363Format");
+        add(p, "Signature", "SHA3-384withDSAinP1363Format",
+                "sun.security.provider.DSA$SHA3_384withDSAinP1363Format");
+        add(p, "Signature", "SHA3-512withDSAinP1363Format",
+                "sun.security.provider.DSA$SHA3_512withDSAinP1363Format");
         /*
          *  Key Pair Generator engines
          */

--- a/src/java.base/share/classes/sun/security/rsa/PSSParameters.java
+++ b/src/java.base/share/classes/sun/security/rsa/PSSParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,7 +103,7 @@ public final class PSSParameters extends AlgorithmParametersSpi {
                     throw new IOException("Only MGF1 mgf is supported");
                 }
                 AlgorithmId params = AlgorithmId.parse(
-                    new DerValue(val.getEncodedParams()));
+                        new DerValue(val.getEncodedParams()));
                 String mgfDigestName = params.getName();
                 switch (mgfDigestName) {
                 case "SHA-1":
@@ -126,6 +126,18 @@ public final class PSSParameters extends AlgorithmParametersSpi {
                     break;
                 case "SHA-512/256":
                     mgfSpec = MGF1ParameterSpec.SHA512_256;
+                    break;
+                case "SHA3-224":
+                    mgfSpec = MGF1ParameterSpec.SHA3_224;
+                    break;
+                case "SHA3-256":
+                    mgfSpec = MGF1ParameterSpec.SHA3_256;
+                    break;
+                case "SHA3-384":
+                    mgfSpec = MGF1ParameterSpec.SHA3_384;
+                    break;
+                case "SHA3-512":
+                    mgfSpec = MGF1ParameterSpec.SHA3_512;
                     break;
                 default:
                     throw new IOException

--- a/src/java.base/share/classes/sun/security/rsa/RSASignature.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,9 @@ import sun.security.x509.AlgorithmId;
  * PKCS#1 v1.5 RSA signatures with the various message digest algorithms.
  * This file contains an abstract base class with all the logic plus
  * a nested static class for each of the message digest algorithms
- * (see end of the file). We support MD2, MD5, SHA-1, SHA-224, SHA-256,
- * SHA-384, SHA-512, SHA-512/224, and SHA-512/256.
+ * (see end of the file). We support MD2, MD5, SHA-1, SHA2 family (
+ * SHA-224, SHA-256, SHA-384, SHA-512, SHA-512/224, and SHA-512/256),
+ * and SHA3 family (SHA3-224, SHA3-256, SHA3-384, SHA3-512) of digests.
  *
  * @since   1.5
  * @author  Andreas Sterbenz
@@ -358,6 +359,34 @@ public abstract class RSASignature extends SignatureSpi {
     public static final class SHA512_256withRSA extends RSASignature {
         public SHA512_256withRSA() {
             super("SHA-512/256", AlgorithmId.SHA512_256_oid, 11);
+        }
+    }
+
+    // Nested class for SHA3-224withRSA signatures
+    public static final class SHA3_224withRSA extends RSASignature {
+        public SHA3_224withRSA() {
+            super("SHA3-224", AlgorithmId.SHA3_224_oid, 11);
+        }
+    }
+
+    // Nested class for SHA3-256withRSA signatures
+    public static final class SHA3_256withRSA extends RSASignature {
+        public SHA3_256withRSA() {
+            super("SHA3-256", AlgorithmId.SHA3_256_oid, 11);
+        }
+    }
+
+    // Nested class for SHA3-384withRSA signatures
+    public static final class SHA3_384withRSA extends RSASignature {
+        public SHA3_384withRSA() {
+            super("SHA3-384", AlgorithmId.SHA3_384_oid, 11);
+        }
+    }
+
+    // Nested class for SHA3-512withRSA signatures
+    public static final class SHA3_512withRSA extends RSASignature {
+        public SHA3_512withRSA() {
+            super("SHA3-512", AlgorithmId.SHA3_512_oid, 11);
         }
     }
 }

--- a/src/java.base/share/classes/sun/security/rsa/SunRsaSignEntries.java
+++ b/src/java.base/share/classes/sun/security/rsa/SunRsaSignEntries.java
@@ -84,6 +84,14 @@ public final class SunRsaSignEntries {
                 "sun.security.rsa.RSASignature$SHA512_224withRSA", attrs);
         addA(p, "Signature", "SHA512/256withRSA",
                 "sun.security.rsa.RSASignature$SHA512_256withRSA", attrs);
+        addA(p, "Signature", "SHA3-224withRSA",
+                "sun.security.rsa.RSASignature$SHA3_224withRSA", attrs);
+        addA(p, "Signature", "SHA3-256withRSA",
+                "sun.security.rsa.RSASignature$SHA3_256withRSA", attrs);
+        addA(p, "Signature", "SHA3-384withRSA",
+               "sun.security.rsa.RSASignature$SHA3_384withRSA", attrs);
+        addA(p, "Signature", "SHA3-512withRSA",
+                "sun.security.rsa.RSASignature$SHA3_512withRSA", attrs);
 
         addA(p, "KeyFactory", "RSASSA-PSS",
                 "sun.security.rsa.RSAKeyFactory$PSS", attrs);
@@ -92,7 +100,7 @@ public final class SunRsaSignEntries {
         addA(p, "Signature", "RSASSA-PSS",
                 "sun.security.rsa.RSAPSSSignature", attrs);
         addA(p, "AlgorithmParameters", "RSASSA-PSS",
-                "sun.security.rsa.PSSParameters", attrs);
+                "sun.security.rsa.PSSParameters", null);
     }
 
     public Iterator<Provider.Service> iterator() {

--- a/src/java.base/share/classes/sun/security/util/KnownOIDs.java
+++ b/src/java.base/share/classes/sun/security/util/KnownOIDs.java
@@ -154,6 +154,14 @@ public enum KnownOIDs {
     SHA256withDSA("2.16.840.1.101.3.4.3.2"),
     SHA384withDSA("2.16.840.1.101.3.4.3.3"),
     SHA512withDSA("2.16.840.1.101.3.4.3.4"),
+    SHA3_224withDSA("2.16.840.1.101.3.4.3.5", "SHA3-224withDSA"),
+    SHA3_256withDSA("2.16.840.1.101.3.4.3.6", "SHA3-256withDSA"),
+    SHA3_384withDSA("2.16.840.1.101.3.4.3.7", "SHA3-384withDSA"),
+    SHA3_512withDSA("2.16.840.1.101.3.4.3.8", "SHA3-512withDSA"),
+    SHA3_224withECDSA("2.16.840.1.101.3.4.3.9", "SHA3-224withECDSA"),
+    SHA3_256withECDSA("2.16.840.1.101.3.4.3.10", "SHA3-256withECDSA"),
+    SHA3_384withECDSA("2.16.840.1.101.3.4.3.11", "SHA3-384withECDSA"),
+    SHA3_512withECDSA("2.16.840.1.101.3.4.3.12", "SHA3-512withECDSA"),
     SHA3_224withRSA("2.16.840.1.101.3.4.3.13", "SHA3-224withRSA"),
     SHA3_256withRSA("2.16.840.1.101.3.4.3.14", "SHA3-256withRSA"),
     SHA3_384withRSA("2.16.840.1.101.3.4.3.15", "SHA3-384withRSA"),
@@ -429,9 +437,9 @@ public enum KnownOIDs {
         if (debug != null) {
             debug.println("Setting up name2enum:");
         }
-        List.of(KnownOIDs.values()).forEach(o -> {
+        for (KnownOIDs o : KnownOIDs.values()) {
             register(o);
-        });
+        };
     }
 
     private static void register(KnownOIDs o) {

--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -196,6 +196,10 @@ public class AlgorithmId implements Serializable, DerEncoder {
                 algid.equals((Object)SHA512_oid) ||
                 algid.equals((Object)SHA512_224_oid) ||
                 algid.equals((Object)SHA512_256_oid) ||
+                algid.equals((Object)SHA3_224_oid) ||
+                algid.equals((Object)SHA3_256_oid) ||
+                algid.equals((Object)SHA3_384_oid) ||
+                algid.equals((Object)SHA3_512_oid) ||
                 algid.equals((Object)DSA_oid) ||
                 algid.equals((Object)sha1WithDSA_oid)) {
                 ; // no parameter part encoded
@@ -607,6 +611,18 @@ public class AlgorithmId implements Serializable, DerEncoder {
 
     public static final ObjectIdentifier SHA512_256_oid =
             ObjectIdentifier.of(KnownOIDs.SHA_512$256);
+
+    public static final ObjectIdentifier SHA3_224_oid =
+            ObjectIdentifier.of(KnownOIDs.SHA3_224);
+
+    public static final ObjectIdentifier SHA3_256_oid =
+            ObjectIdentifier.of(KnownOIDs.SHA3_256);
+
+    public static final ObjectIdentifier SHA3_384_oid =
+            ObjectIdentifier.of(KnownOIDs.SHA3_384);
+
+    public static final ObjectIdentifier SHA3_512_oid =
+            ObjectIdentifier.of(KnownOIDs.SHA3_512);
 
     public static final ObjectIdentifier DSA_oid =
             ObjectIdentifier.of(KnownOIDs.DSA);

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDSASignature.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDSASignature.java
@@ -46,12 +46,20 @@ import static sun.security.ec.ECOperations.IntermediateValueException;
  *   . "SHA256withECDSA"
  *   . "SHA384withECDSA"
  *   . "SHA512withECDSA"
+ *   . "SHA3-224withECDSA"
+ *   . "SHA3-256withECDSA"
+ *   . "SHA3-384withECDSA"
+ *   . "SHA3-512withECDSA"
  *   . "NONEwithECDSAinP1363Format"
  *   . "SHA1withECDSAinP1363Format"
  *   . "SHA224withECDSAinP1363Format"
  *   . "SHA256withECDSAinP1363Format"
  *   . "SHA384withECDSAinP1363Format"
  *   . "SHA512withECDSAinP1363Format"
+ *   . "SHA3-224withECDSAinP1363Format"
+ *   . "SHA3-256withECDSAinP1363Format"
+ *   . "SHA3-384withECDSAinP1363Format"
+ *   . "SHA3-512withECDSAinP1363Format"
  *
  * @since   1.7
  */
@@ -275,6 +283,62 @@ abstract class ECDSASignature extends SignatureSpi {
     public static final class SHA512inP1363Format extends ECDSASignature {
         public SHA512inP1363Format() {
             super("SHA-512", true);
+        }
+    }
+
+    // Nested class for SHA3_224withECDSA signatures
+    public static final class SHA3_224 extends ECDSASignature {
+        public SHA3_224() {
+           super("SHA3-224");
+        }
+    }
+
+    // Nested class for SHA3_224withECDSAinP1363Format signatures
+    public static final class SHA3_224inP1363Format extends ECDSASignature {
+        public SHA3_224inP1363Format() {
+            super("SHA3-224", true);
+        }
+    }
+
+    // Nested class for SHA3_256withECDSA signatures
+    public static final class SHA3_256 extends ECDSASignature {
+        public SHA3_256() {
+            super("SHA3-256");
+        }
+    }
+
+    // Nested class for SHA3_256withECDSAinP1363Format signatures
+    public static final class SHA3_256inP1363Format extends ECDSASignature {
+        public SHA3_256inP1363Format() {
+            super("SHA3-256", true);
+        }
+    }
+
+    // Nested class for SHA3_384withECDSA signatures
+    public static final class SHA3_384 extends ECDSASignature {
+        public SHA3_384() {
+            super("SHA3-384");
+        }
+    }
+
+    // Nested class for SHA3_384withECDSAinP1363Format signatures
+    public static final class SHA3_384inP1363Format extends ECDSASignature {
+        public SHA3_384inP1363Format() {
+            super("SHA3-384", true);
+        }
+    }
+
+    // Nested class for SHA3_512withECDSA signatures
+    public static final class SHA3_512 extends ECDSASignature {
+        public SHA3_512() {
+            super("SHA3-512");
+        }
+    }
+
+    // Nested class for SHA3_512withECDSAinP1363Format signatures
+    public static final class SHA3_512inP1363Format extends ECDSASignature {
+        public SHA3_512inP1363Format() {
+            super("SHA3-512", true);
         }
     }
 

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
@@ -157,8 +157,20 @@ public final class SunEC extends Provider {
                     } else if (algo.equals("NONEwithECDSA")) {
                         return (inP1363? new ECDSASignature.RawinP1363Format() :
                             new ECDSASignature.Raw());
-                    }
-                } else  if (type.equals("KeyFactory")) {
+                    } else if (algo.equals("SHA3-224withECDSA")) {
+                        return (inP1363? new ECDSASignature.SHA3_224inP1363Format() :
+                            new ECDSASignature.SHA3_224());
+                    } else if (algo.equals("SHA3-256withECDSA")) {
+                        return (inP1363? new ECDSASignature.SHA3_256inP1363Format() :
+                            new ECDSASignature.SHA3_256());
+                    } else if (algo.equals("SHA3-384withECDSA")) {
+                        return (inP1363? new ECDSASignature.SHA3_384inP1363Format() :
+                            new ECDSASignature.SHA3_384());
+                    } else if (algo.equals("SHA3-512withECDSA")) {
+                        return (inP1363? new ECDSASignature.SHA3_512inP1363Format() :
+                            new ECDSASignature.SHA3_512());
+                     }
+                } else if (type.equals("KeyFactory")) {
                     if (algo.equals("EC")) {
                         return new ECKeyFactory();
                     } else if (algo.equals("XDH")) {
@@ -304,6 +316,18 @@ public final class SunEC extends Provider {
         putService(new ProviderServiceA(this, "Signature",
             "SHA512withECDSA", "sun.security.ec.ECDSASignature$SHA512",
             ATTRS));
+        putService(new ProviderServiceA(this, "Signature",
+            "SHA3-224withECDSA", "sun.security.ec.ECDSASignature$SHA3_224",
+            ATTRS));
+        putService(new ProviderServiceA(this, "Signature",
+            "SHA3-256withECDSA", "sun.security.ec.ECDSASignature$SHA3_256",
+            ATTRS));
+        putService(new ProviderServiceA(this, "Signature",
+            "SHA3-384withECDSA", "sun.security.ec.ECDSASignature$SHA3_384",
+            ATTRS));
+        putService(new ProviderServiceA(this, "Signature",
+            "SHA3-512withECDSA", "sun.security.ec.ECDSASignature$SHA3_512",
+            ATTRS));
 
         putService(new ProviderService(this, "Signature",
              "NONEwithECDSAinP1363Format",
@@ -323,6 +347,19 @@ public final class SunEC extends Provider {
         putService(new ProviderService(this, "Signature",
             "SHA512withECDSAinP1363Format",
             "sun.security.ec.ECDSASignature$SHA512inP1363Format"));
+
+        putService(new ProviderService(this, "Signature",
+             "SHA3-224withECDSAinP1363Format",
+             "sun.security.ec.ECDSASignature$SHA3_224inP1363Format"));
+        putService(new ProviderService(this, "Signature",
+             "SHA3-256withECDSAinP1363Format",
+             "sun.security.ec.ECDSASignature$SHA3_256inP1363Format"));
+        putService(new ProviderService(this, "Signature",
+            "SHA3-384withECDSAinP1363Format",
+            "sun.security.ec.ECDSASignature$SHA3_384inP1363Format"));
+        putService(new ProviderService(this, "Signature",
+            "SHA3-512withECDSAinP1363Format",
+            "sun.security.ec.ECDSASignature$SHA3_512inP1363Format"));
 
         /*
          *  Key Pair Generator engine

--- a/test/jdk/java/security/SignedObject/Chain.java
+++ b/test/jdk/java/security/SignedObject/Chain.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+/*
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,13 @@ public class Chain {
         SHA1withDSA("SHA1withDSA"),
         SHA224withDSA("SHA224withDSA"),
         SHA256withDSA("SHA256withDSA"),
+        SHA384withDSA("SHA384withDSA"),
+        SHA512withDSA("SHA512withDSA"),
+
+        SHA3_224withDSA("SHA3-224withDSA"),
+        SHA3_256withDSA("SHA3-256withDSA"),
+        SHA3_384withDSA("SHA3-384withDSA"),
+        SHA3_512withDSA("SHA3-512withDSA"),
 
         SHA1withRSA("Sha1withrSA"),
         SHA224withRSA("SHA224withRSA"),
@@ -79,12 +86,20 @@ public class Chain {
         SHA512withRSA("SHA512withRSA"),
         SHA512_224withRSA("SHA512/224withRSA"),
         SHA512_256withRSA("SHA512/256withRSA"),
+        SHA3_224withRSA("SHA3-224withRSA"),
+        SHA3_256withRSA("SHA3-256withRSA"),
+        SHA3_384withRSA("SHA3-384withRSA"),
+        SHA3_512withRSA("SHA3-512withRSA"),
 
         SHA1withECDSA("SHA1withECDSA"),
-        SHA256withECDSA("SHA256withECDSA"),
         SHA224withECDSA("SHA224withECDSA"),
+        SHA256withECDSA("SHA256withECDSA"),
         SHA384withECDSA("SHA384withECDSA"),
         SHA512withECDSA("SHA512withECDSA"),
+        SHA3_224withECDSA("SHA3-224withECDSA"),
+        SHA3_256withECDSA("SHA3-256withECDSA"),
+        SHA3_384withECDSA("SHA3-384withECDSA"),
+        SHA3_512withECDSA("SHA3-512withECDSA"),
 
         MD5andSHA1withRSA("MD5andSHA1withRSA"),
 
@@ -147,7 +162,10 @@ public class Chain {
         new Test(SigAlg.SHA1withDSA, KeyAlg.DSA, Provider.Default, 1024),
         new Test(SigAlg.MD2withRSA, KeyAlg.RSA, Provider.Default),
         new Test(SigAlg.MD5withRSA, KeyAlg.RSA, Provider.Default),
-        new Test(SigAlg.SHA1withRSA, KeyAlg.RSA, Provider.Default),
+        new Test(SigAlg.SHA3_224withRSA, KeyAlg.RSA, Provider.Default),
+        new Test(SigAlg.SHA3_256withRSA, KeyAlg.RSA, Provider.Default),
+        new Test(SigAlg.SHA3_384withRSA, KeyAlg.RSA, Provider.Default),
+        new Test(SigAlg.SHA3_512withRSA, KeyAlg.RSA, Provider.Default),
         new Test(SigAlg.SHA1withDSA, KeyAlg.DSA, Provider.Sun, 1024),
         new Test(SigAlg.SHA224withDSA, KeyAlg.DSA, Provider.Sun, 2048),
         new Test(SigAlg.SHA256withDSA, KeyAlg.DSA, Provider.Sun, 2048),

--- a/test/jdk/sun/security/ec/SignatureKAT.java
+++ b/test/jdk/sun/security/ec/SignatureKAT.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Convert;
+
+import java.security.*;
+import java.security.spec.*;
+import java.math.*;
+import java.util.*;
+
+/*
+ * @test
+ * @bug 8172366
+ * @summary Known Answer Test for ECDSA signature
+ * @library /test/lib
+ * @build jdk.test.lib.Convert
+ * @run main/othervm SignatureKAT
+ */
+public class SignatureKAT {
+
+    private static String checkHex(String hex) {
+        // if hex length is odd, need to prepend 0
+        if (hex.length() % 2 != 0) {
+            hex = "0" + hex;
+        }
+        return hex;
+    }
+
+    private static class CurveData {
+        private String name;
+        private byte[] msgBytes;
+        private BigInteger priv;
+        private BigInteger pubX;
+        private BigInteger pubY;
+
+        private static BigInteger toBigInteger(String hex) {
+            byte[] bytes = Convert.hexStringToByteArray(checkHex(hex));
+            return new BigInteger(1, bytes);
+        }
+        CurveData(String name, String msg, String priv, String pubX,
+                String pubY) {
+            this.name = name;
+            this.msgBytes = msg.getBytes();
+            this.priv = toBigInteger(priv);
+            this.pubX = toBigInteger(pubX);
+            this.pubY = toBigInteger(pubY);
+        }
+    }
+
+    private static class TestData {
+        private String sigName;
+        private CurveData cd;
+        private byte[] expSig;
+
+        TestData(String sigName, CurveData cd, String r, String s) {
+            this.sigName = sigName;
+            this.cd = cd;
+            if (r.length() != s.length() || r != checkHex(r) ||
+                s != checkHex(s)) {
+                throw new RuntimeException("Error: invalid r, s");
+            }
+            this.expSig = Convert.hexStringToByteArray(r + s);
+        }
+    }
+
+    // These test values are from the examples shown in the page below:
+    // https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values
+    private static final CurveData P_256 = new CurveData(
+        "secp256r1", "Example of ECDSA with P-256",
+        "C477F9F65C22CCE20657FAA5B2D1D8122336F851A508A1ED04E479C34985BF96",
+        "B7E08AFDFE94BAD3F1DC8C734798BA1C62B3A0AD1E9EA2A38201CD0889BC7A19",
+        "3603F747959DBF7A4BB226E41928729063ADC7AE43529E61B563BBC606CC5E09"
+    );
+
+    private static final CurveData P_384 = new CurveData(
+        "secp384r1", "Example of ECDSA with P-384",
+        "F92C02ED629E4B48C0584B1C6CE3A3E3B4FAAE4AFC6ACB0455E73DFC392E6A0AE393A8565E6B9714D1224B57D83F8A08",
+        "3BF701BC9E9D36B4D5F1455343F09126F2564390F2B487365071243C61E6471FB9D2AB74657B82F9086489D9EF0F5CB5",
+        "D1A358EAFBF952E68D533855CCBDAA6FF75B137A5101443199325583552A6295FFE5382D00CFCDA30344A9B5B68DB855"
+    );
+
+    private static final CurveData P_521 = new CurveData(
+        "secp521r1", "Example of ECDSA with P-521",
+        "100085F47B8E1B8B11B7EB33028C0B2888E304BFC98501955B45BBA1478DC184EEEDF09B86A5F7C21994406072787205E69A63709FE35AA93BA333514B24F961722",
+        "98E91EEF9A68452822309C52FAB453F5F117C1DA8ED796B255E9AB8F6410CCA16E59DF403A6BDC6CA467A37056B1E54B3005D8AC030DECFEB68DF18B171885D5C4",
+        "164350C321AECFC1CCA1BA4364C9B15656150B4B78D6A48D7D28E7F31985EF17BE8554376B72900712C4B83AD668327231526E313F5F092999A4632FD50D946BC2E"
+    );
+
+    private static TestData[] TEST_DATUM = {
+        // secp256r1, secp384r1, and secp521r1 remain enabled
+        new TestData("SHA256withECDSAinP1363Format", P_256,
+            "2B42F576D07F4165FF65D1F3B1500F81E44C316F1F0B3EF57325B69ACA46104F",
+            "DC42C2122D6392CD3E3A993A89502A8198C1886FE69D262C4B329BDB6B63FAF1"),
+        new TestData("SHA3-256withECDSAinP1363Format", P_256,
+            "2B42F576D07F4165FF65D1F3B1500F81E44C316F1F0B3EF57325B69ACA46104F",
+            "0A861C2526900245C73BACB9ADAEC1A5ACB3BA1F7114A3C334FDCD5B7690DADD"),
+        new TestData("SHA384withECDSAinP1363Format", P_384,
+            "30EA514FC0D38D8208756F068113C7CADA9F66A3B40EA3B313D040D9B57DD41A332795D02CC7D507FCEF9FAF01A27088",
+            "CC808E504BE414F46C9027BCBF78ADF067A43922D6FCAA66C4476875FBB7B94EFD1F7D5DBE620BFB821C46D549683AD8"),
+        new TestData("SHA3-384withECDSAinP1363Format", P_384,
+            "30EA514FC0D38D8208756F068113C7CADA9F66A3B40EA3B313D040D9B57DD41A332795D02CC7D507FCEF9FAF01A27088",
+            "691B9D4969451A98036D53AA725458602125DE74881BBC333012CA4FA55BDE39D1BF16A6AAE3FE4992C567C6E7892337"),
+        new TestData("SHA512withECDSAinP1363Format", P_521,
+            "0140C8EDCA57108CE3F7E7A240DDD3AD74D81E2DE62451FC1D558FDC79269ADACD1C2526EEEEF32F8C0432A9D56E2B4A8A732891C37C9B96641A9254CCFE5DC3E2BA",
+            "00D72F15229D0096376DA6651D9985BFD7C07F8D49583B545DB3EAB20E0A2C1E8615BD9E298455BDEB6B61378E77AF1C54EEE2CE37B2C61F5C9A8232951CB988B5B1"),
+        new TestData("SHA3-512withECDSAinP1363Format", P_521,
+            "0140C8EDCA57108CE3F7E7A240DDD3AD74D81E2DE62451FC1D558FDC79269ADACD1C2526EEEEF32F8C0432A9D56E2B4A8A732891C37C9B96641A9254CCFE5DC3E2BA",
+            "00B25188492D58E808EDEBD7BF440ED20DB771CA7C618595D5398E1B1C0098E300D8C803EC69EC5F46C84FC61967A302D366C627FCFA56F87F241EF921B6E627ADBF"),
+    };
+
+    private static void runTest(TestData td) throws Exception {
+        System.out.println("Testing " + td.sigName + " with " + td.cd.name);
+
+        AlgorithmParameters params =
+            AlgorithmParameters.getInstance("EC", "SunEC");
+        params.init(new ECGenParameterSpec(td.cd.name));
+        ECParameterSpec ecParams =
+            params.getParameterSpec(ECParameterSpec.class);
+
+        KeyFactory kf = KeyFactory.getInstance("EC", "SunEC");
+        PrivateKey privKey = kf.generatePrivate
+                (new ECPrivateKeySpec(td.cd.priv, ecParams));
+
+        Signature sig = Signature.getInstance(td.sigName, "SunEC");
+        sig.initSign(privKey);
+        sig.update(td.cd.msgBytes);
+        // NOTE: there is no way to set the nonce value into current SunEC
+        // ECDSA signature, thus the output signature bytes likely won't
+        // match the expected signature bytes
+        byte[] ov = sig.sign();
+
+        ECPublicKeySpec pubKeySpec = new ECPublicKeySpec
+                (new ECPoint(td.cd.pubX, td.cd.pubY), ecParams);
+        PublicKey pubKey = kf.generatePublic(pubKeySpec);
+
+        sig.initVerify(pubKey);
+        sig.update(td.cd.msgBytes);
+        if (!sig.verify(ov)) {
+            throw new RuntimeException("Error verifying actual sig bytes");
+        }
+
+        sig.update(td.cd.msgBytes);
+        if (!sig.verify(td.expSig)) {
+            throw new RuntimeException("Error verifying expected sig bytes");
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        for (TestData td : TEST_DATUM) {
+            runTest(td);
+        }
+    }
+}

--- a/test/jdk/sun/security/ec/SignatureOffsets.java
+++ b/test/jdk/sun/security/ec/SignatureOffsets.java
@@ -43,6 +43,10 @@ import java.security.SignatureException;
  * @run main SignatureOffsets SunEC SHA224withECDSA
  * @run main SignatureOffsets SunEC SHA384withECDSA
  * @run main SignatureOffsets SunEC SHA512withECDSA
+ * @run main SignatureOffsets SunEC SHA3-256withECDSA
+ * @run main SignatureOffsets SunEC SHA3-224withECDSA
+ * @run main SignatureOffsets SunEC SHA3-384withECDSA
+ * @run main SignatureOffsets SunEC SHA3-512withECDSA
  */
 public class SignatureOffsets {
 

--- a/test/jdk/sun/security/ec/SignedObjectChain.java
+++ b/test/jdk/sun/security/ec/SignedObjectChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8050374 8146293
+ * @bug 8050374 8146293 8172366
  * @summary Verify a chain of signed objects
  * @library /test/lib
  * @build jdk.test.lib.SigTestUtil
@@ -41,10 +41,14 @@ public class SignedObjectChain {
 
     private static final Test[] tests = {
         new Test(Chain.SigAlg.SHA1withECDSA),
-        new Test(Chain.SigAlg.SHA256withECDSA),
         new Test(Chain.SigAlg.SHA224withECDSA),
+        new Test(Chain.SigAlg.SHA256withECDSA),
         new Test(Chain.SigAlg.SHA384withECDSA),
         new Test(Chain.SigAlg.SHA512withECDSA),
+        new Test(Chain.SigAlg.SHA3_224withECDSA),
+        new Test(Chain.SigAlg.SHA3_256withECDSA),
+        new Test(Chain.SigAlg.SHA3_384withECDSA),
+        new Test(Chain.SigAlg.SHA3_512withECDSA),
     };
 
     public static void main(String argv[]) {

--- a/test/jdk/sun/security/rsa/SignatureOffsets.java
+++ b/test/jdk/sun/security/rsa/SignatureOffsets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ import java.security.SignatureException;
 
 /*
  * @test
- * @bug 8050374 8146293
+ * @bug 8050374 8146293 8172366
  * @key randomness
  * @summary This test validates signature verification
  *          Signature.verify(byte[], int, int). The test uses RandomFactory to
@@ -46,6 +46,10 @@ import java.security.SignatureException;
  * @run main SignatureOffsets SunRsaSign SHA512withRSA
  * @run main SignatureOffsets SunRsaSign SHA512/224withRSA
  * @run main SignatureOffsets SunRsaSign SHA512/256withRSA
+ * @run main SignatureOffsets SunRsaSign SHA3-224withRSA
+ * @run main SignatureOffsets SunRsaSign SHA3-256withRSA
+ * @run main SignatureOffsets SunRsaSign SHA3-384withRSA
+ * @run main SignatureOffsets SunRsaSign SHA3-512withRSA
  */
 public class SignatureOffsets {
 

--- a/test/jdk/sun/security/rsa/pss/PSSParametersTest.java
+++ b/test/jdk/sun/security/rsa/pss/PSSParametersTest.java
@@ -31,7 +31,7 @@ import static javax.crypto.Cipher.PUBLIC_KEY;
 
 /**
  * @test
- * @bug 8146293 8242556
+ * @bug 8146293 8242556 8172366
  * @summary Test RSASSA-PSS AlgorithmParameters impl of SunRsaSign provider.
  * @run main PSSParametersTest
  */
@@ -50,6 +50,8 @@ public class PSSParametersTest {
         System.out.println("Testing against custom parameters");
         test(new PSSParameterSpec("SHA-512/224", "MGF1",
                 MGF1ParameterSpec.SHA384, 100, 1));
+        test(new PSSParameterSpec("SHA3-256", "MGF1",
+            new MGF1ParameterSpec("SHA3-256"), 256>>3, 1));
         System.out.println("Test Passed");
     }
 
@@ -57,6 +59,7 @@ public class PSSParametersTest {
     // bytes, then initialize w/ the DER bytes, retrieve the spec.
     // compare both spec for equality and throw exception if the check failed.
     private static void test(PSSParameterSpec spec) throws Exception {
+        System.out.println("Testing PSS spec: " + spec);
         String ALGORITHMS[] = { PSS_ALGO, PSS_OID };
         for (String alg : ALGORITHMS) {
             AlgorithmParameters params = AlgorithmParameters.getInstance
@@ -67,9 +70,9 @@ public class PSSParametersTest {
                     (alg, PROVIDER);
             params2.init(encoded);
             PSSParameterSpec spec2 = params2.getParameterSpec
-                (PSSParameterSpec.class);
+                    (PSSParameterSpec.class);
             if (!isEqual(spec, spec2)) {
-                throw new RuntimeException("Spec check Failed for " +  alg);
+                throw new RuntimeException("Spec check Failed for " + alg);
             }
         }
     }

--- a/test/jdk/sun/security/rsa/pss/SignatureTest2.java
+++ b/test/jdk/sun/security/rsa/pss/SignatureTest2.java
@@ -31,7 +31,7 @@ import static javax.crypto.Cipher.PUBLIC_KEY;
 
 /**
  * @test
- * @bug 8146293 8238448
+ * @bug 8146293 8238448 8172366
  * @summary Create a signature for RSASSA-PSS and get its signed data.
  *          re-initiate the signature with the public key. The signature
  *          can be verified by acquired signed data.
@@ -68,7 +68,8 @@ public class SignatureTest2 {
      */
     private static final String[] DIGEST_ALG = {
         "SHA-1", "SHA-224", "SHA-256", "SHA-384",
-        "SHA-512", "SHA-512/224", "SHA-512/256"
+        "SHA-512", "SHA-512/224", "SHA-512/256",
+        "SHA3-224", "SHA3-256", "SHA3-384", "SHA3-512"
     };
 
     private static final String SIG_ALG = "RSASSA-PSS";

--- a/test/jdk/sun/security/rsa/pss/TestPSSKeySupport.java
+++ b/test/jdk/sun/security/rsa/pss/TestPSSKeySupport.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8146293 8242556
+ * @bug 8146293 8242556 8172366
  * @summary Test RSASSA-PSS Key related support such as KeyPairGenerator
  * and KeyFactory of the SunRsaSign provider
  */
@@ -145,11 +145,18 @@ public class TestPSSKeySupport {
         KeyPair kp2 = kpg.generateKeyPair();
         checkKeyPair(kp2);
 
+        params = new PSSParameterSpec("SHA3-256", "MGF1",
+            new MGF1ParameterSpec("SHA3-256"), 32, 1);
+        kpg.initialize(new RSAKeyGenParameterSpec(2048, pubExp, params));
+        KeyPair kp3 = kpg.generateKeyPair();
+        checkKeyPair(kp3);
+
         KeyFactory kf = KeyFactory.getInstance(ALGO, "SunRsaSign");
         test(kf, kp.getPublic());
         test(kf, kp.getPrivate());
         test(kf, kp2.getPublic());
         test(kf, kp2.getPrivate());
-
+        test(kf, kp3.getPublic());
+        test(kf, kp3.getPrivate());
     }
 }

--- a/test/lib/jdk/test/lib/SigTestUtil.java
+++ b/test/lib/jdk/test/lib/SigTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,10 +54,14 @@ public class SigTestUtil {
     // collection of all supported digest algorithms
     // note that the entries are ordered by required key sizes
     private static final String[] DIGEST_ALGS = {
+        "SHA3-512",
         "SHA-512",
+        "SHA3-384",
         "SHA-384",
+        "SHA3-256",
         "SHA-256",
         "SHA-512/256",
+        "SHA3-224",
         "SHA-224",
         "SHA-512/224",
         "SHA-1",
@@ -66,14 +70,14 @@ public class SigTestUtil {
 
     // indice for message digest algorithms lookup
     // may need to be adjusted if new algorithms are added
-    private static final int PKCS1_5_INDEX_768 = 0;
-    private static final int PKCS1_5_INDEX_512 = 2;
+    private static final int PKCS1_5_INDEX_768 = 0; // 512, 384-bit digests
+    private static final int PKCS1_5_INDEX_512 = 4; // 256-bit digests
     private static final int PKCS1_5_INDEX_END = DIGEST_ALGS.length;
-    private static final int PSS_INDEX_2048 = 0;
-    private static final int PSS_INDEX_1024 = 1;
-    private static final int PSS_INDEX_768 = 2;
-    private static final int PSS_INDEX_512 = 4;
-    private static final int PSS_INDEX_END = 7;
+    private static final int PSS_INDEX_2048 = 0; // 512-bit digests
+    private static final int PSS_INDEX_1024 = 2; // 384-bit digests
+    private static final int PSS_INDEX_768 = 4; // 256-bit digests
+    private static final int PSS_INDEX_512 = 7; // 224-bit digests
+    private static final int PSS_INDEX_END = DIGEST_ALGS.length - 2;
 
     public static Iterable<String> getDigestAlgorithms(SignatureType type,
             int keysize) throws RuntimeException {
@@ -135,9 +139,8 @@ public class SigTestUtil {
             String mdAlg) throws RuntimeException {
         switch (type) {
         case RSA:
-            int idx = mdAlg.indexOf("-");
-            if (idx != -1) {
-                mdAlg = mdAlg.substring(0, idx) + mdAlg.substring(idx+1);
+            if (mdAlg.startsWith("SHA-")) {
+                mdAlg = mdAlg.substring(0, 3) + mdAlg.substring(4);
             }
             return mdAlg + "with" + type.toString();
         case RSASSA_PSS:


### PR DESCRIPTION
Could someone please help review this RFE?

Enhance default JDK providers except SunPKCS11 with signatures using SHA-3 family of digests. SunPKCS11 provider will be updated separately (JDK-8242332).

This changes covers SUN, SunRsaSign, and SunEC providers. Changes are straightforward, just add SHA-3 digests to various signature algorithms. 

Please review the corresponding CSR as well. It's at: https://bugs.openjdk.java.net/browse/JDK-8252260

Thanks!
Valerie
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8172366](https://bugs.openjdk.java.net/browse/JDK-8172366): Support SHA-3 based signatures


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to 62fb5a39eb0895e68417c2c8a87df5b9c416f918


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/102/head:pull/102`
`$ git checkout pull/102`
