### PR TITLE
8253089: Windows (MSVC 2017) build fails after JDK-8243208

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlagLookup.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagLookup.cpp
@@ -30,9 +30,9 @@
 #define DO_FLAG(type, name,...) DO_HASH(FLAG_MEMBER_ENUM(name), XSTR(name))
 
 #define DO_HASH(flag_enum, flag_name) {          \
-  unsigned int hash = hash_code(flag_name);      \
+  u2 hash = hash_code(flag_name);      \
   int bucket_index = (int)(hash % NUM_BUCKETS);  \
-  _hashes[flag_enum] = (u2)(hash);               \
+  _hashes[flag_enum] = hash;                     \
   _table[flag_enum] = _buckets[bucket_index];    \
   _buckets[bucket_index] = (short)flag_enum;     \
 }
@@ -54,10 +54,10 @@ constexpr JVMFlagLookup::JVMFlagLookup() : _buckets(), _table(), _hashes() {
 constexpr JVMFlagLookup _flag_lookup_table;
 
 JVMFlag* JVMFlagLookup::find_impl(const char* name, size_t length) const {
-  unsigned int hash = hash_code(name, length);
+  u2 hash = hash_code(name, length);
   int bucket_index = (int)(hash % NUM_BUCKETS);
   for (int flag_enum = _buckets[bucket_index]; flag_enum >= 0; ) {
-    if (_hashes[flag_enum] == (u2)hash) {
+    if (_hashes[flag_enum] == hash) {
       JVMFlag* flag = JVMFlag::flags + flag_enum;
       if (strncmp(name, flag->_name, length) == 0) {
         // We know flag->_name has at least <length> bytes.

--- a/src/hotspot/share/runtime/flags/jvmFlagLookup.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagLookup.cpp
@@ -39,7 +39,7 @@
 
 constexpr JVMFlagLookup::JVMFlagLookup() : _buckets(), _table(), _hashes() {
   for (int i = 0; i < NUM_BUCKETS; i++) {
-    _buckets[i] = (short)-1;
+    _buckets[i] = -1;
   }
 
   ALL_FLAGS(DO_FLAG,

--- a/src/hotspot/share/runtime/flags/jvmFlagLookup.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagLookup.cpp
@@ -39,7 +39,7 @@
 
 constexpr JVMFlagLookup::JVMFlagLookup() : _buckets(), _table(), _hashes() {
   for (int i = 0; i < NUM_BUCKETS; i++) {
-    _buckets[i] = -1;
+    _buckets[i] = (short)-1;
   }
 
   ALL_FLAGS(DO_FLAG,

--- a/src/hotspot/share/runtime/flags/jvmFlagLookup.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagLookup.cpp
@@ -30,7 +30,7 @@
 #define DO_FLAG(type, name,...) DO_HASH(FLAG_MEMBER_ENUM(name), XSTR(name))
 
 #define DO_HASH(flag_enum, flag_name) {          \
-  u2 hash = hash_code(flag_name);      \
+  u2 hash = hash_code(flag_name);                \
   int bucket_index = (int)(hash % NUM_BUCKETS);  \
   _hashes[flag_enum] = hash;                     \
   _table[flag_enum] = _buckets[bucket_index];    \

--- a/src/hotspot/share/runtime/flags/jvmFlagLookup.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagLookup.hpp
@@ -58,7 +58,7 @@ class JVMFlagLookup {
   static constexpr u2 hash_code(const char* s, size_t len) {
     u2 h = 0;
     while (len -- > 0) {
-      h = (u2)(h*31 + (u2) *s);
+      h = (u2)(31*h + (u2) *s);
       s++;
     }
     return h;

--- a/src/hotspot/share/runtime/flags/jvmFlagLookup.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagLookup.hpp
@@ -51,14 +51,14 @@ class JVMFlagLookup {
 
   // This is executed at build-time only, so it doesn't matter if we walk
   // the string twice.
-  static constexpr unsigned int hash_code(const char* s) {
+  static constexpr u2 hash_code(const char* s) {
     return hash_code(s, string_len(s));
   }
 
-  static constexpr unsigned int hash_code(const char* s, size_t len) {
-    unsigned int h = 0;
+  static constexpr u2 hash_code(const char* s, size_t len) {
+    u2 h = 0;
     while (len -- > 0) {
-      h = 31*h + (unsigned int) *s;
+      h = (u2)(h*31 + (u2) *s);
       s++;
     }
     return h;


### PR DESCRIPTION
It seems that MSVC 2017 is getting confused about the differences in `unsigned int` and `u2`. After a few attempts at fixing this, I think we need to use `u2` consistently for hash code computations. `u2` is the final storage type for the hash code in `JVMFlagLookup::_hashes`.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253089](https://bugs.openjdk.java.net/browse/JDK-8253089): Windows (MSVC 2017) build fails after JDK-8243208


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/150/head:pull/150`
`$ git checkout pull/150`
