### PR TITLE
8253033: CheckUnhandledOops check fails in ThreadSnapshot::initialize…

### DIFF
--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -886,6 +886,9 @@ void ThreadSnapshot::initialize(ThreadsList * t_list, JavaThread* thread) {
       _thread_status == java_lang_Thread::IN_OBJECT_WAIT_TIMED) {
 
     Handle obj = ThreadService::get_current_contended_monitor(thread);
+    // Need to re-set oop's to pass CheckUnhandledOops check
+    blocker_object = NULL;
+    blocker_object_owner = NULL;
     if (obj() == NULL) {
       // monitor no longer exists; thread is not blocked
       _thread_status = java_lang_Thread::RUNNABLE;

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -878,6 +878,8 @@ void ThreadSnapshot::initialize(ThreadsList * t_list, JavaThread* thread) {
   _is_ext_suspended = thread->is_being_ext_suspended();
   _is_in_native = (thread->thread_state() == _thread_in_native);
 
+  Handle obj = ThreadService::get_current_contended_monitor(thread);
+
   oop blocker_object = NULL;
   oop blocker_object_owner = NULL;
 
@@ -885,10 +887,6 @@ void ThreadSnapshot::initialize(ThreadsList * t_list, JavaThread* thread) {
       _thread_status == java_lang_Thread::IN_OBJECT_WAIT ||
       _thread_status == java_lang_Thread::IN_OBJECT_WAIT_TIMED) {
 
-    Handle obj = ThreadService::get_current_contended_monitor(thread);
-    // Need to re-set oop's to pass CheckUnhandledOops check
-    blocker_object = NULL;
-    blocker_object_owner = NULL;
     if (obj() == NULL) {
       // monitor no longer exists; thread is not blocked
       _thread_status = java_lang_Thread::RUNNABLE;


### PR DESCRIPTION
The NULL oops are corrupted by CheckUnhandledOops and should be re-written with NULL to pass testing with -XX:+CheckUnhandledOops.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253033](https://bugs.openjdk.java.net/browse/JDK-8253033): CheckUnhandledOops check fails in ThreadSnapshot::initialize(...) ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/123/head:pull/123`
`$ git checkout pull/123`
