### PR TITLE
8253280: Use class name as class loading lock

### DIFF
--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -661,7 +661,7 @@ public abstract class ClassLoader {
     protected Object getClassLoadingLock(String className) {
         Object lock = this;
         if (parallelLockMap != null) {
-            Object newLock = new Object();
+            Object newLock = new String(className);
             lock = parallelLockMap.putIfAbsent(className, newLock);
             if (lock == null) {
                 lock = newLock;

--- a/src/java.management/share/classes/java/lang/management/LockInfo.java
+++ b/src/java.management/share/classes/java/lang/management/LockInfo.java
@@ -57,6 +57,24 @@ public class LockInfo {
 
     private String className;
     private int    identityHashCode;
+    private String stringValue;
+
+    /**
+     * Constructs a {@code LockInfo} object.
+     *
+     * @param className the fully qualified name of the class of the lock object.
+     * @param identityHashCode the {@link System#identityHashCode
+     *                         identity hash code} of the lock object.
+     * @param stringValue the string value of the lock object.
+     */
+    public LockInfo(String className, int identityHashCode, String stringValue) {
+        if (className == null) {
+            throw new NullPointerException("Parameter className cannot be null");
+        }
+        this.className = className;
+        this.identityHashCode = identityHashCode;
+        this.stringValue = stringValue;
+    }
 
     /**
      * Constructs a {@code LockInfo} object.
@@ -77,6 +95,7 @@ public class LockInfo {
      * package-private constructors
      */
     LockInfo(Object lock) {
+        this.stringValue = String.valueOf(lock);
         this.className = lock.getClass().getName();
         this.identityHashCode = System.identityHashCode(lock);
     }
@@ -88,6 +107,15 @@ public class LockInfo {
      */
     public String getClassName() {
         return className;
+    }
+
+    /**
+     * Returns the string value of lock object.
+     *
+     * @return the string value of lock object.
+     */
+    public String getStringValue() {
+        return stringValue;
     }
 
     /**

--- a/src/java.management/share/classes/java/lang/management/MonitorInfo.java
+++ b/src/java.management/share/classes/java/lang/management/MonitorInfo.java
@@ -77,6 +77,39 @@ public class MonitorInfo extends LockInfo {
     }
 
     /**
+     * Construct a {@code MonitorInfo} object.
+     *
+     * @param className the fully qualified name of the class of the lock object.
+     * @param identityHashCode the {@link System#identityHashCode
+     *                         identity hash code} of the lock object.
+     * @param stringValue the string value of the lock object.
+     * @param stackDepth the depth in the stack trace where the object monitor
+     *                   was locked.
+     * @param stackFrame the stack frame that locked the object monitor.
+     * @throws IllegalArgumentException if
+     *    {@code stackDepth} &ge; 0 but {@code stackFrame} is {@code null},
+     *    or {@code stackDepth} &lt; 0 but {@code stackFrame} is not
+     *       {@code null}.
+     */
+    public MonitorInfo(String className,
+                       int identityHashCode,
+                       String stringValue,
+                       int stackDepth,
+                       StackTraceElement stackFrame) {
+        super(className, identityHashCode, stringValue);
+        if (stackDepth >= 0 && stackFrame == null) {
+            throw new IllegalArgumentException("Parameter stackDepth is " +
+                stackDepth + " but stackFrame is null");
+        }
+        if (stackDepth < 0 && stackFrame != null) {
+            throw new IllegalArgumentException("Parameter stackDepth is " +
+                stackDepth + " but stackFrame is not null");
+        }
+        this.stackDepth = stackDepth;
+        this.stackFrame = stackFrame;
+    }
+
+    /**
      * Returns the depth in the stack trace where the object monitor
      * was locked.  The depth is the index to the {@code StackTraceElement}
      * array returned in the {@link ThreadInfo#getStackTrace} method.
@@ -149,10 +182,12 @@ public class MonitorInfo extends LockInfo {
             MonitorInfoCompositeData.validateCompositeData(cd);
             String className = MonitorInfoCompositeData.getClassName(cd);
             int identityHashCode = MonitorInfoCompositeData.getIdentityHashCode(cd);
+            String stringValue = MonitorInfoCompositeData.getStringValue(cd);
             int stackDepth = MonitorInfoCompositeData.getLockedStackDepth(cd);
             StackTraceElement stackFrame = MonitorInfoCompositeData.getLockedStackFrame(cd);
             return new MonitorInfo(className,
                                    identityHashCode,
+                                   stringValue,
                                    stackDepth,
                                    stackFrame);
         }

--- a/src/java.management/share/classes/java/lang/management/ThreadInfo.java
+++ b/src/java.management/share/classes/java/lang/management/ThreadInfo.java
@@ -172,11 +172,13 @@ public class ThreadInfo {
                 Object lock = monitors[i];
                 String className = lock.getClass().getName();
                 int identityHashCode = System.identityHashCode(lock);
+                String stringValue = String.valueOf(lock);
                 int depth = stackDepths[i];
                 StackTraceElement ste = (depth >= 0 ? stackTrace[depth]
                                                     : null);
                 lockedMonitors[i] = new MonitorInfo(className,
                                                     identityHashCode,
+                                                    stringValue,
                                                     depth,
                                                     ste);
             }

--- a/src/java.management/share/classes/sun/management/MonitorInfoCompositeData.java
+++ b/src/java.management/share/classes/sun/management/MonitorInfoCompositeData.java
@@ -62,6 +62,7 @@ public class MonitorInfoCompositeData extends LazyCompositeData {
                                              : null;
         // values may be null; can't use Map.of
         Map<String,Object> items = new HashMap<>();
+        items.put(STRING_VALUE,       lock.getStringValue());
         items.put(CLASS_NAME,         lock.getClassName());
         items.put(IDENTITY_HASH_CODE, lock.getIdentityHashCode());
         items.put(LOCKED_STACK_FRAME, steCData);
@@ -75,12 +76,14 @@ public class MonitorInfoCompositeData extends LazyCompositeData {
         }
     }
 
+    private static final String STRING_VALUE       = "stringValue";
     private static final String CLASS_NAME         = "className";
     private static final String IDENTITY_HASH_CODE = "identityHashCode";
     private static final String LOCKED_STACK_FRAME = "lockedStackFrame";
     private static final String LOCKED_STACK_DEPTH = "lockedStackDepth";
 
     private static final String[] MONITOR_INFO_ATTRIBUTES = {
+        STRING_VALUE,
         CLASS_NAME,
         IDENTITY_HASH_CODE,
         LOCKED_STACK_FRAME,
@@ -114,6 +117,10 @@ public class MonitorInfoCompositeData extends LazyCompositeData {
 
     static CompositeType v6CompositeType() {
         return V6_COMPOSITE_TYPE;
+    }
+
+    public static String getStringValue(CompositeData cd) {
+        return getString(cd, STRING_VALUE);
     }
 
     public static String getClassName(CompositeData cd) {


### PR DESCRIPTION
When many thread try to load same class, the thread will stuck on `ClassLoader.loadClass`.
At current jdk, the stacktrace by example program is:
```
"Thread-1" prio=5 Id=12 BLOCKED on java.lang.Object@2e817b38 owned by "Thread-0" Id=11
        at java.base@15/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:616)
        -  blocked on java.lang.Object@2e817b38
        at java.base@15/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:604)
        at java.base@15/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:168)
        at java.base@15/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at app//Main.test(Main.java:19)
        at app//Main$$Lambda$2/0x0000000800b8c468.run(Unknown Source)
        at java.base@15/java.lang.Thread.run(Thread.java:832)
```
There is no way to get which class stuck the thread.

**After this patch, the stacktrace will be**:
```
"Thread-1" prio=5 Id=13 BLOCKED on java.lang.String@724af044 owned by "Thread-0" Id=12
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:646)
        -  blocked on java.lang.String@724af044 val="java.lang.String"
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:634)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:182)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)
        at app//Main2.test(Main2.java:19)
        at app//Main2$$Lambda$37/0x00000001000c2a20.run(Unknown Source)
        at java.base/java.lang.Thread.run(Thread.java:831)
```
That is, user will know which class stuck the thread, in this example, the class is `java.lang.String`. It's helpful for troubleshooting.

The example program:
Before patch:
<details>
<summary>Main.java</summary>

```java
// Main.java
import java.io.PrintStream;
import java.lang.management.*;

public final class Main {
    private synchronized static void test1() {
        while (true) {
            try {
                Thread.sleep(1000);
            } catch (InterruptedException e) {
                e.printStackTrace();
            }
        }
    }

    private static void test() {
        while (true) {
            try {
                Main.class.getClassLoader().loadClass("java.lang.String");
            } catch (ClassNotFoundException e) {
            }
        }
    }

    public static void main(String[] args) throws InterruptedException, NoSuchFieldException, IllegalAccessException {
        new Thread(Main::test).start();
        new Thread(Main::test).start();
        new Thread(Main::test).start();
        new Thread(Main::test).start();
        new Thread(Main::test).start();

        while (true) {
            Thread.sleep(1000);
            ThreadMXBean bean = ManagementFactory.getThreadMXBean();
            ThreadInfo[] infos = bean.dumpAllThreads(true, true);
            for (ThreadInfo info : infos) {
                System.out.println(printThreadInfo(info));
            }
        }
    }

    private static String printThreadInfo(ThreadInfo threadInfo) {
        StringBuilder sb = new StringBuilder("\"" + threadInfo.getThreadName() + "\"" +
                (threadInfo.isDaemon() ? " daemon" : "") +
                " prio=" + threadInfo.getPriority() +
                " Id=" + threadInfo.getThreadId() + " " +
                threadInfo.getThreadState());
        if (threadInfo.getLockName() != null) {
            sb.append(" on " + threadInfo.getLockName());
        }
        if (threadInfo.getLockOwnerName() != null) {
            sb.append(" owned by \"" + threadInfo.getLockOwnerName() +
                    "\" Id=" + threadInfo.getLockOwnerId());
        }
        if (threadInfo.isSuspended()) {
            sb.append(" (suspended)");
        }
        if (threadInfo.isInNative()) {
            sb.append(" (in native)");
        }
        sb.append('\n');
        int i = 0;
        StackTraceElement[] stackTrace = threadInfo.getStackTrace();
        for (; i < stackTrace.length; i++) {
            StackTraceElement ste = stackTrace[i];
            sb.append("\tat " + ste.toString());
            sb.append('\n');
            if (i == 0 && threadInfo.getLockInfo() != null) {
                Thread.State ts = threadInfo.getThreadState();
                switch (ts) {
                    case BLOCKED:
                        sb.append("\t-  blocked on " + printLockInfo(threadInfo.getLockInfo()));
                        sb.append('\n');
                        break;
                    case WAITING:
                        sb.append("\t-  waiting on " + printLockInfo(threadInfo.getLockInfo()));
                        sb.append('\n');
                        break;
                    case TIMED_WAITING:
                        sb.append("\t-  waiting on " + printLockInfo(threadInfo.getLockInfo()));
                        sb.append('\n');
                        break;
                    default:
                }
            }

            for (MonitorInfo mi : threadInfo.getLockedMonitors()) {
                if (mi.getLockedStackDepth() == i) {
                    sb.append("\t-  locked " + printLockInfo(mi));
                    sb.append('\n');
                }
            }
        }
        if (i < stackTrace.length) {
            sb.append("\t...");
            sb.append('\n');
        }

        LockInfo[] locks = threadInfo.getLockedSynchronizers();
        if (locks.length > 0) {
            sb.append("\n\tNumber of locked synchronizers = " + locks.length);
            sb.append('\n');
            for (LockInfo li : locks) {
                sb.append("\t- " + printLockInfo(li));
                sb.append('\n');
            }
        }
        sb.append('\n');
        return sb.toString();
    }

    private static String printLockInfo(LockInfo li) {
        String res = li.getClassName() + '@' + Integer.toHexString(li.getIdentityHashCode());
        return res;
    }
}
```
</details>
After patch:
<details>
<summary>Main2.java</summary>

```java
// Main2.java
import java.io.PrintStream;
import java.lang.management.*;

public final class Main2 {
    private synchronized static void test1() {
        while (true) {
            try {
                Thread.sleep(1000);
            } catch (InterruptedException e) {
                e.printStackTrace();
            }
        }
    }

    private static void test() {
        while (true) {
            try {
                Main2.class.getClassLoader().loadClass("java.lang.String");
            } catch (ClassNotFoundException e) {
            }
        }
    }

    public static void main(String[] args) throws InterruptedException, NoSuchFieldException, IllegalAccessException {
        new Thread(Main2::test).start();
        new Thread(Main2::test).start();
        new Thread(Main2::test).start();
        new Thread(Main2::test).start();
        new Thread(Main2::test).start();

        while (true) {
            Thread.sleep(1000);
            ThreadMXBean bean = ManagementFactory.getThreadMXBean();
            ThreadInfo[] infos = bean.dumpAllThreads(true, true);
            for (ThreadInfo info : infos) {
                System.out.println(printThreadInfo(info));
            }
        }
    }

    private static String printThreadInfo(ThreadInfo threadInfo) {
        StringBuilder sb = new StringBuilder("\"" + threadInfo.getThreadName() + "\"" +
                (threadInfo.isDaemon() ? " daemon" : "") +
                " prio=" + threadInfo.getPriority() +
                " Id=" + threadInfo.getThreadId() + " " +
                threadInfo.getThreadState());
        if (threadInfo.getLockName() != null) {
            sb.append(" on " + threadInfo.getLockName());
        }
        if (threadInfo.getLockOwnerName() != null) {
            sb.append(" owned by \"" + threadInfo.getLockOwnerName() +
                    "\" Id=" + threadInfo.getLockOwnerId());
        }
        if (threadInfo.isSuspended()) {
            sb.append(" (suspended)");
        }
        if (threadInfo.isInNative()) {
            sb.append(" (in native)");
        }
        sb.append('\n');
        int i = 0;
        StackTraceElement[] stackTrace = threadInfo.getStackTrace();
        for (; i < stackTrace.length; i++) {
            StackTraceElement ste = stackTrace[i];
            sb.append("\tat " + ste.toString());
            sb.append('\n');
            if (i == 0 && threadInfo.getLockInfo() != null) {
                Thread.State ts = threadInfo.getThreadState();
                switch (ts) {
                    case BLOCKED:
                        sb.append("\t-  blocked on " + printLockInfo(threadInfo.getLockInfo()));
                        sb.append('\n');
                        break;
                    case WAITING:
                        sb.append("\t-  waiting on " + printLockInfo(threadInfo.getLockInfo()));
                        sb.append('\n');
                        break;
                    case TIMED_WAITING:
                        sb.append("\t-  waiting on " + printLockInfo(threadInfo.getLockInfo()));
                        sb.append('\n');
                        break;
                    default:
                }
            }

            for (MonitorInfo mi : threadInfo.getLockedMonitors()) {
                if (mi.getLockedStackDepth() == i) {
                    sb.append("\t-  locked " + printLockInfo(mi));
                    sb.append('\n');
                }
            }
        }
        if (i < stackTrace.length) {
            sb.append("\t...");
            sb.append('\n');
        }

        LockInfo[] locks = threadInfo.getLockedSynchronizers();
        if (locks.length > 0) {
            sb.append("\n\tNumber of locked synchronizers = " + locks.length);
            sb.append('\n');
            for (LockInfo li : locks) {
                sb.append("\t- " + printLockInfo(li));
                sb.append('\n');
            }
        }
        sb.append('\n');
        return sb.toString();
    }

    private static String printLockInfo(LockInfo li) {
        String res = li.getClassName() + '@' + Integer.toHexString(li.getIdentityHashCode());
        // There is no getLock method in current jdk
        if (li.getStringValue() != null) {
            return res + " val=\"" + li.getStringValue() + "\"";
        }
        return res;
    }
}
```
</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8253280](https://bugs.openjdk.java.net/browse/JDK-8253280): Use class name as class loading lock


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/104/head:pull/104`
`$ git checkout pull/104`
