### PR TITLE
8253066: typo in Stream.mapMulti

### DIFF
--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -375,7 +375,7 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
      * </ul>
      *
      * <p>If a lambda expression is provided as the mapper function argument, additional type
-     * information maybe be necessary for proper inference of the element type {@code <R>} of
+     * information may be necessary for proper inference of the element type {@code <R>} of
      * the returned stream. This can be provided in the form of explicit type declarations for
      * the lambda parameters or as an explicit type argument to the {@code mapMulti} call.
      *


### PR DESCRIPTION
A simple typo fix.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253066](https://bugs.openjdk.java.net/browse/JDK-8253066): typo in Stream.mapMulti


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/137/head:pull/137`
`$ git checkout pull/137`
