### PR TITLE
8253016: Box.Filler components should be unfocusable by default

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/Box.java
+++ b/src/java.desktop/share/classes/javax/swing/Box.java
@@ -316,6 +316,7 @@ public class Box extends JComponent implements Accessible {
             setMinimumSize(min);
             setPreferredSize(pref);
             setMaximumSize(max);
+            setFocusable(false);
         }
 
         /**

--- a/test/jdk/javax/swing/Box/TestBoxFiller.java
+++ b/test/jdk/javax/swing/Box/TestBoxFiller.java
@@ -70,6 +70,7 @@ public class TestBoxFiller
                 frame.setFocusTraversalPolicy(new ContainerOrderFocusTraversalPolicy());
                 frame.pack();
                 frame.setVisible(true);
+                frame.setLocationRelativeTo(null);
                 tf1.requestFocusInWindow();
             });
             robot.waitForIdle();

--- a/test/jdk/javax/swing/Box/TestBoxFiller.java
+++ b/test/jdk/javax/swing/Box/TestBoxFiller.java
@@ -43,14 +43,14 @@ public class TestBoxFiller
     private static void showFocusOwner(PropertyChangeEvent e)
     {
         Object c = e.getNewValue();
-	if (c instanceof Box.Filler) {
+        if (c instanceof Box.Filler) {
             throw new RuntimeException("Box.Filler having focus");
-	}
+        }
     }
 
     public static void main(String[] args) throws Exception
     {
-	try {
+        try {
             Robot robot = new Robot();
             robot.setAutoDelay(100);
             SwingUtilities.invokeAndWait(() -> {

--- a/test/jdk/javax/swing/Box/TestBoxFiller.java
+++ b/test/jdk/javax/swing/Box/TestBoxFiller.java
@@ -72,7 +72,7 @@ public class TestBoxFiller
                 frame.setVisible(true);
                 tf1.requestFocusInWindow();
 	    });
-	    robot.waitForIdle();
+            robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_TAB);
             robot.keyRelease(KeyEvent.VK_TAB);
 	} finally {

--- a/test/jdk/javax/swing/Box/TestBoxFiller.java
+++ b/test/jdk/javax/swing/Box/TestBoxFiller.java
@@ -71,11 +71,11 @@ public class TestBoxFiller
                 frame.pack();
                 frame.setVisible(true);
                 tf1.requestFocusInWindow();
-	    });
+            });
             robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_TAB);
             robot.keyRelease(KeyEvent.VK_TAB);
-	} finally {
+        } finally {
             if (frame != null) {
                 SwingUtilities.invokeAndWait(frame::dispose);
             }

--- a/test/jdk/javax/swing/Box/TestBoxFiller.java
+++ b/test/jdk/javax/swing/Box/TestBoxFiller.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8253016
+   @key headful
+   @summary Verifies Box.Filler components should be unfocusable by default
+   @run main TestBoxFiller
+ */
+import java.awt.ContainerOrderFocusTraversalPolicy;
+import java.awt.KeyboardFocusManager;
+import java.beans.PropertyChangeEvent;
+import javax.swing.Box;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+
+public class TestBoxFiller
+{
+    private static JFrame frame;
+    private static void showFocusOwner(PropertyChangeEvent e)
+    {
+        Object c = e.getNewValue();
+	if (c instanceof Box.Filler) {
+            throw new RuntimeException("Box.Filler having focus");
+	}
+    }
+
+    public static void main(String[] args) throws Exception
+    {
+	try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                KeyboardFocusManager m = KeyboardFocusManager.getCurrentKeyboardFocusManager();
+                m.addPropertyChangeListener("focusOwner", TestBoxFiller::showFocusOwner);
+
+                Box box = Box.createHorizontalBox();
+                JTextField tf1 = new JTextField("Test");
+                tf1.setColumns(40);
+                JTextField tf2 = new JTextField("Test");
+                tf2.setColumns(40);
+                box.add(tf1);
+                box.add(Box.createHorizontalStrut(20));
+                box.add(tf2);
+                frame.setContentPane(box);
+                frame.setFocusTraversalPolicy(new ContainerOrderFocusTraversalPolicy());
+                frame.pack();
+                frame.setVisible(true);
+                tf1.requestFocusInWindow();
+	    });
+	    robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+	} finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Please review a fix for an issue where it is seen that even though Box.Filler components are invisible components that are created by Box methods to return struts and glue, they ( Box.Filler instances) are focusable by default. As a consequence, they become members of the implicitly created focus traversal policies, which means that their existence as components can be seen by users.

Proposed fix is to make this Filler components unfocusable by default. 
All automated headful tests and JCK tests are unaffected by these.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253016](https://bugs.openjdk.java.net/browse/JDK-8253016): Box.Filler components should be unfocusable by default


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to d62da2e257220c7fe03629dca724b9ada7ee6527
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/149/head:pull/149`
`$ git checkout pull/149`
