### PR TITLE
8253002: Remove the unused SafePointNode::_oop_map field

### DIFF
--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -54,7 +54,6 @@ class     BoxLockNode;
 class     LockNode;
 class     UnlockNode;
 class JVMState;
-class OopMap;
 class State;
 class StartNode;
 class MachCallNode;
@@ -335,8 +334,6 @@ public:
     init_class_id(Class_SafePoint);
   }
 
-  // There is no OopMap field, the oop map is set after matching in
-  // OopFlow::compute_reach on the MachSafePointNode. (See buildOopMap.cpp)
   JVMState* const _jvms;      // Pointer to list of JVM State objects
   const TypePtr*  _adr_type;  // What type of memory does this node produce?
   ReplacedNodes   _replaced_nodes; // During parsing: list of pair of nodes from calls to GraphKit::replace_in_map()

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -329,14 +329,14 @@ public:
                 // A plain safepoint advertises no memory effects (NULL):
                 const TypePtr* adr_type = NULL)
     : MultiNode( edges ),
-      _oop_map(NULL),
       _jvms(jvms),
       _adr_type(adr_type)
   {
     init_class_id(Class_SafePoint);
   }
 
-  OopMap*         _oop_map;   // Array of OopMap info (8-bit char) for GC
+  // There is no OopMap field, the oop map is set after matching in
+  // OopFlow::compute_reach on the MachSafePointNode. (See buildOopMap.cpp)
   JVMState* const _jvms;      // Pointer to list of JVM State objects
   const TypePtr*  _adr_type;  // What type of memory does this node produce?
   ReplacedNodes   _replaced_nodes; // During parsing: list of pair of nodes from calls to GraphKit::replace_in_map()
@@ -349,8 +349,6 @@ public:
   void set_jvms(JVMState* s) {
     *(JVMState**)&_jvms = s;  // override const attribute in the accessor
   }
-  OopMap *oop_map() const { return _oop_map; }
-  void set_oop_map(OopMap *om) { _oop_map = om; }
 
  private:
   void verify_input(JVMState* jvms, uint idx) const {

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -1346,9 +1346,6 @@ MachNode *Matcher::match_sfpt( SafePointNode *sfpt ) {
   assert((mcall == NULL) || (mcall->jvms() == NULL) ||
          (mcall->jvms()->debug_start() + mcall->_jvmadj == mcall->tf()->domain()->cnt()), "");
 
-  // Move the OopMap
-  msfpt->_oop_map = sfpt->_oop_map;
-
   // Add additional edges.
   if (msfpt->mach_constant_base_node_input() != (uint)-1 && !msfpt->is_MachCallLeaf()) {
     // For these calls we can not add MachConstantBase in expand(), as the


### PR DESCRIPTION
Hi,

I've been looking a lot at the code for generating oop maps for call nodes lately, and noticed that SafePointNode had an oopMap field that was unused (which led to some confusion as to where the oop map was actually set).

The oop map is instead generated and set in buildOopMap OopFlow::compute_reach after matching: https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/buildOopMap.cpp#L122 So the field on the ideal node is unused.

This patch removes the field and cleans up related code. I've left a comment in SafePointNode to point people looking for the oop map at buildOopMap.cpp

Thanks,
Jorn

Testing: local build + tier1,tier2,tier3
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253002](https://bugs.openjdk.java.net/browse/JDK-8253002): Remove the unused SafePointNode::_oop_map field


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/109/head:pull/109`
`$ git checkout pull/109`
