### PR TITLE
8253084: Zero VM is broken after JDK-8252689

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -320,7 +320,7 @@ public:
   static void print_table_statistics(outputStream* st) NOT_CDS_RETURN;
   static bool empty_dumptime_table() NOT_CDS_RETURN_(true);
   static void start_dumping() NOT_CDS_RETURN;
-  static Handle create_jar_manifest(const char* man, size_t size, TRAPS) NOT_CDS_RETURN_(NULL);
+  static Handle create_jar_manifest(const char* man, size_t size, TRAPS) NOT_CDS_RETURN_(Handle());
 
   DEBUG_ONLY(static bool no_class_loading_should_happen() {return _no_class_loading_should_happen;})
 


### PR DESCRIPTION
Hi all,

JBS: https://bugs.openjdk.java.net/browse/JDK-8253084

The build fails due to 'NULL' can't be converted from type 'long' to type 'Handle'
The fix returns 'Handle()' instead of 'NULL'.

Best regards,
Jie
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253084](https://bugs.openjdk.java.net/browse/JDK-8253084): Zero VM is broken after JDK-8252689


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/147/head:pull/147`
`$ git checkout pull/147`
