### PR TITLE
8253049: Enhance itable_stub for AArch64 and x86_64

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -909,6 +909,16 @@ public:
                                Label& no_such_interface,
                    bool return_method = true);
 
+  // for itable_stub
+  void lookup_interface_method_in_stub(Register recv_klass,
+                                       Register resolved_klass,
+                                       Register holder_klass,
+                                       int itable_index,
+                                       Register method_result,
+                                       Register scan_temp,
+                                       Register count,
+                                       Label& no_such_interface);
+
   // virtual method calling
   // n.b. x86 allows RegisterOrConstant for vtable_index
   void lookup_virtual_method(Register recv_klass,

--- a/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
@@ -174,9 +174,9 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   // so all registers except arguments are free at this point.
   const Register recv_klass_reg     = r10;
   const Register holder_klass_reg   = r16; // declaring interface klass (DECC)
-  const Register resolved_klass_reg = rmethod; // resolved interface klass (REFC)
+  const Register resolved_klass_reg = r13; // resolved interface klass (REFC)
   const Register temp_reg           = r11;
-  const Register temp_reg2          = r15;
+  const Register count_reg          = r15;
   const Register icholder_reg       = rscratch2;
 
   Label L_no_such_interface;
@@ -190,29 +190,14 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   address npe_addr = __ pc();
   __ load_klass(recv_klass_reg, j_rarg0);
 
-  // Receiver subtype check against REFC.
-  __ lookup_interface_method(// inputs: rec. class, interface
-                             recv_klass_reg, resolved_klass_reg, noreg,
-                             // outputs:  scan temp. reg1, scan temp. reg2
-                             temp_reg2, temp_reg,
-                             L_no_such_interface,
-                             /*return_method=*/false);
-
-  const ptrdiff_t  typecheckSize = __ pc() - start_pc;
-  start_pc = __ pc();
-
-  // Get selected method from declaring class and itable index
-  __ lookup_interface_method(// inputs: rec. class, interface, itable index
-                             recv_klass_reg, holder_klass_reg, itable_index,
-                             // outputs: method, scan temp. reg
-                             rmethod, temp_reg,
-                             L_no_such_interface);
-
-  const ptrdiff_t lookupSize = __ pc() - start_pc;
+  __ lookup_interface_method_in_stub(
+    recv_klass_reg, resolved_klass_reg, holder_klass_reg, itable_index,
+    rmethod, temp_reg, count_reg,
+    L_no_such_interface);
 
   // Reduce "estimate" such that "padding" does not drop below 8.
   const ptrdiff_t estimate = 124;
-  const ptrdiff_t codesize = typecheckSize + lookupSize;
+  const ptrdiff_t codesize = __ pc() - start_pc;
   slop_delta  = (int)(estimate - codesize);
   slop_bytes += slop_delta;
   assert(slop_delta >= 0, "itable #%d: Code size estimate (%d) for lookup_interface_method too small, required: %d", itable_index, (int)estimate, (int)codesize);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -536,6 +536,16 @@ class MacroAssembler: public Assembler {
                                Label& no_such_interface,
                                bool return_method = true);
 
+  // for itable_stub
+  void lookup_interface_method_in_stub(Register recv_klass,
+                               Register holder_klass,
+                               Register resolved_klass,
+                               int itable_index,
+                               Register method_result,
+                               Register scan_temp,
+                               Register count,
+                               Label& no_such_interface);
+
   // virtual method calling
   void lookup_virtual_method(Register recv_klass,
                              RegisterOrConstant vtable_index,

--- a/src/hotspot/cpu/x86/vtableStubs_x86_64.cpp
+++ b/src/hotspot/cpu/x86/vtableStubs_x86_64.cpp
@@ -175,10 +175,13 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   // (various calling sequences use r[cd]x, r[sd]i, r[89]; stay away from them)
   const Register recv_klass_reg     = r10;
   const Register holder_klass_reg   = rax; // declaring interface klass (DECC)
-  const Register resolved_klass_reg = rbx; // resolved interface klass (REFC)
+  const Register resolved_klass_reg = r14; // resolved interface klass (REFC)
   const Register temp_reg           = r11;
 
   const Register icholder_reg = rax;
+  const Register method = rbx;
+  const Register count_reg = r13;
+
   __ movptr(resolved_klass_reg, Address(icholder_reg, CompiledICHolder::holder_klass_offset()));
   __ movptr(holder_klass_reg,   Address(icholder_reg, CompiledICHolder::holder_metadata_offset()));
 
@@ -190,35 +193,15 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   __ load_klass(recv_klass_reg, j_rarg0, temp_reg);
 
   start_pc = __ pc();
-
-  // Receiver subtype check against REFC.
-  // Destroys recv_klass_reg value.
-  __ lookup_interface_method(// inputs: rec. class, interface
-                             recv_klass_reg, resolved_klass_reg, noreg,
-                             // outputs:  scan temp. reg1, scan temp. reg2
-                             recv_klass_reg, temp_reg,
-                             L_no_such_interface,
-                             /*return_method=*/false);
-
-  const ptrdiff_t  typecheckSize = __ pc() - start_pc;
-  start_pc = __ pc();
-
-  // Get selected method from declaring class and itable index
-  const Register method = rbx;
-  __ load_klass(recv_klass_reg, j_rarg0, temp_reg);   // restore recv_klass_reg
-  __ lookup_interface_method(// inputs: rec. class, interface, itable index
-                             recv_klass_reg, holder_klass_reg, itable_index,
-                             // outputs: method, scan temp. reg
-                             method, temp_reg,
-                             L_no_such_interface);
-
-  const ptrdiff_t  lookupSize = __ pc() - start_pc;
+  __ lookup_interface_method_in_stub(recv_klass_reg, holder_klass_reg, resolved_klass_reg, itable_index,
+                                     method, temp_reg, count_reg,
+                                     L_no_such_interface);
 
   // We expect we need index_dependent_slop extra bytes. Reason:
   // The emitted code in lookup_interface_method changes when itable_index exceeds 15.
   // For linux, a very narrow estimate would be 112, but Solaris requires some more space (130).
   const ptrdiff_t estimate = 136;
-  const ptrdiff_t codesize = typecheckSize + lookupSize + index_dependent_slop;
+  const ptrdiff_t codesize = __ pc() - start_pc + index_dependent_slop;
   slop_delta  = (int)(estimate - codesize);
   slop_bytes += slop_delta;
   assert(slop_delta >= 0, "itable #%d: Code size estimate (%d) for lookup_interface_method too small, required: %d", itable_index, (int)estimate, (int)codesize);

--- a/test/micro/org/openjdk/bench/vm/compiler/InterfaceCalls.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/InterfaceCalls.java
@@ -24,6 +24,7 @@ package org.openjdk.bench.vm.compiler;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
@@ -52,6 +53,17 @@ public class InterfaceCalls {
 
     interface AloneInterface {
         public int getNumber();
+    }
+
+    interface SuperInterface {
+        public int getInt();
+    }
+
+    interface SuperInterface2 extends SuperInterface {
+        default int getInt2() {return 2;}
+    }
+
+    interface SubInterface extends SuperInterface2 {
     }
 
     class SingleImplementor implements OnlyHasOneImplInterface {
@@ -88,6 +100,76 @@ public class InterfaceCalls {
     }
 
     class FifthClass implements AnInterface {
+        public int getInt() {
+            return -5;
+        }
+    }
+
+    class FirstClassNotInline implements AnInterface {
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        public int getInt() {
+            return 1;
+        }
+    }
+
+    class SecondClassNotInline implements AnInterface {
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        public int getInt() {
+            return 2;
+        }
+    }
+
+    class ThirdClassNotInline implements AnInterface {
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        public int getInt() {
+            return -3;
+        }
+    }
+
+    class FourthClassNotInline implements AnInterface {
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        public int getInt() {
+            return -4;
+        }
+    }
+
+    class FifthClassNotInline implements AnInterface {
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        public int getInt() {
+            return -5;
+        }
+    }
+
+    class FirstSubClassNotInline implements SubInterface {
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        public int getInt() {
+            return 1;
+        }
+    }
+
+    class SecondSubClassNotInline implements SubInterface {
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        public int getInt() {
+            return 2;
+        }
+    }
+
+    class ThirdSubClassNotInline implements SubInterface {
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        public int getInt() {
+            return -3;
+        }
+    }
+
+    class FourthSubClassNotInline implements SubInterface {
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        public int getInt() {
+            return -4;
+        }
+    }
+
+    class FifthSubClassNotInline implements SubInterface {
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
         public int getInt() {
             return -5;
         }
@@ -132,6 +214,8 @@ public class InterfaceCalls {
     public Object multic, multic2;
 
     public AnInterface[] as = new AnInterface[5];
+    public AnInterface[] as2 = new AnInterface[5];
+    public SubInterface[] as3 = new SubInterface[5];
 
     public AnInterface multi;
 
@@ -153,6 +237,16 @@ public class InterfaceCalls {
         as[2] = new ThirdClass();
         as[3] = new FourthClass();
         as[4] = new FifthClass();
+        as2[0] = new FirstClassNotInline();
+        as2[1] = new SecondClassNotInline();
+        as2[2] = new ThirdClassNotInline();
+        as2[3] = new FourthClassNotInline();
+        as2[4] = new FifthClassNotInline();
+        as3[0] = new FirstSubClassNotInline();
+        as3[1] = new SecondSubClassNotInline();
+        as3[2] = new ThirdSubClassNotInline();
+        as3[3] = new FourthSubClassNotInline();
+        as3[4] = new FifthSubClassNotInline();
         MultiClass1 mc1 = new MultiClass1();
         multi1a = mc1;
         multi1b = mc1;
@@ -260,8 +354,40 @@ public class InterfaceCalls {
     /** Interface call with five different receivers. */
     @Benchmark
     public void testCallPoly5(Blackhole bh) {
-        for (int kk = 0; kk < 3; kk++) {
+        for (int kk = 0; kk < 5; kk++) {
             bh.consume(as[kk].getInt());
+        }
+    }
+
+    /** Interface methods are not inline, test itable stub */
+    @Benchmark
+    public void testStubPoly3(Blackhole bh) {
+        for (int kk = 0; kk < 3; kk++) {
+            bh.consume(as2[kk].getInt());
+        }
+    }
+
+    /** Interface methods are not inline, test itable stub */
+    @Benchmark
+    public void testStubPoly5(Blackhole bh) {
+        for (int kk = 0; kk < 5; kk++) {
+            bh.consume(as2[kk].getInt());
+        }
+    }
+
+    /** Interface methods are not inline, test itable stub in slow loop*/
+    @Benchmark
+    public void testSlowStubPoly3(Blackhole bh) {
+        for (int kk = 0; kk < 3; kk++) {
+            bh.consume(as3[kk].getInt());
+        }
+    }
+
+    /** Interface methods are not inline, test itable stub in slow loop*/
+    @Benchmark
+    public void testSlowStubPoly5(Blackhole bh) {
+        for (int kk = 0; kk < 5; kk++) {
+            bh.consume(as3[kk].getInt());
         }
     }
 


### PR DESCRIPTION
Now itable_stub will go through instanceKlass's itable twice to look up a method entry. resolved klass is used for type checking and method holder klass is used to find method entry. In many cases , we observed resolved klass is as same as holder klass. So we can improve itable stub based on it. If they are same klass, stub uses a fast loop to check only one klass. If not, a slow loop is used to checking both klasses.

Even entering in slow loop, new implementation can be better than old one in some cases. Because new stub just need go through itable once and reduce memory operations.


bug: https://bugs.openjdk.java.net/browse/JDK-8253049

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8253049](https://bugs.openjdk.java.net/browse/JDK-8253049): Enhance itable_stub for AArch64 and x86_64


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/128/head:pull/128`
`$ git checkout pull/128`
