### PR TITLE
8253026: Remove dummy call to gc alot from VM Thread

### DIFF
--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -446,9 +446,6 @@ void VMThread::loop() {
             // something. This will run all the clean-up processing that needs
             // to be done at a safepoint.
             SafepointSynchronize::begin();
-            #ifdef ASSERT
-            if (GCALotAtAllSafepoints) InterfaceSupport::check_gc_alot();
-            #endif
             SafepointSynchronize::end();
             _cur_vm_operation = NULL;
           }


### PR DESCRIPTION
GC Alot can only be performed by a Java Thread:

void InterfaceSupport::gc_alot() {
  Thread *thread = Thread::current();
  if (!thread->is_Java_thread()) return; // Avoid concurrent calls

Lets remove the dummy call from the VM thread.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253026](https://bugs.openjdk.java.net/browse/JDK-8253026): Remove dummy call to gc alot from VM Thread


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/113/head:pull/113`
`$ git checkout pull/113`
