### PR TITLE
8223187: Remove setLocale() call in jpackage native launcher

### DIFF
--- a/src/jdk.incubator.jpackage/linux/native/applauncher/LinuxLauncher.cpp
+++ b/src/jdk.incubator.jpackage/linux/native/applauncher/LinuxLauncher.cpp
@@ -44,8 +44,6 @@ size_t hash(const std::string& str) {
 }
 
 void launchApp() {
-    setlocale(LC_ALL, "en_US.utf8");
-
     const tstring launcherPath = SysInfo::getProcessModulePath();
 
     const Package ownerPackage = Package::findOwnerOfFile(launcherPath);

--- a/src/jdk.incubator.jpackage/macosx/native/applauncher/MacLauncher.cpp
+++ b/src/jdk.incubator.jpackage/macosx/native/applauncher/MacLauncher.cpp
@@ -67,7 +67,6 @@ void initJvmLauncher() {
 
 
 int main(int argc, char *argv[]) {
-    setlocale(LC_ALL, "en_US.utf8");
     if (jvmLauncher) {
         // This is the call from the thread spawned by JVM.
         // Skip initialization phase as we have done this already in the first


### PR DESCRIPTION
setlocale() affects several C functions. We do not use most of these functions. We only using isspace() and toLower(). Based on how we use it I do not see any needs for setlocale(). After removing it I retested jpackage by changing locally on machine and using different language as input parameters for jpackage. No issues found.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8223187](https://bugs.openjdk.java.net/browse/JDK-8223187): Remove setLocale() call in jpackage native launcher


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/138/head:pull/138`
`$ git checkout pull/138`
