### PR TITLE
8252995: Non-PCH builds broken by JDK-8250961

### DIFF
--- a/src/hotspot/share/gc/shared/referencePolicy.cpp
+++ b/src/hotspot/share/gc/shared/referencePolicy.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/javaClasses.hpp"
+#include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/referencePolicy.hpp"
 #include "memory/universe.hpp"
 #include "runtime/arguments.hpp"


### PR DESCRIPTION
8252995: Non-PCH builds broken by JDK-8250961

Please review this trivial fix for no-PCH build failures, introduced by
JDK-8250961.

Only one file _requires_ an additional #include.  There are other files that
were modified by that change that probably should have had an include added,
on the "include what you use" theory.  But in the interest of faster
turn-around to fix the build failure, I'm not dealing with any of those in
this change.

Testing:
local (linux-x64) no-pch build with shenandoah included
mach5 builds-tier1 (in progress)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252995](https://bugs.openjdk.java.net/browse/JDK-8252995): Non-PCH builds broken by JDK-8250961


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/107/head:pull/107`
`$ git checkout pull/107`
