### PR TITLE
8252933: com.sun.tools.jdi.ObjectReferenceImpl#validateAssignment always requests referenceType

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ObjectReferenceImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ObjectReferenceImpl.java
@@ -586,12 +586,14 @@ public class ObjectReferenceImpl extends ValueImpl
          */
 
         JNITypeParser destSig = new JNITypeParser(destination.signature());
-        JNITypeParser sourceSig = new JNITypeParser(type().signature());
         if (destSig.isPrimitive()) {
             throw new InvalidTypeException("Can't assign object value to primitive");
         }
-        if (destSig.isArray() && !sourceSig.isArray()) {
-            throw new InvalidTypeException("Can't assign non-array value to an array");
+        if (destSig.isArray()) {
+            JNITypeParser sourceSig = new JNITypeParser(type().signature());
+            if (!sourceSig.isArray()) {
+                throw new InvalidTypeException("Can't assign non-array value to an array");
+            }
         }
         if (destSig.isVoid()) {
             throw new InvalidTypeException("Can't assign object value to a void");


### PR DESCRIPTION
The change fixes the regression introduced by https://bugs.openjdk.java.net/browse/JDK-8241080. 

Method validateAssignment() in com.sun.tools.jdi.ObjectReferenceImpl now always retrieves the reference type and that requires one more JDWP packet if the value is not cached yet. Before https://bugs.openjdk.java.net/browse/JDK-8241080 this happened for arrays only. 

Testing: tier1-tier3 tests passes.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252933](https://bugs.openjdk.java.net/browse/JDK-8252933): com.sun.tools.jdi.ObjectReferenceImpl#validateAssignment always requests referenceType


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/124/head:pull/124`
`$ git checkout pull/124`
