### PR TITLE
8253030: ZGC: Change ZMarkCompleteTimeout unit to microseconds

### DIFF
--- a/src/hotspot/share/gc/z/zGlobals.hpp
+++ b/src/hotspot/share/gc/z/zGlobals.hpp
@@ -149,6 +149,6 @@ const size_t      ZMarkProactiveFlushMax        = 10;
 const size_t      ZMarkTerminateFlushMax        = 3;
 
 // Try complete mark timeout
-const uint64_t    ZMarkCompleteTimeout          = 1; // ms
+const uint64_t    ZMarkCompleteTimeout          = 1000; // us
 
 #endif // SHARE_GC_Z_ZGLOBALS_HPP

--- a/src/hotspot/share/runtime/timer.cpp
+++ b/src/hotspot/share/runtime/timer.cpp
@@ -42,6 +42,11 @@ jlong TimeHelper::millis_to_counter(jlong millis) {
   return millis * freq;
 }
 
+jlong TimeHelper::micros_to_counter(jlong micros) {
+  jlong freq = os::elapsed_frequency() / MICROUNITS;
+  return micros * freq;
+}
+
 elapsedTimer::elapsedTimer(jlong time, jlong timeUnitsPerSecond) {
   _active = false;
   jlong osTimeUnitsPerSecond = os::elapsed_frequency();

--- a/src/hotspot/share/runtime/timer.hpp
+++ b/src/hotspot/share/runtime/timer.hpp
@@ -77,6 +77,7 @@ class TimeHelper {
   static double counter_to_seconds(jlong counter);
   static double counter_to_millis(jlong counter);
   static jlong millis_to_counter(jlong millis);
+  static jlong micros_to_counter(jlong micros);
 };
 
 #endif // SHARE_RUNTIME_TIMER_HPP


### PR DESCRIPTION
The ZMarkCompleteTimeout is currently specified in milliseconds, and its value is 1 (i.e. as low as it can be). In preparation for using a lower time out value than 1ms we should change the ZMarkCompleteTimeout unit to be microseconds, instead of milliseconds.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253030](https://bugs.openjdk.java.net/browse/JDK-8253030): ZGC: Change ZMarkCompleteTimeout unit to microseconds


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/120/head:pull/120`
`$ git checkout pull/120`
