### PR TITLE
8227745, 8233915: Enable Escape Analysis for Better Performance in the Presence of JVMTI Agents

### DIFF
--- a/src/hotspot/share/c1/c1_IR.hpp
+++ b/src/hotspot/share/c1/c1_IR.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -244,7 +244,11 @@ class IRScopeDebugInfo: public CompilationResourceObj {
     bool reexecute = topmost ? should_reexecute() : false;
     bool return_oop = false; // This flag will be ignored since it used only for C2 with escape analysis.
     bool rethrow_exception = false;
-    recorder->describe_scope(pc_offset, methodHandle(), scope()->method(), bci(), reexecute, rethrow_exception, is_method_handle_invoke, return_oop, locvals, expvals, monvals);
+    bool has_ea_local_in_scope = false;
+    bool arg_escape = false;
+    recorder->describe_scope(pc_offset, methodHandle(), scope()->method(), bci(),
+                             reexecute, rethrow_exception, is_method_handle_invoke, return_oop,
+                             has_ea_local_in_scope, arg_escape, locvals, expvals, monvals);
   }
 };
 

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -241,6 +241,7 @@ bool ciEnv::cache_jvmti_state() {
   _jvmti_can_post_on_exceptions         = JvmtiExport::can_post_on_exceptions();
   _jvmti_can_pop_frame                  = JvmtiExport::can_pop_frame();
   _jvmti_can_get_owned_monitor_info     = JvmtiExport::can_get_owned_monitor_info();
+  _jvmti_can_walk_any_space             = JvmtiExport::can_walk_any_space();
   return _task != NULL && _task->method()->is_old();
 }
 
@@ -268,6 +269,10 @@ bool ciEnv::jvmti_state_changed() const {
   }
   if (!_jvmti_can_get_owned_monitor_info &&
       JvmtiExport::can_get_owned_monitor_info()) {
+    return true;
+  }
+  if (!_jvmti_can_walk_any_space &&
+      JvmtiExport::can_walk_any_space()) {
     return true;
   }
 

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -73,6 +73,7 @@ private:
   bool  _jvmti_can_post_on_exceptions;
   bool  _jvmti_can_pop_frame;
   bool  _jvmti_can_get_owned_monitor_info; // includes can_get_owned_monitor_stack_depth_info
+  bool  _jvmti_can_walk_any_space;
 
   // Cache DTrace flags
   bool  _dtrace_extended_probes;
@@ -348,6 +349,7 @@ public:
   bool  jvmti_can_hotswap_or_post_breakpoint() const { return _jvmti_can_hotswap_or_post_breakpoint; }
   bool  jvmti_can_post_on_exceptions()         const { return _jvmti_can_post_on_exceptions; }
   bool  jvmti_can_get_owned_monitor_info()     const { return _jvmti_can_get_owned_monitor_info; }
+  bool  jvmti_can_walk_any_space()             const { return _jvmti_can_walk_any_space; }
 
   // Cache DTrace flags
   void  cache_dtrace_flags();

--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -286,17 +286,13 @@ void CompiledMethod::verify_oop_relocations() {
 ScopeDesc* CompiledMethod::scope_desc_at(address pc) {
   PcDesc* pd = pc_desc_at(pc);
   guarantee(pd != NULL, "scope must be present");
-  return new ScopeDesc(this, pd->scope_decode_offset(),
-                       pd->obj_decode_offset(), pd->should_reexecute(), pd->rethrow_exception(),
-                       pd->return_oop());
+  return new ScopeDesc(this, pd);
 }
 
 ScopeDesc* CompiledMethod::scope_desc_near(address pc) {
   PcDesc* pd = pc_desc_near(pc);
   guarantee(pd != NULL, "scope must be present");
-  return new ScopeDesc(this, pd->scope_decode_offset(),
-                       pd->obj_decode_offset(), pd->should_reexecute(), pd->rethrow_exception(),
-                       pd->return_oop());
+  return new ScopeDesc(this, pd);
 }
 
 address CompiledMethod::oops_reloc_begin() const {

--- a/src/hotspot/share/code/debugInfoRec.cpp
+++ b/src/hotspot/share/code/debugInfoRec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -287,6 +287,8 @@ void DebugInformationRecorder::describe_scope(int         pc_offset,
                                               bool        rethrow_exception,
                                               bool        is_method_handle_invoke,
                                               bool        return_oop,
+                                              bool        has_ea_local_in_scope,
+                                              bool        arg_escape,
                                               DebugToken* locals,
                                               DebugToken* expressions,
                                               DebugToken* monitors) {
@@ -303,6 +305,8 @@ void DebugInformationRecorder::describe_scope(int         pc_offset,
   last_pd->set_rethrow_exception(rethrow_exception);
   last_pd->set_is_method_handle_invoke(is_method_handle_invoke);
   last_pd->set_return_oop(return_oop);
+  last_pd->set_has_ea_local_in_scope(has_ea_local_in_scope);
+  last_pd->set_arg_escape(arg_escape);
 
   // serialize sender stream offest
   stream()->write_int(sender_stream_offset);

--- a/src/hotspot/share/code/debugInfoRec.hpp
+++ b/src/hotspot/share/code/debugInfoRec.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,6 +105,8 @@ class DebugInformationRecorder: public ResourceObj {
                       bool        rethrow_exception = false,
                       bool        is_method_handle_invoke = false,
                       bool        return_oop = false,
+                      bool        has_ea_local_in_scope = false,
+                      bool        arg_escape = false,
                       DebugToken* locals      = NULL,
                       DebugToken* expressions = NULL,
                       DebugToken* monitors    = NULL);

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2418,9 +2418,7 @@ void nmethod::verify_interrupt_point(address call_site) {
 
   PcDesc* pd = pc_desc_at(nativeCall_at(call_site)->return_address());
   assert(pd != NULL, "PcDesc must exist");
-  for (ScopeDesc* sd = new ScopeDesc(this, pd->scope_decode_offset(),
-                                     pd->obj_decode_offset(), pd->should_reexecute(), pd->rethrow_exception(),
-                                     pd->return_oop());
+  for (ScopeDesc* sd = new ScopeDesc(this, pd);
        !sd->is_top(); sd = sd->sender()) {
     sd->verify();
   }
@@ -3055,9 +3053,7 @@ const char* nmethod::reloc_string_for(u_char* begin, u_char* end) {
 ScopeDesc* nmethod::scope_desc_in(address begin, address end) {
   PcDesc* p = pc_desc_near(begin+1);
   if (p != NULL && p->real_pc(this) <= end) {
-    return new ScopeDesc(this, p->scope_decode_offset(),
-                         p->obj_decode_offset(), p->should_reexecute(), p->rethrow_exception(),
-                         p->return_oop());
+    return new ScopeDesc(this, p);
   }
   return NULL;
 }

--- a/src/hotspot/share/code/pcDesc.hpp
+++ b/src/hotspot/share/code/pcDesc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,9 @@ class PcDesc {
     PCDESC_reexecute               = 1 << 0,
     PCDESC_is_method_handle_invoke = 1 << 1,
     PCDESC_return_oop              = 1 << 2,
-    PCDESC_rethrow_exception       = 1 << 3
+    PCDESC_rethrow_exception       = 1 << 3,
+    PCDESC_has_ea_local_in_scope   = 1 << 4,
+    PCDESC_arg_escape              = 1 << 5
   };
 
   int _flags;
@@ -88,6 +90,16 @@ class PcDesc {
 
   bool     return_oop()                    const { return (_flags & PCDESC_return_oop) != 0;     }
   void set_return_oop(bool z)                    { set_flag(PCDESC_return_oop, z); }
+
+  // Indicates if there are objects in scope that, based on escape analysis, are local to the
+  // compiled method or local to the current thread, i.e. NoEscape or ArgEscape
+  bool     has_ea_local_in_scope()         const { return (_flags & PCDESC_has_ea_local_in_scope) != 0; }
+  void set_has_ea_local_in_scope(bool z)         { set_flag(PCDESC_has_ea_local_in_scope, z); }
+
+  // Indicates if this pc descriptor is at a call site where objects that do not escape the
+  // current thread are passed as arguments.
+  bool     arg_escape()                    const { return (_flags & PCDESC_arg_escape) != 0; }
+  void set_arg_escape(bool z)                    { set_flag(PCDESC_arg_escape, z); }
 
   // Returns the real pc
   address real_pc(const CompiledMethod* code) const;

--- a/src/hotspot/share/code/scopeDesc.cpp
+++ b/src/hotspot/share/code/scopeDesc.cpp
@@ -31,23 +31,16 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.inline.hpp"
 
-ScopeDesc::ScopeDesc(const CompiledMethod* code, int decode_offset, int obj_decode_offset, bool reexecute, bool rethrow_exception, bool return_oop) {
+ScopeDesc::ScopeDesc(const CompiledMethod* code, PcDesc* pd, bool ignore_objects) {
+  int obj_decode_offset = ignore_objects ? DebugInformationRecorder::serialized_null : pd->obj_decode_offset();
   _code          = code;
-  _decode_offset = decode_offset;
+  _decode_offset = pd->scope_decode_offset();
   _objects       = decode_object_values(obj_decode_offset);
-  _reexecute     = reexecute;
-  _rethrow_exception = rethrow_exception;
-  _return_oop    = return_oop;
-  decode_body();
-}
-
-ScopeDesc::ScopeDesc(const CompiledMethod* code, int decode_offset, bool reexecute, bool rethrow_exception, bool return_oop) {
-  _code          = code;
-  _decode_offset = decode_offset;
-  _objects       = decode_object_values(DebugInformationRecorder::serialized_null);
-  _reexecute     = reexecute;
-  _rethrow_exception = rethrow_exception;
-  _return_oop    = return_oop;
+  _reexecute     = pd->should_reexecute();
+  _rethrow_exception = pd->rethrow_exception();
+  _return_oop    = pd->return_oop();
+  _has_ea_local_in_scope = ignore_objects ? false : pd->has_ea_local_in_scope();
+  _arg_escape    = ignore_objects ? false : pd->arg_escape();
   decode_body();
 }
 
@@ -59,6 +52,8 @@ void ScopeDesc::initialize(const ScopeDesc* parent, int decode_offset) {
   _reexecute     = false; //reexecute only applies to the first scope
   _rethrow_exception = false;
   _return_oop    = false;
+  _has_ea_local_in_scope = parent->has_ea_local_in_scope();
+  _arg_escape    = false;
   decode_body();
 }
 

--- a/src/hotspot/share/code/scopeDesc.hpp
+++ b/src/hotspot/share/code/scopeDesc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,12 +60,7 @@ class SimpleScopeDesc : public StackObj {
 class ScopeDesc : public ResourceObj {
  public:
   // Constructor
-  ScopeDesc(const CompiledMethod* code, int decode_offset, int obj_decode_offset, bool reexecute, bool rethrow_exception, bool return_oop);
-
-  // Calls above, giving default value of "serialized_null" to the
-  // "obj_decode_offset" argument.  (We don't use a default argument to
-  // avoid a .hpp-.hpp dependency.)
-  ScopeDesc(const CompiledMethod* code, int decode_offset, bool reexecute, bool rethrow_exception, bool return_oop);
+  ScopeDesc(const CompiledMethod* code, PcDesc* pd, bool ignore_objects = false);
 
   // Direct access to scope
   ScopeDesc* at_offset(int decode_offset) { return new ScopeDesc(this, decode_offset); }
@@ -76,6 +71,10 @@ class ScopeDesc : public ResourceObj {
   bool should_reexecute() const { return _reexecute; }
   bool rethrow_exception() const { return _rethrow_exception; }
   bool return_oop()       const { return _return_oop; }
+  // Returns true if one or more NoEscape or ArgEscape objects exist in
+  // any of the scopes at compiled pc.
+  bool has_ea_local_in_scope() const { return _has_ea_local_in_scope; }
+  bool arg_escape()       const { return _arg_escape; }
 
   GrowableArray<ScopeValue*>*   locals();
   GrowableArray<ScopeValue*>*   expressions();
@@ -105,6 +104,9 @@ class ScopeDesc : public ResourceObj {
   bool          _reexecute;
   bool          _rethrow_exception;
   bool          _return_oop;
+  bool          _has_ea_local_in_scope;       // One or more NoEscape or ArgEscape objects exist in
+                                              // any of the scopes at compiled pc.
+  bool          _arg_escape;                  // Compiled Java call in youngest scope passes ArgEscape
 
   // Decoding offsets
   int _decode_offset;

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -805,19 +805,98 @@ Handle CompileBroker::create_thread_oop(const char* name, TRAPS) {
                        CHECK_NH);
 }
 
+#if defined(ASSERT) && COMPILER2_OR_JVMCI
+// Stress testing. Dedicated threads revert optimizations based on escape analysis concurrently to
+// the running java application.  Configured with vm options DeoptimizeObjectsALot*.
+class DeoptimizeObjectsALotThread : public JavaThread {
 
-JavaThread* CompileBroker::make_thread(jobject thread_handle, CompileQueue* queue, AbstractCompiler* comp, Thread* THREAD) {
+  static void deopt_objs_alot_thread_entry(JavaThread* thread, TRAPS);
+  void deoptimize_objects_alot_loop_single();
+  void deoptimize_objects_alot_loop_all();
+
+public:
+  DeoptimizeObjectsALotThread() : JavaThread(&deopt_objs_alot_thread_entry) { }
+
+  bool is_hidden_from_external_view() const      { return true; }
+};
+
+// Entry for DeoptimizeObjectsALotThread. The threads are started in
+// CompileBroker::init_compiler_sweeper_threads() iff DeoptimizeObjectsALot is enabled
+void DeoptimizeObjectsALotThread::deopt_objs_alot_thread_entry(JavaThread* thread, TRAPS) {
+    DeoptimizeObjectsALotThread* dt = ((DeoptimizeObjectsALotThread*) thread);
+    bool enter_single_loop;
+    {
+      MonitorLocker ml(dt, EscapeBarrier_lock, Mutex::_no_safepoint_check_flag);
+      static int single_thread_count = 0;
+      enter_single_loop = single_thread_count++ < DeoptimizeObjectsALotThreadCountSingle;
+    }
+    if (enter_single_loop) {
+      dt->deoptimize_objects_alot_loop_single();
+    } else {
+      dt->deoptimize_objects_alot_loop_all();
+    }
+  }
+
+// Execute EscapeBarriers in an endless loop to revert optimizations based on escape analysis. Each
+// barrier targets a single thread which is selected round robin.
+void DeoptimizeObjectsALotThread::deoptimize_objects_alot_loop_single() {
+  HandleMark hm(this);
+  while (!this->is_terminated()) {
+    for (JavaThreadIteratorWithHandle jtiwh; JavaThread *deoptee_thread = jtiwh.next(); ) {
+      { // Begin new scope for escape barrier
+        HandleMarkCleaner hmc(this);
+        ResourceMark rm(this);
+        EscapeBarrier eb(this, deoptee_thread, true);
+        eb.deoptimize_objects(100);
+      }
+      // Now sleep after the escape barriers destructor resumed deoptee_thread.
+      sleep(DeoptimizeObjectsALotInterval);
+    }
+  }
+}
+
+// Execute EscapeBarriers in an endless loop to revert optimizations based on escape analysis. Each
+// barrier targets all java threads in the vm at once.
+void DeoptimizeObjectsALotThread::deoptimize_objects_alot_loop_all() {
+  HandleMark hm(this);
+  while (!is_terminated()) {
+    { // Begin new scope for escape barrier
+      HandleMarkCleaner hmc(this);
+      ResourceMark rm(this);
+      EscapeBarrier eb(this, true);
+      eb.deoptimize_objects_all_threads();
+    }
+    // Now sleep after the escape barriers destructor resumed the java threads.
+    sleep(DeoptimizeObjectsALotInterval);
+  }
+}
+#endif // defined(ASSERT) && COMPILER2_OR_JVMCI
+
+
+JavaThread* CompileBroker::make_thread(ThreadType type, jobject thread_handle, CompileQueue* queue, AbstractCompiler* comp, Thread* THREAD) {
   JavaThread* new_thread = NULL;
   {
     MutexLocker mu(THREAD, Threads_lock);
-    if (comp != NULL) {
-      if (!InjectCompilerCreationFailure || comp->num_compiler_threads() == 0) {
-        CompilerCounters* counters = new CompilerCounters();
-        new_thread = new CompilerThread(queue, counters);
-      }
-    } else {
-      new_thread = new CodeCacheSweeperThread();
+    switch (type) {
+      case compiler_t:
+        assert(comp != NULL, "Compiler instance missing.");
+        if (!InjectCompilerCreationFailure || comp->num_compiler_threads() == 0) {
+          CompilerCounters* counters = new CompilerCounters();
+          new_thread = new CompilerThread(queue, counters);
+        }
+        break;
+      case sweeper_t:
+        new_thread = new CodeCacheSweeperThread();
+        break;
+#if defined(ASSERT) && COMPILER2_OR_JVMCI
+      case deoptimizer_t:
+        new_thread = new DeoptimizeObjectsALotThread();
+        break;
+#endif // ASSERT
+      default:
+        ShouldNotReachHere();
     }
+
     // At this point the new CompilerThread data-races with this startup
     // thread (which I believe is the primoridal thread and NOT the VM
     // thread).  This means Java bytecodes being executed at startup can
@@ -859,7 +938,7 @@ JavaThread* CompileBroker::make_thread(jobject thread_handle, CompileQueue* queu
       java_lang_Thread::set_daemon(JNIHandles::resolve_non_null(thread_handle));
 
       new_thread->set_threadObj(JNIHandles::resolve_non_null(thread_handle));
-      if (comp != NULL) {
+      if (type == compiler_t) {
         new_thread->as_CompilerThread()->set_compiler(comp);
       }
       Threads::add(new_thread);
@@ -869,7 +948,7 @@ JavaThread* CompileBroker::make_thread(jobject thread_handle, CompileQueue* queu
 
   // First release lock before aborting VM.
   if (new_thread == NULL || new_thread->osthread() == NULL) {
-    if (UseDynamicNumberOfCompilerThreads && comp != NULL && comp->num_compiler_threads() > 0) {
+    if (UseDynamicNumberOfCompilerThreads && type == compiler_t && comp->num_compiler_threads() > 0) {
       if (new_thread != NULL) {
         new_thread->smr_delete();
       }
@@ -924,7 +1003,7 @@ void CompileBroker::init_compiler_sweeper_threads() {
     _compiler2_logs[i] = NULL;
 
     if (!UseDynamicNumberOfCompilerThreads || i == 0) {
-      JavaThread *ct = make_thread(thread_handle, _c2_compile_queue, _compilers[1], THREAD);
+      JavaThread *ct = make_thread(compiler_t, thread_handle, _c2_compile_queue, _compilers[1], THREAD);
       assert(ct != NULL, "should have been handled for initial thread");
       _compilers[1]->set_num_compiler_threads(i + 1);
       if (TraceCompilerThreads) {
@@ -944,7 +1023,7 @@ void CompileBroker::init_compiler_sweeper_threads() {
     _compiler1_logs[i] = NULL;
 
     if (!UseDynamicNumberOfCompilerThreads || i == 0) {
-      JavaThread *ct = make_thread(thread_handle, _c1_compile_queue, _compilers[0], THREAD);
+      JavaThread *ct = make_thread(compiler_t, thread_handle, _c1_compile_queue, _compilers[0], THREAD);
       assert(ct != NULL, "should have been handled for initial thread");
       _compilers[0]->set_num_compiler_threads(i + 1);
       if (TraceCompilerThreads) {
@@ -963,8 +1042,20 @@ void CompileBroker::init_compiler_sweeper_threads() {
     // Initialize the sweeper thread
     Handle thread_oop = create_thread_oop("Sweeper thread", CHECK);
     jobject thread_handle = JNIHandles::make_local(THREAD, thread_oop());
-    make_thread(thread_handle, NULL, NULL, THREAD);
+    make_thread(sweeper_t, thread_handle, NULL, NULL, THREAD);
   }
+
+#if defined(ASSERT) && COMPILER2_OR_JVMCI
+  if (DeoptimizeObjectsALot) {
+    // Initialize and start the object deoptimizer threads
+    const int total_count = DeoptimizeObjectsALotThreadCountSingle + DeoptimizeObjectsALotThreadCountAll;
+    for (int count = 0; count < total_count; count++) {
+      Handle thread_oop = create_thread_oop("Deoptimize objects a lot single mode", CHECK);
+      jobject thread_handle = JNIHandles::make_local(THREAD, thread_oop());
+      make_thread(deoptimizer_t, thread_handle, NULL, NULL, THREAD);
+    }
+  }
+#endif // defined(ASSERT) && COMPILER2_OR_JVMCI
 }
 
 void CompileBroker::possibly_add_compiler_threads(Thread* THREAD) {
@@ -1018,7 +1109,7 @@ void CompileBroker::possibly_add_compiler_threads(Thread* THREAD) {
         _compiler2_objects[i] = thread_handle;
       }
 #endif
-      JavaThread *ct = make_thread(compiler2_object(i), _c2_compile_queue, _compilers[1], THREAD);
+      JavaThread *ct = make_thread(compiler_t, compiler2_object(i), _c2_compile_queue, _compilers[1], THREAD);
       if (ct == NULL) break;
       _compilers[1]->set_num_compiler_threads(i + 1);
       if (TraceCompilerThreads) {
@@ -1038,7 +1129,7 @@ void CompileBroker::possibly_add_compiler_threads(Thread* THREAD) {
         (int)(available_cc_p / (128*K)));
 
     for (int i = old_c1_count; i < new_c1_count; i++) {
-      JavaThread *ct = make_thread(compiler1_object(i), _c1_compile_queue, _compilers[0], THREAD);
+      JavaThread *ct = make_thread(compiler_t, compiler1_object(i), _c1_compile_queue, _compilers[0], THREAD);
       if (ct == NULL) break;
       _compilers[0]->set_num_compiler_threads(i + 1);
       if (TraceCompilerThreads) {

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -228,8 +228,14 @@ class CompileBroker: AllStatic {
 
   static volatile int _print_compilation_warning;
 
+  enum ThreadType {
+    compiler_t,
+    sweeper_t,
+    deoptimizer_t
+  };
+
   static Handle create_thread_oop(const char* name, TRAPS);
-  static JavaThread* make_thread(jobject thread_oop, CompileQueue* queue, AbstractCompiler* comp, Thread* THREAD);
+  static JavaThread* make_thread(ThreadType type, jobject thread_oop, CompileQueue* queue, AbstractCompiler* comp, Thread* THREAD);
   static void init_compiler_sweeper_threads();
   static void possibly_add_compiler_threads(Thread* THREAD);
   static bool compilation_is_prohibited(const methodHandle& method, int osr_bci, int comp_level, bool excluded);

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.cpp
@@ -295,7 +295,7 @@ bool ReferenceToThreadRootClosure::do_thread_stack_detailed(JavaThread* jt) {
     return true;
   }
 
-  GrowableArray<jvmtiDeferredLocalVariableSet*>* const list = jt->deferred_locals();
+  GrowableArray<jvmtiDeferredLocalVariableSet*>* const list = JvmtiDeferredUpdates::deferred_locals(jt);
   if (list != NULL) {
     for (int i = 0; i < list->length(); i++) {
       list->at(i)->oops_do(&rcl);

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -1181,7 +1181,11 @@ void CodeInstaller::record_scope(jint pc_offset, JVMCIObject position, ScopeMode
     throw_exception = jvmci_env()->get_BytecodeFrame_rethrowException(frame) == JNI_TRUE;
   }
 
+  // has_ea_local_in_scope and arg_escape should be added to JVMCI
+  const bool has_ea_local_in_scope = false;
+  const bool arg_escape            = false;
   _debug_recorder->describe_scope(pc_offset, method, NULL, bci, reexecute, throw_exception, is_mh_invoke, return_oop,
+                                  has_ea_local_in_scope, arg_escape,
                                   locals_token, expressions_token, monitors_token);
 }
 

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -93,8 +93,7 @@ void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, boo
   assert(is_initialized(), "Compiler thread must be initialized");
 
   bool subsume_loads = SubsumeLoads;
-  bool do_escape_analysis = DoEscapeAnalysis && !env->should_retain_local_variables()
-                                             && !env->jvmti_can_get_owned_monitor_info();
+  bool do_escape_analysis = DoEscapeAnalysis;
   bool eliminate_boxing = EliminateAutoBox;
 
   while (!env->failing()) {

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -331,7 +331,8 @@ public:
     : MultiNode( edges ),
       _oop_map(NULL),
       _jvms(jvms),
-      _adr_type(adr_type)
+      _adr_type(adr_type),
+      _has_ea_local_in_scope(false)
   {
     init_class_id(Class_SafePoint);
   }
@@ -340,6 +341,7 @@ public:
   JVMState* const _jvms;      // Pointer to list of JVM State objects
   const TypePtr*  _adr_type;  // What type of memory does this node produce?
   ReplacedNodes   _replaced_nodes; // During parsing: list of pair of nodes from calls to GraphKit::replace_in_map()
+  bool            _has_ea_local_in_scope; // NoEscape or ArgEscape objects in JVM States
 
   // Many calls take *all* of memory as input,
   // but some produce a limited subset of that memory as output.
@@ -460,6 +462,12 @@ public:
   }
   bool has_replaced_nodes() const {
     return !_replaced_nodes.is_empty();
+  }
+  void set_has_ea_local_in_scope(bool b) {
+    _has_ea_local_in_scope = b;
+  }
+  bool has_ea_local_in_scope() const {
+    return _has_ea_local_in_scope;
   }
 
   void disconnect_from_root(PhaseIterGVN *igvn);
@@ -661,6 +669,7 @@ protected:
   bool    _method_handle_invoke;
   bool    _override_symbolic_info; // Override symbolic call site info from bytecode
   ciMethod* _method;               // Method being direct called
+  bool    _arg_escape;             // ArgEscape in parameter list
 public:
   const int       _bci;         // Byte Code Index of call byte code
   CallJavaNode(const TypeFunc* tf , address addr, ciMethod* method, int bci)
@@ -668,7 +677,8 @@ public:
       _optimized_virtual(false),
       _method_handle_invoke(false),
       _override_symbolic_info(false),
-      _method(method), _bci(bci)
+      _method(method),
+      _arg_escape(false), _bci(bci)
   {
     init_class_id(Class_CallJava);
   }
@@ -682,6 +692,8 @@ public:
   bool  is_method_handle_invoke() const    { return _method_handle_invoke; }
   void  set_override_symbolic_info(bool f) { _override_symbolic_info = f; }
   bool  override_symbolic_info() const     { return _override_symbolic_info; }
+  void  set_arg_escape(bool f)             { _arg_escape = f; }
+  bool  arg_escape() const                 { return _arg_escape; }
 
   DEBUG_ONLY( bool validate_symbolic_info() const; )
 

--- a/src/hotspot/share/opto/escape.hpp
+++ b/src/hotspot/share/opto/escape.hpp
@@ -553,6 +553,11 @@ private:
     return (phi == NULL) ? NULL : phi->as_Phi();
   }
 
+  // Returns true if there is an object in the scope of sfn that does not escape globally.
+  bool has_ea_local_in_scope(SafePointNode* sfn);
+
+  bool has_arg_escape(CallJavaNode* call);
+
   // Notify optimizer that a node has been modified
   void record_for_optimizer(Node *n);
 

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -820,10 +820,11 @@ public:
   OopMap*         _oop_map;     // Array of OopMap info (8-bit char) for GC
   JVMState*       _jvms;        // Pointer to list of JVM State Objects
   uint            _jvmadj;      // Extra delta to jvms indexes (mach. args)
+  bool            _has_ea_local_in_scope; // NoEscape or ArgEscape objects in JVM States
   OopMap*         oop_map() const { return _oop_map; }
   void            set_oop_map(OopMap* om) { _oop_map = om; }
 
-  MachSafePointNode() : MachReturnNode(), _oop_map(NULL), _jvms(NULL), _jvmadj(0) {
+  MachSafePointNode() : MachReturnNode(), _oop_map(NULL), _jvms(NULL), _jvmadj(0), _has_ea_local_in_scope(false) {
     init_class_id(Class_MachSafePoint);
   }
 
@@ -925,6 +926,7 @@ public:
   int       _bci;                    // Byte Code index of call byte code
   bool      _optimized_virtual;      // Tells if node is a static call or an optimized virtual
   bool      _method_handle_invoke;   // Tells if the call has to preserve SP
+  bool      _arg_escape;             // ArgEscape in parameter list
   MachCallJavaNode() : MachCallNode(), _override_symbolic_info(false) {
     init_class_id(Class_MachCallJava);
   }

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1093,7 +1093,7 @@ bool PhaseMacroExpand::eliminate_allocate_node(AllocateNode *alloc) {
   // if reallocation fails during deoptimization we'll pop all
   // interpreter frames for this compiled frame and that won't play
   // nice with JVMTI popframe.
-  if (!EliminateAllocations || JvmtiExport::can_pop_frame() || !alloc->_is_non_escaping) {
+  if (!EliminateAllocations || !alloc->_is_non_escaping) {
     return false;
   }
   Node* klass = alloc->in(AllocateNode::KlassNode);

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -1195,6 +1195,7 @@ MachNode *Matcher::match_sfpt( SafePointNode *sfpt ) {
       is_method_handle_invoke = call_java->is_method_handle_invoke();
       mcall_java->_method_handle_invoke = is_method_handle_invoke;
       mcall_java->_override_symbolic_info = call_java->override_symbolic_info();
+      mcall_java->_arg_escape = call_java->arg_escape();
       if (is_method_handle_invoke) {
         C->set_has_method_handle_invokes(true);
       }
@@ -1219,6 +1220,7 @@ MachNode *Matcher::match_sfpt( SafePointNode *sfpt ) {
     msfpt = mn->as_MachSafePoint();
     cnt = TypeFunc::Parms;
   }
+  msfpt->_has_ea_local_in_scope = sfpt->has_ea_local_in_scope();
 
   // Advertise the correct memory effects (for anti-dependence computation).
   msfpt->set_adr_type(sfpt->adr_type());

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -933,6 +933,8 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
   int safepoint_pc_offset = current_offset;
   bool is_method_handle_invoke = false;
   bool return_oop = false;
+  bool has_ea_local_in_scope = sfn->_has_ea_local_in_scope;
+  bool arg_escape = false;
 
   // Add the safepoint in the DebugInfoRecorder
   if( !mach->is_MachCall() ) {
@@ -947,6 +949,7 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
         assert(C->has_method_handle_invokes(), "must have been set during call generation");
         is_method_handle_invoke = true;
       }
+      arg_escape = mcall->as_MachCallJava()->_arg_escape;
     }
 
     // Check if a call returns an object.
@@ -1067,7 +1070,10 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
     // Now we can describe the scope.
     methodHandle null_mh;
     bool rethrow_exception = false;
-    C->debug_info()->describe_scope(safepoint_pc_offset, null_mh, scope_method, jvms->bci(), jvms->should_reexecute(), rethrow_exception, is_method_handle_invoke, return_oop, locvals, expvals, monvals);
+    C->debug_info()->describe_scope(safepoint_pc_offset, null_mh, scope_method, jvms->bci(),
+                                    jvms->should_reexecute(), rethrow_exception, is_method_handle_invoke,
+                                    return_oop, has_ea_local_in_scope, arg_escape,
+                                    locvals, expvals, monvals);
   } // End jvms loop
 
   // Mark the end of the scope set.

--- a/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
+++ b/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
@@ -275,7 +275,7 @@ void JvmtiCodeBlobEvents::build_jvmti_addr_location_map(nmethod *nm,
 
     address scopes_data = nm->scopes_data_begin();
     for( pcd = nm->scopes_pcs_begin(); pcd < nm->scopes_pcs_end(); ++pcd ) {
-      ScopeDesc sc0(nm, pcd->scope_decode_offset(), pcd->should_reexecute(), pcd->rethrow_exception(), pcd->return_oop());
+      ScopeDesc sc0(nm, pcd, true);
       ScopeDesc *sd  = &sc0;
       while( !sd->is_top() ) { sd = sd->sender(); }
       int bci = sd->bci();

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1206,6 +1206,11 @@ JvmtiEnv::GetOwnedMonitorInfo(JavaThread* java_thread, jint* owned_monitor_count
   GrowableArray<jvmtiMonitorStackDepthInfo*> *owned_monitors_list =
       new (ResourceObj::C_HEAP, mtServiceability) GrowableArray<jvmtiMonitorStackDepthInfo*>(1, mtServiceability);
 
+  EscapeBarrier eb(calling_thread, java_thread, true);
+  if (!eb.deoptimize_objects(MaxJavaStackTraceDepth)) {
+    return JVMTI_ERROR_OUT_OF_MEMORY;
+  }
+
   // It is only safe to perform the direct operation on the current
   // thread. All other usage needs to use a direct handshake for safety.
   if (java_thread == calling_thread) {
@@ -1250,6 +1255,11 @@ JvmtiEnv::GetOwnedMonitorStackDepthInfo(JavaThread* java_thread, jint* monitor_i
   // growable array of jvmti monitors info on the C-heap
   GrowableArray<jvmtiMonitorStackDepthInfo*> *owned_monitors_list =
          new (ResourceObj::C_HEAP, mtServiceability) GrowableArray<jvmtiMonitorStackDepthInfo*>(1, mtServiceability);
+
+  EscapeBarrier eb(calling_thread, java_thread, true);
+  if (!eb.deoptimize_objects(MaxJavaStackTraceDepth)) {
+    return JVMTI_ERROR_OUT_OF_MEMORY;
+  }
 
   // It is only safe to perform the direct operation on the current
   // thread. All other usage needs to use a direct handshake for safety.
@@ -1666,6 +1676,13 @@ JvmtiEnv::PopFrame(JavaThread* java_thread) {
     }
   }
 
+  if (java_thread->frames_to_pop_failed_realloc() > 0) {
+    // VM is in the process of popping the top frame because it has scalar replaced objects which
+    // could not be reallocated on the heap.
+    // Return JVMTI_ERROR_OUT_OF_MEMORY to avoid interfering with the VM.
+    return JVMTI_ERROR_OUT_OF_MEMORY;
+  }
+
   {
     ResourceMark rm(current_thread);
     // Check if there are more than one Java frame in this thread, that the top two frames
@@ -1697,9 +1714,15 @@ JvmtiEnv::PopFrame(JavaThread* java_thread) {
     }
 
     // If any of the top 2 frames is a compiled one, need to deoptimize it
+    EscapeBarrier eb(current_thread, java_thread, !is_interpreted[0] || !is_interpreted[1]);
     for (int i = 0; i < 2; i++) {
       if (!is_interpreted[i]) {
         Deoptimization::deoptimize_frame(java_thread, frame_sp[i]);
+        // Eagerly reallocate scalar replaced objects.
+        if (!eb.deoptimize_objects(frame_sp[i])) {
+          // Reallocation of scalar replaced objects failed -> return with error
+          return JVMTI_ERROR_OUT_OF_MEMORY;
+        }
       }
     }
 

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -427,6 +427,7 @@ VM_GetOrSetLocal::VM_GetOrSetLocal(JavaThread* thread, jint depth, jint index, B
   , _type(type)
   , _jvf(NULL)
   , _set(false)
+  , _eb(NULL, NULL, type == T_OBJECT)
   , _result(JVMTI_ERROR_NONE)
 {
 }
@@ -441,6 +442,7 @@ VM_GetOrSetLocal::VM_GetOrSetLocal(JavaThread* thread, jint depth, jint index, B
   , _value(value)
   , _jvf(NULL)
   , _set(true)
+  , _eb(JavaThread::current(), thread, type == T_OBJECT)
   , _result(JVMTI_ERROR_NONE)
 {
 }
@@ -454,6 +456,7 @@ VM_GetOrSetLocal::VM_GetOrSetLocal(JavaThread* thread, JavaThread* calling_threa
   , _type(T_OBJECT)
   , _jvf(NULL)
   , _set(false)
+  , _eb(calling_thread, thread, true)
   , _result(JVMTI_ERROR_NONE)
 {
 }
@@ -626,8 +629,64 @@ static bool can_be_deoptimized(vframe* vf) {
   return (vf->is_compiled_frame() && vf->fr().can_be_deoptimized());
 }
 
+// Revert optimizations based on escape analysis if this is an access to a local object
+bool VM_GetOrSetLocal::deoptimize_objects(javaVFrame* jvf) {
+#if COMPILER2_OR_JVMCI
+  assert(_type == T_OBJECT, "EscapeBarrier should not be active if _type != T_OBJECT");
+  if (_depth < _thread->frames_to_pop_failed_realloc()) {
+    // cannot access frame with failed reallocations
+    _result = JVMTI_ERROR_OUT_OF_MEMORY;
+    return false;
+  }
+  if (can_be_deoptimized(jvf)) {
+    compiledVFrame* cf = compiledVFrame::cast(jvf);
+    if (cf->has_ea_local_in_scope() && !_eb.deoptimize_objects(cf->fr().id())) {
+      // reallocation of scalar replaced objects failed because heap is exhausted
+      _result = JVMTI_ERROR_OUT_OF_MEMORY;
+      return false;
+    }
+  }
+
+  // With this access the object could escape the thread changing its escape state from ArgEscape,
+  // to GlobalEscape so we must deoptimize callers which could have optimized on the escape state.
+  vframe* vf = jvf;
+  do {
+    // move to next physical frame
+    while(!vf->is_top()) {
+      vf = vf->sender();
+    }
+    vf = vf->sender();
+
+    if (vf != NULL && vf->is_compiled_frame()) {
+      compiledVFrame* cvf = compiledVFrame::cast(vf);
+      // Deoptimize objects if arg escape is being passed down the stack.
+      // Note that deoptimizing the frame is not enough because objects need to be relocked
+      if (cvf->arg_escape() && !_eb.deoptimize_objects(cvf->fr().id())) {
+        // reallocation of scalar replaced objects failed because heap is exhausted
+        _result = JVMTI_ERROR_OUT_OF_MEMORY;
+        return false;
+      }
+    }
+  } while(vf != NULL && !vf->is_entry_frame());
+#endif // COMPILER2_OR_JVMCI
+  return true;
+}
+
+bool VM_GetOrSetLocal::doit_prologue() {
+  if (_eb.barrier_active()) {
+    _jvf = get_java_vframe();
+    NULL_CHECK(_jvf, false);
+
+    if (!deoptimize_objects(_jvf)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 void VM_GetOrSetLocal::doit() {
-  _jvf = get_java_vframe();
+  _jvf = _jvf == NULL ? get_java_vframe() : _jvf;
   if (_jvf == NULL) {
     return;
   };

--- a/src/hotspot/share/prims/jvmtiImpl.hpp
+++ b/src/hotspot/share/prims/jvmtiImpl.hpp
@@ -32,6 +32,7 @@
 #include "prims/jvmtiEventController.hpp"
 #include "prims/jvmtiTrace.hpp"
 #include "prims/jvmtiUtil.hpp"
+#include "runtime/deoptimization.hpp"
 #include "runtime/stackValueCollection.hpp"
 #include "runtime/vmOperations.hpp"
 #include "utilities/ostream.hpp"
@@ -321,6 +322,8 @@ class VM_GetOrSetLocal : public VM_Operation {
   javaVFrame* _jvf;
   bool        _set;
 
+  EscapeBarrier _eb;
+
   // It is possible to get the receiver out of a non-static native wrapper
   // frame.  Use VM_GetReceiver to do this.
   virtual bool getting_receiver() const { return false; }
@@ -331,6 +334,7 @@ class VM_GetOrSetLocal : public VM_Operation {
   javaVFrame* get_java_vframe();
   bool check_slot_type_lvt(javaVFrame* vf);
   bool check_slot_type_no_lvt(javaVFrame* vf);
+  bool deoptimize_objects(javaVFrame* vf);
 
 public:
   // Constructor for non-object getter
@@ -347,6 +351,7 @@ public:
   jvalue value()         { return _value; }
   jvmtiError result()    { return _result; }
 
+  bool doit_prologue();
   void doit();
   bool allow_nested_vm_operations() const;
   const char* name() const                       { return "get/set locals"; }

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,11 +36,13 @@ class ObjectValue;
 class AutoBoxObjectValue;
 class ScopeValue;
 class compiledVFrame;
+class EscapeBarrier;
 
 template<class E> class GrowableArray;
 
 class Deoptimization : AllStatic {
   friend class VMStructs;
+  friend class EscapeBarrier;
 
  public:
   // What condition caused the deoptimization?
@@ -134,7 +136,8 @@ class Deoptimization : AllStatic {
     Unpack_exception            = 1, // exception is pending
     Unpack_uncommon_trap        = 2, // redo last byte code (C2 only)
     Unpack_reexecute            = 3, // reexecute bytecode (C1 only)
-    Unpack_LIMIT                = 4
+    Unpack_none                 = 4, // not deoptimizing the frame, just reallocating/relocking for JVMTI
+    Unpack_LIMIT                = 5
   };
 
 #if INCLUDE_JVMCI
@@ -152,6 +155,9 @@ class Deoptimization : AllStatic {
   // Revoke biased locks at deopt.
   static void revoke_from_deopt_handler(JavaThread* thread, frame fr, RegisterMap* map);
 
+  static void revoke_for_object_deoptimization(JavaThread* deoptee_thread, frame fr,
+                                               RegisterMap* map, JavaThread* thread);
+
  public:
   // Deoptimizes a frame lazily. Deopt happens on return to the frame.
   static void deoptimize(JavaThread* thread, frame fr, DeoptReason reason = Reason_constraint);
@@ -166,6 +172,11 @@ class Deoptimization : AllStatic {
   static void deoptimize_single_frame(JavaThread* thread, frame fr, DeoptReason reason);
 
 #if COMPILER2_OR_JVMCI
+  // Deoptimize objects, that is reallocate and relock them, just before they
+  // escape through JVMTI.  The given vframes cover one physical frame.
+  static bool deoptimize_objects_internal(JavaThread* thread, GrowableArray<compiledVFrame*>* chunk,
+                                          bool& realloc_failures);
+
  public:
 
   // Support for restoring non-escaping objects
@@ -173,7 +184,8 @@ class Deoptimization : AllStatic {
   static void reassign_type_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, typeArrayOop obj, BasicType type);
   static void reassign_object_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, objArrayOop obj);
   static void reassign_fields(frame* fr, RegisterMap* reg_map, GrowableArray<ScopeValue*>* objects, bool realloc_failures, bool skip_internal);
-  static void relock_objects(GrowableArray<MonitorInfo*>* monitors, JavaThread* thread, bool realloc_failures);
+  static bool relock_objects(JavaThread* thread, GrowableArray<MonitorInfo*>* monitors,
+                             JavaThread* deoptee_thread, frame& fr, int exec_mode, bool realloc_failures);
   static void pop_frames_failed_reallocs(JavaThread* thread, vframeArray* array);
   NOT_PRODUCT(static void print_objects(GrowableArray<ScopeValue*>* objects, bool realloc_failures);)
 #endif // COMPILER2_OR_JVMCI
@@ -464,6 +476,93 @@ class Deoptimization : AllStatic {
 
  public:
   static void update_method_data_from_interpreter(MethodData* trap_mdo, int trap_bci, int reason);
+};
+
+// EscapeBarriers should be put on execution paths where JVMTI agents can access object
+// references held by java threads.
+// They provide means to revert optimizations based on escape analysis in a well synchronized manner
+// just before local references escape through JVMTI.
+class EscapeBarrier : StackObj {
+#if COMPILER2_OR_JVMCI
+  JavaThread* const _calling_thread;
+  JavaThread* const _deoptee_thread;
+  bool        const _barrier_active;
+
+  static bool _deoptimizing_objects_for_all_threads;
+  static bool _self_deoptimization_in_progress;
+
+  void sync_and_suspend_one();
+  void sync_and_suspend_all();
+  void resume_one();
+  void resume_all();
+
+  // Deoptimize the given frame and deoptimize objects with optimizations based on escape analysis.
+  bool deoptimize_objects_internal(JavaThread* deoptee, intptr_t* fr_id);
+
+public:
+  // Revert ea based optimizations for given deoptee thread
+  EscapeBarrier(JavaThread* calling_thread, JavaThread* deoptee_thread, bool barrier_active)
+    : _calling_thread(calling_thread), _deoptee_thread(deoptee_thread),
+      _barrier_active(barrier_active && (JVMCI_ONLY(UseJVMCICompiler) NOT_JVMCI(false)
+                      COMPILER2_PRESENT(|| DoEscapeAnalysis)))
+  {
+    if (_barrier_active) sync_and_suspend_one();
+  }
+
+  // Revert ea based optimizations for all java threads
+  EscapeBarrier(JavaThread* calling_thread, bool barrier_active)
+    : _calling_thread(calling_thread), _deoptee_thread(NULL),
+      _barrier_active(barrier_active && (JVMCI_ONLY(UseJVMCICompiler) NOT_JVMCI(false)
+                      COMPILER2_PRESENT(|| DoEscapeAnalysis)))
+  {
+    if (_barrier_active) sync_and_suspend_all();
+  }
+#else
+public:
+  EscapeBarrier(JavaThread* calling_thread, JavaThread* deoptee_thread, bool barrier_active) { }
+  EscapeBarrier(JavaThread* calling_thread, bool barrier_active) { }
+  static bool deoptimizing_objects_for_all_threads() { return false; }
+  bool barrier_active() const                        { return false; }
+#endif // COMPILER2_OR_JVMCI
+
+  // Deoptimize objects, i.e. reallocate and relock them. The target frames are deoptimized.
+  // The methods return false iff at least one reallocation failed.
+  bool deoptimize_objects(intptr_t* fr_id) {
+    return true COMPILER2_OR_JVMCI_PRESENT(&& deoptimize_objects_internal(deoptee_thread(), fr_id));
+  }
+  bool deoptimize_objects(int depth)                           NOT_COMPILER2_OR_JVMCI_RETURN_(true);
+  // Find and deoptimize non escaping objects and the holding frames on all stacks.
+  bool deoptimize_objects_all_threads()                        NOT_COMPILER2_OR_JVMCI_RETURN_(true);
+
+  // A java thread was added to the list of threads
+  static void thread_added(JavaThread* jt)                     NOT_COMPILER2_OR_JVMCI_RETURN;
+  // A java thread was removed from the list of threads
+  static void thread_removed(JavaThread* jt)                   NOT_COMPILER2_OR_JVMCI_RETURN;
+
+#if COMPILER2_OR_JVMCI
+  // Returns true iff objects were reallocated and relocked because of access through JVMTI
+  static bool objs_are_deoptimized(JavaThread* thread, intptr_t* fr_id);
+
+  static bool deoptimizing_objects_for_all_threads() { return _deoptimizing_objects_for_all_threads; }
+
+  ~EscapeBarrier() {
+    if (!barrier_active()) return;
+    if (all_threads()) {
+      resume_all();
+    } else {
+      resume_one();
+    }
+  }
+
+
+  bool all_threads()    const { return _deoptee_thread == NULL; }            // Should revert optimizations for all threads.
+  bool self_deopt()     const { return _calling_thread == _deoptee_thread; } // Current thread deoptimizes its own objects.
+  bool barrier_active() const { return _barrier_active; }                    // Inactive barriers are created if no local objects can escape.
+
+  // accessors
+  JavaThread* calling_thread() const     { return _calling_thread; }
+  JavaThread* deoptee_thread() const     { return _deoptee_thread; }
+#endif // COMPILER2_OR_JVMCI
 };
 
 class DeoptimizationMarker : StackObj {  // for profiling

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -378,6 +378,29 @@ const size_t minimumSymbolTableSize = 1024;
   notproduct(bool, WalkStackALot, false,                                    \
           "Trace stack (no print) at every exit from the runtime system")   \
                                                                             \
+  develop(bool, DeoptimizeObjectsALot, false,                               \
+          "For testing purposes concurrent threads revert optimizations "   \
+          "based on escape analysis at intervals given with "               \
+          "DeoptimizeObjectsALotInterval=n. The thread count is given "     \
+          "with DeoptimizeObjectsALotThreadCountSingle and "                \
+          "DeoptimizeObjectsALotThreadCountAll.")                           \
+                                                                            \
+  develop(uint64_t, DeoptimizeObjectsALotInterval, 5,                       \
+          "Interval for DeoptimizeObjectsALot.")                            \
+          range(0, max_jlong)                                               \
+                                                                            \
+  develop(int, DeoptimizeObjectsALotThreadCountSingle, 1,                   \
+          "The number of threads that revert optimizations based on "       \
+          "escape analysis for a single thread if DeoptimizeObjectsALot "   \
+          "is enabled. The target thread is selected round robin." )        \
+          range(0, max_jint)                                                \
+                                                                            \
+  develop(int, DeoptimizeObjectsALotThreadCountAll, 1,                      \
+          "The number of threads that revert optimizations based on "       \
+          "escape analysis for all threads if DeoptimizeObjectsALot "       \
+          "is enabled." )                                                   \
+          range(0, max_jint)                                                \
+                                                                            \
   product(bool, Debugging, false,                                           \
           "Set when executing debug methods in debug.cpp "                  \
           "(to prevent triggering assertions)")                             \

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -52,6 +52,7 @@ Mutex*   JmethodIdCreation_lock       = NULL;
 Mutex*   JfieldIdCreation_lock        = NULL;
 Monitor* JNICritical_lock             = NULL;
 Mutex*   JvmtiThreadState_lock        = NULL;
+Monitor* EscapeBarrier_lock           = NULL;
 Monitor* Heap_lock                    = NULL;
 Mutex*   ExpandHeap_lock              = NULL;
 Mutex*   AdapterHandlerLibrary_lock   = NULL;
@@ -299,6 +300,7 @@ void mutex_init() {
   def(MultiArray_lock              , PaddedMutex  , nonleaf+2,   false, _safepoint_check_always);
 
   def(JvmtiThreadState_lock        , PaddedMutex  , nonleaf+2,   false, _safepoint_check_always); // Used by JvmtiThreadState/JvmtiEventController
+  def(EscapeBarrier_lock           , PaddedMonitor, leaf,        false, _safepoint_check_never);  // Used to synchronize object reallocation/relocking triggered by JVMTI
   def(Management_lock              , PaddedMutex  , nonleaf+2,   false, _safepoint_check_always); // used for JVM management
 
   def(ConcurrentGCBreakpoints_lock , PaddedMonitor, nonleaf,     true,  _safepoint_check_always);

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -45,6 +45,7 @@ extern Mutex*   JmethodIdCreation_lock;          // a lock on creating JNI metho
 extern Mutex*   JfieldIdCreation_lock;           // a lock on creating JNI static field identifiers
 extern Monitor* JNICritical_lock;                // a lock used while entering and exiting JNI critical regions, allows GC to sometimes get in
 extern Mutex*   JvmtiThreadState_lock;           // a lock on modification of JVMTI thread data
+extern Monitor* EscapeBarrier_lock;              // a lock to sync reallocating and relocking objects because of JVMTI access
 extern Monitor* Heap_lock;                       // a lock on the heap
 extern Mutex*   ExpandHeap_lock;                 // a lock on expanding the heap
 extern Mutex*   AdapterHandlerLibrary_lock;      // a lock on the AdapterHandlerLibrary

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -44,6 +44,7 @@
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "runtime/thread.inline.hpp"
+#include "runtime/vframe_hp.hpp"
 #include "services/threadService.hpp"
 #include "utilities/dtrace.hpp"
 #include "utilities/macros.hpp"
@@ -1517,7 +1518,8 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
   jt->set_current_waiting_monitor(NULL);
 
   guarantee(_recursions == 0, "invariant");
-  _recursions = save;     // restore the old recursion count
+  _recursions = save      // restore the old recursion count
+                + JvmtiDeferredUpdates::get_and_reset_relock_count_after_wait(jt); //  increased by the deferred relock count
   _waiters--;             // decrement the number of waiters
 
   // Verify a few postconditions

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -80,7 +80,7 @@ class vframe;
 class javaVFrame;
 
 class DeoptResourceMark;
-class jvmtiDeferredLocalVariableSet;
+class JvmtiDeferredUpdates;
 
 class ThreadClosure;
 class ICRefillVerifier;
@@ -292,7 +292,8 @@ class Thread: public ThreadShadow {
     _has_async_exception    = 0x00000001U, // there is a pending async exception
     _critical_native_unlock = 0x00000002U, // Must call back to unlock JNI critical lock
 
-    _trace_flag             = 0x00000004U  // call tracing backend
+    _trace_flag             = 0x00000004U, // call tracing backend
+    _obj_deopt              = 0x00000008U  // suspend for object reallocation and relocking for JVMTI agent
   };
 
   // various suspension related flags - atomically updated
@@ -543,6 +544,9 @@ class Thread: public ThreadShadow {
   inline void set_trace_flag();
   inline void clear_trace_flag();
 
+  inline void set_obj_deopt_flag();
+  inline void clear_obj_deopt_flag();
+
   // Support for Unhandled Oop detection
   // Add the field for both, fastdebug and debug, builds to keep
   // Thread's fields layout the same.
@@ -616,6 +620,8 @@ class Thread: public ThreadShadow {
   JFR_ONLY(DEFINE_THREAD_LOCAL_ACCESSOR_JFR;)
 
   bool is_trace_suspend()               { return (_suspend_flags & _trace_flag) != 0; }
+
+  bool is_obj_deopt_suspend()           { return (_suspend_flags & _obj_deopt) != 0; }
 
   // VM operation support
   int vm_operation_ticket()                      { return ++_vm_operation_started_count; }
@@ -1055,11 +1061,10 @@ class JavaThread: public Thread {
   CompiledMethod*       _deopt_nmethod;         // CompiledMethod that is currently being deoptimized
   vframeArray*  _vframe_array_head;              // Holds the heap of the active vframeArrays
   vframeArray*  _vframe_array_last;              // Holds last vFrameArray we popped
-  // Because deoptimization is lazy we must save jvmti requests to set locals
-  // in compiled frames until we deoptimize and we have an interpreter frame.
-  // This holds the pointer to array (yeah like there might be more than one) of
-  // description of compiled vframes that have locals that need to be updated.
-  GrowableArray<jvmtiDeferredLocalVariableSet*>* _deferred_locals_updates;
+  // Holds updates by JVMTI agents for compiled frames that cannot be performed immediately. They
+  // will be carried out as soon as possible which, in most cases, is just before deoptimization of
+  // the frame, when control returns to it.
+  JvmtiDeferredUpdates* _jvmti_deferred_updates;
 
   // Handshake value for fixing 6243940. We need a place for the i2c
   // adapter to store the callee Method*. This value is NEVER live
@@ -1374,6 +1379,10 @@ class JavaThread: public Thread {
   inline void set_ext_suspended();
   inline void clear_ext_suspended();
 
+  // Synchronize with another thread (most likely a JVMTI agent) that is deoptimizing objects of the
+  // current thread, i.e. reverts optimizations based on escape analysis.
+  void wait_for_object_deoptimization();
+
  public:
   void java_suspend(); // higher-level suspension logic called by the public APIs
   void java_resume();  // higher-level resume logic called by the public APIs
@@ -1438,7 +1447,7 @@ class JavaThread: public Thread {
   // Whenever a thread transitions from native to vm/java it must suspend
   // if external|deopt suspend is present.
   bool is_suspend_after_native() const {
-    return (_suspend_flags & (_external_suspend JFR_ONLY(| _trace_flag))) != 0;
+    return (_suspend_flags & (_external_suspend | _obj_deopt JFR_ONLY(| _trace_flag))) != 0;
   }
 
   // external suspend request is completed
@@ -1511,7 +1520,7 @@ class JavaThread: public Thread {
     // we have checked is_external_suspend(), we will recheck its value
     // under SR_lock in java_suspend_self().
     return (_special_runtime_exit_condition != _no_async_condition) ||
-            is_external_suspend() || is_trace_suspend();
+            is_external_suspend() || is_trace_suspend() || is_obj_deopt_suspend();
   }
 
   void set_pending_unsafe_access_error()          { _special_runtime_exit_condition = _async_unsafe_access_error; }
@@ -1528,8 +1537,8 @@ class JavaThread: public Thread {
   vframeArray* vframe_array_head() const         { return _vframe_array_head;  }
 
   // Side structure for deferring update of java frame locals until deopt occurs
-  GrowableArray<jvmtiDeferredLocalVariableSet*>* deferred_locals() const { return _deferred_locals_updates; }
-  void set_deferred_locals(GrowableArray<jvmtiDeferredLocalVariableSet *>* vf) { _deferred_locals_updates = vf; }
+  JvmtiDeferredUpdates* deferred_updates() const      { return _jvmti_deferred_updates; }
+  void set_deferred_updates(JvmtiDeferredUpdates* du) { _jvmti_deferred_updates = du; }
 
   // These only really exist to make debugging deopt problems simpler
 

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,12 @@ inline void Thread::set_trace_flag() {
 }
 inline void Thread::clear_trace_flag() {
   clear_suspend_flag(_trace_flag);
+}
+inline void Thread::set_obj_deopt_flag() {
+  set_suspend_flag(_obj_deopt);
+}
+inline void Thread::clear_obj_deopt_flag() {
+  clear_suspend_flag(_obj_deopt);
 }
 
 inline jlong Thread::cooked_allocated_bytes() {

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -82,6 +82,11 @@ vframe* vframe::new_vframe(const frame* f, const RegisterMap* reg_map, JavaThrea
     }
   }
 
+  // Entry frame
+  if (f->is_entry_frame()) {
+    return new entryVFrame(f, reg_map, thread);
+  }
+
   // External frame
   return new externalVFrame(f, reg_map, thread);
 }

--- a/src/hotspot/share/runtime/vframe_hp.hpp
+++ b/src/hotspot/share/runtime/vframe_hp.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ class compiledVFrame: public javaVFrame {
   StackValueCollection*        expressions()        const;
   GrowableArray<MonitorInfo*>* monitors()           const;
   int                          vframe_id()          const { return _vframe_id; }
+  bool                         has_ea_local_in_scope() const;
+  bool                         arg_escape()         const; // at call with arg escape in parameter list
 
   void set_locals(StackValueCollection* values) const;
 
@@ -95,6 +97,48 @@ class compiledVFrame: public javaVFrame {
 #endif
 };
 
+// Holds updates for compiled frames by JVMTI agents that cannot be performed immediately.
+class jvmtiDeferredLocalVariableSet;
+class JvmtiDeferredUpdates : public CHeapObj<mtCompiler> {
+
+  // Relocking has to be deferred if the lock owning thread is currently waiting on the monitor.
+  int _relock_count_after_wait;
+
+  // Deferred updates of locals, expressions, and monitors
+  GrowableArray<jvmtiDeferredLocalVariableSet*> _deferred_locals_updates;
+
+  void inc_relock_count_after_wait() {
+    _relock_count_after_wait++;
+  }
+
+  int get_and_reset_relock_count_after_wait() {
+    int result = _relock_count_after_wait;
+    _relock_count_after_wait = 0;
+    return result;
+  }
+
+  GrowableArray<jvmtiDeferredLocalVariableSet*>* deferred_locals() { return &_deferred_locals_updates; }
+
+  JvmtiDeferredUpdates() :
+    _relock_count_after_wait(0),
+    _deferred_locals_updates((ResourceObj::set_allocation_type((address) &_deferred_locals_updates,
+                              ResourceObj::C_HEAP), 1), mtCompiler) { }
+
+public:
+  static void create_for(JavaThread* thread);
+
+  static GrowableArray<jvmtiDeferredLocalVariableSet*>* deferred_locals(JavaThread* jt) {
+    return jt->deferred_updates() == NULL ? NULL : jt->deferred_updates()->deferred_locals();
+  }
+
+  // Relocking has to be deferred if the lock owning thread is currently waiting on the monitor.
+  static int get_and_reset_relock_count_after_wait(JavaThread* jt) {
+    return jt->deferred_updates() == NULL ? 0 : jt->deferred_updates()->get_and_reset_relock_count_after_wait();
+  }
+  static void inc_relock_count_after_wait(JavaThread* thread);
+};
+
+
 // In order to implement set_locals for compiled vframes we must
 // store updated locals in a data structure that contains enough
 // information to recognize equality with a vframe and to store
@@ -111,6 +155,7 @@ private:
   intptr_t* _id;
   int _vframe_id;
   GrowableArray<jvmtiDeferredLocalVariable*>* _locals;
+  bool _objects_are_deoptimized;
 
   void                              update_value(StackValueCollection* locals, BasicType type, int index, jvalue value);
 
@@ -122,13 +167,17 @@ private:
   int                               bci()            const  { return _bci; }
   intptr_t*                         id()             const  { return _id; }
   int                               vframe_id()      const  { return _vframe_id; }
+  bool                              objects_are_deoptimized() const { return _objects_are_deoptimized; }
 
   void                              update_locals(StackValueCollection* locals);
   void                              update_stack(StackValueCollection* locals);
   void                              update_monitors(GrowableArray<MonitorInfo*>* monitors);
+  void                              set_objs_are_deoptimized() { _objects_are_deoptimized = true; }
 
   // Does the vframe match this jvmtiDeferredLocalVariableSet
   bool                              matches(const vframe* vf);
+  // Does the underlying physical frame match this jvmtiDeferredLocalVariableSet
+  bool                              matches(intptr_t* fr_id) { return id() == fr_id; }
   // GC
   void                              oops_do(OopClosure* f);
 

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -327,10 +327,14 @@
 #define COMPILER2_OR_JVMCI 1
 #define COMPILER2_OR_JVMCI_PRESENT(code) code
 #define NOT_COMPILER2_OR_JVMCI(code)
+#define NOT_COMPILER2_OR_JVMCI_RETURN        /* next token must be ; */
+#define NOT_COMPILER2_OR_JVMCI_RETURN_(code) /* next token must be ; */
 #else
 #define COMPILER2_OR_JVMCI 0
 #define COMPILER2_OR_JVMCI_PRESENT(code)
 #define NOT_COMPILER2_OR_JVMCI(code) code
+#define NOT_COMPILER2_OR_JVMCI_RETURN {}
+#define NOT_COMPILER2_OR_JVMCI_RETURN_(code) { return code; }
 #endif
 
 #ifdef TIERED

--- a/test/hotspot/jtreg/serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java
@@ -1,0 +1,610 @@
+/*
+ * Copyright (c) 2020 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8230956
+ * @summary JVMTI agents can obtain references to not escaping objects using JVMTI Heap functions.
+ *          Therefore optimizations based on escape analysis have to be reverted,
+ *          i.e. scalar replaced objects need to be reallocated on the heap and objects with eliminated locking
+ *          need to be relocked.
+ * @requires ((vm.compMode == "Xmixed") & vm.compiler2.enabled & vm.jvmti)
+ * @library /test/lib /test/hotspot/jtreg
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @compile IterateHeapWithEscapeAnalysisEnabled.java
+ *
+ * @comment BLOCK BEGIN EXCLUSIVE TESTCASES {
+ *
+ *          The following test cases are executed in fresh VMs because they require that the
+ *          capability can_tag_objects is not taken until dontinline_testMethod is jit compiled and
+ *          an activation of the compiled version is on stack of the target thread.
+ *
+ *          Without JDK-8227745 these test cases require that escape analysis is disabled at
+ *          start-up because can_tag_objects can be taken lazily, potentially after loading an
+ *          agent dynamically by means of the attach API. Disabling escape analysis and invalidating
+ *          compiled methods does not help then because there may be compiled frames with ea-based
+ *          optimizations on stack. Just like in this collection of test cases.
+ *
+ * @run main/othervm/native
+ *                  -agentlib:IterateHeapWithEscapeAnalysisEnabled
+ *                  -XX:+UnlockDiagnosticVMOptions
+ *                  -Xms256m -Xmx256m
+ *                  -XX:+PrintCompilation -XX:+PrintInlining
+ *                  -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                  -Xbatch
+ *                  -XX:CompileCommand=dontinline,*::dontinline_*
+ *                  -XX:+DoEscapeAnalysis
+ *                  IterateHeapWithEscapeAnalysisEnabled IterateOverReachableObjects
+ * @run main/othervm/native
+ *                  -agentlib:IterateHeapWithEscapeAnalysisEnabled
+ *                  -XX:+UnlockDiagnosticVMOptions
+ *                  -Xms256m -Xmx256m
+ *                  -XX:+PrintCompilation -XX:+PrintInlining
+ *                  -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                  -Xbatch
+ *                  -XX:CompileCommand=dontinline,*::dontinline_*
+ *                  -XX:+DoEscapeAnalysis
+ *                  IterateHeapWithEscapeAnalysisEnabled IterateOverHeap
+ * @run main/othervm/native
+ *                  -agentlib:IterateHeapWithEscapeAnalysisEnabled
+ *                  -XX:+UnlockDiagnosticVMOptions
+ *                  -Xms256m -Xmx256m
+ *                  -XX:+PrintCompilation -XX:+PrintInlining
+ *                  -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                  -Xbatch
+ *                  -XX:CompileCommand=dontinline,*::dontinline_*
+ *                  -XX:+DoEscapeAnalysis
+ *                  IterateHeapWithEscapeAnalysisEnabled IterateOverInstancesOfClass
+ * @run main/othervm/native
+ *                  -agentlib:IterateHeapWithEscapeAnalysisEnabled
+ *                  -XX:+UnlockDiagnosticVMOptions
+ *                  -Xms256m -Xmx256m
+ *                  -XX:+PrintCompilation -XX:+PrintInlining
+ *                  -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                  -Xbatch
+ *                  -XX:CompileCommand=dontinline,*::dontinline_*
+ *                  -XX:+DoEscapeAnalysis
+ *                  IterateHeapWithEscapeAnalysisEnabled FollowReferences
+ * @run main/othervm/native
+ *                  -agentlib:IterateHeapWithEscapeAnalysisEnabled
+ *                  -XX:+UnlockDiagnosticVMOptions
+ *                  -Xms256m -Xmx256m
+ *                  -XX:+PrintCompilation -XX:+PrintInlining
+ *                  -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                  -Xbatch
+ *                  -XX:CompileCommand=dontinline,*::dontinline_*
+ *                  -XX:+DoEscapeAnalysis
+ *                  IterateHeapWithEscapeAnalysisEnabled IterateThroughHeap
+ *
+ * @comment } BLOCK END EXCLUSIVE TESTCASES
+ *
+ * @comment BLOCK BEGIN NON EXCLUSIVE TESTCASES {
+ *
+ * @run main/othervm/native
+ *                  -agentlib:IterateHeapWithEscapeAnalysisEnabled
+ *                  -XX:+UnlockDiagnosticVMOptions
+ *                  -Xms256m -Xmx256m
+ *                  -XX:CompileCommand=dontinline,*::dontinline_*
+ *                  -XX:+PrintCompilation
+ *                  -XX:+PrintInlining
+ *                  -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                  -Xbatch
+ *                  -XX:+DoEscapeAnalysis -XX:+EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks -XX:+UseBiasedLocking
+ *                  IterateHeapWithEscapeAnalysisEnabled
+ * @run main/othervm/native
+ *                  -agentlib:IterateHeapWithEscapeAnalysisEnabled
+ *                  -XX:+UnlockDiagnosticVMOptions
+ *                  -Xms256m -Xmx256m
+ *                  -XX:CompileCommand=dontinline,*::dontinline_*
+ *                  -XX:+PrintCompilation
+ *                  -XX:+PrintInlining
+ *                  -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                  -Xbatch
+ *                  -XX:+DoEscapeAnalysis -XX:-EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks -XX:+UseBiasedLocking
+ *                  IterateHeapWithEscapeAnalysisEnabled
+ * @run main/othervm/native
+ *                  -agentlib:IterateHeapWithEscapeAnalysisEnabled
+ *                  -XX:+UnlockDiagnosticVMOptions
+ *                  -Xms256m -Xmx256m
+ *                  -XX:CompileCommand=dontinline,*::dontinline_*
+ *                  -XX:+PrintCompilation
+ *                  -XX:+PrintInlining
+ *                  -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                  -Xbatch
+ *                  -XX:-DoEscapeAnalysis -XX:-EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks -XX:+UseBiasedLocking
+ *                  IterateHeapWithEscapeAnalysisEnabled
+ *
+ * @comment } BLOCK END NON EXCLUSIVE TESTCASES
+ */
+
+import compiler.whitebox.CompilerWhiteBoxTest;
+import jdk.test.lib.Asserts;
+import sun.hotspot.WhiteBox;
+
+public class IterateHeapWithEscapeAnalysisEnabled {
+
+    public static final WhiteBox WB = WhiteBox.getWhiteBox();
+
+    public static final int COMPILE_THRESHOLD = CompilerWhiteBoxTest.THRESHOLD;
+
+    public static native int jvmtiTagClass(Class<?> cls, long tag);
+
+    // Methods to tag or count instances of a given class available in JVMTI
+    public static enum TaggingAndCountingMethods {
+        IterateOverReachableObjects,
+        IterateOverHeap,
+        IterateOverInstancesOfClass,
+        FollowReferences,
+        IterateThroughHeap
+    }
+
+    public static native int acquireCanTagObjectsCapability();
+    public static native int registerMethod(TaggingAndCountingMethods m, String name);
+    public static native void agentTearDown();
+
+    /**
+     * Count and tag instances of a given class.
+     * @param cls Used by the method {@link TaggingAndCountingMethods#IterateOverInstancesOfClass} as class to count and tag instances of.
+     *        Ignored by other counting methods.
+     * @param clsTag Tag of the class to count and tag instances of. Used by all methods except
+     *        {@link TaggingAndCountingMethods#IterateOverInstancesOfClass}
+     * @param instanceTag The tag to be set for selected instances.
+     * @param method JVMTI counting and tagging method to be used.
+     * @return The number of instances or -1 if the call fails.
+     */
+    public static native int countAndTagInstancesOfClass(Class<?> cls, long clsTag, long instanceTag, TaggingAndCountingMethods method);
+
+    /**
+     * Get all objects tagged with the given tag.
+     * @param tag The tag used to select objects.
+     * @param result Selected objects are copied into this array.
+     * @return -1 to indicated failure and 0 for success.
+     */
+    public static native int getObjectsWithTag(long tag, Object[] result);
+
+    public static void main(String[] args) throws Exception {
+        try {
+            new IterateHeapWithEscapeAnalysisEnabled().runTestCases(args);
+        } finally {
+            agentTearDown();
+        }
+    }
+
+    public void runTestCases(String[] args) throws Exception {
+        // register various instance tagging and counting methods with agent
+        for (TaggingAndCountingMethods m : TaggingAndCountingMethods.values()) {
+            msg("register instance count method " + m.name());
+            int rc = registerMethod(m, m.name());
+            Asserts.assertGreaterThanOrEqual(rc, 0, "method " + m.name() + " is unknown to agent");
+        }
+
+        if (args.length > 0) {
+            // EXCLUSIVE TEST CASES
+            // cant_tag_objects is acquired after warmup. Use given tagging/counting method.
+            new TestCase01(true, 100, TaggingAndCountingMethods.valueOf(args[0])).run();
+        } else {
+            // NON-EXCLUSIVE TEST CASES
+            // cant_tag_objects is acquired before test cases are run but still during live phase.
+            msgHL("Acquire capability can_tag_objects before first test case.");
+            int err = acquireCanTagObjectsCapability();
+            Asserts.assertEQ(0, err, "acquireCanTagObjectsCapability FAILED");
+
+            // run test cases
+            for (TaggingAndCountingMethods m : TaggingAndCountingMethods.values()) {
+                new TestCase01(false, 200, m).run();
+            }
+            new TestCase02a(200).run();
+            new TestCase02b(300).run();
+        }
+    }
+
+    static class ABBox {
+        public int aVal;
+        public int bVal;
+        public TestCaseBase testCase;
+
+        public ABBox() { /* empty */ }
+
+        public ABBox(TestCaseBase testCase) {
+            this.testCase = testCase;
+        }
+
+        /**
+         * Increment {@link #aVal} and {@link #bVal} under lock. The method is supposed to
+         * be inlined into the test method and locking is supposed to be eliminated. After
+         * this object escaped to the JVMTI agent, the code with eliminated locking must
+         * not be used anymore.
+         */
+        public synchronized void synchronizedSlowInc() {
+            aVal++;
+            testCase.waitingForCheck = true;
+            dontinline_waitForCheck(testCase);
+            testCase.waitingForCheck = false;
+            bVal++;
+        }
+
+        public static void dontinline_waitForCheck(TestCaseBase testCase) {
+            if (testCase.warmUpDone) {
+                while(!testCase.checkingNow) {
+                    try {
+                        Thread.sleep(50);
+                    } catch (InterruptedException e) { /*ign*/ }
+                }
+            }
+        }
+
+        /**
+         * This method and incrementing {@link #aVal} and {@link #bVal} are synchronized.
+         * So {@link #aVal} and {@link #bVal} should always be equal. Unless the optimized version
+         * of {@link #synchronizedSlowInc()} without locking is still used after this object
+         * escaped to the JVMTI agent.
+         * @return
+         */
+        public synchronized boolean check() {
+            return aVal == bVal;
+        }
+    }
+
+    public static abstract class TestCaseBase implements Runnable {
+        public final long classTag;
+        public long instanceTag;
+
+        public final Class<?> taggedClass;
+
+        public long checkSum;
+        public long loopCount;
+        public volatile boolean doLoop;
+        public volatile boolean targetIsInLoop;
+
+        public volatile boolean waitingForCheck;
+        public volatile boolean checkingNow;
+
+        public boolean warmUpDone;
+
+        public TestCaseBase(long classTag, Class<?> taggedClass) {
+            this.classTag = classTag;
+            this.taggedClass = taggedClass;
+        }
+
+        public void setUp() {
+            // Tag the class of instances to be scalar replaced
+            msg("tagging " + taggedClass.getName() + " with tag " +  classTag);
+            int err = jvmtiTagClass(taggedClass, classTag);
+            Asserts.assertEQ(0, err, "jvmtiTagClass FAILED");
+        }
+
+        // to be overridden by test cases
+        abstract public void dontinline_testMethod();
+
+        public void warmUp() {
+            msg("WarmUp: START");
+            int callCount = COMPILE_THRESHOLD + 1000;
+            doLoop = true;
+            while (callCount-- > 0) {
+                dontinline_testMethod();
+            }
+            warmUpDone = true;
+            msg("WarmUp: DONE");
+        }
+
+        public Object dontinline_endlessLoop(Object argEscape) {
+            long cs = checkSum;
+            while (loopCount-- > 0 && doLoop) {
+                targetIsInLoop = true;
+                checkSum += checkSum % ++cs;
+            }
+            loopCount = 3;
+            targetIsInLoop = false;
+            return argEscape;
+        }
+
+        public void waitUntilTargetThreadHasEnteredEndlessLoop() {
+            while(!targetIsInLoop) {
+                msg("Target has not yet entered the loop. Sleep 100ms.");
+                try { Thread.sleep(100); } catch (InterruptedException e) { /*ignore */ }
+            }
+            msg("Target has entered the loop.");
+        }
+
+        public void terminateEndlessLoop() throws Exception {
+            msg("Terminate endless loop");
+            doLoop = false;
+        }
+    }
+
+    /**
+     * Use JVMTI heap functions associated with the elements of {@link TaggingAndCountingMethods} to
+     * get a reference to an object allocated in {@link TestCase01#dontinline_testMethod()}. The
+     * allocation can be eliminated / scalar replaced.  The test case can be run in two modes: (1)
+     * the capability can_tag_objects which is required to use the JVMTI heap functions is taken
+     * before the test case (2) the capability is taken after {@link TestCase01#dontinline_testMethod()}
+     * is compiled and the target thread has an activation of it on stack.
+     */
+    public static class TestCase01 extends TestCaseBase {
+
+        public volatile int testMethod_result;
+        public boolean acquireCanTagObjectsCapabilityAfterWarmup;
+        public TaggingAndCountingMethods taggingMethod;
+
+        public TestCase01(boolean acquireCanTagObjectsCapabilityAfterWarmup, long classTag, TaggingAndCountingMethods taggingMethod) {
+            super(classTag, ABBox.class);
+            instanceTag = classTag + 1;
+            this.acquireCanTagObjectsCapabilityAfterWarmup = acquireCanTagObjectsCapabilityAfterWarmup;
+            this.taggingMethod = taggingMethod;
+        }
+
+        @Override
+        public void setUp() {
+            if (!acquireCanTagObjectsCapabilityAfterWarmup) {
+                super.setUp();
+            }
+        }
+
+        public void setUpAfterWarmUp() {
+            if (acquireCanTagObjectsCapabilityAfterWarmup) {
+                msg("Acquire capability can_tag_objects " + (warmUpDone ? "after" : "before") + " warmup.");
+                int err = acquireCanTagObjectsCapability();
+                Asserts.assertEQ(0, err, "acquireCanTagObjectsCapability FAILED");
+                super.setUp();
+            }
+        }
+
+        public void run() {
+            try {
+                msgHL(getClass().getName() + ": test if object that may be scalar replaced is found using " + taggingMethod);
+                msg("The capability can_tag_object is acquired " + (acquireCanTagObjectsCapabilityAfterWarmup ? "AFTER" : "BEFORE")
+                        + " warmup.");
+                setUp();
+                warmUp();
+                WB.deflateIdleMonitors();
+                WB.fullGC(); // get rid of dead instances from previous test cases
+                runTest(taggingMethod);
+            } catch (Exception e) {
+                Asserts.fail("Unexpected Exception", e);
+            }
+        }
+
+        public void runTest(TaggingAndCountingMethods m) throws Exception {
+            loopCount = 1L << 62; // endless loop
+            doLoop = true;
+            testMethod_result = 0;
+            Thread t1 = new Thread(() -> dontinline_testMethod(), "Target Thread (" + getClass().getName() + ")");
+            try {
+                t1.start();
+                try {
+                    waitUntilTargetThreadHasEnteredEndlessLoop();
+                    setUpAfterWarmUp();
+                    msg("count and tag instances of " + taggedClass.getName() + " with tag " + instanceTag + " using JVMTI " + m.name());
+                    int count = countAndTagInstancesOfClass(taggedClass, classTag, instanceTag, m);
+                    msg("Done. Count is " + count);
+                    Asserts.assertGreaterThanOrEqual(count, 0, "countAndTagInstancesOfClass FAILED");
+                    Asserts.assertEQ(count, 1, "unexpected number of instances");
+
+                    ABBox[] result = new ABBox[1];
+                    msg("get instances tagged with " + instanceTag + ". The instances escape thereby.");
+                    int err = getObjectsWithTag(instanceTag, result);
+                    msg("Done.");
+                    Asserts.assertEQ(0, err, "getObjectsWithTag FAILED");
+
+                    msg("change the now escaped instance' bVal");
+                    ABBox abBox = result[0];
+                    abBox.bVal = 3;
+                    terminateEndlessLoop();
+
+                    msg("wait until target thread has set testMethod_result");
+                    while (testMethod_result == 0) {
+                        Thread.sleep(50);
+                    }
+                    msg("check if the modification of bVal is reflected in testMethod_result.");
+                    Asserts.assertEQ(7, testMethod_result, " testMethod_result has wrong value");
+                    msg("ok.");
+                } finally {
+                    terminateEndlessLoop();
+                }
+            } finally {
+                t1.join();
+            }
+        }
+
+        @Override
+        public void dontinline_testMethod() {
+            ABBox ab = new ABBox();     // can be scalar replaced
+            ab.aVal = 4;
+            ab.bVal = 2;
+            dontinline_endlessLoop(null);   // JVMTI agent acquires reference to ab and changes bVal
+            testMethod_result = ab.aVal + ab.bVal;
+        }
+    }
+
+    /**
+     * {@link #dontinline_testMethod()} creates an ArgEscape instance of {@link TestCaseBase#taggedClass} on stack.
+     * The jvmti agent tags all instances of this class using one of the {@link TaggingAndCountingMethods}. Then it gets the tagged
+     * instances using <code>GetObjectsWithTags()</code>. This is where the ArgEscape globally escapes.
+     * It happens at a location without eliminated locking but there is
+     * eliminated locking following, so the compiled frame must be deoptimized. This is checked by letting the agent call the
+     * synchronized method {@link ABBox#check()} on the escaped instance.
+     */
+    public static class TestCase02a extends TestCaseBase {
+
+        public long instanceTag;
+
+        public TestCase02a(long classTag) {
+            super(classTag, ABBox.class);
+            instanceTag = classTag + 1;
+        }
+
+        public void run() {
+            try {
+                msgHL(getClass().getName() + ": test if owning frame is deoptimized if ArgEscape escapes globally");
+                setUp();
+                warmUp();
+                for (TaggingAndCountingMethods m : TaggingAndCountingMethods.values()) {
+                    msgHL(getClass().getName() + ": Tag and Get of ArgEscapes using " + m.name());
+                    waitingForCheck = false;
+                    checkingNow = false;
+                    WB.deflateIdleMonitors();
+                    WB.fullGC(); // get rid of dead instances from previous test cases
+                    runTest(m);
+                }
+            } catch (Exception e) {
+                Asserts.fail("Unexpected Exception", e);
+            }
+        }
+
+        public void runTest(TaggingAndCountingMethods m) throws Exception {
+            loopCount = 1L << 62; // endless loop
+            doLoop = true;
+            Thread t1 = new Thread(() -> dontinline_testMethod(), "Target Thread (" + getClass().getName() + ")");
+            try {
+                t1.start();
+                try {
+                    waitUntilTargetThreadHasEnteredEndlessLoop();
+                    msg("count and tag instances of " + taggedClass.getName() + " with tag " + instanceTag + " using JVMTI " + m.name());
+                    int count = countAndTagInstancesOfClass(taggedClass, classTag, instanceTag, m);
+                    msg("Done. Count is " + count);
+                    Asserts.assertGreaterThanOrEqual(count, 0, "countAndTagInstancesOfClass FAILED");
+                    Asserts.assertEQ(count, 1, "unexpected number of instances");
+                } finally {
+                    terminateEndlessLoop();
+                }
+
+                ABBox[] result = new ABBox[1];
+                msg("get instances tagged with " + instanceTag);
+                int err = getObjectsWithTag(instanceTag, result);
+                msg("Done.");
+                Asserts.assertEQ(0, err, "getObjectsWithTag FAILED");
+
+                ABBox abBoxArgEscape = result[0];
+                while (!waitingForCheck) {
+                    Thread.yield();
+                }
+                msg("Check abBoxArgEscape's state is consistent");
+                checkingNow = true;
+                Asserts.assertTrue(abBoxArgEscape.check(), "Detected inconsistent state. abBoxArgEscape.aVal != abBoxArgEscape.bVal");
+                msg("Ok.");
+            } finally {
+                checkingNow = true;
+                t1.join();
+            }
+        }
+
+        @Override
+        public void dontinline_testMethod() {
+            ABBox ab = new ABBox(this);
+            dontinline_endlessLoop(ab);
+            ab.synchronizedSlowInc();
+        }
+    }
+
+    /**
+     * Like {@link TestCase02a}, with the exception that at the location in {@link #dontinline_testMethod()} where the
+     * ArgEscape escapes it is not referenced by a local variable.
+     */
+    public static class TestCase02b extends TestCaseBase {
+
+        public long instanceTag;
+
+        public TestCase02b(long classTag) {
+            super(classTag, ABBox.class);
+            instanceTag = classTag + 1;
+        }
+
+        public void run() {
+            try {
+                msgHL(getClass().getName() + ": test if owning frame is deoptimized if ArgEscape escapes globally");
+                setUp();
+                warmUp();
+                for (TaggingAndCountingMethods m : TaggingAndCountingMethods.values()) {
+                    msgHL(getClass().getName() + ": Tag and Get of ArgEscapes using " + m.name());
+                    waitingForCheck = false;
+                    checkingNow = false;
+                    WB.deflateIdleMonitors();
+                    WB.fullGC(); // get rid of dead instances from previous test cases
+                    runTest(m);
+                }
+            } catch (Exception e) {
+                Asserts.fail("Unexpected Exception", e);
+            }
+        }
+
+        public void runTest(TaggingAndCountingMethods m) throws Exception {
+            loopCount = 1L << 62; // endless loop
+            doLoop = true;
+            Thread t1 = new Thread(() -> dontinline_testMethod(), "Target Thread (" + getClass().getName() + ")");
+            try {
+                t1.start();
+                try {
+                    waitUntilTargetThreadHasEnteredEndlessLoop();
+                    msg("count and tag instances of " + taggedClass.getName() + " with tag " + instanceTag + " using JVMTI " + m.name());
+                    int count = countAndTagInstancesOfClass(taggedClass, classTag, instanceTag, m);
+                    msg("Done. Count is " + count);
+                    Asserts.assertGreaterThanOrEqual(count, 0, "countAndTagInstancesOfClass FAILED");
+                    Asserts.assertEQ(count, 1, "unexpected number of instances");
+                } finally {
+                    terminateEndlessLoop();
+                }
+
+                ABBox[] result = new ABBox[1];
+                msg("get instances tagged with " + instanceTag);
+                int err = getObjectsWithTag(instanceTag, result);
+                msg("Done.");
+                Asserts.assertEQ(0, err, "getObjectsWithTag FAILED");
+
+                ABBox abBoxArgEscape = result[0];
+                while (!waitingForCheck) {
+                    Thread.yield();
+                }
+                msg("Check abBoxArgEscape's state is consistent");
+                checkingNow = true;
+                Asserts.assertTrue(abBoxArgEscape.check(), "Detected inconsistent state. abBoxArgEscape.aVal != abBoxArgEscape.bVal");
+                msg("Ok.");
+            } finally {
+                checkingNow = true;
+                t1.join();
+            }
+        }
+
+        @Override
+        public void dontinline_testMethod() {
+            // The new instance is an ArgEscape instance and escapes to the JVMTI agent
+            // while the target thread is in the call to dontinline_endlessLoop(). At this
+            // location there is no local variable that references the ArgEscape.
+            ((ABBox) dontinline_endlessLoop(new ABBox(this))).synchronizedSlowInc();;
+        }
+    }
+
+    public static void msg(String m) {
+        System.out.println();
+        System.out.println("### " + m);
+        System.out.println();
+    }
+
+    public static void msgHL(String m) {
+        System.out.println(); System.out.println(); System.out.println();
+        System.out.println("#####################################################");
+        System.out.println("### " + m);
+        System.out.println("###");
+        System.out.println();
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/Heap/libIterateHeapWithEscapeAnalysisEnabled.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/Heap/libIterateHeapWithEscapeAnalysisEnabled.cpp
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) 2020 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "jvmti.h"
+#include "jni.h"
+
+extern "C" {
+
+#define FAILED -1
+#define OK      0
+
+static jvmtiEnv *jvmti;
+
+static jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved);
+
+static void ShowErrorMessage(jvmtiEnv *jvmti, jvmtiError errCode, const char *message) {
+  char *errMsg;
+  jvmtiError result;
+
+  result = jvmti->GetErrorName(errCode, &errMsg);
+  if (result == JVMTI_ERROR_NONE) {
+    fprintf(stderr, "%s: %s (%d)\n", message, errMsg, errCode);
+    jvmti->Deallocate((unsigned char *)errMsg);
+  } else {
+    fprintf(stderr, "%s (%d)\n", message, errCode);
+  }
+}
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT jint JNICALL
+Agent_OnAttach(JavaVM *jvm, char *options, void *reserved) {
+  return Agent_Initialize(jvm, options, reserved);
+}
+
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM *jvm, void *reserved) {
+  jint res;
+  JNIEnv *env;
+
+  res = jvm->GetEnv((void **) &env, JNI_VERSION_9);
+  if (res != JNI_OK || env == NULL) {
+    fprintf(stderr, "Error: GetEnv call failed(%d)!\n", res);
+    return JNI_ERR;
+  }
+
+  return JNI_VERSION_9;
+}
+
+static jint
+Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
+  jint res;
+
+  printf("Agent_OnLoad started\n");
+
+  res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_9);
+  if (res != JNI_OK || jvmti == NULL) {
+    fprintf(stderr, "Error: wrong result of a valid call to GetEnv!\n");
+    return JNI_ERR;
+  }
+
+  printf("Agent_OnLoad finished\n");
+  return JNI_OK;
+}
+
+JNIEXPORT jint JNICALL
+Java_IterateHeapWithEscapeAnalysisEnabled_acquireCanTagObjectsCapability(JNIEnv *env, jclass cls) {
+  jvmtiError err;
+  jvmtiCapabilities caps;
+
+  memset(&caps, 0, sizeof(caps));
+
+  caps.can_tag_objects = 1;
+
+  err = jvmti->AddCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    ShowErrorMessage(jvmti, err,
+                     "acquireCanTagObjectsCapability: error in JVMTI AddCapabilities");
+    return JNI_ERR;
+  }
+
+  err = jvmti->GetCapabilities(&caps);
+  if (err != JVMTI_ERROR_NONE) {
+    ShowErrorMessage(jvmti, err,
+                     "acquireCanTagObjectsCapability: error in JVMTI GetCapabilities");
+    return JNI_ERR;
+  }
+
+  if (!caps.can_tag_objects) {
+    fprintf(stderr, "Warning: didn't get the capability can_tag_objects\n");
+    return JNI_ERR;
+  }
+
+  return JNI_OK;
+}
+
+static jobject method_IterateOverReachableObjects;
+static jobject method_IterateOverHeap;
+static jobject method_IterateOverInstancesOfClass;
+static jobject method_FollowReferences;
+static jobject method_IterateThroughHeap;
+
+JNIEXPORT jint JNICALL
+Java_IterateHeapWithEscapeAnalysisEnabled_registerMethod(JNIEnv *env, jclass cls, jobject method, jstring name) {
+  const char *name_chars = env->GetStringUTFChars(name, 0);
+  int rc = FAILED;
+  if (rc != OK && strcmp(name_chars, "IterateOverReachableObjects") == 0) {
+    method_IterateOverReachableObjects = env->NewGlobalRef(method);
+    rc = OK;
+  }
+  if (rc != OK && strcmp(name_chars, "IterateOverHeap") == 0) {
+    method_IterateOverHeap = env->NewGlobalRef(method);
+    rc = OK;
+  }
+  if (rc != OK && strcmp(name_chars, "IterateOverInstancesOfClass") == 0) {
+    method_IterateOverInstancesOfClass = env->NewGlobalRef(method);
+    rc = OK;
+  }
+  if (rc != OK && strcmp(name_chars, "IterateThroughHeap") == 0) {
+    method_IterateThroughHeap = env->NewGlobalRef(method);
+    rc = OK;
+  }
+  if (rc != OK && strcmp(name_chars, "FollowReferences") == 0) {
+    method_FollowReferences = env->NewGlobalRef(method);
+    rc = OK;
+  }
+  env->ReleaseStringUTFChars(name, name_chars);
+  return rc;
+}
+
+JNIEXPORT void JNICALL
+Java_IterateHeapWithEscapeAnalysisEnabled_agentTearDown(JNIEnv *env, jclass cls) {
+  env->DeleteGlobalRef(method_IterateOverReachableObjects);
+  env->DeleteGlobalRef(method_IterateOverHeap);
+  env->DeleteGlobalRef(method_IterateOverInstancesOfClass);
+  env->DeleteGlobalRef(method_FollowReferences);
+  env->DeleteGlobalRef(method_IterateThroughHeap);
+}
+
+JNIEXPORT jint JNICALL
+Java_IterateHeapWithEscapeAnalysisEnabled_jvmtiTagClass(JNIEnv *env, jclass cls, jclass clsToTag, jlong tag) {
+  jvmtiError err;
+  err = jvmti->SetTag(clsToTag, tag);
+  if (err != JVMTI_ERROR_NONE) {
+    ShowErrorMessage(jvmti, err,
+                     "jvmtiTagClass: error in JVMTI SetTag");
+    return FAILED;
+  }
+  return OK;
+}
+
+typedef struct Tag_And_Counter {
+  jlong instance_counter;
+  jlong class_tag;
+  jlong instance_tag;
+} Tag_And_Counter;
+
+static jvmtiIterationControl JNICALL
+__stackReferenceCallback(jvmtiHeapRootKind root_kind,
+                       jlong class_tag,
+                       jlong size,
+                       jlong* tag_ptr,
+                       jlong thread_tag,
+                       jint depth,
+                       jmethodID method,
+                       jint slot,
+                         void* d) {
+  Tag_And_Counter* data = (Tag_And_Counter*) d;
+  if (class_tag == data->class_tag && *tag_ptr == 0) {
+    data->instance_counter++;
+    *tag_ptr = data->instance_tag;
+  }
+  return JVMTI_ITERATION_CONTINUE;
+}
+
+static jvmtiIterationControl JNICALL
+__jvmtiHeapObjectCallback(jlong class_tag, jlong size, jlong* tag_ptr, void* d) {
+  Tag_And_Counter* data = (Tag_And_Counter*) d;
+  if (class_tag == data->class_tag && *tag_ptr == 0) {
+    data->instance_counter++;
+    *tag_ptr = data->instance_tag;
+  }
+  return JVMTI_ITERATION_CONTINUE;
+}
+
+static jint JNICALL
+__jvmtiHeapReferenceCallback(jvmtiHeapReferenceKind reference_kind,
+                             const jvmtiHeapReferenceInfo* reference_info,
+                             jlong class_tag,
+                             jlong referrer_class_tag,
+                             jlong size,
+                             jlong* tag_ptr,
+                             jlong* referrer_tag_ptr,
+                             jint length,
+                             void* d) {
+  Tag_And_Counter* data = (Tag_And_Counter*) d;
+  if (class_tag == data->class_tag && *tag_ptr == 0) {
+    data->instance_counter++;
+    *tag_ptr = data->instance_tag;
+  }
+  return JVMTI_VISIT_OBJECTS;
+}
+
+static jint JNICALL
+__jvmtiHeapIterationCallback(jlong class_tag,
+                             jlong size,
+                             jlong* tag_ptr,
+                             jint length,
+                             void* d) {
+  Tag_And_Counter* data = (Tag_And_Counter*) d;
+  if (class_tag == data->class_tag && *tag_ptr == 0) {
+    data->instance_counter++;
+    *tag_ptr = data->instance_tag;
+  }
+  return JVMTI_VISIT_OBJECTS;
+}
+
+
+JNIEXPORT jlong JNICALL
+Java_IterateHeapWithEscapeAnalysisEnabled_countAndTagInstancesOfClass(JNIEnv *env,
+                                                                      jclass cls,
+                                                                      jclass tagged_class,
+                                                                      jlong cls_tag,
+                                                                      jlong instance_tag,
+                                                                      jobject method) {
+  jvmtiError err;
+  jvmtiHeapCallbacks callbacks = {};
+  Tag_And_Counter data = {0, cls_tag, instance_tag};
+  jboolean method_found = JNI_FALSE;
+
+  jint idx = 0;
+
+  if (env->IsSameObject(method, method_IterateOverReachableObjects)) {
+    method_found = JNI_TRUE;
+    err = jvmti->IterateOverReachableObjects(NULL /*jvmtiHeapRootCallback*/,
+                                             __stackReferenceCallback,
+                                             NULL /* jvmtiObjectReferenceCallback */,
+                                             &data);
+    if (err != JVMTI_ERROR_NONE) {
+      ShowErrorMessage(jvmti, err,
+                       "countAndTagInstancesOfClass: error in JVMTI IterateOverReachableObjects");
+      return FAILED;
+    }
+  }
+  if (env->IsSameObject(method, method_IterateOverHeap)) {
+    method_found = JNI_TRUE;
+    err = jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_EITHER,
+                                 __jvmtiHeapObjectCallback,
+                                 &data);
+    if (err != JVMTI_ERROR_NONE) {
+      ShowErrorMessage(jvmti, err,
+                       "countAndTagInstancesOfClass: error in JVMTI IterateOverHeap");
+      return FAILED;
+    }
+  }
+  if (env->IsSameObject(method, method_IterateOverInstancesOfClass)) {
+    method_found = JNI_TRUE;
+    err = jvmti->IterateOverInstancesOfClass(tagged_class,
+                                             JVMTI_HEAP_OBJECT_EITHER,
+                                             __jvmtiHeapObjectCallback,
+                                             &data);
+    if (err != JVMTI_ERROR_NONE) {
+      ShowErrorMessage(jvmti, err,
+                       "countAndTagInstancesOfClass: error in JVMTI IterateOverHeap");
+      return FAILED;
+    }
+  }
+  if (env->IsSameObject(method, method_FollowReferences)) {
+    method_found = JNI_TRUE;
+    callbacks.heap_reference_callback = __jvmtiHeapReferenceCallback;
+    err = jvmti->FollowReferences(0 /* filter nothing */,
+                                  NULL /* no class filter */,
+                                  NULL /* no initial object, follow roots */,
+                                  &callbacks,
+                                  &data);
+    if (err != JVMTI_ERROR_NONE) {
+      ShowErrorMessage(jvmti, err,
+                       "countAndTagInstancesOfClass: error in JVMTI FollowReferences");
+      return FAILED;
+    }
+  }
+  if (env->IsSameObject(method, method_IterateThroughHeap)) {
+    method_found = JNI_TRUE;
+    callbacks.heap_iteration_callback = __jvmtiHeapIterationCallback;
+    err = jvmti->IterateThroughHeap(0 /* filter nothing */,
+                                    NULL /* no class filter */,
+                                    &callbacks,
+                                    &data);
+    if (err != JVMTI_ERROR_NONE) {
+      ShowErrorMessage(jvmti, err,
+                       "countAndTagInstancesOfClass: error in JVMTI IterateThroughHeap");
+      return FAILED;
+    }
+  }
+
+  if (!method_found) {
+    fprintf(stderr, "countAndTagInstancesOfClass: unknown method\n");
+    return FAILED;
+  }
+
+  return data.instance_counter;
+}
+
+JNIEXPORT jlong JNICALL
+Java_IterateHeapWithEscapeAnalysisEnabled_getObjectsWithTag(JNIEnv *env,
+                                                            jclass cls,
+                                                            jlong tag,
+                                                            jobjectArray res_instances) {
+  jvmtiError  err;
+  const jlong tags[1] = {tag};
+  jint        res_count = -1;
+  jobject*    res_instances_raw;
+  jlong*      res_tags;
+  jint        res_instances_length;
+  jint        idx;
+
+  err = jvmti->GetObjectsWithTags(1,
+                                  tags,
+                                  &res_count,
+                                  &res_instances_raw,
+                                  &res_tags);
+  if (err != JVMTI_ERROR_NONE) {
+    ShowErrorMessage(jvmti, err,
+                     "getObjectsWithTags: error in JVMTI GetObjectsWithTags");
+    return FAILED;
+  }
+
+  res_instances_length = env->GetArrayLength(res_instances);
+  if (res_count != res_instances_length) {
+    fprintf(stderr, "getObjectsWithTags: result array lenght (%d) does not match instance count returned by GetObjectsWithTags (%d) \n",
+            res_instances_length, res_count);
+    return FAILED;
+  }
+
+  for (idx = 0; idx < res_count; idx++) {
+    env->SetObjectArrayElement(res_instances, idx, res_instances_raw[idx]);
+  }
+
+  jvmti->Deallocate((unsigned char *)res_instances_raw);
+  jvmti->Deallocate((unsigned char *)res_tags);
+
+  return OK;
+}
+
+}

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -55,6 +55,7 @@ requires.properties= \
     vm.debug \
     vm.hasSA \
     vm.hasJFR \
+    vm.jvmci \
     docker.support \
     release.implementor
 

--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -1,0 +1,3145 @@
+/*
+ * Copyright (c) 2020 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8227745
+ * @summary Collection of test cases that check if optimizations based on escape analysis are reverted just before non-escaping objects escape through JVMTI.
+ * @author Richard Reingruber richard DOT reingruber AT sap DOT com
+ *
+ * @requires ((vm.compMode == "Xmixed") & vm.compiler2.enabled)
+ * @library /test/lib /test/hotspot/jtreg
+ *
+ * @run build TestScaffold VMConnection TargetListener TargetAdapter sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run compile -g EATests.java
+ * @run driver EATests
+ *                 -XX:+UnlockDiagnosticVMOptions
+ *                 -Xms256m -Xmx256m
+ *                 -Xbootclasspath/a:.
+ *                 -XX:CompileCommand=dontinline,*::dontinline_*
+ *                 -XX:+WhiteBoxAPI
+ *                 -Xbatch
+ *                 -XX:+DoEscapeAnalysis -XX:+EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks -XX:+UseBiasedLocking
+ * @run driver EATests
+ *                 -XX:+UnlockDiagnosticVMOptions
+ *                 -Xms256m -Xmx256m
+ *                 -Xbootclasspath/a:.
+ *                 -XX:CompileCommand=dontinline,*::dontinline_*
+ *                 -XX:+WhiteBoxAPI
+ *                 -Xbatch
+ *                 -XX:+DoEscapeAnalysis -XX:+EliminateAllocations -XX:-EliminateLocks -XX:+EliminateNestedLocks -XX:+UseBiasedLocking -XX:-UseOptoBiasInlining
+ * @run driver EATests
+ *                 -XX:+UnlockDiagnosticVMOptions
+ *                 -Xms256m -Xmx256m
+ *                 -Xbootclasspath/a:.
+ *                 -XX:CompileCommand=dontinline,*::dontinline_*
+ *                 -XX:+WhiteBoxAPI
+ *                 -Xbatch
+ *                 -XX:+DoEscapeAnalysis -XX:-EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks -XX:+UseBiasedLocking
+ * @run driver EATests
+ *                 -XX:+UnlockDiagnosticVMOptions
+ *                 -Xms256m -Xmx256m
+ *                 -Xbootclasspath/a:.
+ *                 -XX:CompileCommand=dontinline,*::dontinline_*
+ *                 -XX:+WhiteBoxAPI
+ *                 -Xbatch
+ *                 -XX:-DoEscapeAnalysis -XX:-EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks -XX:+UseBiasedLocking
+ * @run driver EATests
+ *                 -XX:+UnlockDiagnosticVMOptions
+ *                 -Xms256m -Xmx256m
+ *                 -Xbootclasspath/a:.
+ *                 -XX:CompileCommand=dontinline,*::dontinline_*
+ *                 -XX:+WhiteBoxAPI
+ *                 -Xbatch
+ *                 -XX:+DoEscapeAnalysis -XX:+EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks -XX:-UseBiasedLocking
+ * @run driver EATests
+ *                 -XX:+UnlockDiagnosticVMOptions
+ *                 -Xms256m -Xmx256m
+ *                 -Xbootclasspath/a:.
+ *                 -XX:CompileCommand=dontinline,*::dontinline_*
+ *                 -XX:+WhiteBoxAPI
+ *                 -Xbatch
+ *                 -XX:+DoEscapeAnalysis -XX:-EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks -XX:-UseBiasedLocking
+ * @run driver EATests
+ *                 -XX:+UnlockDiagnosticVMOptions
+ *                 -Xms256m -Xmx256m
+ *                 -Xbootclasspath/a:.
+ *                 -XX:CompileCommand=dontinline,*::dontinline_*
+ *                 -XX:+WhiteBoxAPI
+ *                 -Xbatch
+ *                 -XX:-DoEscapeAnalysis -XX:-EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks -XX:-UseBiasedLocking
+ *
+ * @comment Excercise -XX:+DeoptimizeObjectsALot. Mostly to prevent bit-rot because the option is meant to stress object deoptimization
+ *          with non-synthetic workloads.
+ * @run driver EATests
+ *                 -XX:+UnlockDiagnosticVMOptions
+ *                 -Xms256m -Xmx256m
+ *                 -Xbootclasspath/a:.
+ *                 -XX:CompileCommand=dontinline,*::dontinline_*
+ *                 -XX:+WhiteBoxAPI
+ *                 -Xbatch
+ *                 -XX:-DoEscapeAnalysis -XX:-EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks -XX:-UseBiasedLocking
+ *                 -XX:+IgnoreUnrecognizedVMOptions -XX:+DeoptimizeObjectsALot
+ *
+ */
+/**
+ * @test
+ * @bug 8227745
+ *
+ * @summary This is another configuration of EATests.java to test Graal. Some testcases are expected
+ *          to fail because Graal does not provide all information about non-escaping objects in
+ *          scope. These are skipped.
+ *
+ * @author Richard Reingruber richard DOT reingruber AT sap DOT com
+ *
+ * @requires ((vm.compMode == "Xmixed") & vm.jvmci)
+ *
+ * @library /test/lib /test/hotspot/jtreg
+ *
+ * @run build TestScaffold VMConnection TargetListener TargetAdapter sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run compile -g EATests.java
+ *
+ * @comment Test with Graal. Some testcases are expected to fail because Graal does not provide all information about non-escaping
+ *          objects in scope. These are skipped.
+ * @run driver EATests
+ *                 -XX:+UnlockDiagnosticVMOptions
+ *                 -Xms256m -Xmx256m
+ *                 -Xbootclasspath/a:.
+ *                 -XX:CompileCommand=dontinline,*::dontinline_*
+ *                 -XX:+WhiteBoxAPI
+ *                 -Xbatch
+ *                 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler
+ */
+
+import com.sun.jdi.*;
+import com.sun.jdi.event.*;
+import compiler.testlibrary.CompilerUtils;
+import compiler.whitebox.CompilerWhiteBoxTest;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import jdk.test.lib.Asserts;
+import sun.hotspot.WhiteBox;
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Shared base class for test cases for both, debugger and debuggee.
+//
+/////////////////////////////////////////////////////////////////////////////
+
+class EATestCaseBaseShared {
+    // In interactive mode we wait for a keypress before every test case.
+    public static final boolean INTERACTIVE =
+            System.getProperty("EATests.interactive") != null &&
+            System.getProperty("EATests.interactive").equals("true");
+
+    // If the property is given, then just the test case it refers to is executed.
+    // Use it to diagnose test failures.
+    public static final String RUN_ONLY_TEST_CASE_PROPERTY = "EATests.onlytestcase";
+    public static final String RUN_ONLY_TEST_CASE = System.getProperty(RUN_ONLY_TEST_CASE_PROPERTY);
+
+    public final String testCaseName;
+
+    public EATestCaseBaseShared() {
+        String clName = getClass().getName();
+        int tidx = clName.lastIndexOf("Target");
+        testCaseName = tidx > 0 ? clName.substring(0, tidx) : clName;
+    }
+
+    public boolean shouldSkip() {
+        return EATestCaseBaseShared.RUN_ONLY_TEST_CASE != null &&
+               EATestCaseBaseShared.RUN_ONLY_TEST_CASE.length() > 0 &&
+               !testCaseName.equals(EATestCaseBaseShared.RUN_ONLY_TEST_CASE);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Target main class, i.e. the program to be debugged.
+//
+/////////////////////////////////////////////////////////////////////////////
+
+class EATestsTarget {
+
+    public static void main(String[] args) {
+        EATestCaseBaseTarget.staticSetUp();
+        EATestCaseBaseTarget.staticSetUpDone();
+
+        // Materializing test cases, i.e. reallocating objects on the heap
+        new EAMaterializeLocalVariableUponGetTarget()                                       .run();
+        new EAGetWithoutMaterializeTarget()                                                 .run();
+        new EAMaterializeLocalAtObjectReturnTarget()                                        .run();
+        new EAMaterializeLocalAtObjectPollReturnReturnTarget()                              .run();
+        new EAMaterializeIntArrayTarget()                                                   .run();
+        new EAMaterializeLongArrayTarget()                                                  .run();
+        new EAMaterializeFloatArrayTarget()                                                 .run();
+        new EAMaterializeDoubleArrayTarget()                                                .run();
+        new EAMaterializeObjectArrayTarget()                                                .run();
+        new EAMaterializeObjectWithConstantAndNotConstantValuesTarget()                     .run();
+        new EAMaterializeObjReferencedBy2LocalsTarget()                                     .run();
+        new EAMaterializeObjReferencedBy2LocalsAndModifyTarget()                            .run();
+        new EAMaterializeObjReferencedBy2LocalsInDifferentVirtFramesTarget()                .run();
+        new EAMaterializeObjReferencedBy2LocalsInDifferentVirtFramesAndModifyTarget()       .run();
+        new EAMaterializeObjReferencedFromOperandStackTarget()                              .run();
+        new EAMaterializeLocalVariableUponGetAfterSetIntegerTarget()                        .run();
+
+        // Relocking test cases
+        new EARelockingSimpleTarget()                                                       .run();
+        new EARelockingSimple_2Target()                                                     .run();
+        new EARelockingRecursiveTarget()                                                    .run();
+        new EARelockingNestedInflatedTarget()                                               .run();
+        new EARelockingNestedInflated_02Target()                                            .run();
+        new EARelockingArgEscapeLWLockedInCalleeFrameTarget()                               .run();
+        new EARelockingArgEscapeLWLockedInCalleeFrame_2Target()                             .run();
+        new EARelockingArgEscapeLWLockedInCalleeFrame_3Target()                             .run();
+        new EARelockingArgEscapeLWLockedInCalleeFrame_4Target()                             .run();
+        new EAGetOwnedMonitorsTarget()                                                      .run();
+        new EAEntryCountTarget()                                                            .run();
+        new EARelockingObjectCurrentlyWaitingOnTarget()                                     .run();
+
+        // Test cases that require deoptimization even though neither
+        // locks nor allocations are eliminated at the point where
+        // escape state is changed.
+        new EADeoptFrameAfterReadLocalObject_01Target()                                     .run();
+        new EADeoptFrameAfterReadLocalObject_01BTarget()                                    .run();
+        new EADeoptFrameAfterReadLocalObject_02Target()                                     .run();
+        new EADeoptFrameAfterReadLocalObject_02BTarget()                                    .run();
+        new EADeoptFrameAfterReadLocalObject_02CTarget()                                    .run();
+        new EADeoptFrameAfterReadLocalObject_03Target()                                     .run();
+
+        // PopFrame test cases
+        new EAPopFrameNotInlinedTarget()                                                    .run();
+        new EAPopFrameNotInlinedReallocFailureTarget()                                      .run();
+        new EAPopInlinedMethodWithScalarReplacedObjectsReallocFailureTarget()               .run();
+
+        // ForceEarlyReturn test cases
+        new EAForceEarlyReturnNotInlinedTarget()                                            .run();
+        new EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjectsTarget()              .run();
+        new EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjectsReallocFailureTarget().run();
+
+        // Instances of ReferenceType
+        new EAGetInstancesOfReferenceTypeTarget()                                           .run();
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Debugger main class
+//
+/////////////////////////////////////////////////////////////////////////////
+
+public class EATests extends TestScaffold {
+
+    public TargetVMOptions targetVMOptions;
+    public ThreadReference targetMainThread;
+
+    EATests(String args[]) {
+        super(args);
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (EATestCaseBaseShared.RUN_ONLY_TEST_CASE != null) {
+            args = Arrays.copyOf(args, args.length + 1);
+            args[args.length - 1] = "-D" + EATestCaseBaseShared.RUN_ONLY_TEST_CASE_PROPERTY + "=" + EATestCaseBaseShared.RUN_ONLY_TEST_CASE;
+        }
+        new EATests(args).startTests();
+    }
+
+    public static class TargetVMOptions {
+
+        public final boolean UseJVMCICompiler;
+        public final boolean EliminateAllocations;
+        public final boolean DeoptimizeObjectsALot;
+
+        public TargetVMOptions(EATests env, ClassType testCaseBaseTargetClass) {
+            Value val = testCaseBaseTargetClass.getValue(testCaseBaseTargetClass.fieldByName("EliminateAllocations"));
+            EliminateAllocations = ((PrimitiveValue) val).booleanValue();
+            val = testCaseBaseTargetClass.getValue(testCaseBaseTargetClass.fieldByName("DeoptimizeObjectsALot"));
+            DeoptimizeObjectsALot = ((PrimitiveValue) val).booleanValue();
+            val = testCaseBaseTargetClass.getValue(testCaseBaseTargetClass.fieldByName("UseJVMCICompiler"));
+            UseJVMCICompiler = ((PrimitiveValue) val).booleanValue();
+        }
+
+    }
+
+    // Execute known test cases
+    protected void runTests() throws Exception {
+        String targetProgName = EATestsTarget.class.getName();
+        msg("starting to main method in class " +  targetProgName);
+        startToMain(targetProgName);
+        msg("resuming to EATestCaseBaseTarget.staticSetUpDone()V");
+        targetMainThread = resumeTo("EATestCaseBaseTarget", "staticSetUpDone", "()V").thread();
+        Location loc = targetMainThread.frame(0).location();
+        Asserts.assertEQ("staticSetUpDone", loc.method().name());
+
+        targetVMOptions = new TargetVMOptions(this, (ClassType) loc.declaringType());
+
+        // Materializing test cases, i.e. reallocating objects on the heap
+        new EAMaterializeLocalVariableUponGet()                                       .run(this);
+        new EAGetWithoutMaterialize()                                                 .run(this);
+        new EAMaterializeLocalAtObjectReturn()                                        .run(this);
+        new EAMaterializeLocalAtObjectPollReturnReturn()                              .run(this);
+        new EAMaterializeIntArray()                                                   .run(this);
+        new EAMaterializeLongArray()                                                  .run(this);
+        new EAMaterializeFloatArray()                                                 .run(this);
+        new EAMaterializeDoubleArray()                                                .run(this);
+        new EAMaterializeObjectArray()                                                .run(this);
+        new EAMaterializeObjectWithConstantAndNotConstantValues()                     .run(this);
+        new EAMaterializeObjReferencedBy2Locals()                                     .run(this);
+        new EAMaterializeObjReferencedBy2LocalsAndModify()                            .run(this);
+        new EAMaterializeObjReferencedBy2LocalsInDifferentVirtFrames()                .run(this);
+        new EAMaterializeObjReferencedBy2LocalsInDifferentVirtFramesAndModify()       .run(this);
+        new EAMaterializeObjReferencedFromOperandStack()                              .run(this);
+        new EAMaterializeLocalVariableUponGetAfterSetInteger()                        .run(this);
+
+        // Relocking test cases
+        new EARelockingSimple()                                                       .run(this);
+        new EARelockingSimple_2()                                                     .run(this);
+        new EARelockingRecursive()                                                    .run(this);
+        new EARelockingNestedInflated()                                               .run(this);
+        new EARelockingNestedInflated_02()                                            .run(this);
+        new EARelockingArgEscapeLWLockedInCalleeFrame()                               .run(this);
+        new EARelockingArgEscapeLWLockedInCalleeFrame_2()                             .run(this);
+        new EARelockingArgEscapeLWLockedInCalleeFrame_3()                             .run(this);
+        new EARelockingArgEscapeLWLockedInCalleeFrame_4()                             .run(this);
+        new EAGetOwnedMonitors()                                                      .run(this);
+        new EAEntryCount()                                                            .run(this);
+        new EARelockingObjectCurrentlyWaitingOn()                                     .run(this);
+
+        // Test cases that require deoptimization even though neither
+        // locks nor allocations are eliminated at the point where
+        // escape state is changed.
+        new EADeoptFrameAfterReadLocalObject_01()                                     .run(this);
+        new EADeoptFrameAfterReadLocalObject_01B()                                    .run(this);
+        new EADeoptFrameAfterReadLocalObject_02()                                     .run(this);
+        new EADeoptFrameAfterReadLocalObject_02B()                                    .run(this);
+        new EADeoptFrameAfterReadLocalObject_02C()                                    .run(this);
+        new EADeoptFrameAfterReadLocalObject_03()                                     .run(this);
+
+        // PopFrame test cases
+        new EAPopFrameNotInlined()                                                    .run(this);
+        new EAPopFrameNotInlinedReallocFailure()                                      .run(this);
+        new EAPopInlinedMethodWithScalarReplacedObjectsReallocFailure()               .run(this);
+
+        // ForceEarlyReturn test cases
+        new EAForceEarlyReturnNotInlined()                                            .run(this);
+        new EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjects()              .run(this);
+        new EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjectsReallocFailure().run(this);
+
+        // Instances of ReferenceType
+        new EAGetInstancesOfReferenceType()                                           .run(this);
+
+        // resume the target listening for events
+        listenUntilVMDisconnect();
+    }
+
+    // Print a Message
+    public void msg(String m) {
+        System.out.println();
+        System.out.println("###(Debugger) " + m);
+        System.out.println();
+    }
+
+    // Highlighted message.
+    public void msgHL(String m) {
+        System.out.println();
+        System.out.println();
+        System.out.println("##########################################################");
+        System.out.println("### " + m);
+        System.out.println("### ");
+        System.out.println();
+        System.out.println();
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Base class for debugger side of test cases.
+//
+/////////////////////////////////////////////////////////////////////////////
+
+abstract class EATestCaseBaseDebugger  extends EATestCaseBaseShared {
+
+    protected EATests env;
+
+    public ObjectReference testCase;
+
+    public static final String TARGET_TESTCASE_BASE_NAME = EATestCaseBaseTarget.class.getName();
+
+    public static final String XYVAL_NAME = XYVal.class.getName();
+
+    public abstract void runTestCase() throws Exception;
+
+    public void run(EATests env) {
+        this.env = env;
+        if (shouldSkip()) {
+            msg("skipping " + testCaseName);
+            return;
+        }
+        try {
+            msgHL("Executing test case " + getClass().getName());
+            env.testFailed = false;
+
+            if (INTERACTIVE)
+                env.waitForInput();
+
+            resumeToWarmupDone();
+            runTestCase();
+            Asserts.assertTrue(env.targetMainThread.isSuspended(), "must be suspended after the testcase");
+            resumeToTestCaseDone();
+            checkPostConditions();
+        } catch (Exception e) {
+            Asserts.fail("Unexpected exception in test case " + getClass().getName(), e);
+        }
+    }
+
+    public void resumeToWarmupDone() throws Exception {
+        msg("resuming to " + TARGET_TESTCASE_BASE_NAME + ".warmupDone()V");
+        env.resumeTo(TARGET_TESTCASE_BASE_NAME, "warmupDone", "()V");
+        testCase = env.targetMainThread.frame(0).thisObject();
+    }
+
+    public void resumeToTestCaseDone() {
+        msg("resuming to " + TARGET_TESTCASE_BASE_NAME + ".testCaseDone()V");
+        env.resumeTo(TARGET_TESTCASE_BASE_NAME, "testCaseDone", "()V");
+    }
+
+    public void checkPostConditions() throws Exception {
+        Asserts.assertFalse(env.getExceptionCaught(), "Uncaught exception in Debuggee");
+
+        String testName = getClass().getName();
+        if (!env.testFailed) {
+            env.println(testName  + ": passed");
+        } else {
+            throw new Exception(testName + ": failed");
+        }
+    }
+
+    public void printStack(ThreadReference thread) throws Exception {
+        msg("Debuggee Stack:");
+        List<StackFrame> stack_frames = thread.frames();
+        int i = 0;
+        for (StackFrame ff : stack_frames) {
+            System.out.println("frame[" + i++ +"]: " + ff.location().method() + " (bci:" + ff.location().codeIndex() + ")");
+        }
+    }
+
+    public void msg(String m) {
+        env.msg(m);
+    }
+
+    public void msgHL(String m) {
+        env.msgHL(m);
+    }
+
+    // See Field Descriptors in The Java Virtual Machine Specification
+    // (https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.3.2)
+    enum FD {
+        I, // int
+        J, // long
+        F, // float
+        D, // double
+    }
+
+    // Map field descriptor to jdi type string
+    public static final Map<FD, String> FD2JDIArrType = Map.of(FD.I, "int[]", FD.J, "long[]", FD.F, "float[]", FD.D, "double[]");
+
+    // Map field descriptor to PrimitiveValue getter
+    public static final Function<PrimitiveValue, Integer> v2I = PrimitiveValue::intValue;
+    public static final Function<PrimitiveValue, Long>    v2J = PrimitiveValue::longValue;
+    public static final Function<PrimitiveValue, Float>   v2F = PrimitiveValue::floatValue;
+    public static final Function<PrimitiveValue, Double>  v2D = PrimitiveValue::doubleValue;
+    Map<FD, Function<PrimitiveValue, ?>> FD2getter = Map.of(FD.I, v2I, FD.J, v2J, FD.F, v2F, FD.D, v2D);
+
+    /**
+     * Retrieve array of primitive values referenced by a local variable in target and compare with
+     * an array of expected values.
+     * @param frame Frame in the target holding the local variable
+     * @param lName Name of the local variable referencing the array to be retrieved
+     * @param desc Array element type given as field descriptor.
+     * @param expVals Array of expected values.
+     * @throws Exception
+     */
+    protected void checkLocalPrimitiveArray(StackFrame frame, String lName, FD desc, Object expVals) throws Exception {
+        String lType = FD2JDIArrType.get(desc);
+        Asserts.assertNotNull(lType, "jdi type not found");
+        Asserts.assertEQ(EATestCaseBaseTarget.TESTMETHOD_DEFAULT_NAME, frame .location().method().name());
+        List<LocalVariable> localVars = frame.visibleVariables();
+        msg("Check if the local array variable '" + lName  + "' in " + EATestCaseBaseTarget.TESTMETHOD_DEFAULT_NAME + " has the expected elements: ");
+        boolean found = false;
+        for (LocalVariable lv : localVars) {
+            if (lv.name().equals(lName)) {
+                found  = true;
+                Value lVal = frame.getValue(lv);
+                Asserts.assertNotNull(lVal);
+                Asserts.assertEQ(lVal.type().name(), lType);
+                ArrayReference aRef = (ArrayReference) lVal;
+                Asserts.assertEQ(3, aRef.length());
+                // now check the elements
+                for (int i = 0; i < aRef.length(); i++) {
+                    Object actVal = FD2getter.get(desc).apply((PrimitiveValue)aRef.getValue(i));
+                    Object expVal = Array.get(expVals, i);
+                    Asserts.assertEQ(expVal, actVal, "checking element at index " + i);
+                }
+            }
+        }
+        Asserts.assertTrue(found);
+        msg("OK.");
+    }
+
+    /**
+     * Retrieve array of objects referenced by a local variable in target and compare with an array
+     * of expected values.
+     * @param frame Frame in the target holding the local variable
+     * @param lName Name of the local variable referencing the array to be retrieved
+     * @param lType Local type, e.g. java.lang.Long[]
+     * @param expVals Array of expected values.
+     * @throws Exception
+     */
+    protected void checkLocalObjectArray(StackFrame frame, String lName, String lType, ObjectReference[] expVals) throws Exception {
+        Asserts.assertEQ(EATestCaseBaseTarget.TESTMETHOD_DEFAULT_NAME, frame .location().method().name());
+        List<LocalVariable> localVars = frame.visibleVariables();
+        msg("Check if the local array variable '" + lName  + "' in " + EATestCaseBaseTarget.TESTMETHOD_DEFAULT_NAME + " has the expected elements: ");
+        boolean found = false;
+        for (LocalVariable lv : localVars) {
+            if (lv.name().equals(lName)) {
+                found  = true;
+                Value lVal = frame.getValue(lv);
+                Asserts.assertNotNull(lVal);
+                Asserts.assertEQ(lType, lVal.type().name());
+                ArrayReference aRef = (ArrayReference) lVal;
+                Asserts.assertEQ(3, aRef.length());
+                // now check the elements
+                for (int i = 0; i < aRef.length(); i++) {
+                    ObjectReference actVal = (ObjectReference)aRef.getValue(i);
+                    Asserts.assertSame(expVals[i], actVal, "checking element at index " + i);
+                }
+            }
+        }
+        Asserts.assertTrue(found);
+        msg("OK.");
+    }
+
+    /**
+     * Retrieve a reference held by a local variable in the given frame. Check if the frame's method
+     * is the expected method if the retrieved local value has the expected type and is not null.
+     * @param frame The frame to retrieve the local variable value from.
+     * @param expectedMethodName The name of the frames method should match the expectedMethodName.
+     * @param lName The name of the local variable which is read.
+     * @param expectedType Is the expected type of the object referenced by the local variable.
+     * @return
+     * @throws Exception
+     */
+    protected ObjectReference getLocalRef(StackFrame frame, String expectedMethodName, String lName, String expectedType) throws Exception {
+        Asserts.assertEQ(expectedMethodName, frame.location().method().name());
+        List<LocalVariable> localVars = frame.visibleVariables();
+        msg("Get and check local variable '" + lName + "' in " + expectedMethodName);
+        ObjectReference lRef = null;
+        for (LocalVariable lv : localVars) {
+            if (lv.name().equals(lName)) {
+                Value lVal = frame.getValue(lv);
+                Asserts.assertNotNull(lVal);
+                Asserts.assertEQ(expectedType, lVal.type().name());
+                lRef = (ObjectReference) lVal;
+                break;
+            }
+        }
+        Asserts.assertNotNull(lRef, "Local variable '" + lName + "' not found");
+        msg("OK.");
+        return lRef;
+    }
+
+    /**
+     * Retrieve a reference held by a local variable in the given frame. Check if the frame's method
+     * matches {@link EATestCaseBaseTarget#TESTMETHOD_DEFAULT_NAME} if the retrieved local value has
+     * the expected type and is not null.
+     * @param frame The frame to retrieve the local variable value from.
+     * @param expectedMethodName The name of the frames method should match the expectedMethodName.
+     * @param lName The name of the local variable which is read.
+     * @param expectedType Is the expected type of the object referenced by the local variable.
+     * @return
+     * @throws Exception
+     */
+    protected ObjectReference getLocalRef(StackFrame frame, String lType, String lName) throws Exception {
+        return getLocalRef(frame, EATestCaseBaseTarget.TESTMETHOD_DEFAULT_NAME, lName, lType);
+    }
+
+    /**
+     * Set the value of a local variable in the given frame. Check if the frame's method is the expected method.
+     * @param frame The frame holding the local variable.
+     * @param expectedMethodName The expected name of the frame's method.
+     * @param lName The name of the local variable to change.
+     * @param val The new value of the local variable.
+     * @throws Exception
+     */
+    public void setLocal(StackFrame frame, String expectedMethodName, String lName, Value val) throws Exception {
+        Asserts.assertEQ(expectedMethodName, frame.location().method().name());
+        List<LocalVariable> localVars = frame.visibleVariables();
+        msg("Set local variable '" + lName + "' = " + val + " in " + expectedMethodName);
+        for (LocalVariable lv : localVars) {
+            if (lv.name().equals(lName)) {
+                frame.setValue(lv, val);
+                break;
+            }
+        }
+        msg("OK.");
+    }
+
+    /**
+     * Set the value of a local variable in the given frame. Check if the frame's method matches
+     * {@link EATestCaseBaseTarget#TESTMETHOD_DEFAULT_NAME}.
+     * @param frame The frame holding the local variable.
+     * @param expectedMethodName The expected name of the frame's method.
+     * @param lName The name of the local variable to change.
+     * @param val The new value of the local variable.
+     * @throws Exception
+     */
+    public void setLocal(StackFrame frame, String lName, Value val) throws Exception {
+        setLocal(frame, EATestCaseBaseTarget.TESTMETHOD_DEFAULT_NAME, lName, val);
+    }
+
+    /**
+     * Check if a field has the expected primitive value.
+     * @param o Object holding the field.
+     * @param desc Field descriptor.
+     * @param fName Field name
+     * @param expVal Expected primitive value
+     * @throws Exception
+     */
+    protected void checkPrimitiveField(ObjectReference o, FD desc, String fName, Object expVal) throws Exception {
+        msg("check field " + fName);
+        ReferenceType rt = o.referenceType();
+        Field fld = rt.fieldByName(fName);
+        Value val = o.getValue(fld);
+        Object actVal = FD2getter.get(desc).apply((PrimitiveValue) val);
+        Asserts.assertEQ(expVal, actVal, "field '" + fName + "' has unexpected value.");
+        msg("ok");
+    }
+
+    /**
+     * Check if a field references the expected object.
+     * @param obj Object holding the field.
+     * @param fName Field name
+     * @param expVal Object expected to be referenced by the field
+     * @throws Exception
+     */
+    protected void checkObjField(ObjectReference obj, String fName, ObjectReference expVal) throws Exception {
+        msg("check field " + fName);
+        ReferenceType rt = obj.referenceType();
+        Field fld = rt.fieldByName(fName);
+        Value actVal = obj.getValue(fld);
+        Asserts.assertEQ(expVal, actVal, "field '" + fName + "' has unexpected value.");
+        msg("ok");
+    }
+
+    protected void setField(ObjectReference obj, String fName, Value val) throws Exception {
+        msg("set field " + fName + " = " + val);
+        ReferenceType rt = obj.referenceType();
+        Field fld = rt.fieldByName(fName);
+        obj.setValue(fld, val);
+        msg("ok");
+    }
+
+    protected Value getField(ObjectReference obj, String fName) throws Exception {
+        msg("get field " + fName);
+        ReferenceType rt = obj.referenceType();
+        Field fld = rt.fieldByName(fName);
+        Value val = obj.getValue(fld);
+        msg("result : " + val);
+        return val;
+    }
+
+    /**
+     * Free the memory consumed in the target by {@link EATestCaseBaseTarget#consumedMemory}
+     * @throws Exception
+     */
+    public void freeAllMemory() throws Exception {
+        msg("free consumed memory");
+        setField(testCase, "consumedMemory", null);
+    }
+
+    /**
+     * @return The value of {@link EATestCaseBaseTarget#targetIsInLoop}. The target must set that field to true as soon as it
+     *         enters the endless loop.
+     * @throws Exception
+     */
+    public boolean targetHasEnteredEndlessLoop() throws Exception {
+        Value v = getField(testCase, "targetIsInLoop");
+        return ((PrimitiveValue) v).booleanValue();
+    }
+
+    /**
+     * Poll {@link EATestCaseBaseTarget#targetIsInLoop} and return if it is found to be true.
+     * @throws Exception
+     */
+    public void waitUntilTargetHasEnteredEndlessLoop() throws Exception {
+        while(!targetHasEnteredEndlessLoop()) {
+            msg("Target has not yet entered the loop. Sleep 200ms.");
+            try { Thread.sleep(200); } catch (InterruptedException e) { /*ignore */ }
+        }
+    }
+
+    /**
+     * Set {@link EATestCaseBaseTarget#doLoop} to <code>false</code>. This will allow the target to
+     * leave the endless loop.
+     * @throws Exception
+     */
+    public void terminateEndlessLoop() throws Exception {
+        msg("terminate loop");
+        setField(testCase, "doLoop", env.vm().mirrorOf(false));
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Base class for debuggee side of test cases.
+//
+/////////////////////////////////////////////////////////////////////////////
+
+abstract class EATestCaseBaseTarget extends EATestCaseBaseShared implements Runnable {
+
+    /**
+     * The target must set that field to true as soon as it enters the endless loop.
+     */
+    public volatile boolean targetIsInLoop;
+
+    /**
+     * Used for busy loops. See {@link #dontinline_endlessLoop()}.
+     */
+    public volatile long loopCount;
+
+    /**
+     * Used in {@link EATestCaseBaseDebugger#terminateEndlessLoop()} to signal target to leave the endless loop.
+     */
+    public volatile boolean doLoop;
+
+    public long checkSum;
+
+    public static final String TESTMETHOD_DEFAULT_NAME = "dontinline_testMethod";
+
+    public static final WhiteBox WB = WhiteBox.getWhiteBox();
+
+    public static boolean unbox(Boolean value, boolean dflt) {
+        return value == null ? dflt : value;
+    }
+
+    public static final boolean UseJVMCICompiler     = unbox(WB.getBooleanVMFlag("UseJVMCICompiler"), false); // read by debugger
+    public static final boolean DoEscapeAnalysis     = unbox(WB.getBooleanVMFlag("DoEscapeAnalysis"), UseJVMCICompiler);
+    public static final boolean EliminateAllocations = unbox(WB.getBooleanVMFlag("EliminateAllocations"), UseJVMCICompiler); // read by debugger
+    public static final boolean DeoptimizeObjectsALot   = WB.getBooleanVMFlag("DeoptimizeObjectsALot");                      // read by debugger
+    public static final long BiasedLockingBulkRebiasThreshold = WB.getIntxVMFlag("BiasedLockingBulkRebiasThreshold");
+    public static final long BiasedLockingBulkRevokeThreshold = WB.getIntxVMFlag("BiasedLockingBulkRevokeThreshold");
+
+    public String testMethodName;
+    public int testMethodDepth;
+
+    // Results produced by dontinline_testMethod()
+    public int  iResult;
+    public long lResult;
+    public float  fResult;
+    public double dResult;
+
+
+    public boolean warmupDone;
+    // With UseJVMCICompiler it is possible that a compilation is made a
+    // background compilation even though -Xbatch is given (e.g. if JVMCI is not
+    // yet fully initialized). Therefore it is possible that the test method has
+    // not reached the highest compilation level after warm-up.
+    public boolean testMethodReachedHighestCompLevel;
+
+    public volatile Object biasToBeRevoked;
+
+    // an object with an inflated monitor
+    public static XYVal inflatedLock;
+    public static Thread  inflatorThread;
+    public static boolean inflatedLockIsPermanentlyInflated;
+
+    public static int    NOT_CONST_1I = 1;
+    public static long   NOT_CONST_1L = 1L;
+    public static float  NOT_CONST_1F = 1.1F;
+    public static double NOT_CONST_1D = 1.1D;
+
+    public static          Long NOT_CONST_1_OBJ = Long.valueOf(1);
+
+
+    public static final    Long CONST_2_OBJ     = Long.valueOf(2);
+    public static final    Long CONST_3_OBJ     = Long.valueOf(3);
+
+    /**
+     * Main driver of a test case.
+     * <ul>
+     * <li> Skips test case if not selected (see {@link EATestCaseBaseShared#RUN_ONLY_TEST_CASE}
+     * <li> Call {@link #setUp()}
+     * <li> warm-up and compile {@link #dontinline_testMethod()} (see {@link #compileTestMethod()}
+     * <li> calling {@link #dontinline_testMethod()}
+     * <li> checking the result (see {@link #checkResult()}
+     * <ul>
+     */
+    public void run() {
+        try {
+            if (shouldSkip()) {
+                msg("skipping " + testCaseName);
+                return;
+            }
+            setUp();
+            msg(testCaseName + " is up and running.");
+            compileTestMethod();
+            msg(testCaseName + " warmup done.");
+            warmupDone();
+            checkCompLevel();
+            dontinline_testMethod();
+            checkResult();
+            msg(testCaseName + " done.");
+            testCaseDone();
+        } catch (Exception e) {
+            Asserts.fail("Caught unexpected exception", e);
+        }
+    }
+
+    public static void staticSetUp() {
+        inflatedLock = new XYVal(1, 1);
+        synchronized (inflatedLock) {
+            inflatorThread = new Thread("Lock Inflator (test thread)") {
+                @Override
+                public void run() {
+                    synchronized (inflatedLock) {
+                        inflatedLockIsPermanentlyInflated = true;
+                        inflatedLock.notify(); // main thread
+                        while (true) {
+                            try {
+                                // calling wait() on a monitor will cause inflation into a heavy monitor
+                                inflatedLock.wait();
+                            } catch (InterruptedException e) { /* ignored */ }
+                        }
+                    }
+                }
+            };
+            inflatorThread.setDaemon(true);
+            inflatorThread.start();
+
+            // wait until the lock is permanently inflated by the inflatorThread
+            while(!inflatedLockIsPermanentlyInflated) {
+                try {
+                    inflatedLock.wait(); // until inflated
+                } catch (InterruptedException e1) { /* ignored */ }
+            }
+        }
+    }
+
+    // Debugger will set breakpoint here to sync with target.
+    public static void staticSetUpDone() {
+    }
+
+    public void setUp() {
+        testMethodDepth = 1;
+        testMethodName = TESTMETHOD_DEFAULT_NAME;
+    }
+
+    public abstract void dontinline_testMethod() throws Exception;
+
+    public int dontinline_brkpt_iret() {
+        dontinline_brkpt();
+        return 42;
+    }
+
+    /**
+     * It is a common protocol to have the debugger set a breakpoint in this method and have {@link
+     * #dontinline_testMethod()} call it and then perform some test actions on debugger side.
+     * After that it is checked if a frame of {@link #dontinline_testMethod()} is found at the
+     * expected depth on stack and if it is (not) marked for deoptimization as expected.
+     */
+    public void dontinline_brkpt() {
+        // will set breakpoint here after warmup
+        if (warmupDone) {
+            // check if test method is at expected depth
+            StackTraceElement[] frames = Thread.currentThread().getStackTrace();
+            int stackTraceDepth = testMethodDepth + 1; // ignore java.lang.Thread.getStackTrace()
+            Asserts.assertEQ(testMethodName, frames[stackTraceDepth].getMethodName(),
+                    testCaseName + ": test method not found at depth " + testMethodDepth);
+            // check if the frame is (not) deoptimized as expected
+            if (!DeoptimizeObjectsALot) {
+                if (testFrameShouldBeDeoptimized() && testMethodReachedHighestCompLevel) {
+                    Asserts.assertTrue(WB.isFrameDeoptimized(testMethodDepth+1),
+                            testCaseName + ": expected test method frame at depth " + testMethodDepth + " to be deoptimized");
+                } else {
+                    Asserts.assertFalse(WB.isFrameDeoptimized(testMethodDepth+1),
+                            testCaseName + ": expected test method frame at depth " + testMethodDepth + " not to be deoptimized");
+                }
+            }
+        }
+    }
+
+    /**
+     * Some test cases run busy endless loops by initializing {@link #loopCount}
+     * to {@link Long#MAX_VALUE} after warm-up and then counting down to 0 in their main test method.
+     * During warm-up {@link #loopCount} is initialized to a small value.
+     */
+    public long dontinline_endlessLoop() {
+        long cs = checkSum;
+        doLoop = true;
+        while (loopCount-- > 0 && doLoop) {
+            targetIsInLoop = true;
+            checkSum += checkSum % ++cs;
+        }
+        loopCount = 3;
+        targetIsInLoop = false;
+        return checkSum;
+    }
+
+    public boolean testFrameShouldBeDeoptimized() {
+        return DoEscapeAnalysis;
+    }
+
+    public void warmupDone() {
+        warmupDone = true;
+    }
+
+    // Debugger will set breakpoint here to sync with target.
+    public void testCaseDone() {
+    }
+
+    public void compileTestMethod() throws Exception {
+        int callCount = CompilerWhiteBoxTest.THRESHOLD;
+        while (callCount-- > 0) {
+            dontinline_testMethod();
+        }
+    }
+
+    public void checkCompLevel() {
+        java.lang.reflect.Method m = null;
+        try {
+            m = getClass().getMethod(TESTMETHOD_DEFAULT_NAME);
+        } catch (NoSuchMethodException | SecurityException e) {
+            Asserts.fail("could not check compilation level of", e);
+        }
+        // Background compilation (-Xbatch) cannot always be disabled with JVMCI
+        // compiler (e.g. if JVMCI is not yet fully initialized), therefore it
+        // is possible that due to background compilation we reach here before
+        // the test method is compiled on the highest level.
+        int highestLevel = CompilerUtils.getMaxCompilationLevel();
+        int compLevel = WB.getMethodCompilationLevel(m);
+        testMethodReachedHighestCompLevel = highestLevel == compLevel;
+        if (!UseJVMCICompiler) {
+            Asserts.assertEQ(highestLevel, compLevel,
+                             m + " not on expected compilation level");
+        }
+    }
+
+    // to be overridden as appropriate
+    public int getExpectedIResult() {
+        return 0;
+    }
+
+    // to be overridden as appropriate
+    public long getExpectedLResult() {
+        return 0;
+    }
+
+    // to be overridden as appropriate
+    public float getExpectedFResult() {
+        return 0f;
+    }
+
+    // to be overridden as appropriate
+    public double getExpectedDResult() {
+        return 0d;
+    }
+
+    private void checkResult() {
+        Asserts.assertEQ(getExpectedIResult(), iResult, "checking iResult");
+        Asserts.assertEQ(getExpectedLResult(), lResult, "checking lResult");
+        Asserts.assertEQ(getExpectedFResult(), fResult, "checking fResult");
+        Asserts.assertEQ(getExpectedDResult(), dResult, "checking dResult");
+    }
+
+    public void msg(String m) {
+        System.out.println();
+        System.out.println("###(Target) " + m);
+        System.out.println();
+    }
+
+    // The object passed will be ArgEscape if it was NoEscape before.
+    public final void dontinline_make_arg_escape(XYVal xy) {
+    }
+
+    /**
+     * Call a method indirectly using reflection. The indirection is a limit for escape
+     * analysis in the sense that the VM need not search beyond for frames that might have
+     * an object being read by an JVMTI agent as ArgEscape.
+     * @param receiver The receiver object of the call.
+     * @param methodName The name of the method to be called.
+     */
+    public final void dontinline_call_with_entry_frame(Object receiver, String methodName) {
+        Asserts.assertTrue(warmupDone, "We want to take the slow path through jni, so don't call in warmup");
+
+        Class<?> cls = receiver.getClass();
+        Class<?>[] none = {};
+
+        java.lang.reflect.Method m;
+        try {
+            m = cls.getDeclaredMethod(methodName, none);
+            m.invoke(receiver);
+        } catch (Exception e) {
+            Asserts.fail("Call through reflection failed", e);
+        }
+    }
+
+    /**
+     * Trigger bulk rebiasing for the given class by creating new instances and calling <code> hashCode() </code> on them.
+     * @param cls The class to bulk rebias
+     */
+    public void dontinline_bulkRebiasAfterWarmup(Class<?> cls) {
+        if (warmupDone) {
+            try {
+                for (int i=0; i < BiasedLockingBulkRebiasThreshold+2; i++) {
+                    biasToBeRevoked = cls.getDeclaredConstructor(int.class, int.class).newInstance(1, 1);
+                    synchronized (biasToBeRevoked) { // bias towards current thread
+                        checkSum++;
+                    }
+                    biasToBeRevoked.hashCode(); // calling hashCode triggers revocation
+                }
+            } catch (Throwable e) {
+                Asserts.fail("failed to create new instance of " + cls.getName(), e);
+            }
+        }
+    }
+
+    /**
+     * Trigger bulk revoke of biases for the given class by creating new instances and calling <code> hashCode() </code> on them.
+     * @param cls The class to bulk rebias
+     */
+    public void dontinline_bulkRevokeAfterWarmup(Class<?> cls) {
+        if (warmupDone) {
+            try {
+                for (int i=0; i < BiasedLockingBulkRevokeThreshold+2; i++) {
+                    biasToBeRevoked = cls.getDeclaredConstructor(int.class, int.class).newInstance(1, 1);
+                    synchronized (biasToBeRevoked) { // bias towards current thread
+                        checkSum++;
+                    }
+                    biasToBeRevoked.hashCode(); // calling hashCode triggers revocation
+                }
+            } catch (Throwable e) {
+                Asserts.fail("failed to create new instance of " + cls.getName(), e);
+            }
+        }
+    }
+
+    static class LinkedList {
+        LinkedList l;
+        public long[] array;
+        public LinkedList(LinkedList l, int size) {
+            this.array = new long[size];
+            this.l = l;
+        }
+    }
+
+    public LinkedList consumedMemory;
+
+    public void consumeAllMemory() {
+        msg("consume all memory");
+        int size = 128 * 1024 * 1024;
+        while(size > 0) {
+            try {
+                while(true) {
+                    consumedMemory = new LinkedList(consumedMemory, size);
+                }
+            } catch(OutOfMemoryError oom) {
+            }
+            size = size / 2;
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Test Cases
+//
+/////////////////////////////////////////////////////////////////////////////
+
+// make sure a compiled frame is not deoptimized if an escaping local is accessed
+class EAGetWithoutMaterializeTarget extends EATestCaseBaseTarget {
+
+    public XYVal getAway;
+
+    public void dontinline_testMethod() {
+        XYVal xy = new XYVal(4, 2);
+        getAway = xy;  // allocated object escapes
+        dontinline_brkpt();
+        iResult = xy.x + xy.y;
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 4 + 2;
+    }
+
+    @Override
+    public boolean testFrameShouldBeDeoptimized() {
+        return false;
+    }
+}
+
+class EAGetWithoutMaterialize extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        ObjectReference o = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "xy");
+        checkPrimitiveField(o, FD.I, "x", 4);
+        checkPrimitiveField(o, FD.I, "y", 2);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+//
+// Tests the following:
+//
+// 1. Debugger can obtain a reference to a scalar replaced object R from java thread J.
+//    See runTestCase.
+//
+// 2. Subsequent modifications of R by J are noticed by the debugger.
+//    See checkPostConditions.
+//
+class EAMaterializeLocalVariableUponGet extends EATestCaseBaseDebugger {
+
+    private ObjectReference o;
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        // check 1.
+        o = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "xy");
+        checkPrimitiveField(o, FD.I, "x", 4);
+        checkPrimitiveField(o, FD.I, "y", 2);
+    }
+
+    @Override
+    public void checkPostConditions() throws Exception {
+        super.checkPostConditions();
+        // check 2.
+        checkPrimitiveField(o, FD.I, "x", 5);
+    }
+}
+
+class EAMaterializeLocalVariableUponGetTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        XYVal xy = new XYVal(4, 2);
+        dontinline_brkpt();       // Debugger obtains scalar replaced object at this point.
+        xy.x += 1;                // Change scalar replaced object after debugger obtained a reference to it.
+        iResult = xy.x + xy.y;
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 4 + 2 + 1;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// Test if an eliminated object can be reallocated in a frame with an active
+// call that will return another object
+class EAMaterializeLocalAtObjectReturn extends EATestCaseBaseDebugger {
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        ObjectReference o = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "xy");
+        checkPrimitiveField(o, FD.I, "x", 4);
+        checkPrimitiveField(o, FD.I, "y", 2);
+    }
+}
+
+class EAMaterializeLocalAtObjectReturnTarget extends EATestCaseBaseTarget {
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    public void dontinline_testMethod() {
+        XYVal xy = new XYVal(4, 2);
+        Integer io =                 // Read xy here triggers reallocation
+                dontinline_brkpt_return_Integer();
+        iResult = xy.x + xy.y + io;
+    }
+
+    public Integer dontinline_brkpt_return_Integer() {
+        // We can't break directly in this method, as this results in making
+        // the test method not entrant caused by an existing dependency
+        dontinline_brkpt();
+        return Integer.valueOf(23);
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 4 + 2 + 23;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// Test if an eliminated object can be reallocated *just* before a call returns an object.
+// (See CompiledMethod::is_at_poll_return())
+// Details: the callee method has just one safepoint poll at the return. The other safepoint
+// is at the end of an iteration of the endless loop. We can detect if we suspended the target
+// there because the local xy is out of scope there.
+class EAMaterializeLocalAtObjectPollReturnReturn extends EATestCaseBaseDebugger {
+    public void runTestCase() throws Exception {
+        msg("Resume " + env.targetMainThread);
+        env.targetMainThread.resume();
+        waitUntilTargetHasEnteredEndlessLoop();
+        ObjectReference o = null;
+        do {
+            env.targetMainThread.suspend();
+            printStack(env.targetMainThread);
+            try {
+                o = getLocalRef(env.targetMainThread.frame(0), XYVAL_NAME, "xy");
+            } catch (Exception e) {
+                msg("The local variable xy is out of scope because we suspended at the wrong bci. Resume and try again!");
+                env.targetMainThread.resume();
+            }
+        } while (o == null);
+        checkPrimitiveField(o, FD.I, "x", 4);
+        checkPrimitiveField(o, FD.I, "y", 2);
+        terminateEndlessLoop();
+    }
+}
+
+class EAMaterializeLocalAtObjectPollReturnReturnTarget extends EATestCaseBaseTarget {
+    @Override
+    public void setUp() {
+        super.setUp();
+        loopCount = 3;
+        doLoop = true;
+    }
+
+    public void warmupDone() {
+        super.warmupDone();
+        msg("enter 'endless' loop by setting loopCount = Long.MAX_VALUE");
+        loopCount = Long.MAX_VALUE; // endless loop
+    }
+
+    public void dontinline_testMethod() {
+        long result = 0;
+        while (doLoop && loopCount-- > 0) {
+            targetIsInLoop = true;
+            XYVal xy = new XYVal(4, 2);
+            Integer io =           // Read xy here triggers reallocation just before the call returns
+                    dontinline_brkpt_return_Integer();
+            result += xy.x + xy.y + io;
+        }  // Here is a second safepoint. We were suspended here if xy is not in scope.
+        targetIsInLoop = false;
+        lResult = result;
+    }
+
+    public Integer dontinline_brkpt_return_Integer() {
+        return Integer.valueOf(23);
+    }
+
+    @Override
+    public long getExpectedLResult() {
+        return (Long.MAX_VALUE - loopCount) * (4+2+23);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Test case collection that tests rematerialization of different
+// array types where the first element is always not constant and the
+// other elements are constants. Not constant values are stored in
+// the stack frame for rematerialization whereas constants are kept
+// in the debug info of the nmethod.
+
+class EAMaterializeIntArrayTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        int nums[] = {NOT_CONST_1I , 2, 3};
+        dontinline_brkpt();
+        iResult = nums[0] + nums[1] + nums[2];
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return NOT_CONST_1I + 2 + 3;
+    }
+}
+
+class EAMaterializeIntArray extends EATestCaseBaseDebugger {
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        int[] expectedVals = {1, 2, 3};
+        checkLocalPrimitiveArray(bpe.thread().frame(1), "nums", FD.I, expectedVals);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+class EAMaterializeLongArrayTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        long nums[] = {NOT_CONST_1L , 2, 3};
+        dontinline_brkpt();
+        lResult = nums[0] + nums[1] + nums[2];
+    }
+
+    @Override
+    public long getExpectedLResult() {
+        return NOT_CONST_1L + 2 + 3;
+    }
+}
+
+class EAMaterializeLongArray extends EATestCaseBaseDebugger {
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        long[] expectedVals = {1, 2, 3};
+        checkLocalPrimitiveArray(bpe.thread().frame(1), "nums", FD.J, expectedVals);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+class EAMaterializeFloatArrayTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        float nums[] = {NOT_CONST_1F , 2.2f, 3.3f};
+        dontinline_brkpt();
+        fResult = nums[0] + nums[1] + nums[2];
+    }
+
+    @Override
+    public float getExpectedFResult() {
+        return NOT_CONST_1F + 2.2f + 3.3f;
+    }
+}
+
+class EAMaterializeFloatArray extends EATestCaseBaseDebugger {
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        float[] expectedVals = {1.1f, 2.2f, 3.3f};
+        checkLocalPrimitiveArray(bpe.thread().frame(1), "nums", FD.F, expectedVals);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+class EAMaterializeDoubleArrayTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        double nums[] = {NOT_CONST_1D , 2.2d, 3.3d};
+        dontinline_brkpt();
+        dResult = nums[0] + nums[1] + nums[2];
+    }
+
+    @Override
+    public double getExpectedDResult() {
+        return NOT_CONST_1D + 2.2d + 3.3d;
+    }
+}
+
+class EAMaterializeDoubleArray extends EATestCaseBaseDebugger {
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        double[] expectedVals = {1.1d, 2.2d, 3.3d};
+        checkLocalPrimitiveArray(bpe.thread().frame(1), "nums", FD.D, expectedVals);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+class EAMaterializeObjectArrayTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        Long nums[] = {NOT_CONST_1_OBJ , CONST_2_OBJ, CONST_3_OBJ};
+        dontinline_brkpt();
+        lResult = nums[0] + nums[1] + nums[2];
+    }
+
+    @Override
+    public long getExpectedLResult() {
+        return 1 + 2 + 3;
+    }
+}
+
+class EAMaterializeObjectArray extends EATestCaseBaseDebugger {
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        ReferenceType clazz = bpe.thread().frame(0).location().declaringType();
+        ObjectReference[] expectedVals = {
+                (ObjectReference) clazz.getValue(clazz.fieldByName("NOT_CONST_1_OBJ")),
+                (ObjectReference) clazz.getValue(clazz.fieldByName("CONST_2_OBJ")),
+                (ObjectReference) clazz.getValue(clazz.fieldByName("CONST_3_OBJ"))
+        };
+        checkLocalObjectArray(bpe.thread().frame(1), "nums", "java.lang.Long[]", expectedVals);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// Materialize an object whose fields have constant and not constant values at
+// the point where the object is materialized.
+class EAMaterializeObjectWithConstantAndNotConstantValuesTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        ILFDO o = new ILFDO(NOT_CONST_1I, 2,
+                            NOT_CONST_1L, 2L,
+                            NOT_CONST_1F, 2.1F,
+                            NOT_CONST_1D, 2.1D,
+                            NOT_CONST_1_OBJ, CONST_2_OBJ
+                            );
+        dontinline_brkpt();
+        dResult =
+            o.i + o.i2 + o.l + o.l2 + o.f + o.f2 + o.d + o.d2 + o.o + o.o2;
+    }
+
+    @Override
+    public double getExpectedDResult() {
+        return NOT_CONST_1I + 2 + NOT_CONST_1L + 2L + NOT_CONST_1F + 2.1F + NOT_CONST_1D + 2.1D + NOT_CONST_1_OBJ + CONST_2_OBJ;
+    }
+}
+
+class EAMaterializeObjectWithConstantAndNotConstantValues extends EATestCaseBaseDebugger {
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        ObjectReference o = getLocalRef(bpe.thread().frame(1), "ILFDO", "o");
+        checkPrimitiveField(o, FD.I, "i", 1);
+        checkPrimitiveField(o, FD.I, "i2", 2);
+        checkPrimitiveField(o, FD.J, "l", 1L);
+        checkPrimitiveField(o, FD.J, "l2", 2L);
+        checkPrimitiveField(o, FD.F, "f", 1.1f);
+        checkPrimitiveField(o, FD.F, "f2", 2.1f);
+        checkPrimitiveField(o, FD.D, "d", 1.1d);
+        checkPrimitiveField(o, FD.D, "d2", 2.1d);
+        ReferenceType clazz = bpe.thread().frame(1).location().declaringType();
+        ObjectReference[] expVals = {
+                (ObjectReference) clazz.getValue(clazz.fieldByName("NOT_CONST_1_OBJ")),
+                (ObjectReference) clazz.getValue(clazz.fieldByName("CONST_2_OBJ")),
+        };
+        checkObjField(o, "o", expVals[0]);
+        checkObjField(o, "o2", expVals[1]);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// Two local variables reference the same object.
+// Check if the debugger obtains the same object when reading the two variables
+class EAMaterializeObjReferencedBy2LocalsTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        XYVal xy = new XYVal(2, 3);
+        XYVal alias = xy;
+        dontinline_brkpt();
+        iResult = xy.x + alias.x;
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 2 + 2;
+    }
+}
+
+class EAMaterializeObjReferencedBy2Locals extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        ObjectReference xy = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "xy");
+        ObjectReference alias = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "alias");
+        Asserts.assertSame(xy, alias, "xy and alias are expected to reference the same object");
+    }
+
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// Two local variables reference the same object.
+// Check if it has the expected effect in the target if the debugger modifies the object.
+class EAMaterializeObjReferencedBy2LocalsAndModifyTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        XYVal xy = new XYVal(2, 3);
+        XYVal alias = xy;
+        dontinline_brkpt(); // debugger: alias.x = 42
+        iResult = xy.x + alias.x;
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 42 + 42;
+    }
+}
+
+class EAMaterializeObjReferencedBy2LocalsAndModify extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        ObjectReference alias = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "alias");
+        setField(alias, "x", env.vm().mirrorOf(42));
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// Two local variables of the same compiled frame but in different virtual frames reference the same
+// object.
+// Check if the debugger obtains the same object when reading the two variables
+class EAMaterializeObjReferencedBy2LocalsInDifferentVirtFramesTarget extends EATestCaseBaseTarget {
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    public void dontinline_testMethod() {
+        XYVal xy = new XYVal(2, 3);
+        testMethod_inlined(xy);
+        iResult += xy.x;
+    }
+
+    public void testMethod_inlined(XYVal xy) {
+        XYVal alias = xy;
+        dontinline_brkpt();
+        iResult = alias.x;
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 2 + 2;
+    }
+}
+
+class EAMaterializeObjReferencedBy2LocalsInDifferentVirtFrames extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        ObjectReference xy = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "xy");
+        ObjectReference alias = getLocalRef(bpe.thread().frame(1), "testMethod_inlined", "alias", XYVAL_NAME);
+        Asserts.assertSame(xy, alias, "xy and alias are expected to reference the same object");
+    }
+
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// Two local variables of the same compiled frame but in different virtual frames reference the same
+// object.
+// Check if it has the expected effect in the target if the debugger modifies the object.
+class EAMaterializeObjReferencedBy2LocalsInDifferentVirtFramesAndModifyTarget extends EATestCaseBaseTarget {
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    public void dontinline_testMethod() {
+        XYVal xy = new XYVal(2, 3);
+        testMethod_inlined(xy);   // debugger: xy.x = 42
+        iResult += xy.x;
+    }
+
+    public void testMethod_inlined(XYVal xy) {
+        XYVal alias = xy;
+        dontinline_brkpt();
+        iResult = alias.x;
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 42 + 42;
+    }
+}
+
+class EAMaterializeObjReferencedBy2LocalsInDifferentVirtFramesAndModify extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        ObjectReference alias = getLocalRef(bpe.thread().frame(1), "testMethod_inlined", "alias", XYVAL_NAME);
+        setField(alias, "x", env.vm().mirrorOf(42));
+    }
+
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// Test materialization of an object referenced only from expression stack
+class EAMaterializeObjReferencedFromOperandStackTarget extends EATestCaseBaseTarget {
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    public void dontinline_testMethod() {
+        @SuppressWarnings("unused")
+        XYVal xy1 = new XYVal(2, 3);
+        // Debugger breaks in call to dontinline_brkpt_ret_100() and reads
+        // the value of the local 'xy1'. This triggers materialization
+        // of the object on the operand stack
+        iResult = testMethodInlined(new XYVal(4, 2), dontinline_brkpt_ret_100());
+    }
+
+    public int testMethodInlined(XYVal xy2, int dontinline_brkpt_ret_100) {
+        return xy2.x + dontinline_brkpt_ret_100;
+    }
+
+    public int dontinline_brkpt_ret_100() {
+        dontinline_brkpt();
+        return 100;
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 4 + 100;
+    }
+}
+
+class EAMaterializeObjReferencedFromOperandStack extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        ObjectReference xy1 = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "xy1");
+        checkPrimitiveField(xy1, FD.I, "x", 2);
+        checkPrimitiveField(xy1, FD.I, "y", 3);
+    }
+
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Tests a regression in the implementation by setting the value of a local int which triggers the
+ * creation of a deferred update and then getting the reference to a scalar replaced object.  The
+ * issue was that the scalar replaced object was not reallocated. Because of the deferred update it
+ * was assumed that the reallocation already happened.
+ */
+class EAMaterializeLocalVariableUponGetAfterSetInteger extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        setLocal(bpe.thread().frame(1), "i", env.vm().mirrorOf(43));
+        ObjectReference o = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "xy");
+        checkPrimitiveField(o, FD.I, "x", 4);
+        checkPrimitiveField(o, FD.I, "y", 2);
+    }
+}
+
+class EAMaterializeLocalVariableUponGetAfterSetIntegerTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        XYVal xy = new XYVal(4, 2);
+        int i = 42;
+        dontinline_brkpt();
+        iResult = xy.x + xy.y + i;
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 4 + 2 + 43;
+    }
+
+    @Override
+    public boolean testFrameShouldBeDeoptimized() {
+        return true; // setting local variable i always triggers deoptimization
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Locking Tests
+//
+/////////////////////////////////////////////////////////////////////////////
+
+class EARelockingSimple extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference o = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "l1");
+    }
+}
+
+class EARelockingSimpleTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        XYVal l1 = new XYVal(4, 2);
+        synchronized (l1) {
+            dontinline_brkpt();
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Test if the bias of an object O that escapes globally is revoked correctly if local objects
+ * escape through JVMTI. O is referenced by field l0.
+ * This tests a regression of a previous version of the implementation.
+ */
+class EARelockingSimple_2 extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference o = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "l1");
+    }
+}
+
+class EARelockingSimple_2Target extends EATestCaseBaseTarget {
+
+    public XYVal l0;
+
+    public void dontinline_testMethod() {
+        l0 = new XYVal(4, 2);         // GobalEscape
+        XYVal l1 = new XYVal(4, 2);
+        synchronized (l0) {
+            synchronized (l1) {
+                dontinline_brkpt();
+            }
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// Test recursive locking
+class EARelockingRecursiveTarget extends EATestCaseBaseTarget {
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    public void dontinline_testMethod() {
+        XYVal l1 = new XYVal(4, 2);
+        synchronized (l1) {
+            testMethod_inlined(l1);
+        }
+    }
+
+    public void testMethod_inlined(XYVal l2) {
+        synchronized (l2) {
+            dontinline_brkpt();
+        }
+    }
+}
+
+class EARelockingRecursive extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference o = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "l1");
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// Object ref l1 is retrieved by the debugger at a location where nested locks are omitted. The
+// accessed object is globally reachable already before the access, therefore no relocking is done.
+class EARelockingNestedInflatedTarget extends EATestCaseBaseTarget {
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    @Override
+    public boolean testFrameShouldBeDeoptimized() {
+        // Access does not trigger deopt., as escape state is already global escape.
+        return false;
+    }
+
+    public void dontinline_testMethod() {
+        XYVal l1 = inflatedLock;
+        synchronized (l1) {
+            testMethod_inlined(l1);
+        }
+    }
+
+    public void testMethod_inlined(XYVal l2) {
+        synchronized (l2) {                 // eliminated nested locking
+            dontinline_brkpt();
+        }
+    }
+}
+
+class EARelockingNestedInflated extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference o = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "l1");
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Like {@link EARelockingNestedInflated} with the difference that there is
+ * a scalar replaced object in the scope from which the object with eliminated nested locking
+ * is read. This triggers materialization and relocking.
+ */
+class EARelockingNestedInflated_02 extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference o = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "l1");
+    }
+}
+
+class EARelockingNestedInflated_02Target extends EATestCaseBaseTarget {
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    public void dontinline_testMethod() {
+        @SuppressWarnings("unused")
+        XYVal xy = new XYVal(1, 1);     // scalar replaced
+        XYVal l1 = inflatedLock;          // read by debugger
+        synchronized (l1) {
+            testMethod_inlined(l1);
+        }
+    }
+
+    public void testMethod_inlined(XYVal l2) {
+        synchronized (l2) {                 // eliminated nested locking
+            dontinline_brkpt();
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Checks if an eliminated lock of an ArgEscape object l1 can be relocked if
+ * l1 is locked in a callee frame.
+ */
+class EARelockingArgEscapeLWLockedInCalleeFrame extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference o = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "l1");
+    }
+}
+
+class EARelockingArgEscapeLWLockedInCalleeFrameTarget extends EATestCaseBaseTarget {
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    public void dontinline_testMethod() {
+        XYVal l1 = new XYVal(1, 1);       // ArgEscape
+        synchronized (l1) {                   // eliminated
+            l1.dontinline_sync_method(this);  // l1 escapes
+        }
+    }
+
+    @Override
+    public boolean testFrameShouldBeDeoptimized() {
+        // Graal does not provide debug info about arg escape objects, therefore the frame is not deoptimized
+        return !UseJVMCICompiler && super.testFrameShouldBeDeoptimized();
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Similar to {@link EARelockingArgEscapeLWLockedInCalleeFrame}. In addition
+ * the test method has got a scalar replaced object with eliminated locking.
+ * This pattern matches a regression in the implementation.
+ */
+class EARelockingArgEscapeLWLockedInCalleeFrame_2 extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference o = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "l1");
+    }
+}
+
+class EARelockingArgEscapeLWLockedInCalleeFrame_2Target extends EATestCaseBaseTarget {
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    public void dontinline_testMethod() {
+        XYVal l1 = new XYVal(1, 1);       // ArgEscape
+        XYVal l2 = new XYVal(4, 2);       // NoEscape, scalar replaced
+        synchronized (l1) {                   // eliminated
+            synchronized (l2) {               // eliminated
+                l1.dontinline_sync_method(this);  // l1 escapes
+            }
+        }
+        iResult = l2.x + l2.y;
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 6;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Similar to {@link EARelockingArgEscapeLWLockedInCalleeFrame}.
+ * A bulk rebias operation is triggered at a position where all locks on the local object referenced
+ * by l1 are eliminated. This leaves the object with an outdated biased locking epoch which has to be
+ * considered when relocking.
+ * This tests a regression in a previous version.
+ */
+class EARelockingArgEscapeLWLockedInCalleeFrame_3 extends EATestCaseBaseDebugger {
+
+    public static final String XYVAL_LOCAL_NAME = EARelockingArgEscapeLWLockedInCalleeFrame_3Target.XYValLocal.class.getName();
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference o = getLocalRef(bpe.thread().frame(1), XYVAL_LOCAL_NAME, "l1");
+    }
+}
+
+class EARelockingArgEscapeLWLockedInCalleeFrame_3Target extends EATestCaseBaseTarget {
+
+    // Using local type to avoid side effects on biased locking heuristics
+    public static class XYValLocal extends XYVal {
+        public XYValLocal(int x, int y) {
+            super(x,y);
+        }
+    }
+
+    public void dontinline_testMethod() {
+        XYVal l1 = new XYValLocal(1, 1);       // ArgEscape
+        synchronized (l1) {                    // eliminated
+            l1.dontinline_sync_method_no_brkpt(this);  // l1 escapes
+            // trigger bulk rebias
+            dontinline_bulkRebiasAfterWarmup(l1.getClass());
+            // Now the epoch of l1 does not match the epoch of its class.
+            // This has to be considered when relocking because of JVMTI access
+            dontinline_brkpt();
+        }
+    }
+
+    @Override
+    public boolean testFrameShouldBeDeoptimized() {
+        // Graal does not provide debug info about arg escape objects, therefore the frame is not deoptimized
+        return !UseJVMCICompiler && super.testFrameShouldBeDeoptimized();
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Similar to {@link EARelockingArgEscapeLWLockedInCalleeFrame_3}.
+ * But instead of a bulk rebias a bulk revoke operation is triggered.
+ * This leaves the object with a stale bias as the prototype header of its calls lost its bias
+ * pattern in the bulk revoke which has to be considered during relocking.
+ * This tests a regression in a previous version.
+ */
+class EARelockingArgEscapeLWLockedInCalleeFrame_4 extends EATestCaseBaseDebugger {
+
+    public static final String XYVAL_LOCAL_NAME = EARelockingArgEscapeLWLockedInCalleeFrame_4Target.XYValLocal.class.getName();
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference o = getLocalRef(bpe.thread().frame(1), XYVAL_LOCAL_NAME, "l1");
+    }
+}
+
+class EARelockingArgEscapeLWLockedInCalleeFrame_4Target extends EATestCaseBaseTarget {
+
+    // Using local type to avoid side effects on biased locking heuristics
+    public static class XYValLocal extends XYVal {
+        public XYValLocal(int x, int y) {
+            super(x,y);
+        }
+    }
+
+    public void dontinline_testMethod() {
+        XYVal l1 = new XYValLocal(1, 1);       // ArgEscape
+        synchronized (l1) {                    // eliminated
+            l1.dontinline_sync_method_no_brkpt(this);  // l1 escapes
+            // trigger bulk rebias
+            dontinline_bulkRevokeAfterWarmup(l1.getClass());
+            // Now the epoch of l1 does not match the epoch of its class.
+            // This has to be considered when relocking because of JVMTI access
+            dontinline_brkpt();
+        }
+    }
+
+
+    @Override
+    public boolean testFrameShouldBeDeoptimized() {
+        // Graal does not provide debug info about arg escape objects, therefore the frame is not deoptimized
+        return !UseJVMCICompiler && super.testFrameShouldBeDeoptimized();
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Test relocking eliminated (nested) locks of an object on which the
+ * target thread currently waits.
+ */
+class EARelockingObjectCurrentlyWaitingOn extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        env.targetMainThread.resume();
+        boolean inWait = false;
+        do {
+            Thread.sleep(100);
+            env.targetMainThread.suspend();
+            printStack(env.targetMainThread);
+            inWait = env.targetMainThread.frame(0).location().method().name().equals("wait");
+            if (!inWait) {
+                msg("Target not yet in java.lang.Object.wait(long).");
+                env.targetMainThread.resume();
+            }
+        } while(!inWait);
+        StackFrame testMethodFrame = env.targetMainThread.frame(4);
+        // Access triggers relocking of all eliminated locks, including nested locks of l1 which references
+        // the object on which the target main thread is currently waiting.
+        ObjectReference l0 = getLocalRef(testMethodFrame, EARelockingObjectCurrentlyWaitingOnTarget.ForLocking.class.getName(), "l0");
+        Asserts.assertEQ(l0.entryCount(), 1, "wrong entry count");
+        ObjectReference l1 = getLocalRef(testMethodFrame, EARelockingObjectCurrentlyWaitingOnTarget.ForLocking.class.getName(), "l1");
+        Asserts.assertEQ(l1.entryCount(), 0, "wrong entry count");
+        setField(testCase, "objToNotifyOn", l1);
+    }
+}
+
+class EARelockingObjectCurrentlyWaitingOnTarget extends EATestCaseBaseTarget {
+
+    public static class ForLocking {
+    }
+
+    public volatile Object objToNotifyOn; // debugger assigns value when notify thread should call objToNotifyOn.notifyAll()
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    @Override
+    public void warmupDone() {
+        super.warmupDone();
+        Thread t = new Thread(() -> doNotify());
+        t.start();
+    }
+
+    public void doNotify() {
+        while (objToNotifyOn == null) {
+            try {
+                msg("objToNotifyOn is still null");
+                Thread.sleep(100);
+            } catch (InterruptedException e) { /* ignored */ }
+        }
+        synchronized (objToNotifyOn) {
+            // will be received by the target main thread waiting in dontinline_waitWhenWarmupDone
+            msg("calling objToNotifyOn.notifyAll()");
+            objToNotifyOn.notifyAll();
+        }
+    }
+
+    @Override
+    public boolean testFrameShouldBeDeoptimized() {
+        return false;
+    }
+
+    @Override
+    public void dontinline_testMethod() throws Exception {
+        ForLocking l0 = new ForLocking(); // will be scalar replaced; access triggers realloc/relock
+        ForLocking l1 = new ForLocking();
+        synchronized (l0) {
+            synchronized (l1) {
+                testMethod_inlined(l1);
+            }
+        }
+    }
+
+    public void testMethod_inlined(ForLocking l2) throws Exception {
+        synchronized (l2) {                 // eliminated nested locking
+            dontinline_waitWhenWarmupDone(l2);
+        }
+    }
+
+    public void dontinline_waitWhenWarmupDone(ForLocking l2) throws Exception {
+        if (warmupDone) {
+            l2.wait();
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Test cases that require deoptimization even though neither locks
+// nor allocations are eliminated at the point where escape state is changed.
+//
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Let xy be NoEscape whose allocation cannot be eliminated (simulated by
+ * -XX:-EliminateAllocations). The holding compiled frame has to be deoptimized when debugger
+ * accesses xy because afterwards locking on xy is omitted.
+ * Note: there are no EA based optimizations at the escape point.
+ */
+class EADeoptFrameAfterReadLocalObject_01 extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference xy = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "xy");
+    }
+}
+
+class EADeoptFrameAfterReadLocalObject_01Target extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        XYVal xy = new XYVal(1, 1);
+        dontinline_brkpt();              // Debugger reads xy, when there are no virtual objects or eliminated locks in scope
+        synchronized (xy) {              // Locking is eliminated.
+            xy.x++;
+            xy.y++;
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Similar to {@link EADeoptFrameAfterReadLocalObject_01} with the difference that the debugger
+ * reads xy from an inlined callee. So xy is NoEscape instead of ArgEscape.
+ */
+class EADeoptFrameAfterReadLocalObject_01BTarget extends EATestCaseBaseTarget {
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    public void dontinline_testMethod() {
+        XYVal xy  = new XYVal(1, 1);
+        callee(xy);                 // Debugger acquires ref to xy from inlined callee
+                                    // xy is NoEscape, nevertheless the object is not replaced
+                                    // by scalars if running with -XX:-EliminateAllocations.
+                                    // In that case there are no EA based optimizations were
+                                    // the debugger reads the NoEscape object.
+        synchronized (xy) {         // Locking is eliminated.
+            xy.x++;
+            xy.y++;
+        }
+    }
+
+    public void callee(XYVal xy) {
+        dontinline_brkpt();              // Debugger reads xy.
+                                         // There are no virtual objects or eliminated locks.
+    }
+}
+
+class EADeoptFrameAfterReadLocalObject_01B extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference xy = getLocalRef(bpe.thread().frame(1), "callee", "xy", XYVAL_NAME);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Let xy be ArgEscape. The frame dontinline_testMethod() has to be deoptimized when debugger
+ * acquires xy from dontinline_callee() because afterwards locking on xy is omitted.
+ * Note: there are no EA based optimizations at the escape point.
+ */
+class EADeoptFrameAfterReadLocalObject_02 extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference xy = getLocalRef(bpe.thread().frame(1), "dontinline_callee", "xy", XYVAL_NAME);
+    }
+}
+
+class EADeoptFrameAfterReadLocalObject_02Target extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        XYVal xy  = new XYVal(1, 1);
+        dontinline_callee(xy);      // xy is ArgEscape, debugger acquires ref to xy from callee
+        synchronized (xy) {         // Locking is eliminated.
+            xy.x++;
+            xy.y++;
+        }
+    }
+
+    public void dontinline_callee(XYVal xy) {
+        dontinline_brkpt();              // Debugger reads xy.
+                                         // There are no virtual objects or eliminated locks.
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    @Override
+    public boolean testFrameShouldBeDeoptimized() {
+        // Graal does not provide debug info about arg escape objects, therefore the frame is not deoptimized
+        return !UseJVMCICompiler && super.testFrameShouldBeDeoptimized();
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Similar to {@link EADeoptFrameAfterReadLocalObject_02} there is an ArgEscape object xy, but in
+ * contrast it is not in the parameter list of a call when the debugger reads an object.
+ * Therefore the frame of the test method should not be deoptimized
+ */
+class EADeoptFrameAfterReadLocalObject_02B extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference xy = getLocalRef(bpe.thread().frame(1), "dontinline_callee", "xy", XYVAL_NAME);
+    }
+}
+
+class EADeoptFrameAfterReadLocalObject_02BTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        XYVal xy  = new XYVal(1, 1);
+        dontinline_make_arg_escape(xy);  // because of this call xy is ArgEscape
+        dontinline_callee();             // xy is ArgEscape, but not a parameter of this call
+        synchronized (xy) {              // Locking is eliminated.
+            xy.x++;
+            xy.y++;
+        }
+    }
+
+    public void dontinline_callee() {
+        @SuppressWarnings("unused")
+        XYVal xy  = new XYVal(2, 2);
+        dontinline_brkpt();              // Debugger reads xy.
+                                         // No need to deoptimize the caller frame
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    @Override
+    public boolean testFrameShouldBeDeoptimized() {
+        return false;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Similar to {@link EADeoptFrameAfterReadLocalObject_02} there is an ArgEscape object xy in
+ * dontinline_testMethod() which is being passed as parameter when the debugger accesses a local object.
+ * Nevertheless dontinline_testMethod must not be deoptimized because there is an entry frame
+ * between it and the frame accessed by the debugger.
+ */
+class EADeoptFrameAfterReadLocalObject_02C extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference xy = getLocalRef(bpe.thread().frame(1), "dontinline_callee_accessed_by_debugger", "xy", XYVAL_NAME);
+    }
+}
+
+class EADeoptFrameAfterReadLocalObject_02CTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        XYVal xy  = new XYVal(1, 1);
+        dontinline_callee(xy);           // xy is ArgEscape and being passed as parameter
+        synchronized (xy) {              // Locking is eliminated.
+            xy.x++;
+            xy.y++;
+        }
+    }
+
+    public void dontinline_callee(XYVal xy) {
+        if (warmupDone) {
+            dontinline_call_with_entry_frame(this, "dontinline_callee_accessed_by_debugger");
+        }
+    }
+
+    public void dontinline_callee_accessed_by_debugger() {
+        @SuppressWarnings("unused")
+        XYVal xy  = new XYVal(2, 2);
+        dontinline_brkpt();              // Debugger reads xy.
+                                         // No need to deoptimize the caller frame
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 8;
+    }
+
+    @Override
+    public boolean testFrameShouldBeDeoptimized() {
+        return false;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Let xy be NoEscape whose allocation cannot be eliminated (e.g. because of
+ * -XX:-EliminateAllocations).  The holding compiled frame has to be deoptimized when debugger
+ * accesses xy because the following field accesses get eliminated.  Note: there are no EA based
+ * optimizations at the escape point.
+ */
+class EADeoptFrameAfterReadLocalObject_03 extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        ObjectReference xy = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "xy");
+        setField(xy, "x", env.vm().mirrorOf(1));
+    }
+}
+
+class EADeoptFrameAfterReadLocalObject_03Target extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        XYVal xy = new XYVal(0, 1);
+        dontinline_brkpt();              // Debugger reads xy, when there are no virtual objects or
+                                         // eliminated locks in scope and modifies xy.x
+        iResult = xy.x + xy.y;           // Loads are replaced by constants 0 and 1.
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 1 + 1;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Monitor info tests
+//
+/////////////////////////////////////////////////////////////////////////////
+
+class EAGetOwnedMonitorsTarget extends EATestCaseBaseTarget {
+
+    public long checkSum;
+
+    public void dontinline_testMethod() {
+        XYVal l1 = new XYVal(4, 2);
+        synchronized (l1) {
+            dontinline_endlessLoop();
+        }
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+        loopCount = 3;
+    }
+
+    public void warmupDone() {
+        super.warmupDone();
+        msg("enter 'endless' loop by setting loopCount = Long.MAX_VALUE");
+        loopCount = Long.MAX_VALUE; // endless loop
+    }
+}
+
+class EAGetOwnedMonitors extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        msg("resume");
+        env.targetMainThread.resume();
+        waitUntilTargetHasEnteredEndlessLoop();
+        // In contrast to JVMTI, JDWP requires a target thread to be suspended, before the owned monitors can be queried
+        msg("suspend target");
+        env.targetMainThread.suspend();
+        msg("Get owned monitors");
+        List<ObjectReference> monitors = env.targetMainThread.ownedMonitors();
+        Asserts.assertEQ(monitors.size(), 1, "unexpected number of owned monitors");
+        terminateEndlessLoop();
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+class EAEntryCountTarget extends EATestCaseBaseTarget {
+
+    public long checkSum;
+
+    public void dontinline_testMethod() {
+        XYVal l1 = new XYVal(4, 2);
+        synchronized (l1) {
+            inline_testMethod2(l1);
+        }
+    }
+
+    public void inline_testMethod2(XYVal l1) {
+        synchronized (l1) {
+            dontinline_endlessLoop();
+        }
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+        loopCount = 3;
+    }
+
+    public void warmupDone() {
+        super.warmupDone();
+        msg("enter 'endless' loop by setting loopCount = Long.MAX_VALUE");
+        loopCount = Long.MAX_VALUE; // endless loop
+    }
+}
+
+class EAEntryCount extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        msg("resume");
+        env.targetMainThread.resume();
+        waitUntilTargetHasEnteredEndlessLoop();
+        // In contrast to JVMTI, JDWP requires a target thread to be suspended, before the owned monitors can be queried
+        msg("suspend target");
+        env.targetMainThread.suspend();
+        msg("Get owned monitors");
+        List<ObjectReference> monitors = env.targetMainThread.ownedMonitors();
+        Asserts.assertEQ(monitors.size(), 1, "unexpected number of owned monitors");
+        msg("Get entry count");
+        int entryCount = monitors.get(0).entryCount();
+        Asserts.assertEQ(entryCount, 2, "wrong entry count");
+        terminateEndlessLoop();
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// PopFrame tests
+//
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * PopFrame into caller frame with scalar replaced objects.
+ */
+class EAPopFrameNotInlined extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        msg("PopFrame");
+        bpe.thread().popFrames(bpe.thread().frame(0));
+        msg("PopFrame DONE");
+    }
+
+    @Override
+    public boolean shouldSkip() {
+        // And Graal currently doesn't support PopFrame
+        return super.shouldSkip() || env.targetVMOptions.UseJVMCICompiler;
+    }
+}
+
+class EAPopFrameNotInlinedTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        XYVal xy = new XYVal(4, 2);
+        dontinline_brkpt();
+        iResult = xy.x + xy.y;
+    }
+
+    @Override
+    public boolean testFrameShouldBeDeoptimized() {
+        // Test is only performed after the frame pop.
+        // Then dontinline_testMethod is interpreted.
+        return false;
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 4 + 2;
+    }
+
+    @Override
+    public boolean shouldSkip() {
+        // And Graal currently doesn't support PopFrame
+        return super.shouldSkip() || UseJVMCICompiler;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Pop frames into {@link EAPopFrameNotInlinedReallocFailureTarget#dontinline_testMethod()} which
+ * holds scalar replaced objects. In preparation of the pop frame operations the vm eagerly
+ * reallocates scalar replaced objects to avoid failures when actually popping the frames. We provoke
+ * a reallocation failures and expect {@link VMOutOfMemoryException}.
+ */
+class EAPopFrameNotInlinedReallocFailure extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        ThreadReference thread = bpe.thread();
+        printStack(thread);
+        // frame[0]: EATestCaseBaseTarget.dontinline_brkpt()
+        // frame[1]: EAPopFrameNotInlinedReallocFailureTarget.dontinline_consume_all_memory_brkpt()
+        // frame[2]: EAPopFrameNotInlinedReallocFailureTarget.dontinline_testMethod()
+        // frame[3]: EATestCaseBaseTarget.run()
+        // frame[4]: EATestsTarget.main(java.lang.String[])
+        msg("PopFrame");
+        boolean coughtOom = false;
+        try {
+            // try to pop dontinline_consume_all_memory_brkpt
+            thread.popFrames(thread.frame(1));
+        } catch (VMOutOfMemoryException oom) {
+            // as expected
+            msg("cought OOM");
+            coughtOom  = true;
+        }
+        freeAllMemory();
+        // We succeeded to pop just one frame. When we continue, we will call dontinline_brkpt() again.
+        Asserts.assertTrue(coughtOom || !env.targetVMOptions.EliminateAllocations, "PopFrame should have triggered an OOM exception in target");
+        String expectedTopFrame =
+                env.targetVMOptions.EliminateAllocations ? "dontinline_consume_all_memory_brkpt" : "dontinline_testMethod";
+        Asserts.assertEQ(expectedTopFrame, thread.frame(0).location().method().name());
+        printStack(thread);
+    }
+
+    @Override
+    public boolean shouldSkip() {
+        // OOMEs because of realloc failures with DeoptimizeObjectsALot are too random.
+        // And Graal currently doesn't provide all information about non-escaping objects in debug info
+        return super.shouldSkip() || env.targetVMOptions.DeoptimizeObjectsALot || env.targetVMOptions.UseJVMCICompiler;
+    }
+}
+
+class EAPopFrameNotInlinedReallocFailureTarget extends EATestCaseBaseTarget {
+
+    public boolean doneAlready;
+
+    public void dontinline_testMethod() {
+        long a[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};                // scalar replaced
+        Vector10 v = new Vector10(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);  // scalar replaced
+        dontinline_consume_all_memory_brkpt();
+        lResult = a[0] + a[1] + a[2] + a[3] + a[4] + a[5] + a[6] + a[7] + a[8] + a[9]
+               + v.i0 + v.i1 + v.i2 + v.i3 + v.i4 + v.i5 + v.i6 + v.i7 + v.i8 + v.i9;
+    }
+
+    public void dontinline_consume_all_memory_brkpt() {
+        if (warmupDone && !doneAlready) {
+            doneAlready = true;
+            consumeAllMemory(); // provoke reallocation failure
+            dontinline_brkpt();
+        }
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    @Override
+    public long getExpectedLResult() {
+        long n = 10;
+        return 2*n*(n+1)/2;
+    }
+
+    @Override
+    public boolean shouldSkip() {
+        // OOMEs because of realloc failures with DeoptimizeObjectsALot are too random.
+        // And Graal currently doesn't provide all information about non-escaping objects in debug info
+        return super.shouldSkip() || DeoptimizeObjectsALot || UseJVMCICompiler;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Pop inlined top frame dropping into method with scalar replaced opjects.
+ */
+class EAPopInlinedMethodWithScalarReplacedObjectsReallocFailure extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        ThreadReference thread = env.targetMainThread;
+        thread.resume();
+        waitUntilTargetHasEnteredEndlessLoop();
+
+        thread.suspend();
+        printStack(thread);
+        // frame[0]: EAPopInlinedMethodWithScalarReplacedObjectsReallocFailureTarget.inlinedCallForcedToReturn()
+        // frame[1]: EAPopInlinedMethodWithScalarReplacedObjectsReallocFailureTarget.dontinline_testMethod()
+        // frame[2]: EATestCaseBaseTarget.run()
+
+        msg("Pop Frames");
+        boolean coughtOom = false;
+        try {
+            thread.popFrames(thread.frame(0));    // Request pop frame of inlinedCallForcedToReturn()
+                                                  // reallocation is triggered here
+        } catch (VMOutOfMemoryException oom) {
+            // as expected
+            msg("cought OOM");
+            coughtOom = true;
+        }
+        printStack(thread);
+        // frame[0]: EAPopInlinedMethodWithScalarReplacedObjectsReallocFailureTarget.inlinedCallForcedToReturn()
+        // frame[1]: EAPopInlinedMethodWithScalarReplacedObjectsReallocFailureTarget.dontinline_testMethod()
+        // frame[2]: EATestCaseBaseTarget.run()
+
+        freeAllMemory();
+        setField(testCase, "loopCount", env.vm().mirrorOf(0)); // terminate loop
+        Asserts.assertTrue(coughtOom || !env.targetVMOptions.EliminateAllocations, "PopFrame should have triggered an OOM exception in target");
+        String expectedTopFrame =
+                env.targetVMOptions.EliminateAllocations ? "inlinedCallForcedToReturn" : "dontinline_testMethod";
+        Asserts.assertEQ(expectedTopFrame, thread.frame(0).location().method().name());
+    }
+
+    @Override
+    public boolean shouldSkip() {
+        // OOMEs because of realloc failures with DeoptimizeObjectsALot are too random.
+        // And Graal currently doesn't provide all information about non-escaping objects in debug info
+        return super.shouldSkip() || env.targetVMOptions.DeoptimizeObjectsALot || env.targetVMOptions.UseJVMCICompiler;
+    }
+}
+
+class EAPopInlinedMethodWithScalarReplacedObjectsReallocFailureTarget extends EATestCaseBaseTarget {
+
+    public long checkSum;
+
+    public void dontinline_testMethod() {
+        long a[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};                // scalar replaced
+        Vector10 v = new Vector10(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);  // scalar replaced
+        long l = inlinedCallForcedToReturn();
+        lResult = a[0] + a[1] + a[2] + a[3] + a[4] + a[5] + a[6] + a[7] + a[8] + a[9]
+               + v.i0 + v.i1 + v.i2 + v.i3 + v.i4 + v.i5 + v.i6 + v.i7 + v.i8 + v.i9;
+    }
+
+    public long inlinedCallForcedToReturn() {
+        long cs = checkSum;
+        dontinline_consumeAllMemory();
+        while (loopCount-- > 0) {
+            targetIsInLoop = true;
+            checkSum += checkSum % ++cs;
+        }
+        loopCount = 3;
+        targetIsInLoop = false;
+        return checkSum;
+    }
+
+    public void dontinline_consumeAllMemory() {
+        if (warmupDone && (loopCount > 3)) {
+            consumeAllMemory();
+        }
+    }
+
+    @Override
+    public long getExpectedLResult() {
+        long n = 10;
+        return 2*n*(n+1)/2;
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        loopCount = 3;
+    }
+
+    public void warmupDone() {
+        super.warmupDone();
+        msg("enter 'endless' loop by setting loopCount = Long.MAX_VALUE");
+        loopCount = Long.MAX_VALUE; // endless loop
+    }
+
+    @Override
+    public boolean shouldSkip() {
+        // OOMEs because of realloc failures with DeoptimizeObjectsALot are too random.
+        // And Graal currently doesn't provide all information about non-escaping objects in debug info
+        return super.shouldSkip() || DeoptimizeObjectsALot || UseJVMCICompiler;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// ForceEarlyReturn tests
+//
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * ForceEarlyReturn into caller frame with scalar replaced objects.
+ */
+class EAForceEarlyReturnNotInlined extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        ThreadReference thread = bpe.thread();
+        printStack(thread);
+        // frame[0]: EATestCaseBaseTarget.dontinline_brkpt()
+        // frame[1]: EATestCaseBaseTarget.dontinline_brkpt_iret()
+        // frame[2]: EAForceEarlyReturnNotInlinedTarget.dontinline_testMethod()
+        // frame[3]: EATestCaseBaseTarget.run()
+        // frame[4]: EATestsTarget.main(java.lang.String[])
+
+        msg("Step out");
+        env.stepOut(thread);                               // return from dontinline_brkpt
+        printStack(thread);
+        msg("ForceEarlyReturn");
+        thread.forceEarlyReturn(env.vm().mirrorOf(43));    // return from dontinline_brkpt_iret,
+                                                           // does not trigger reallocation in contrast to PopFrame
+        msg("Step over line");
+        env.stepOverLine(thread);                          // reallocation is triggered here
+        printStack(thread);
+        msg("ForceEarlyReturn DONE");
+    }
+
+    @Override
+    public boolean shouldSkip() {
+        // Graal currently doesn't support Force Early Return
+        return super.shouldSkip() || env.targetVMOptions.UseJVMCICompiler;
+    }
+}
+
+class EAForceEarlyReturnNotInlinedTarget extends EATestCaseBaseTarget {
+
+    public void dontinline_testMethod() {
+        XYVal xy = new XYVal(4, 2);
+        int i = dontinline_brkpt_iret();
+        iResult = xy.x + xy.y + i;
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 4 + 2 + 43;
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+    }
+
+    public boolean testFrameShouldBeDeoptimized() {
+        return true; // because of stepping
+    }
+
+    @Override
+    public boolean shouldSkip() {
+        // Graal currently doesn't support Force Early Return
+        return super.shouldSkip() || UseJVMCICompiler;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * ForceEarlyReturn at safepoint in frame with scalar replaced objects.
+ */
+class EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjects extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        ThreadReference thread = env.targetMainThread;
+        thread.resume();
+        waitUntilTargetHasEnteredEndlessLoop();
+
+        thread.suspend();
+        printStack(thread);
+        // frame[0]: EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjectsTarget.inlinedCallForcedToReturn()
+        // frame[1]: EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjectsTarget.dontinline_testMethod()
+        // frame[2]: EATestCaseBaseTarget.run()
+
+        msg("ForceEarlyReturn");
+        thread.forceEarlyReturn(env.vm().mirrorOf(43));    // Request force return 43 from inlinedCallForcedToReturn()
+                                                           // reallocation is triggered here
+        msg("Step over instruction to do the forced return");
+        env.stepOverInstruction(thread);
+        printStack(thread);
+        msg("ForceEarlyReturn DONE");
+    }
+
+    @Override
+    public boolean shouldSkip() {
+        // Graal currently doesn't support Force Early Return
+        return super.shouldSkip() || env.targetVMOptions.UseJVMCICompiler;
+    }
+}
+
+class EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjectsTarget extends EATestCaseBaseTarget {
+
+    public int checkSum;
+
+    public void dontinline_testMethod() {
+        XYVal xy = new XYVal(4, 2);
+        int i = inlinedCallForcedToReturn();
+        iResult = xy.x + xy.y + i;
+    }
+
+    public int inlinedCallForcedToReturn() {               // forced to return 43
+        int i = checkSum;
+        while (loopCount-- > 0) {
+            targetIsInLoop = true;
+            checkSum += checkSum % ++i;
+        }
+        loopCount = 3;
+        targetIsInLoop = false;
+        return checkSum;
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 4 + 2 + 43;
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+        loopCount = 3;
+    }
+
+    public void warmupDone() {
+        super.warmupDone();
+        msg("enter 'endless' loop by setting loopCount = Long.MAX_VALUE");
+        loopCount = Long.MAX_VALUE; // endless loop
+    }
+
+    public boolean testFrameShouldBeDeoptimized() {
+        return true; // because of stepping
+    }
+
+    @Override
+    public boolean shouldSkip() {
+        // Graal currently doesn't support Force Early Return
+        return super.shouldSkip() || UseJVMCICompiler;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * ForceEarlyReturn with reallocation failure.
+ */
+class EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjectsReallocFailure extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        ThreadReference thread = env.targetMainThread;
+        thread.resume();
+        waitUntilTargetHasEnteredEndlessLoop();
+
+        thread.suspend();
+        printStack(thread);
+        // frame[0]: EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjectsReallocFailureTarget.inlinedCallForcedToReturn()
+        // frame[1]: EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjectsReallocFailureTarget.dontinline_testMethod()
+        // frame[2]: EATestCaseBaseTarget.run()
+
+        msg("ForceEarlyReturn");
+        boolean coughtOom = false;
+        try {
+            thread.forceEarlyReturn(env.vm().mirrorOf(43));    // Request force return 43 from inlinedCallForcedToReturn()
+                                                               // reallocation is triggered here
+        } catch (VMOutOfMemoryException oom) {
+            // as expected
+            msg("cought OOM");
+            coughtOom   = true;
+        }
+        freeAllMemory();
+        if (env.targetVMOptions.EliminateAllocations) {
+            Asserts.assertTrue(coughtOom, "PopFrame should have triggered an OOM exception in target");
+            thread.forceEarlyReturn(env.vm().mirrorOf(43));
+        }
+        msg("Step over instruction to do the forced return");
+        env.stepOverInstruction(thread);
+        printStack(thread);
+        msg("ForceEarlyReturn DONE");
+    }
+
+    @Override
+    public boolean shouldSkip() {
+        // OOMEs because of realloc failures with DeoptimizeObjectsALot are too random.
+        // And Graal currently doesn't support Force Early Return
+        return super.shouldSkip() || env.targetVMOptions.DeoptimizeObjectsALot || env.targetVMOptions.UseJVMCICompiler;
+    }
+}
+
+class EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjectsReallocFailureTarget extends EATestCaseBaseTarget {
+
+    public int checkSum;
+
+    public void dontinline_testMethod() {
+        long a[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};                // scalar replaced
+        Vector10 v = new Vector10(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);  // scalar replaced
+        long l = inlinedCallForcedToReturn();
+        lResult = a[0] + a[1] + a[2] + a[3] + a[4] + a[5] + a[6] + a[7] + a[8] + a[9]
+               + v.i0 + v.i1 + v.i2 + v.i3 + v.i4 + v.i5 + v.i6 + v.i7 + v.i8 + v.i9 + l;
+    }
+
+    public long inlinedCallForcedToReturn() {                      // forced to return 43
+        long cs = checkSum;
+        dontinline_consumeAllMemory();
+        while (loopCount-- > 0) {
+            targetIsInLoop = true;
+            checkSum += checkSum % ++cs;
+        }
+        loopCount = 3;
+        targetIsInLoop = false;
+        return checkSum;
+    }
+
+    public void dontinline_consumeAllMemory() {
+        if (warmupDone) {
+            consumeAllMemory();
+        }
+    }
+
+    @Override
+    public long getExpectedLResult() {
+        long n = 10;
+        return 2*n*(n+1)/2 + 43;
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+        loopCount = 3;
+    }
+
+    public void warmupDone() {
+        super.warmupDone();
+        msg("enter 'endless' loop by setting loopCount = Long.MAX_VALUE");
+        loopCount = Long.MAX_VALUE; // endless loop
+    }
+
+    @Override
+    public boolean shouldSkip() {
+        // OOMEs because of realloc failures with DeoptimizeObjectsALot are too random.
+        // And Graal currently doesn't support Force Early Return
+        return super.shouldSkip() || DeoptimizeObjectsALot || UseJVMCICompiler;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Get Instances of ReferenceType
+//
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Check if instances of a type are found even if they are scalar replaced.  To stress the
+ * implementation a little more, the instances should be retrieved while the target is running.
+ */
+class EAGetInstancesOfReferenceType extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        printStack(env.targetMainThread);
+        ReferenceType cls = ((ClassObjectReference)getField(testCase, "cls")).reflectedType();
+        msg("reflected type is " + cls);
+        msg("resume");
+        env.targetMainThread.resume();
+        waitUntilTargetHasEnteredEndlessLoop();
+        // do this while thread is running!
+        msg("Retrieve instances of " + cls.name());
+        List<ObjectReference> instances = cls.instances(10);
+        Asserts.assertEQ(instances.size(), 3, "unexpected number of instances of " + cls.name());
+        // invariant: main thread is suspended at the end of the test case
+        msg("suspend");
+        env.targetMainThread.suspend();
+        terminateEndlessLoop();
+    }
+}
+
+class EAGetInstancesOfReferenceTypeTarget extends EATestCaseBaseTarget {
+
+    public long checkSum;
+
+    public static Class<LocalXYVal> cls = LocalXYVal.class;
+
+    public static class LocalXYVal {
+        public int x, y;
+
+        public LocalXYVal(int x, int y) {
+            this.x = x; this.y = y;
+        }
+    }
+
+    @Override
+    public void dontinline_testMethod() {
+        LocalXYVal p1 = new LocalXYVal(4, 2);
+        LocalXYVal p2 = new LocalXYVal(5, 3);
+        LocalXYVal p3 = new LocalXYVal(6, 4);
+        dontinline_endlessLoop();
+        iResult = p1.x+p1.y + p2.x+p2.y + p3.x+p3.y;
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 6+8+10;
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+        loopCount = 3;
+    }
+
+    public void warmupDone() {
+        super.warmupDone();
+        msg("enter 'endless' loop by setting loopCount = Long.MAX_VALUE");
+        loopCount = Long.MAX_VALUE; // endless loop
+    }
+}
+
+
+// End of test case collection
+/////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////
+// Helper classes
+class XYVal {
+
+    public int x, y;
+
+    public XYVal(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    /**
+     * Note that we don't use a sync block here because javac would generate an synthetic exception
+     * handler for the synchronized block that catches Throwable E, unlocks and throws E
+     * again. The throw bytecode causes the BCEscapeAnalyzer to set the escape state to GlobalEscape
+     * (see comment on exception handlers in BCEscapeAnalyzer::iterate_blocks())
+     */
+    public synchronized void dontinline_sync_method(EATestCaseBaseTarget target) {
+        target.dontinline_brkpt();
+    }
+
+    /**
+     * Just like {@link #dontinline_sync_method(EATestCaseBaseTarget)} but without the call to
+     * {@link EATestCaseBaseTarget#dontinline_brkpt()}.
+     */
+    public synchronized void dontinline_sync_method_no_brkpt(EATestCaseBaseTarget target) {
+    }
+}
+
+class Vector10 {
+    int i0, i1, i2, i3, i4, i5, i6, i7, i8, i9;
+    public Vector10(int j0, int j1, int j2, int j3, int j4, int j5, int j6, int j7, int j8, int j9) {
+        i0=j0; i1=j1; i2=j2; i3=j3; i4=j4; i5=j5; i6=j6; i7=j7; i8=j8; i9=j9;
+    }
+}
+
+class ILFDO {
+
+    public int i;
+    public int i2;
+    public long l;
+    public long l2;
+    public float f;
+    public float f2;
+    public double d;
+    public double d2;
+    public Long o;
+    public Long o2;
+
+    public ILFDO(int i,
+                 int i2,
+                 long l,
+                 long l2,
+                 float f,
+                 float f2,
+                 double d,
+                 double d2,
+                 Long o,
+                 Long o2) {
+        this.i = i;
+        this.i2 = i2;
+        this.l = l;
+        this.l2 = l2;
+        this.f = f;
+        this.f2 = f2;
+        this.d = d;
+        this.d2 = d2;
+        this.o = o;
+        this.o2 = o2;
+    }
+
+}

--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -240,6 +240,7 @@ public class WhiteBox {
   public native int     matchesInline(Executable method, String pattern);
   public native boolean shouldPrintAssembly(Executable method, int comp_level);
   public native int     deoptimizeFrames(boolean makeNotEntrant);
+  public native boolean isFrameDeoptimized(int depth);
   public native void    deoptimizeAll();
 
   public        boolean isMethodCompiled(Executable method) {


### PR DESCRIPTION
Hi,

this is the continuation of the review of the implementation for:

https://bugs.openjdk.java.net/browse/JDK-8227745
https://bugs.openjdk.java.net/browse/JDK-8233915

It allows for JIT optimizations based on escape analysis even if JVMTI agents acquire capabilities to access references to objects that are subject to such optimizations, e.g. scalar replacement.
The implementation reverts such optimizations just before access very much as when switching from JIT compiled execution to the interpreter, aka "deoptimization".

Webrev.8 was the last one before before the transition to Git/Github:

http://cr.openjdk.java.net/~rrich/webrevs/8227745/webrev.8/

Thanks, Richard.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8227745](https://bugs.openjdk.java.net/browse/JDK-8227745): Enable Escape Analysis for Better Performance in the Presence of JVMTI Agents ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * mdoerr - **Reviewer** ⚠️ Added manually
 * goetz - **Reviewer** ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/118/head:pull/118`
`$ git checkout pull/118`
