### PR TITLE
Remove duplicated code in the poll() method of LinkedList

### DIFF
--- a/src/java.base/share/classes/java/util/LinkedList.java
+++ b/src/java.base/share/classes/java/util/LinkedList.java
@@ -674,8 +674,7 @@ public class LinkedList<E>
      * @since 1.5
      */
     public E poll() {
-        final Node<E> f = first;
-        return (f == null) ? null : unlinkFirst(f);
+        return pollFirst();
     }
 
     /**


### PR DESCRIPTION
The poll() and the pollFirst() code is the same in the LinkedList class. We should call directly to pollFirst() from the poll() method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/115/head:pull/115`
`$ git checkout pull/115`
