### PR TITLE
JDK-8230652: Improve verbose output

### DIFF
--- a/src/jdk.incubator.jpackage/macosx/classes/jdk/incubator/jpackage/internal/MacBaseInstallerBundler.java
+++ b/src/jdk.incubator.jpackage/macosx/classes/jdk/incubator/jpackage/internal/MacBaseInstallerBundler.java
@@ -187,7 +187,6 @@ public abstract class MacBaseInstallerBundler extends AbstractBundler {
                 Log.error(MessageFormat.format(I18N.getString(
                         "error.multiple.certs.found"), key, keychainName));
             }
-            Log.verbose("Using key '" + matchedKey + "'");
             return matchedKey;
         } catch (IOException ioe) {
             Log.verbose(ioe);

--- a/src/jdk.incubator.jpackage/macosx/classes/jdk/incubator/jpackage/internal/MacDmgBundler.java
+++ b/src/jdk.incubator.jpackage/macosx/classes/jdk/incubator/jpackage/internal/MacDmgBundler.java
@@ -82,9 +82,6 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
             if (appLocation != null && prepareConfigFiles(params)) {
                 Path configScript = getConfig_Script(params);
                 if (IOUtils.exists(configScript)) {
-                    Log.verbose(MessageFormat.format(
-                            I18N.getString("message.running-script"),
-                            configScript.toAbsolutePath().toString()));
                     IOUtils.run("bash", configScript);
                 }
 

--- a/src/jdk.incubator.jpackage/macosx/classes/jdk/incubator/jpackage/internal/MacPkgBundler.java
+++ b/src/jdk.incubator.jpackage/macosx/classes/jdk/incubator/jpackage/internal/MacPkgBundler.java
@@ -142,9 +142,6 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
 
                 Path configScript = getConfig_Script(params);
                 if (IOUtils.exists(configScript)) {
-                    Log.verbose(MessageFormat.format(I18N.getString(
-                            "message.running-script"),
-                            configScript.toAbsolutePath().toString()));
                     IOUtils.run("bash", configScript);
                 }
 

--- a/src/jdk.incubator.jpackage/share/classes/jdk/incubator/jpackage/internal/IOUtils.java
+++ b/src/jdk.incubator.jpackage/share/classes/jdk/incubator/jpackage/internal/IOUtils.java
@@ -228,6 +228,7 @@ public class IOUtils {
         t.start();
 
         int ret = p.waitFor();
+        Log.verbose(pb.command(), list, ret);
 
         result.clear();
         result.addAll(list);

--- a/src/jdk.incubator.jpackage/share/classes/jdk/incubator/jpackage/internal/JLinkBundlerHelper.java
+++ b/src/jdk.incubator.jpackage/share/classes/jdk/incubator/jpackage/internal/JLinkBundlerHelper.java
@@ -188,15 +188,16 @@ final class JLinkBundlerHelper {
         StringWriter writer = new StringWriter();
         PrintWriter pw = new PrintWriter(writer);
 
-        Log.verbose("jlink arguments: " + args);
         int retVal = LazyLoad.JLINK_TOOL.run(pw, pw, args.toArray(new String[0]));
         String jlinkOut = writer.toString();
+
+        args.add(0, "jlink");
+        Log.verbose(args, List.of(jlinkOut), retVal);
+
 
         if (retVal != 0) {
             throw new PackagerException("error.jlink.failed" , jlinkOut);
         }
-
-        Log.verbose("jlink output: " + jlinkOut);
     }
 
     private static String getPathList(List<Path> pathList) {

--- a/src/jdk.incubator.jpackage/share/classes/jdk/incubator/jpackage/internal/Log.java
+++ b/src/jdk.incubator.jpackage/share/classes/jdk/incubator/jpackage/internal/Log.java
@@ -28,6 +28,7 @@ package jdk.incubator.jpackage.internal;
 import java.io.PrintWriter;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 
 /**
  * Log
@@ -115,6 +116,25 @@ public class Log {
             }
         }
 
+        public void verbose(List<String> strings,
+                List<String> output, int returnCode) {
+            if (verbose) {
+                StringBuffer sb = new StringBuffer("Command:\n   ");
+                for (String s : strings) {
+                    sb.append(" " + s);
+                }
+                verbose(new String(sb));
+                if (output != null && !output.isEmpty()) {
+                    sb = new StringBuffer("Output:");
+                    for (String s : output) {
+                        sb.append("\n    " + s);
+                    }
+                    verbose(new String(sb));
+                }
+                verbose("Returned: " + returnCode + "\n");
+            }
+        }
+
         private String addTimestamp(String msg) {
             SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS");
             Date time = new Date(System.currentTimeMillis());
@@ -173,4 +193,11 @@ public class Log {
            delegate.verbose(t);
         }
     }
+
+    public static void verbose(List<String> strings, List<String> out, int ret) {
+        if (delegate != null) {
+           delegate.verbose(strings, out, ret);
+        }
+    }
+
 }

--- a/src/jdk.incubator.jpackage/share/classes/jdk/incubator/jpackage/internal/ToolValidator.java
+++ b/src/jdk.incubator.jpackage/share/classes/jdk/incubator/jpackage/internal/ToolValidator.java
@@ -94,7 +94,7 @@ public final class ToolValidator {
             }
 
             String[] version = new String[1];
-            Executor.of(pb).setOutputConsumer(lines -> {
+            Executor.of(pb).setQuiet(true).setOutputConsumer(lines -> {
                 if (versionParser != null && minimalVersion != null) {
                     version[0] = versionParser.apply(lines);
                     if (minimalVersion.compareTo(version[0]) < 0) {

--- a/test/jdk/tools/jpackage/windows/WinL10nTest.java
+++ b/test/jdk/tools/jpackage/windows/WinL10nTest.java
@@ -95,9 +95,7 @@ public class WinL10nTest {
     private final static Stream<String> getLightCommandLine(
             Executor.Result result) {
         return result.getOutput().stream()
-                .filter(s -> s.contains("Running"))
-                .filter(s -> s.contains("light.exe"))
-                .filter(s -> !s.contains("/?"));
+                .filter(s -> s.trim().startsWith("light.exe"));
     }
 
     @Test


### PR DESCRIPTION
JDK-8230652 
Extracting the commands displayed by verbose output (including commands called thru ToolProvider) , to contain the the command, it's output, and it's return value on separate lines and formatted in a way that they can be easily cut and pasted into a script.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8230652](https://bugs.openjdk.java.net/browse/JDK-8230652): Improve verbose output


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/141/head:pull/141`
`$ git checkout pull/141`
