### PR TITLE
8244706: GZIP "OS" header flag hard-coded to 0 instead of 255 (RFC 1952 non-compliance)

### DIFF
--- a/src/java.base/share/classes/java/util/zip/GZIPOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPOutputStream.java
@@ -52,7 +52,7 @@ public class GZIPOutputStream extends DeflaterOutputStream {
      */
     private static final int TRAILER_SIZE = 8;
 
-    // OS header value
+    // Represents the default "unknown" value for OS header, per RFC-1952
     private static final byte OS_UNKNOWN = (byte) 255;
 
     /**

--- a/src/java.base/share/classes/java/util/zip/GZIPOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,9 @@ public class GZIPOutputStream extends DeflaterOutputStream {
      *
      */
     private static final int TRAILER_SIZE = 8;
+
+    // OS header value
+    private static final byte OS_UNKNOWN = (byte) 255;
 
     /**
      * Creates a new output stream with the specified buffer size.
@@ -189,7 +192,7 @@ public class GZIPOutputStream extends DeflaterOutputStream {
                       0,                        // Modification time MTIME (int)
                       0,                        // Modification time MTIME (int)
                       0,                        // Extra flags (XFLG)
-                      0                         // Operating system (OS)
+                      OS_UNKNOWN                // Operating system (OS)
                   });
     }
 

--- a/test/jdk/java/util/zip/GZIP/GZIPOutputStreamHeaderTest.java
+++ b/test/jdk/java/util/zip/GZIP/GZIPOutputStreamHeaderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * @test
+ * @bug 8244706
+ * @summary Verify that the OS header flag in the stream written out by java.util.zip.GZIPOutputStream
+ * has the correct expected value
+ * @run testng GZIPOutputStreamHeaderTest
+ */
+public class GZIPOutputStreamHeaderTest {
+
+    private static final int OS_HEADER_INDEX = 9;
+    private static final int HEADER_VALUE_OS_UNKNOWN = 255;
+
+    /**
+     * Test that the {@code OS} header field in the GZIP output stream
+     * has a value of {@code 255} which represents "unknown"
+     */
+    @Test
+    public void testOSHeader() throws Exception {
+        final String data = "Hello world!!!";
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (final GZIPOutputStream gzipOutputStream = new GZIPOutputStream(baos);) {
+            gzipOutputStream.write(data.getBytes(StandardCharsets.UTF_8));
+        }
+        final byte[] compressed = baos.toByteArray();
+        Assert.assertNotNull(compressed, "Compressed data is null");
+        Assert.assertEquals(toUnsignedByte(compressed[OS_HEADER_INDEX]), HEADER_VALUE_OS_UNKNOWN,
+                "Unexpected value for OS header");
+        // finally verify that the compressed data is readable back to the original
+        final String uncompressed;
+        try (final ByteArrayOutputStream os = new ByteArrayOutputStream();
+             final ByteArrayInputStream bis = new ByteArrayInputStream(compressed);
+             final GZIPInputStream gzipInputStream = new GZIPInputStream(bis)) {
+            gzipInputStream.transferTo(os);
+            uncompressed = new String(os.toByteArray(), StandardCharsets.UTF_8);
+        }
+        Assert.assertEquals(uncompressed, data, "Unexpected data read from GZIPInputStream");
+    }
+
+    private static int toUnsignedByte(final byte b) {
+        return b & 0xff;
+    }
+}


### PR DESCRIPTION
Can I please get a review and a sponsor for this patch which fixes the issue reported in https://bugs.openjdk.java.net/browse/JDK-8244706?

The commit here sets the `OS` header flag to `255` (which represents `unknown`) as noted in [1]. A new test has been included in this commit to verify the change. Furthermore, this doesn't impact the `java.util.zip.GZIPInputStream` since it ignores [2] this header value while reading the headers from the stream.

[1] https://tools.ietf.org/html/rfc1952#page-7
[2] https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/zip/GZIPInputStream.java#L173
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244706](https://bugs.openjdk.java.net/browse/JDK-8244706): GZIP "OS" header flag hard-coded to 0 instead of 255 (RFC 1952 non-compliance)


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/130/head:pull/130`
`$ git checkout pull/130`
