### PR TITLE
JDK-8253001: [JVMCI] Add API for getting stacktraces independently of current thread

### DIFF
--- a/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
@@ -322,6 +322,7 @@
   end_class                                                                                                   \
   start_class(HotSpotStackFrameReference, jdk_vm_ci_hotspot_HotSpotStackFrameReference)                       \
     object_field(HotSpotStackFrameReference, compilerToVM, "Ljdk/vm/ci/hotspot/CompilerToVM;")                \
+    object_field(HotSpotStackFrameReference, thread, "Ljava/lang/Thread;")                                    \
     boolean_field(HotSpotStackFrameReference, objectsMaterialized)                                            \
     long_field(HotSpotStackFrameReference, stackPointer)                                                      \
     int_field(HotSpotStackFrameReference, frameNumber)                                                        \

--- a/src/hotspot/share/runtime/stackValue.cpp
+++ b/src/hotspot/share/runtime/stackValue.cpp
@@ -92,6 +92,7 @@ StackValue* StackValue::create_stack_value(const frame* fr, const RegisterMap* r
       // Long   value in an aligned adjacent pair
       return new StackValue(*(intptr_t*)value_addr);
     case Location::narrowoop: {
+      assert(value_addr != NULL, "Location:narrowoop: must be non-null");
       union { intptr_t p; narrowOop noop;} value;
       value.p = (intptr_t) CONST64(0xDEADDEAFDEADDEAF);
       if (loc.is_register()) {
@@ -116,6 +117,7 @@ StackValue* StackValue::create_stack_value(const frame* fr, const RegisterMap* r
     }
 #endif
     case Location::oop: {
+      assert(value_addr != NULL, "Location:oop: must be non-null");
       oop val = *(oop *)value_addr;
 #ifdef _LP64
       if (CompressedOops::is_base(val)) {
@@ -177,7 +179,7 @@ StackValue* StackValue::create_stack_value(const frame* fr, const RegisterMap* r
 #endif
   } else if (sv->is_object()) { // Scalar replaced object in compiled frame
     Handle ov = ((ObjectValue *)sv)->value();
-    return new StackValue(ov, (ov.is_null()) ? 1 : 0);
+    return new StackValue(ov, (ov.is_null()) ? ((ObjectValue *)sv)->id() : -1);
   } else if (sv->is_marker()) {
     // Should never need to directly construct a marker.
     ShouldNotReachHere();

--- a/src/hotspot/share/runtime/stackValue.hpp
+++ b/src/hotspot/share/runtime/stackValue.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,16 +44,16 @@ class StackValue : public ResourceObj {
     _integer_value     = value;
   }
 
-  StackValue(Handle value, intptr_t scalar_replaced = 0) {
+  StackValue(Handle value, intptr_t scalar_replaced = -1) {
     _type                = T_OBJECT;
     _integer_value       = scalar_replaced;
     _handle_value        = value;
-    assert(_integer_value == 0 ||  _handle_value.is_null(), "not null object should not be marked as scalar replaced");
+    assert(_integer_value == -1 ||  _handle_value.is_null(), "not null object should not be marked as scalar replaced");
   }
 
   StackValue() {
     _type           = T_CONFLICT;
-    _integer_value  = 0;
+    _integer_value  = -1;
   }
 
   // Only used during deopt- preserve object type.
@@ -70,7 +70,12 @@ class StackValue : public ResourceObj {
 
   bool obj_is_scalar_replaced() const {
     assert(type() == T_OBJECT, "type check");
-    return _integer_value != 0;
+    return _integer_value != -1;
+  }
+
+  int get_obj_id() {
+    assert(obj_is_scalar_replaced(), "must be!");
+    return _integer_value;
   }
 
   void set_obj(Handle value) {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/stack/StackIntrospection.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/stack/StackIntrospection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,4 +43,63 @@ public interface StackIntrospection {
      *         should stop), or null if the whole stack was iterated.
      */
     <T> T iterateFrames(ResolvedJavaMethod[] initialMethods, ResolvedJavaMethod[] matchingMethods, int initialSkip, InspectedFrameVisitor<T> visitor);
+
+    /**
+     * Returns a snapshot of the stack frames for each thread in {@code threads} up to and including
+     * {@code limit}. The returned {@link InspectedFrame}s should be seen as a snapshot in the sense
+     * that any client inspecting and possibly mutating the frame contents will do so under the
+     * assumption that the underlying threads might have continued, executing potentially
+     * invalidating the frame state.
+     *
+     * Note that the locals of the {@link InspectedFrame}s will be collected as copies when the
+     * underlying frame was compiled, whereas they'll be references for interpreted frames. Use
+     * {@link InspectedFrame#isVirtual} to determine if locals are virtual copies and
+     * {@link InspectedFrame#materializeVirtualObjects} when a materialization is required. This
+     * means that if the underlying thread continues to execute and a client later read locals, the
+     * values will be either the current value or the value at collecting time. Any client that
+     * requires a deterministic read from a local returned from this method, must do so while the
+     * thread is suspended throughout executing this method and performing the locals read.
+     *
+     * Example use cases:
+     *
+     * A debugger needs access to the content of stack frames such as local variables.
+     * In cases where threads execute in the runtime or in native code, it's not possible to obtain
+     * a thread suspension hook, for which {@link StackIntrospection#iterateFrames} can be used on
+     * the suspended thread. The getStackFrames method enables an immediate stack frames lookup
+     * regardless of the status of the underlying (active) thread.
+     *
+     * Any tool or system that require taking stack frame snapshots will benefit from this method.
+     * Whenever there is a need to fetch the stack frames from n threads at a fixed point in time,
+     * this method provides a way to do so utilizing at most one single safe point.
+     *
+     * The following example shows how to read and manipulate an object stored at a known index in a
+     * frame:
+     * <pre>
+     *     StackIntrospection si = ...;
+     *     Thread[] suspendedThreads = ...;
+     *     InspectedFrame[][] stacks = si.getStackFrames(null, null, 0, -1, suspendedThreads);
+     *     for (InspectedFrame[] stack : stacks) {
+     *         for (InspectedFrame frame : stack) {
+     *             // read the (known MyObject) at index 0
+     *             MyObject value = (MyObject) frame.getLocal(0);
+     *             // manipulating the object requires the local to be materialized
+     *             if (frame.isVirtual(0) {
+     *                 // we got a copy of the MyObject, so materialize the frame
+     *                 frame.materializeVirtualObjects(false);
+     *             }
+     *             value.manipulate();
+     *         }
+     *     }
+     * </pre>
+     *
+     * @param initialMethods if this is non-{@code null}, then the stack walk will start at the
+     *            first frame whose method is one of these methods.
+     * @param matchingMethods if this is non-{@code null}, then only frames whose methods are in
+     *            this array are walked
+     * @param initialSkip the number of matching methods to skip (including the initial method)
+     * @param limit limit the returned frames to this limit or when -1 return all frames
+     * @param threads the input thread array
+     * @return a two-dimensional array of stack frames in the order of the input threads array
+     */
+    InspectedFrame[][] getStackFrames(ResolvedJavaMethod[] initialMethods, ResolvedJavaMethod[] matchingMethods, int initialSkip, int limit, Thread[] threads);
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -33,6 +33,7 @@ import jdk.vm.ci.code.BytecodeFrame;
 import jdk.vm.ci.code.InstalledCode;
 import jdk.vm.ci.code.InvalidInstalledCodeException;
 import jdk.vm.ci.code.TargetDescription;
+import jdk.vm.ci.code.stack.InspectedFrame;
 import jdk.vm.ci.code.stack.InspectedFrameVisitor;
 import jdk.vm.ci.common.InitTimer;
 import jdk.vm.ci.common.JVMCIError;
@@ -587,6 +588,11 @@ final class CompilerToVM {
      * @see jdk.vm.ci.code.stack.StackIntrospection#iterateFrames
      */
     native <T> T iterateFrames(ResolvedJavaMethod[] initialMethods, ResolvedJavaMethod[] matchingMethods, int initialSkip, InspectedFrameVisitor<T> visitor);
+
+    /**
+     * @see jdk.vm.ci.code.stack.StackIntrospection#getStackFrames
+     */
+    native InspectedFrame[][] getStackFrames(ResolvedJavaMethod[] initialMethods, ResolvedJavaMethod[] matchingMethods, int initialSkip, int maxFrames, Thread[] threads);
 
     /**
      * Materializes all virtual objects within {@code stackFrame} and updates its locals.

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotStackFrameReference.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotStackFrameReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ public class HotSpotStackFrameReference implements InspectedFrame {
     @SuppressWarnings("unused") private boolean objectsMaterialized;
 
     // information used to find the stack frame
+    private Thread thread;
     private long stackPointer;
     private int frameNumber;
 
@@ -42,6 +43,10 @@ public class HotSpotStackFrameReference implements InspectedFrame {
     private HotSpotResolvedJavaMethod method;
     private Object[] locals;
     private boolean[] localIsVirtual;
+
+    public Thread getThread() {
+        return thread;
+    }
 
     public long getStackPointer() {
         return stackPointer;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotStackIntrospection.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotStackIntrospection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 package jdk.vm.ci.hotspot;
 
+import jdk.vm.ci.code.stack.InspectedFrame;
 import jdk.vm.ci.code.stack.InspectedFrameVisitor;
 import jdk.vm.ci.code.stack.StackIntrospection;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
@@ -38,5 +39,11 @@ public class HotSpotStackIntrospection implements StackIntrospection {
     public <T> T iterateFrames(ResolvedJavaMethod[] initialMethods, ResolvedJavaMethod[] matchingMethods, int initialSkip, InspectedFrameVisitor<T> visitor) {
         CompilerToVM compilerToVM = runtime.getCompilerToVM();
         return compilerToVM.iterateFrames(initialMethods, matchingMethods, initialSkip, visitor);
+    }
+
+    @Override
+    public InspectedFrame[][] getStackFrames(ResolvedJavaMethod[] initialMethods, ResolvedJavaMethod[] matchingMethods, int initialSkip, int maxFrames, Thread[] threads) {
+        CompilerToVM compilerToVM = runtime.getCompilerToVM();
+        return compilerToVM.getStackFrames(initialMethods, matchingMethods, initialSkip, maxFrames, threads);
     }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/common/patches/jdk.internal.vm.ci/jdk/vm/ci/hotspot/CompilerToVMHelper.java
+++ b/test/hotspot/jtreg/compiler/jvmci/common/patches/jdk.internal.vm.ci/jdk/vm/ci/hotspot/CompilerToVMHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package jdk.vm.ci.hotspot;
 import jdk.vm.ci.code.InstalledCode;
 import jdk.vm.ci.code.InvalidInstalledCodeException;
 import jdk.vm.ci.code.TargetDescription;
+import jdk.vm.ci.code.stack.InspectedFrame;
 import jdk.vm.ci.code.stack.InspectedFrameVisitor;
 import jdk.vm.ci.meta.ConstantPool;
 import jdk.vm.ci.meta.JavaConstant;
@@ -279,6 +280,15 @@ public class CompilerToVMHelper {
             int initialSkip,
             InspectedFrameVisitor<T> visitor) {
         return CTVM.iterateFrames(initialMethods, matchingMethods, initialSkip, visitor);
+    }
+
+    public static InspectedFrame[][] getStackFrames(
+            ResolvedJavaMethod[] initialMethods,
+            ResolvedJavaMethod[] matchingMethods,
+            int initialSkip,
+            int maxFrames,
+            Thread[] threads) {
+        return CTVM.getStackFrames(initialMethods, matchingMethods, initialSkip, maxFrames, threads);
     }
 
     public static void materializeVirtualObjects(

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/GetStackFramesOtherThreadTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/GetStackFramesOtherThreadTest.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8136421
+ *
+ * @requires vm.jvmci & vm.compMode == "Xmixed"
+ * @requires vm.opt.final.EliminateAllocations == true
+ *
+ * @comment no "-Xcomp -XX:-TieredCompilation" combination allowed until JDK-8140018 is resolved
+ * @requires vm.opt.TieredCompilation == null | vm.opt.TieredCompilation == true
+ *
+ * @library / /test/lib
+ * @library ../common/patches
+ * @modules java.base/jdk.internal.misc
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.tree
+ *          jdk.internal.vm.ci/jdk.vm.ci.hotspot
+ *          jdk.internal.vm.ci/jdk.vm.ci.code
+ *          jdk.internal.vm.ci/jdk.vm.ci.code.stack
+ *          jdk.internal.vm.ci/jdk.vm.ci.meta
+ *
+ * @build jdk.internal.vm.ci/jdk.vm.ci.hotspot.CompilerToVMHelper sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbatch -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
+ *                   -XX:CompileCommand=exclude,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::check
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::testFrame
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::testFrame2
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::recurse
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::testFrame3
+ *                   -XX:+DoEscapeAnalysis -XX:-UseCounterDecay
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest.materializeFirst=true
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest.invalidate=false
+ *                   compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest
+ * @run main/othervm -Xbatch -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
+ *                   -XX:CompileCommand=exclude,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::check
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::testFrame
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::testFrame2
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::recurse
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::testFrame3
+ *                   -XX:+DoEscapeAnalysis -XX:-UseCounterDecay
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest.materializeFirst=false
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest.invalidate=false
+ *                   compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest
+ * @run main/othervm -Xbatch -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
+ *                   -XX:CompileCommand=exclude,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::check
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::testFrame
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::testFrame2
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::recurse
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::testFrame3
+ *                   -XX:+DoEscapeAnalysis -XX:-UseCounterDecay
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest.materializeFirst=true
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest.invalidate=true
+ *                   compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest
+ * @run main/othervm -Xbatch -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
+ *                   -XX:CompileCommand=exclude,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::check
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::testFrame
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::testFrame2
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::recurse
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest::testFrame3
+ *                   -XX:+DoEscapeAnalysis -XX:-UseCounterDecay
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest.materializeFirst=false
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest.invalidate=true
+ *                   compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest
+ */
+
+package compiler.jvmci.compilerToVM;
+
+import compiler.jvmci.common.CTVMUtilities;
+import compiler.testlibrary.CompilerUtils;
+import compiler.whitebox.CompilerWhiteBoxTest;
+import jdk.test.lib.Asserts;
+import jdk.vm.ci.code.stack.InspectedFrame;
+import jdk.vm.ci.hotspot.CompilerToVMHelper;
+import jdk.vm.ci.hotspot.HotSpotStackFrameReference;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import jdk.vm.ci.code.stack.InspectedFrame;
+import jtreg.SkippedException;
+import sun.hotspot.WhiteBox;
+
+import java.lang.reflect.Method;
+
+public class GetStackFramesOtherThreadTest {
+    private static final WhiteBox WB;
+    private static final boolean INVALIDATE;
+    private static final int COMPILE_THRESHOLD;
+    private static final Method MATERIALIZED_METHOD;
+    private static final Method NOT_MATERIALIZED_METHOD;
+    private static final Method FRAME3_METHOD;
+    private static final ResolvedJavaMethod MATERIALIZED_RESOLVED;
+    private static final ResolvedJavaMethod NOT_MATERIALIZED_RESOLVED;
+    private static final ResolvedJavaMethod FRAME2_RESOLVED;
+    private static final ResolvedJavaMethod FRAME3_RESOLVED;
+    private static final boolean MATERIALIZE_FIRST;
+
+    static {
+        Method method1;
+        Method method2;
+        WB = WhiteBox.getWhiteBox();
+        try {
+            method1 = GetStackFramesOtherThreadTest.class.getDeclaredMethod("testFrame",
+                    String.class, int.class);
+            method2 = GetStackFramesOtherThreadTest.class.getDeclaredMethod("testFrame2",
+                    String.class, int.class);
+            FRAME3_METHOD = GetStackFramesOtherThreadTest.class.getDeclaredMethod("testFrame3",
+                    Helper.class, int.class);
+        } catch (NoSuchMethodException e) {
+            throw new Error("Can't get executable for test method", e);
+        }
+        ResolvedJavaMethod resolved1;
+        resolved1 = CTVMUtilities.getResolvedMethod(method1);
+        FRAME2_RESOLVED = CTVMUtilities.getResolvedMethod(method2);
+        FRAME3_RESOLVED = CTVMUtilities.getResolvedMethod(FRAME3_METHOD);
+        INVALIDATE = Boolean.getBoolean(
+                "compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest.invalidate");
+        COMPILE_THRESHOLD = WB.getBooleanVMFlag("TieredCompilation")
+                ? CompilerWhiteBoxTest.THRESHOLD
+                : CompilerWhiteBoxTest.THRESHOLD * 2;
+        MATERIALIZE_FIRST = Boolean.getBoolean(
+                "compiler.jvmci.compilerToVM.GetStackFramesOtherThreadTest.materializeFirst");
+        MATERIALIZED_RESOLVED = MATERIALIZE_FIRST ? resolved1 : FRAME2_RESOLVED;
+        NOT_MATERIALIZED_RESOLVED = MATERIALIZE_FIRST ? FRAME2_RESOLVED : resolved1;
+        MATERIALIZED_METHOD = MATERIALIZE_FIRST ? method1 : method2;
+        NOT_MATERIALIZED_METHOD = MATERIALIZE_FIRST ? method2 : method1;
+    }
+
+    public static void main(String[] args) {
+        int levels[] = CompilerUtils.getAvailableCompilationLevels();
+        // we need compilation level 4 to use EscapeAnalysis
+        if (levels.length < 1 || levels[levels.length - 1] != 4) {
+            throw new SkippedException("Test needs compilation level 4");
+        }
+
+        new GetStackFramesOtherThreadTest().test();
+    }
+
+    private static String getName() {
+        return "CASE: invalidate=" + INVALIDATE + ", materializedMethod="
+                + (MATERIALIZE_FIRST ? "testFrame" : "testFrame2")
+                + ", notMaterializedMethod="
+                + (MATERIALIZE_FIRST ? "testFrame2" : "testFrame");
+    }
+
+    private void test() {
+        System.out.println(getName());
+        Asserts.assertFalse(WB.isMethodCompiled(MATERIALIZED_METHOD),
+                getName() + " : materialized method is compiled");
+        Asserts.assertFalse(WB.isMethodCompiled(NOT_MATERIALIZED_METHOD),
+                getName() + " : not materialized method is compiled");
+        for (int i = 0; i < CompilerWhiteBoxTest.THRESHOLD; i++) {
+            testFrame("someString", i);
+        }
+        Asserts.assertTrue(WB.isMethodCompiled(MATERIALIZED_METHOD), getName()
+                + " : materialized method not compiled");
+        Asserts.assertTrue(WB.isMethodCompiled(NOT_MATERIALIZED_METHOD),
+                getName() + " : not materialized method not compiled");
+        testFrame("someString", /* materialize */ CompilerWhiteBoxTest.THRESHOLD);
+
+        // run second test types
+        for (int i = 0; i < CompilerWhiteBoxTest.THRESHOLD; i++) {
+            testFrame("someString", i);
+        }
+        Asserts.assertTrue(WB.isMethodCompiled(MATERIALIZED_METHOD), getName()
+                + " : materialized method not compiled");
+        Asserts.assertTrue(WB.isMethodCompiled(NOT_MATERIALIZED_METHOD),
+                getName() + " : not materialized method not compiled");
+        testFrame("someString", /* materialize */ CompilerWhiteBoxTest.THRESHOLD + 1);
+    }
+
+    private void testFrame(String str, int iteration) {
+        Helper helper = new Helper(str);
+        testFrame2(str, iteration);
+        Asserts.assertTrue((helper.string != null) && (this != null)
+                && (helper != null), String.format("%s : some locals are null", getName()));
+    }
+
+    private void testFrame2(String str, int iteration) {
+        Helper helper = new Helper(str);
+        Helper helper2 = new Helper("bar");
+        testFrame3(helper, iteration);
+        Asserts.assertTrue((helper.string != null) && (this != null) && helper.string == str
+                && (helper != null), String.format("%s : some locals are null", getName()));
+        Asserts.assertTrue((helper2.string != null) && (this != null)
+                && (helper2 != null), String.format("%s : some locals are null", getName()));
+    }
+
+    private void testFrame3(Helper outerHelper, int iteration) {
+        Helper innerHelper = new Helper("foo");
+        recurse(2, iteration);
+        Asserts.assertTrue((innerHelper.string != null) && (this != null)
+                && (innerHelper != null), String.format("%s : some locals are null", getName()));
+        Asserts.assertTrue((outerHelper.string != null) && (this != null)
+                && (outerHelper != null), String.format("%s : some locals are null", getName()));
+    }
+
+    private void recurse(int depth, int iteration) {
+        if (depth == 0) {
+            check(iteration);
+        } else {
+            Integer s = new Integer(depth);
+            recurse(depth - 1, iteration);
+            Asserts.assertEQ(s.intValue(), depth,
+                    String.format("different values: %s != %s", s.intValue(), depth));
+        }
+    }
+
+    private InspectedFrame[] getCurrentThreadFramesFromOtherThread(ResolvedJavaMethod initialMethod, int maxFrames) {
+        InspectedFrame[] frames = new InspectedFrame[maxFrames];
+        SimpleLock lock = new SimpleLock();
+        lock.acquire();
+        Thread current = Thread.currentThread();
+        new Thread(() -> {
+             InspectedFrame[] fetchedFrames = CompilerToVMHelper.getStackFrames(
+                    new ResolvedJavaMethod[] {initialMethod},
+                    null, /* any */
+                    0,
+                    maxFrames,
+                    new Thread[] {current}
+                )[0];
+              for (int i = 0; i < maxFrames; i++) {
+                frames[i] = fetchedFrames[i];
+              }
+              // signal to main thread that frames are ready
+              synchronized (lock) {
+                lock.release();
+                lock.notifyAll();
+              }
+        }).start();
+        synchronized(lock) {
+            while (lock.isLocked()) {
+                try {
+                  lock.wait();
+                } catch (Throwable t) {
+                    throw new RuntimeException("interrupted in wait loop", t);
+                }
+            }
+        }
+        return frames;
+    }
+
+    private void checkStructure(boolean materialize) {
+        boolean[] framesSeen = new boolean[2];
+        Object[] helpers = new Object[1];
+        InspectedFrame[] frames = getCurrentThreadFramesFromOtherThread(FRAME3_RESOLVED, 2);
+        for (InspectedFrame f : frames) {
+            if (!framesSeen[1]) {
+                Asserts.assertTrue(f.isMethod(FRAME3_RESOLVED),
+                        "Expected testFrame3 first");
+                framesSeen[1] = true;
+                Asserts.assertTrue(f.getLocal(0) != null, "this should not be null");
+                Asserts.assertTrue(f.getLocal(1) != null, "outerHelper should not be null");
+                Asserts.assertTrue(f.getLocal(3) != null, "innerHelper should not be null");
+                Asserts.assertEQ(((Helper) f.getLocal(3)).string, "foo", "innerHelper.string should be foo");
+                helpers[0] = f.getLocal(1);
+                if (materialize) {
+                    f.materializeVirtualObjects(false);
+                }
+            } else {
+                Asserts.assertFalse(framesSeen[0], "frame3 can not have been seen");
+                Asserts.assertTrue(f.isMethod(FRAME2_RESOLVED),
+                        "Expected testFrame2 second");
+                framesSeen[0] = true;
+                Asserts.assertTrue(f.getLocal(0) != null, "this should not be null");
+                Asserts.assertTrue(f.getLocal(1) != null, "str should not be null");
+                Asserts.assertTrue(f.getLocal(3) != null, "helper should not be null");
+                Asserts.assertTrue(f.getLocal(4) != null, "helper2 should not be null");
+                Asserts.assertEQ(((Helper) f.getLocal(3)).string, f.getLocal(1), "helper.string should be the same as str");
+                Asserts.assertEQ(((Helper) f.getLocal(4)).string, "bar", "helper2.string should be bar");
+                if (!materialize) {
+                    Asserts.assertEQ(f.getLocal(3), helpers[0], "helper should be the same as frame3's outerHelper");
+                }
+            }
+        }
+
+        Asserts.assertTrue(framesSeen[1], "frame3 should have been seen");
+        Asserts.assertTrue(framesSeen[0], "frame2 should have been seen");
+    }
+
+    private void check(int iteration) {
+        // Materialize virtual objects on last invocation
+        if (iteration == COMPILE_THRESHOLD) {
+            // get frames and check not-null
+            HotSpotStackFrameReference materialized = (HotSpotStackFrameReference) getCurrentThreadFramesFromOtherThread(MATERIALIZED_RESOLVED, 1)[0];
+            Asserts.assertNotNull(materialized, getName()
+                    + " : got null frame for materialized method");
+            Asserts.assertTrue(materialized.isMethod(MATERIALIZED_RESOLVED),
+                "Expected materialized method but got " + materialized);
+            InspectedFrame notMaterialized = getCurrentThreadFramesFromOtherThread(NOT_MATERIALIZED_RESOLVED, 1)[0];
+            Asserts.assertNE(materialized, notMaterialized,
+                    "Got same frame pointer for both tested frames");
+            Asserts.assertTrue(notMaterialized.isMethod(NOT_MATERIALIZED_RESOLVED),
+                "Expected notMaterialized method but got " + notMaterialized);
+            Asserts.assertNotNull(notMaterialized, getName()
+                    + " : got null frame for not materialized method");
+            Asserts.assertTrue(WB.isMethodCompiled(MATERIALIZED_METHOD), getName()
+                + " : materialized method not compiled");
+            Asserts.assertTrue(WB.isMethodCompiled(NOT_MATERIALIZED_METHOD),
+                getName() + " : not materialized method not compiled");
+            // check that frames has virtual objects before materialization stage
+            Asserts.assertTrue(materialized.hasVirtualObjects(), getName()
+                    + ": materialized frame has no virtual object before materialization");
+            Asserts.assertTrue(notMaterialized.hasVirtualObjects(), getName()
+                    + ": notMaterialized frame has no virtual object before materialization");
+            // materialize
+            CompilerToVMHelper.materializeVirtualObjects(materialized, INVALIDATE);
+            // check that only not materialized frame has virtual objects
+            Asserts.assertFalse(materialized.hasVirtualObjects(), getName()
+                    + " : materialized has virtual object after materialization");
+            Asserts.assertTrue(notMaterialized.hasVirtualObjects(), getName()
+                    + " : notMaterialized has no virtual object after materialization");
+            // check that materialized frame was deoptimized in case invalidate=true
+            Asserts.assertEQ(WB.isMethodCompiled(MATERIALIZED_METHOD), !INVALIDATE, getName()
+                    + " : materialized method has unexpected compiled status");
+            // check that not materialized frame wasn't deoptimized
+            Asserts.assertTrue(WB.isMethodCompiled(NOT_MATERIALIZED_METHOD), getName()
+                    + " : not materialized method has unexpected compiled status");
+        } else if (iteration == COMPILE_THRESHOLD + 1) {
+            checkStructure(false);
+            checkStructure(true);
+        }
+    }
+
+    private class Helper {
+        public String string;
+
+        public Helper(String s) {
+            this.string = s;
+        }
+    }
+
+    private class SimpleLock {
+        private volatile boolean locked;
+
+        public synchronized void acquire() {
+            locked = true;
+        }
+
+        public synchronized void release() {
+            locked = false;
+        }
+
+        public boolean isLocked() {
+            return locked;
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/GetStackFramesPrimitiveTypesTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/GetStackFramesPrimitiveTypesTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8136421
+ *
+ * @requires vm.jvmci & vm.compMode == "Xmixed"
+ * @requires vm.opt.final.EliminateAllocations == true
+ *
+ * @comment no "-Xcomp -XX:-TieredCompilation" combination allowed until JDK-8140018 is resolved
+ * @requires vm.opt.TieredCompilation == null | vm.opt.TieredCompilation == true
+ *
+ * @library / /test/lib
+ * @library ../common/patches
+ * @modules java.base/jdk.internal.misc
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.tree
+ *          jdk.internal.vm.ci/jdk.vm.ci.hotspot
+ *          jdk.internal.vm.ci/jdk.vm.ci.code
+ *          jdk.internal.vm.ci/jdk.vm.ci.code.stack
+ *          jdk.internal.vm.ci/jdk.vm.ci.meta
+ *
+ * @build jdk.internal.vm.ci/jdk.vm.ci.hotspot.CompilerToVMHelper sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbatch -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
+ *                   -XX:CompileCommand=exclude,compiler.jvmci.compilerToVM.GetStackFramesPrimitiveTypesTest::checkStructure
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesPrimitiveTypesTest::testFrame1
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesPrimitiveTypesTest::testFrame2
+ *                   -XX:+DoEscapeAnalysis -XX:-UseCounterDecay
+ *                   compiler.jvmci.compilerToVM.GetStackFramesPrimitiveTypesTest
+ */
+
+package compiler.jvmci.compilerToVM;
+
+import compiler.jvmci.common.CTVMUtilities;
+import compiler.testlibrary.CompilerUtils;
+import compiler.whitebox.CompilerWhiteBoxTest;
+import jdk.test.lib.Asserts;
+import jdk.vm.ci.code.stack.InspectedFrame;
+import jdk.vm.ci.hotspot.CompilerToVMHelper;
+import jdk.vm.ci.hotspot.HotSpotStackFrameReference;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import jdk.vm.ci.code.stack.InspectedFrame;
+import jtreg.SkippedException;
+import sun.hotspot.WhiteBox;
+
+import java.lang.reflect.Method;
+
+public class GetStackFramesPrimitiveTypesTest {
+    private static final WhiteBox WB;
+    private static final int COMPILE_THRESHOLD;
+    private static final Method FRAME1_METHOD;
+    private static final Method FRAME2_METHOD;
+    private static final ResolvedJavaMethod FRAME1_RESOLVED;
+    private static final ResolvedJavaMethod FRAME2_RESOLVED;
+
+    static {
+        WB = WhiteBox.getWhiteBox();
+        try {
+            FRAME1_METHOD = GetStackFramesPrimitiveTypesTest.class.getDeclaredMethod("testFrame1",
+                   int.class);
+            FRAME2_METHOD = GetStackFramesPrimitiveTypesTest.class.getDeclaredMethod("testFrame2",
+                   Helper.class, int.class);
+        } catch (NoSuchMethodException e) {
+            throw new Error("Can't get executable for test method", e);
+        }
+        FRAME1_RESOLVED = CTVMUtilities.getResolvedMethod(FRAME1_METHOD);
+        FRAME2_RESOLVED = CTVMUtilities.getResolvedMethod(FRAME2_METHOD);
+        COMPILE_THRESHOLD = WB.getBooleanVMFlag("TieredCompilation")
+                ? CompilerWhiteBoxTest.THRESHOLD
+                : CompilerWhiteBoxTest.THRESHOLD * 2;
+    }
+
+    public static void main(String[] args) {
+        int levels[] = CompilerUtils.getAvailableCompilationLevels();
+        // we need compilation level 4 to use EscapeAnalysis
+        if (levels.length < 1 || levels[levels.length - 1] != 4) {
+            throw new SkippedException("Test needs compilation level 4");
+        }
+
+        new GetStackFramesPrimitiveTypesTest().test();
+    }
+
+    private void test() {
+        Asserts.assertFalse(WB.isMethodCompiled(FRAME1_METHOD), "frame1 method is compiled");
+        Asserts.assertFalse(WB.isMethodCompiled(FRAME2_METHOD), "frame2 method is compiled");
+        testFrame1(COMPILE_THRESHOLD);
+
+        for (int i = 0; i < COMPILE_THRESHOLD * 2; i++) {
+            testFrame1(i);
+        }
+        Asserts.assertTrue(WB.isMethodCompiled(FRAME1_METHOD), "frame1 method not compiled");
+        Asserts.assertTrue(WB.isMethodCompiled(FRAME2_METHOD), "frame2 method not compiled");
+
+        testFrame1(COMPILE_THRESHOLD);
+    }
+
+    private void testFrame1(int iteration) {
+        Helper helper = new Helper("someString", 42, true, (byte) 1, 'c', (short) 42, 42, 0.42, 42f);
+        testFrame2(helper, iteration);
+        Asserts.assertTrue((helper.string != null) && (this != null)
+                        && (helper != null), "some locals are null");
+
+        Asserts.assertTrue("someString".equals(helper.string), "helper.string has unexpected value");
+        Asserts.assertTrue(helper.i == 42, "helper.i has unexpected value");
+        Asserts.assertTrue(helper.z == true, "helper.z has unexpected value");
+        Asserts.assertTrue(helper.b == (byte) 1, "helper.b has unexpected value");
+        Asserts.assertTrue(helper.c == 'c', "helper.c has unexpected value");
+        Asserts.assertTrue(helper.s == (short) 42, "helper.s has unexpected value");
+        Asserts.assertTrue(helper.j == 42, "helper.j has unexpected value");
+        Asserts.assertTrue(helper.d == 0.42, "helper.d has unexpected value");
+        Asserts.assertTrue(helper.f == 42f, "helper.f has unexpected value");
+    }
+
+    private void testFrame2(Helper outerHelper, int iteration) {
+        Helper innerHelper = new Helper("foo", 42, true, (byte) 1, 'c', (short) 42, 42, 0.42, 42f);
+        if (iteration == COMPILE_THRESHOLD) {
+            checkStructure();
+        }
+        Asserts.assertTrue((innerHelper.string != null) && (this != null)
+                  && (innerHelper != null), "some locals are null");
+        Asserts.assertTrue((outerHelper.string != null) && (this != null)
+                  && (outerHelper != null), "some locals are null");
+
+        Asserts.assertTrue("someString".equals(outerHelper.string), "helper.string has unexpected value");
+        Asserts.assertTrue(outerHelper.i == 42, "helper.i has unexpected value");
+        Asserts.assertTrue(outerHelper.z == true, "helper.z has unexpected value");
+        Asserts.assertTrue(outerHelper.b == (byte) 1, "helper.b has unexpected value");
+        Asserts.assertTrue(outerHelper.c == 'c', "helper.c has unexpected value");
+        Asserts.assertTrue(outerHelper.s == (short) 42, "helper.s has unexpected value");
+        Asserts.assertTrue(outerHelper.j == 42, "helper.j has unexpected value");
+        Asserts.assertTrue(outerHelper.d == 0.42, "helper.d has unexpected value");
+        Asserts.assertTrue(outerHelper.f == 42f, "helper.f has unexpected value");
+
+        Asserts.assertTrue("foo".equals(innerHelper.string), "helper.string has unexpected value");
+        Asserts.assertTrue(innerHelper.i == 42, "helper.i has unexpected value");
+        Asserts.assertTrue(innerHelper.z == true, "helper.z has unexpected value");
+        Asserts.assertTrue(innerHelper.b == (byte) 1, "helper.b has unexpected value");
+        Asserts.assertTrue(innerHelper.c == 'c', "helper.c has unexpected value");
+        Asserts.assertTrue(innerHelper.s == (short) 42, "helper.s has unexpected value");
+        Asserts.assertTrue(innerHelper.j == 42, "helper.j has unexpected value");
+        Asserts.assertTrue(innerHelper.d == 0.42, "helper.d has unexpected value");
+        Asserts.assertTrue(innerHelper.f == 42f, "helper.f has unexpected value");
+    }
+
+    private void checkStructure() {
+        boolean[] framesSeen = new boolean[2];
+
+        InspectedFrame[] frames = CompilerToVMHelper.getStackFrames(
+            new ResolvedJavaMethod[] {FRAME2_RESOLVED},
+            null,
+            0,
+            2, // fetch only 2 frames
+            new Thread[] {Thread.currentThread()}
+        )[0];
+
+        for (InspectedFrame f : frames) {
+            if (!framesSeen[1]) {
+                Asserts.assertTrue(f.isMethod(FRAME2_RESOLVED),
+                        "Expected testFrame2 first");
+                framesSeen[1] = true;
+                System.out.println("checking frame: " + f);
+                Asserts.assertTrue(f.getLocal(0) != null, "this should not be null");
+                Asserts.assertTrue(f.getLocal(1) != null, "outerHelper should not be null");
+                Asserts.assertEQ(((Helper) f.getLocal(1)).string, "someString", "outerHelper.string should be foo");
+                Asserts.assertEQ(((Helper) f.getLocal(1)).i, 42, "outerHelper.i should be 42");
+                Asserts.assertEQ(((Helper) f.getLocal(1)).z, true, "outerHelper.z should be true");
+                Asserts.assertEQ(((Helper) f.getLocal(1)).b, (byte) 1, "outerHelper.b should be 1");
+                Asserts.assertEQ(((Helper) f.getLocal(1)).c, 'c', "outerHelper.c should be c");
+                Asserts.assertEQ(((Helper) f.getLocal(1)).s, (short) 42, "outerHelper.s should be 42");
+                Asserts.assertEQ(((Helper) f.getLocal(1)).j, (long) 42, "outerHelper.j should be 42");
+                Asserts.assertEQ(((Helper) f.getLocal(1)).d, 0.42, "outerHelper.d should be 0.42");
+                Asserts.assertEQ(((Helper) f.getLocal(1)).f, 42f, "outerHelper.f should be 42");
+
+                Asserts.assertTrue(f.getLocal(3) != null, "innerHelper should not be null");
+                Asserts.assertEQ(((Helper) f.getLocal(3)).string, "foo", "innerHelper.string should be foo");
+                Asserts.assertEQ(((Helper) f.getLocal(3)).i, 42, "innerHelper.i should be 42");
+                Asserts.assertEQ(((Helper) f.getLocal(3)).z, true, "innerHelper.z should be true");
+                Asserts.assertEQ(((Helper) f.getLocal(3)).b, (byte) 1, "innerHelper.b should be 1");
+                Asserts.assertEQ(((Helper) f.getLocal(3)).c, 'c', "innerHelper.c should be c");
+                Asserts.assertEQ(((Helper) f.getLocal(3)).s, (short) 42, "innerHelper.s should be 42");
+                Asserts.assertEQ(((Helper) f.getLocal(3)).j, (long) 42, "innerHelper.j should be 42");
+                Asserts.assertEQ(((Helper) f.getLocal(3)).d, 0.42, "innerHelper.d should be 0.42");
+                Asserts.assertEQ(((Helper) f.getLocal(3)).f, 42f, "innerHelper.f should be 42");
+            } else {
+                Asserts.assertFalse(framesSeen[0], "frame1 can not have been seen");
+                Asserts.assertTrue(f.isMethod(FRAME1_RESOLVED),
+                        "Expected testFrame1 second");
+                framesSeen[0] = true;
+                Asserts.assertTrue(f.getLocal(0) != null, "this should not be null");
+                Asserts.assertTrue(f.getLocal(2) != null, "helper should not be null");
+            }
+        }
+        Asserts.assertTrue(framesSeen[1], "frame3 should have been seen");
+        Asserts.assertTrue(framesSeen[0], "frame2 should have been seen");
+    }
+
+    private class Helper {
+        public String string;
+        public int i;
+        public boolean z;
+        public byte b;
+        public char c;
+        public short s;
+        public long j;
+        public double d;
+        public float f;
+
+        public Helper(String string, int i, boolean z, byte b, char c, short s, long j, double d, float f) {
+            this.string = string;
+            this.i = i;
+            this.z = z;
+            this.b = b;
+            this.c = c;
+            this.s = s;
+            this.j = j;
+            this.d = d;
+            this.f = f;
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/GetStackFramesTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/GetStackFramesTest.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8136421
+ *
+ * @requires vm.jvmci & vm.compMode == "Xmixed"
+ * @requires vm.opt.final.EliminateAllocations == true
+ *
+ * @comment no "-Xcomp -XX:-TieredCompilation" combination allowed until JDK-8140018 is resolved
+ * @requires vm.opt.TieredCompilation == null | vm.opt.TieredCompilation == true
+ *
+ * @library / /test/lib
+ * @library ../common/patches
+ * @modules java.base/jdk.internal.misc
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.tree
+ *          jdk.internal.vm.ci/jdk.vm.ci.hotspot
+ *          jdk.internal.vm.ci/jdk.vm.ci.code
+ *          jdk.internal.vm.ci/jdk.vm.ci.code.stack
+ *          jdk.internal.vm.ci/jdk.vm.ci.meta
+ *
+ * @build jdk.internal.vm.ci/jdk.vm.ci.hotspot.CompilerToVMHelper sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbatch -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
+ *                   -XX:CompileCommand=exclude,compiler.jvmci.compilerToVM.GetStackFramesTest::check
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesTest::testFrame
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesTest::testFrame2
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesTest::recurse
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesTest::testFrame3
+ *                   -XX:+DoEscapeAnalysis -XX:-UseCounterDecay
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesTest.materializeFirst=true
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesTest.invalidate=false
+ *                   compiler.jvmci.compilerToVM.GetStackFramesTest
+ * @run main/othervm -Xbatch -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
+ *                   -XX:CompileCommand=exclude,compiler.jvmci.compilerToVM.GetStackFramesTest::check
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesTest::testFrame
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesTest::testFrame2
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesTest::recurse
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesTest::testFrame3
+ *                   -XX:+DoEscapeAnalysis -XX:-UseCounterDecay
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesTest.materializeFirst=false
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesTest.invalidate=false
+ *                   compiler.jvmci.compilerToVM.GetStackFramesTest
+ * @run main/othervm -Xbatch -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
+ *                   -XX:CompileCommand=exclude,compiler.jvmci.compilerToVM.GetStackFramesTest::check
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesTest::testFrame
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesTest::testFrame2
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesTest::recurse
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesTest::testFrame3
+ *                   -XX:+DoEscapeAnalysis -XX:-UseCounterDecay
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesTest.materializeFirst=true
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesTest.invalidate=true
+ *                   compiler.jvmci.compilerToVM.GetStackFramesTest
+ * @run main/othervm -Xbatch -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
+ *                   -XX:CompileCommand=exclude,compiler.jvmci.compilerToVM.GetStackFramesTest::check
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesTest::testFrame
+ *                   -XX:CompileCommand=dontinline,compiler.jvmci.compilerToVM.GetStackFramesTest::testFrame2
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesTest::recurse
+ *                   -XX:CompileCommand=inline,compiler.jvmci.compilerToVM.GetStackFramesTest::testFrame3
+ *                   -XX:+DoEscapeAnalysis -XX:-UseCounterDecay
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesTest.materializeFirst=false
+ *                   -Dcompiler.jvmci.compilerToVM.GetStackFramesTest.invalidate=true
+ *                   compiler.jvmci.compilerToVM.GetStackFramesTest
+ */
+
+package compiler.jvmci.compilerToVM;
+
+import compiler.jvmci.common.CTVMUtilities;
+import compiler.testlibrary.CompilerUtils;
+import compiler.whitebox.CompilerWhiteBoxTest;
+import jdk.test.lib.Asserts;
+import jdk.vm.ci.code.stack.InspectedFrame;
+import jdk.vm.ci.hotspot.CompilerToVMHelper;
+import jdk.vm.ci.hotspot.HotSpotStackFrameReference;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import jdk.vm.ci.code.stack.InspectedFrame;
+import jtreg.SkippedException;
+import sun.hotspot.WhiteBox;
+
+import java.lang.reflect.Method;
+
+public class GetStackFramesTest {
+    private static final WhiteBox WB;
+    private static final boolean INVALIDATE;
+    private static final int COMPILE_THRESHOLD;
+    private static final Method MATERIALIZED_METHOD;
+    private static final Method NOT_MATERIALIZED_METHOD;
+    private static final Method FRAME3_METHOD;
+    private static final ResolvedJavaMethod MATERIALIZED_RESOLVED;
+    private static final ResolvedJavaMethod NOT_MATERIALIZED_RESOLVED;
+    private static final ResolvedJavaMethod FRAME2_RESOLVED;
+    private static final ResolvedJavaMethod FRAME3_RESOLVED;
+    private static final boolean MATERIALIZE_FIRST;
+
+    static {
+        Method method1;
+        Method method2;
+        WB = WhiteBox.getWhiteBox();
+        try {
+            method1 = GetStackFramesTest.class.getDeclaredMethod("testFrame",
+                    String.class, int.class);
+            method2 = GetStackFramesTest.class.getDeclaredMethod("testFrame2",
+                    String.class, int.class);
+            FRAME3_METHOD = GetStackFramesTest.class.getDeclaredMethod("testFrame3",
+                    Helper.class, int.class);
+        } catch (NoSuchMethodException e) {
+            throw new Error("Can't get executable for test method", e);
+        }
+        ResolvedJavaMethod resolved1;
+        resolved1 = CTVMUtilities.getResolvedMethod(method1);
+        FRAME2_RESOLVED = CTVMUtilities.getResolvedMethod(method2);
+        FRAME3_RESOLVED = CTVMUtilities.getResolvedMethod(FRAME3_METHOD);
+        INVALIDATE = Boolean.getBoolean(
+                "compiler.jvmci.compilerToVM.GetStackFramesTest.invalidate");
+        COMPILE_THRESHOLD = WB.getBooleanVMFlag("TieredCompilation")
+                ? CompilerWhiteBoxTest.THRESHOLD
+                : CompilerWhiteBoxTest.THRESHOLD * 2;
+        MATERIALIZE_FIRST = Boolean.getBoolean(
+                "compiler.jvmci.compilerToVM.GetStackFramesTest.materializeFirst");
+        MATERIALIZED_RESOLVED = MATERIALIZE_FIRST ? resolved1 : FRAME2_RESOLVED;
+        NOT_MATERIALIZED_RESOLVED = MATERIALIZE_FIRST ? FRAME2_RESOLVED : resolved1;
+        MATERIALIZED_METHOD = MATERIALIZE_FIRST ? method1 : method2;
+        NOT_MATERIALIZED_METHOD = MATERIALIZE_FIRST ? method2 : method1;
+    }
+
+    public static void main(String[] args) {
+        int levels[] = CompilerUtils.getAvailableCompilationLevels();
+        // we need compilation level 4 to use EscapeAnalysis
+        if (levels.length < 1 || levels[levels.length - 1] != 4) {
+            throw new SkippedException("Test needs compilation level 4");
+        }
+
+        new GetStackFramesTest().test();
+    }
+
+    private static String getName() {
+        return "CASE: invalidate=" + INVALIDATE + ", materializedMethod="
+                + (MATERIALIZE_FIRST ? "testFrame" : "testFrame2")
+                + ", notMaterializedMethod="
+                + (MATERIALIZE_FIRST ? "testFrame2" : "testFrame");
+    }
+
+    private void test() {
+        System.out.println(getName());
+        Asserts.assertFalse(WB.isMethodCompiled(MATERIALIZED_METHOD),
+                getName() + " : materialized method is compiled");
+        Asserts.assertFalse(WB.isMethodCompiled(NOT_MATERIALIZED_METHOD),
+                getName() + " : not materialized method is compiled");
+        for (int i = 0; i < CompilerWhiteBoxTest.THRESHOLD; i++) {
+            testFrame("someString", i);
+        }
+        Asserts.assertTrue(WB.isMethodCompiled(MATERIALIZED_METHOD), getName()
+                + " : materialized method not compiled");
+        Asserts.assertTrue(WB.isMethodCompiled(NOT_MATERIALIZED_METHOD),
+                getName() + " : not materialized method not compiled");
+        testFrame("someString", /* materialize */ CompilerWhiteBoxTest.THRESHOLD);
+
+        // run second test types
+        for (int i = 0; i < CompilerWhiteBoxTest.THRESHOLD; i++) {
+            testFrame("someString", i);
+        }
+        Asserts.assertTrue(WB.isMethodCompiled(MATERIALIZED_METHOD), getName()
+                + " : materialized method not compiled");
+        Asserts.assertTrue(WB.isMethodCompiled(NOT_MATERIALIZED_METHOD),
+                getName() + " : not materialized method not compiled");
+        testFrame("someString", /* materialize */ CompilerWhiteBoxTest.THRESHOLD + 1);
+    }
+
+    private void testFrame(String str, int iteration) {
+        Helper helper = new Helper(str);
+        testFrame2(str, iteration);
+        Asserts.assertTrue((helper.string != null) && (this != null)
+                && (helper != null), String.format("%s : some locals are null", getName()));
+    }
+
+    private void testFrame2(String str, int iteration) {
+        Helper helper = new Helper(str);
+        Helper helper2 = new Helper("bar");
+        testFrame3(helper, iteration);
+        Asserts.assertTrue((helper.string != null) && (this != null) && helper.string == str
+                && (helper != null), String.format("%s : some locals are null", getName()));
+        Asserts.assertTrue((helper2.string != null) && (this != null)
+                && (helper2 != null), String.format("%s : some locals are null", getName()));
+    }
+
+    private void testFrame3(Helper outerHelper, int iteration) {
+        Helper innerHelper = new Helper("foo");
+        recurse(2, iteration);
+        Asserts.assertTrue((innerHelper.string != null) && (this != null)
+                && (innerHelper != null), String.format("%s : some locals are null", getName()));
+        Asserts.assertTrue((outerHelper.string != null) && (this != null)
+                && (outerHelper != null), String.format("%s : some locals are null", getName()));
+    }
+
+    private void recurse(int depth, int iteration) {
+        if (depth == 0) {
+            check(iteration);
+        } else {
+            Integer s = new Integer(depth);
+            recurse(depth - 1, iteration);
+            Asserts.assertEQ(s.intValue(), depth,
+                    String.format("different values: %s != %s", s.intValue(), depth));
+        }
+    }
+
+    private void checkStructure(boolean materialize) {
+        boolean[] framesSeen = new boolean[2];
+        Object[] helpers = new Object[1];
+
+        InspectedFrame[] frames = CompilerToVMHelper.getStackFrames(
+            new ResolvedJavaMethod[] {FRAME3_RESOLVED},
+            null, /* any */
+            0,
+            2, // fetch only 2 frames
+            new Thread[] {Thread.currentThread()}
+        )[0];
+
+        for (InspectedFrame f : frames) {
+            if (!framesSeen[1]) {
+                Asserts.assertTrue(f.isMethod(FRAME3_RESOLVED),
+                        "Expected testFrame3 first");
+                framesSeen[1] = true;
+                Asserts.assertTrue(f.getLocal(0) != null, "this should not be null");
+                Asserts.assertTrue(f.getLocal(1) != null, "outerHelper should not be null");
+                Asserts.assertTrue(f.getLocal(3) != null, "innerHelper should not be null");
+                Asserts.assertEQ(((Helper) f.getLocal(3)).string, "foo", "innerHelper.string should be foo");
+                helpers[0] = f.getLocal(1);
+                if (materialize) {
+                    f.materializeVirtualObjects(false);
+                }
+            } else {
+                Asserts.assertFalse(framesSeen[0], "frame3 can not have been seen");
+                Asserts.assertTrue(f.isMethod(FRAME2_RESOLVED),
+                        "Expected testFrame2 second");
+                framesSeen[0] = true;
+                Asserts.assertTrue(f.getLocal(0) != null, "this should not be null");
+                Asserts.assertTrue(f.getLocal(1) != null, "str should not be null");
+                Asserts.assertTrue(f.getLocal(3) != null, "helper should not be null");
+                Asserts.assertTrue(f.getLocal(4) != null, "helper2 should not be null");
+                Asserts.assertEQ(((Helper) f.getLocal(3)).string, f.getLocal(1), "helper.string should be the same as str");
+                Asserts.assertEQ(((Helper) f.getLocal(4)).string, "bar", "helper2.string should be bar");
+                if (!materialize) {
+                    Asserts.assertEQ(f.getLocal(3), helpers[0], "helper should be the same as frame3's outerHelper");
+                }
+            }
+        }
+
+        Asserts.assertTrue(framesSeen[1], "frame3 should have been seen");
+        Asserts.assertTrue(framesSeen[0], "frame2 should have been seen");
+    }
+
+    private void check(int iteration) {
+        // Materialize virtual objects on last invocation
+        if (iteration == COMPILE_THRESHOLD) {
+            // get frames and check not-null
+            HotSpotStackFrameReference materialized = (HotSpotStackFrameReference) CompilerToVMHelper.getStackFrames(
+                  new ResolvedJavaMethod[] {MATERIALIZED_RESOLVED},
+                  null, /* any */
+                  0,
+                  1, // fetch only 1 matching frame
+                  new Thread[] {Thread.currentThread()}
+              )[0][0];
+            Asserts.assertNotNull(materialized, getName()
+                    + " : got null frame for materialized method");
+            Asserts.assertTrue(materialized.isMethod(MATERIALIZED_RESOLVED),
+                "Expected materialized method but got " + materialized);
+            InspectedFrame notMaterialized = CompilerToVMHelper.getStackFrames(
+                  new ResolvedJavaMethod[] {NOT_MATERIALIZED_RESOLVED},
+                  null, /* any */
+                  0,
+                  1, // fetch only 1 matching frame
+                  new Thread[] {Thread.currentThread()}
+              )[0][0];
+            Asserts.assertNE(materialized, notMaterialized,
+                    "Got same frame pointer for both tested frames");
+            Asserts.assertTrue(notMaterialized.isMethod(NOT_MATERIALIZED_RESOLVED),
+                "Expected notMaterialized method but got " + notMaterialized);
+            Asserts.assertNotNull(notMaterialized, getName()
+                    + " : got null frame for not materialized method");
+            Asserts.assertTrue(WB.isMethodCompiled(MATERIALIZED_METHOD), getName()
+                + " : materialized method not compiled");
+            Asserts.assertTrue(WB.isMethodCompiled(NOT_MATERIALIZED_METHOD),
+                getName() + " : not materialized method not compiled");
+            // check that frames has virtual objects before materialization stage
+            Asserts.assertTrue(materialized.hasVirtualObjects(), getName()
+                    + ": materialized frame has no virtual object before materialization");
+            Asserts.assertTrue(notMaterialized.hasVirtualObjects(), getName()
+                    + ": notMaterialized frame has no virtual object before materialization");
+            // materialize
+            CompilerToVMHelper.materializeVirtualObjects(materialized, INVALIDATE);
+            // check that only not materialized frame has virtual objects
+            Asserts.assertFalse(materialized.hasVirtualObjects(), getName()
+                    + " : materialized has virtual object after materialization");
+            Asserts.assertTrue(notMaterialized.hasVirtualObjects(), getName()
+                    + " : notMaterialized has no virtual object after materialization");
+            // check that materialized frame was deoptimized in case invalidate=true
+            Asserts.assertEQ(WB.isMethodCompiled(MATERIALIZED_METHOD), !INVALIDATE, getName()
+                    + " : materialized method has unexpected compiled status");
+            // check that not materialized frame wasn't deoptimized
+            Asserts.assertTrue(WB.isMethodCompiled(NOT_MATERIALIZED_METHOD), getName()
+                    + " : not materialized method has unexpected compiled status");
+        } else if (iteration == COMPILE_THRESHOLD + 1) {
+            checkStructure(false);
+            checkStructure(true);
+        }
+    }
+
+    private class Helper {
+        public String string;
+
+        public Helper(String s) {
+            this.string = s;
+        }
+    }
+}


### PR DESCRIPTION
The idea is to add a more powerful API for cases where the current iterateFrames API cannot be used.

For example, a debugger needs access to the content of stack frames such as local variables or monitors. In cases where threads execute in the runtime or in native code, it's not possible to obtain a thread suspension hook, for which iterateFrames can be used on the suspended thread. The getStackFrames method enables an immediate stack frames lookup regardless of the status of the underlying thread.
Another use case would be for lookup of backtraces for non-current threads.

The implementation is done by means of a VM operation that collects vframe data for each thread during a safepoint, whereafter required object reallocation/reassign fields is performed based on the collected snapshot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8253001](https://bugs.openjdk.java.net/browse/JDK-8253001): [JVMCI] Add API for getting stacktraces independently of current thread


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/110/head:pull/110`
`$ git checkout pull/110`
