### PR TITLE
8252105: parallel heap inspection for ZCollectedHeap

### DIFF
--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -33,6 +33,7 @@
 
 class ZDirector;
 class ZDriver;
+class ZHeapParallelObjectIterator;
 class ZStat;
 
 class ZCollectedHeap : public CollectedHeap {
@@ -97,6 +98,7 @@ public:
   virtual GrowableArray<MemoryPool*> memory_pools();
 
   virtual void object_iterate(ObjectClosure* cl);
+  virtual ParallelObjectIterator* parallel_object_iterator(uint thread_num);
 
   virtual void keep_alive(oop obj);
 

--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -26,7 +26,6 @@
 #include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zGlobals.hpp"
 #include "gc/z/zHeap.inline.hpp"
-#include "gc/z/zHeapIterator.hpp"
 #include "gc/z/zHeuristics.hpp"
 #include "gc/z/zMark.inline.hpp"
 #include "gc/z/zPage.inline.hpp"
@@ -439,6 +438,17 @@ void ZHeap::object_iterate(ObjectClosure* cl, bool visit_weaks) {
 
   ZHeapIterator iter;
   iter.objects_do(cl, visit_weaks);
+}
+
+void ZHeap::process_roots_for_par_iterate(ZHeapIterator* iter, bool visit_weaks) {
+  iter->enqueue_roots(visit_weaks);
+}
+
+void ZHeap::par_references_iterate(ObjectClosure* cl,
+                                   ZHeapIterator* iter,
+                                   uint worker_id,
+                                   bool visit_weaks) {
+  iter->drain_queue(cl, visit_weaks, worker_id);
 }
 
 void ZHeap::pages_do(ZPageClosure* cl) {

--- a/src/hotspot/share/gc/z/zHeap.hpp
+++ b/src/hotspot/share/gc/z/zHeap.hpp
@@ -26,6 +26,7 @@
 
 #include "gc/z/zAllocationFlags.hpp"
 #include "gc/z/zForwardingTable.hpp"
+#include "gc/z/zHeapIterator.hpp"
 #include "gc/z/zMark.hpp"
 #include "gc/z/zObjectAllocator.hpp"
 #include "gc/z/zPage.hpp"
@@ -141,6 +142,9 @@ public:
 
   // Iteration
   void object_iterate(ObjectClosure* cl, bool visit_weaks);
+  void process_roots_for_par_iterate(ZHeapIterator* iter, bool visit_weaks);
+  void par_references_iterate(ObjectClosure* cl, ZHeapIterator* iter,
+                              uint worker_id, bool visit_weaks);
   void pages_do(ZPageClosure* cl);
 
   // Serviceability

--- a/src/hotspot/share/gc/z/zHeapIterator.hpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.hpp
@@ -24,37 +24,53 @@
 #ifndef SHARE_GC_Z_ZHEAPITERATOR_HPP
 #define SHARE_GC_Z_ZHEAPITERATOR_HPP
 
+#include "gc/shared/taskqueue.inline.hpp"
 #include "gc/z/zGranuleMap.hpp"
+#include "gc/z/zLock.inline.hpp"
 #include "memory/allocation.hpp"
 #include "utilities/stack.hpp"
 
 class ObjectClosure;
 class ZHeapIteratorBitMap;
+// Queue and QueueSet for parallel iteration
+typedef OverflowTaskQueue<oop, mtGC>                     ZHeapIterTaskQueue;
+typedef GenericTaskQueueSet<ZHeapIterTaskQueue, mtGC>    ZHeapIterTaskQueueSet;
 
 class ZHeapIterator : public StackObj {
   template<bool Concurrent, bool Weak> friend class ZHeapIteratorRootOopClosure;
-  template<bool VisitReferents> friend class ZHeapIteratorOopClosure;
+  template<bool VisitReferents, bool ParallelIter> friend class ZHeapIteratorOopClosure;
 
 private:
   typedef ZGranuleMap<ZHeapIteratorBitMap*>         ZVisitMap;
   typedef ZGranuleMapIterator<ZHeapIteratorBitMap*> ZVisitMapIterator;
   typedef Stack<oop, mtGC>                          ZVisitStack;
-
+  // For parallel iteration, _visit_stack only contains roots.
+  // For serial iteration, _visit_stack contains all references reached.
   ZVisitStack _visit_stack;
   ZVisitMap   _visit_map;
+  // For parallel iteration
+  uint            _num_workers;
+  ZLock           _map_lock;
+  ZHeapIterTaskQueueSet* _task_queues;
 
   ZHeapIteratorBitMap* object_map(oop obj);
   void push(oop obj);
 
   template <typename RootsIterator, bool Concurrent, bool Weak> void push_roots();
-  template <bool VisitReferents> void push_fields(oop obj);
+  // push_fields is different for serial iterate and parallel iterate.
+  template <bool VisitReferents, bool ParallelIter = false>
+  void push_fields(oop obj, ZHeapIterTaskQueue* queue = NULL);
   template <bool VisitReferents> void objects_do(ObjectClosure* cl);
 
 public:
-  ZHeapIterator();
+  ZHeapIterator(uint num_workers = 0);
   ~ZHeapIterator();
 
   void objects_do(ObjectClosure* cl, bool visit_weaks);
+  // For parallel iteration
+  void par_enqueue(oop obj, ZHeapIterTaskQueue* q);
+  void enqueue_roots(bool visit_weaks);
+  void drain_queue(ObjectClosure* cl, bool visit_weaks, uint worker_id);
 };
 
 #endif // SHARE_GC_Z_ZHEAPITERATOR_HPP


### PR DESCRIPTION
- enable parallel heap inspection for ZCollectedHeap
- preliminary evaluation:
  Time of jmap histo on 8GB heap with ~5GB objects
  * before: 7.103s
  * after : 2.734s (with 4 parallel threads)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8252105](https://bugs.openjdk.java.net/browse/JDK-8252105): parallel heap inspection for ZCollectedHeap


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/103/head:pull/103`
`$ git checkout pull/103`
