### PR TITLE
8253031: git jcheck complains about invalid tags in jdk repo after fix for JDK-8252844

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -6,7 +6,7 @@ jbs=JDK
 error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace
 
 [repository]
-tags=(?:jdk-(?:[1-9]([0-9]*)(?:\\.(?:0|[1-9][0-9]*)){0,4})(?:\\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\\d{1,3})?-(?:(?:b\\d{2,3})|(?:ga)))|(?:hs\\d\\d(?:\\.\\d{1,2})?-b\\d\\d)
+tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)
 branches=
 
 [census]


### PR DESCRIPTION
In the fix for [JDK-8252844](https://bugs.openjdk.java.net/browse/JDK-8252844) the tags entry in `.jcheck/conf` was copied from the Skara Java code. The `\` chars were escaped as `\\` in the Java String so that it would contain `\`. This additional level of escape is not needed in the `.jcheck/conf` file, and causes the regex to not be as intended. The fix is to replace `\\` with `\` in the regex.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253031](https://bugs.openjdk.java.net/browse/JDK-8253031): git jcheck complains about invalid tags in jdk repo after fix for JDK-8252844


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/131/head:pull/131`
`$ git checkout pull/131`
