### PR TITLE
8252981: ObjectMonitor::object() cleanup changes extracted from JDK-8247281

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -663,13 +663,13 @@ JvmtiEnvBase::get_current_contended_monitor(JavaThread *calling_thread, JavaThre
     mon = java_thread->current_pending_monitor();
     if (mon != NULL) {
       // The thread is trying to enter() an ObjectMonitor.
-      obj = (oop)mon->object();
+      obj = mon->object();
       assert(obj != NULL, "ObjectMonitor should have a valid object!");
     }
     // implied else: no contended ObjectMonitor
   } else {
     // thread is doing an Object.wait() call
-    obj = (oop)mon->object();
+    obj = mon->object();
     assert(obj != NULL, "Object.wait() should have an object");
   }
 
@@ -741,7 +741,7 @@ JvmtiEnvBase::get_locked_objects_in_frame(JavaThread* calling_thread, JavaThread
     // Save object of current wait() call (if any) for later comparison.
     ObjectMonitor *mon = java_thread->current_waiting_monitor();
     if (mon != NULL) {
-      wait_obj = (oop)mon->object();
+      wait_obj = mon->object();
     }
   }
   oop pending_obj = NULL;
@@ -752,7 +752,7 @@ JvmtiEnvBase::get_locked_objects_in_frame(JavaThread* calling_thread, JavaThread
     // Save object of current enter() call (if any) for later comparison.
     ObjectMonitor *mon = java_thread->current_pending_monitor();
     if (mon != NULL) {
-      pending_obj = (oop)mon->object();
+      pending_obj = mon->object();
     }
   }
 
@@ -1435,7 +1435,7 @@ JvmtiMonitorClosure::do_monitor(ObjectMonitor* mon) {
   }
   if (mon->owner() == _java_thread ) {
     // Filter out on stack monitors collected during stack walk.
-    oop obj = (oop)mon->object();
+    oop obj = mon->object();
     bool found = false;
     for (int j = 0; j < _owned_monitors_list->length(); j++) {
       jobject jobj = ((jvmtiMonitorStackDepthInfo*)_owned_monitors_list->at(j))->monitor;

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2407,7 +2407,7 @@ void JvmtiExport::post_data_dump() {
 }
 
 void JvmtiExport::post_monitor_contended_enter(JavaThread *thread, ObjectMonitor *obj_mntr) {
-  oop object = (oop)obj_mntr->object();
+  oop object = obj_mntr->object();
   JvmtiThreadState *state = thread->jvmti_thread_state();
   if (state == NULL) {
     return;
@@ -2438,7 +2438,7 @@ void JvmtiExport::post_monitor_contended_enter(JavaThread *thread, ObjectMonitor
 }
 
 void JvmtiExport::post_monitor_contended_entered(JavaThread *thread, ObjectMonitor *obj_mntr) {
-  oop object = (oop)obj_mntr->object();
+  oop object = obj_mntr->object();
   JvmtiThreadState *state = thread->jvmti_thread_state();
   if (state == NULL) {
     return;
@@ -2501,7 +2501,7 @@ void JvmtiExport::post_monitor_wait(JavaThread *thread, oop object,
 }
 
 void JvmtiExport::post_monitor_waited(JavaThread *thread, ObjectMonitor *obj_mntr, jboolean timed_out) {
-  oop object = (oop)obj_mntr->object();
+  oop object = obj_mntr->object();
   JvmtiThreadState *state = thread->jvmti_thread_state();
   if (state == NULL) {
     return;

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -276,9 +276,9 @@ bool ObjectMonitor::enter(TRAPS) {
   if (TrySpin(Self) > 0) {
     assert(_owner == Self, "must be Self: owner=" INTPTR_FORMAT, p2i(_owner));
     assert(_recursions == 0, "must be 0: recursions=" INTX_FORMAT, _recursions);
-    assert(((oop)object())->mark() == markWord::encode(this),
+    assert(object()->mark() == markWord::encode(this),
            "object mark must match encoded this: mark=" INTPTR_FORMAT
-           ", encoded this=" INTPTR_FORMAT, ((oop)object())->mark().value(),
+           ", encoded this=" INTPTR_FORMAT, object()->mark().value(),
            markWord::encode(this).value());
     Self->_Stalled = 0;
     return true;
@@ -297,7 +297,7 @@ bool ObjectMonitor::enter(TRAPS) {
     // Async deflation is in progress and our contentions increment
     // above lost the race to async deflation. Undo the work and
     // force the caller to retry.
-    const oop l_object = (oop)object();
+    const oop l_object = object();
     if (l_object != NULL) {
       // Attempt to restore the header/dmw to the object's header so that
       // we only retry once if the deflater thread happens to be slow.
@@ -311,8 +311,8 @@ bool ObjectMonitor::enter(TRAPS) {
   JFR_ONLY(JfrConditionalFlushWithStacktrace<EventJavaMonitorEnter> flush(jt);)
   EventJavaMonitorEnter event;
   if (event.should_commit()) {
-    event.set_monitorClass(((oop)this->object())->klass());
-    event.set_address((uintptr_t)(this->object_addr()));
+    event.set_monitorClass(object()->klass());
+    event.set_address((uintptr_t)object_addr());
   }
 
   { // Change java thread status to indicate blocked on monitor enter.
@@ -375,7 +375,7 @@ bool ObjectMonitor::enter(TRAPS) {
   assert(_recursions == 0, "invariant");
   assert(_owner == Self, "invariant");
   assert(_succ != Self, "invariant");
-  assert(((oop)(object()))->mark() == markWord::encode(this), "invariant");
+  assert(object()->mark() == markWord::encode(this), "invariant");
 
   // The thread -- now the owner -- is back in vm mode.
   // Report the glorious news via TI,DTrace and jvmstat.
@@ -447,7 +447,7 @@ void ObjectMonitor::install_displaced_markword_in_object(const oop obj) {
     OrderAccess::loadload();
   }
 
-  const oop l_object = (oop)object();
+  const oop l_object = object();
   if (l_object == NULL) {
     // ObjectMonitor's object ref has already been cleared by async
     // deflation so we're done here.
@@ -772,7 +772,7 @@ void ObjectMonitor::ReenterI(Thread * Self, ObjectWaiter * SelfNode) {
   assert(SelfNode != NULL, "invariant");
   assert(SelfNode->_thread == Self, "invariant");
   assert(_waiters > 0, "invariant");
-  assert(((oop)(object()))->mark() == markWord::encode(this), "invariant");
+  assert(object()->mark() == markWord::encode(this), "invariant");
   assert(((JavaThread *)Self)->thread_state() != _thread_blocked, "invariant");
   JavaThread * jt = (JavaThread *) Self;
 
@@ -840,7 +840,7 @@ void ObjectMonitor::ReenterI(Thread * Self, ObjectWaiter * SelfNode) {
   // In addition, Self.TState is stable.
 
   assert(_owner == Self, "invariant");
-  assert(((oop)(object()))->mark() == markWord::encode(this), "invariant");
+  assert(object()->mark() == markWord::encode(this), "invariant");
   UnlinkAfterAcquire(Self, SelfNode);
   if (_succ == Self) _succ = NULL;
   assert(_succ != Self, "invariant");
@@ -1304,7 +1304,7 @@ static void post_monitor_wait_event(EventJavaMonitorWait* event,
                                     bool timedout) {
   assert(event != NULL, "invariant");
   assert(monitor != NULL, "invariant");
-  event->set_monitorClass(((oop)monitor->object())->klass());
+  event->set_monitorClass(monitor->object()->klass());
   event->set_timeout(timeout);
   event->set_address((uintptr_t)monitor->object_addr());
   event->set_notifier(notifier_tid);
@@ -1523,7 +1523,7 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
   // Verify a few postconditions
   assert(_owner == Self, "invariant");
   assert(_succ != Self, "invariant");
-  assert(((oop)(object()))->mark() == markWord::encode(this), "invariant");
+  assert(object()->mark() == markWord::encode(this), "invariant");
 
   // check if the notification happened
   if (!WasNotified) {
@@ -2107,7 +2107,7 @@ void ObjectMonitor::print() const { print_on(tty); }
 void ObjectMonitor::print_debug_style_on(outputStream* st) const {
   st->print_cr("(ObjectMonitor*) " INTPTR_FORMAT " = {", p2i(this));
   st->print_cr("  _header = " INTPTR_FORMAT, header().value());
-  st->print_cr("  _object = " INTPTR_FORMAT, p2i(_object));
+  st->print_cr("  _object = " INTPTR_FORMAT, p2i(object()));
   st->print("  _allocation_state = ");
   if (is_free()) {
     st->print("Free");

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -328,9 +328,9 @@ class ObjectMonitor {
 
  public:
 
-  void*     object() const;
-  void*     object_addr();
-  void      set_object(void* obj);
+  oop       object() const;
+  oop*      object_addr();
+  void      set_object(oop obj);
   void      release_set_allocation_state(AllocationState s);
   void      set_allocation_state(AllocationState s);
   AllocationState allocation_state() const;

--- a/src/hotspot/share/runtime/objectMonitor.inline.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.inline.hpp
@@ -92,22 +92,22 @@ inline void ObjectMonitor::clear_common() {
   assert(contentions() <= 0, "must not be positive: contentions=%d", contentions());
   assert(_waiters == 0, "must be 0: waiters=%d", _waiters);
   assert(_recursions == 0, "must be 0: recursions=" INTX_FORMAT, _recursions);
-  assert(_object != NULL, "must be non-NULL");
+  assert(object() != NULL, "must be non-NULL");
 
   set_allocation_state(Free);
-  _object = NULL;
+  set_object(NULL);
 }
 
-inline void* ObjectMonitor::object() const {
-  return _object;
+inline oop ObjectMonitor::object() const {
+  return (oop)_object;
 }
 
-inline void* ObjectMonitor::object_addr() {
-  return (void *)(&_object);
+inline oop* ObjectMonitor::object_addr() {
+  return (oop*)&_object;
 }
 
-inline void ObjectMonitor::set_object(void* obj) {
-  _object = obj;
+inline void ObjectMonitor::set_object(oop obj) {
+  _object = (void*)obj;
 }
 
 // Return number of threads contending for this monitor.

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -2531,7 +2531,6 @@ void ObjectSynchronizer::deflate_common_idle_monitors_using_JT(bool is_global, J
   if (ls != NULL) {
     if (is_global) {
       ls->print_cr("async-deflating global idle monitors, %3.7f secs, %d monitors", timer.seconds(), deflated_count);
-      GVars.stw_random = os::random();
     } else {
       ls->print_cr("jt=" INTPTR_FORMAT ": async-deflating per-thread idle monitors, %3.7f secs, %d monitors", p2i(target), timer.seconds(), deflated_count);
     }

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -229,12 +229,12 @@ Handle ThreadService::get_current_contended_monitor(JavaThread* thread) {
   oop obj = NULL;
   if (wait_obj != NULL) {
     // thread is doing an Object.wait() call
-    obj = (oop) wait_obj->object();
+    obj = wait_obj->object();
   } else {
     ObjectMonitor *enter_obj = thread->current_pending_monitor();
     if (enter_obj != NULL) {
       // thread is trying to enter() an ObjectMonitor.
-      obj = (oop) enter_obj->object();
+      obj = enter_obj->object();
     }
   }
 
@@ -626,7 +626,7 @@ public:
   }
   void do_monitor(ObjectMonitor* mid) {
     if (mid->owner() == _thread) {
-      oop object = (oop) mid->object();
+      oop object = mid->object();
       if (!_stack_trace->is_owned_monitor_on_stack(object)) {
         _stack_trace->add_jni_locked_monitor(object);
       }
@@ -998,7 +998,7 @@ void DeadlockCycle::print_on_with(ThreadsList * t_list, outputStream* st) const 
 
     if (waitingToLockMonitor != NULL) {
       st->print("  waiting to lock monitor " INTPTR_FORMAT, p2i(waitingToLockMonitor));
-      oop obj = (oop)waitingToLockMonitor->object();
+      oop obj = waitingToLockMonitor->object();
       st->print(" (object " INTPTR_FORMAT ", a %s)", p2i(obj),
                  obj->klass()->external_name());
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectMonitor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectMonitor.java
@@ -100,8 +100,8 @@ public class ObjectMonitor extends VMObject {
   }
 
   // FIXME
-  //  void*     object_addr();
-  //  void      set_object(void* obj);
+  //  oop*      object_addr();
+  //  void      set_object(oop obj);
 
   // The following four either aren't expressed as typed fields in
   // vmStructs.cpp because they aren't strongly typed in the VM, or


### PR DESCRIPTION
This is a trivial review request. This changeset was tested with Mach5 Tier[1-3],4,5,6,7,8
testing along with JDK-8252980 and JDK-8247281.

Since Erik and I are both contributors, we will need one other reviewer.

This sub-task is tracking ObjectMonitor::object() cleanup changes
extracted from Erik's work on JDK-8247281. This extraction is done
to ease the code review for the JDK-8247281 changes.

Here's the core cleanup:

diff -r fd7f6a424cd1 src/hotspot/share/runtime/objectMonitor.hpp
--- a/src/hotspot/share/runtime/objectMonitor.hpp Fri Aug 28 16:43:09 2020 -0400
+++ b/src/hotspot/share/runtime/objectMonitor.hpp Wed Sep 02 17:22:56 2020 -0400
@@ -328,9 +328,9 @@

  public:

- void* object() const;
- void* object_addr();
- void set_object(void* obj);
+ oop object() const;
+ oop* object_addr();
+ void set_object(oop obj);
   void release_set_allocation_state(AllocationState s);
   void set_allocation_state(AllocationState s);
   AllocationState allocation_state() const;

and those type changes ripple into the other files.

Note: The type for the ObjectMonitor::_object field is intentionally not
being changed from "void*" in this changeset. That will be done in JDK-8247281.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252981](https://bugs.openjdk.java.net/browse/JDK-8252981): ObjectMonitor::object() cleanup changes extracted from JDK-8247281


### Reviewers
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to 36649369d13d3bb1926bcc36192dae784aa2363e
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to 36649369d13d3bb1926bcc36192dae784aa2363e
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to 36649369d13d3bb1926bcc36192dae784aa2363e


### Contributors
 * Erik Österlund `<erik.osterlund@oracle.com>`
 * Daniel Daugherty `<daniel.daugherty@oracle.com>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/114/head:pull/114`
`$ git checkout pull/114`
