### PR TITLE
8250855: Address reliance on default constructors in the Java 2D APIs

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Image.java
+++ b/src/java.desktop/share/classes/java/awt/Image.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,11 @@ import sun.awt.image.SurfaceManager;
  * @since       1.0
  */
 public abstract class Image {
+
+    /**
+     * Constructor for subclasses to call.
+     */
+    protected Image() {}
 
     /**
      * convenience object; we can use this single static object for

--- a/src/java.desktop/share/classes/java/awt/PrintJob.java
+++ b/src/java.desktop/share/classes/java/awt/PrintJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,11 @@ package java.awt;
  * @author      Amy Fowler
  */
 public abstract class PrintJob {
+
+    /**
+     * Constructor for subclasses to call.
+     */
+    protected PrintJob() {}
 
     /**
      * Gets a Graphics object that will draw to the next page.

--- a/src/java.desktop/share/classes/java/awt/font/GlyphVector.java
+++ b/src/java.desktop/share/classes/java/awt/font/GlyphVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,6 +107,11 @@ import java.awt.font.GlyphJustificationInfo;
  */
 
 public abstract class GlyphVector implements Cloneable {
+
+    /**
+     * Constructor for subclasses to call.
+     */
+    protected GlyphVector() {}
 
     //
     // methods associated with creation-time state

--- a/src/java.desktop/share/classes/java/awt/font/LayoutPath.java
+++ b/src/java.desktop/share/classes/java/awt/font/LayoutPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,12 @@ import java.awt.geom.Point2D;
  * @since 1.6
  */
 public abstract class LayoutPath {
+
+    /**
+     * Constructor for subclasses to call.
+     */
+    protected LayoutPath() {}
+
     /**
      * Convert a point in user space to a location relative to the
      * path. The location is chosen so as to minimize the distance

--- a/src/java.desktop/share/classes/java/awt/font/LineMetrics.java
+++ b/src/java.desktop/share/classes/java/awt/font/LineMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,10 @@ package java.awt.font;
 
 public abstract class LineMetrics {
 
+    /**
+     * Constructor for subclasses to call.
+     */
+    protected LineMetrics() {}
 
     /**
      * Returns the number of characters ({@code char} values) in the text whose

--- a/src/java.desktop/share/classes/java/awt/image/AbstractMultiResolutionImage.java
+++ b/src/java.desktop/share/classes/java/awt/image/AbstractMultiResolutionImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,11 @@ import java.awt.Image;
  */
 public abstract class AbstractMultiResolutionImage extends java.awt.Image
         implements MultiResolutionImage {
+
+    /**
+     * Constructor for subclasses to call.
+     */
+    protected AbstractMultiResolutionImage() {}
 
     /**
      * This method simply delegates to the same method on the base image and

--- a/src/java.desktop/share/classes/java/awt/image/BufferStrategy.java
+++ b/src/java.desktop/share/classes/java/awt/image/BufferStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,6 +133,11 @@ import java.awt.Image;
  * @since 1.4
  */
 public abstract class BufferStrategy {
+
+    /**
+     * Constructor for subclasses to call.
+     */
+    protected BufferStrategy() {}
 
     /**
      * Returns the {@code BufferCapabilities} for this

--- a/src/java.desktop/share/classes/java/awt/image/ImageFilter.java
+++ b/src/java.desktop/share/classes/java/awt/image/ImageFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,12 @@ import java.util.Hashtable;
  * @author      Jim Graham
  */
 public class ImageFilter implements ImageConsumer, Cloneable {
+
+    /**
+     * Constructs an {@code ImageFilter}.
+     */
+    public ImageFilter() {}
+
     /**
      * The consumer of the particular image data stream for which this
      * instance of the ImageFilter is filtering data.  It is not

--- a/src/java.desktop/share/classes/java/awt/image/RGBImageFilter.java
+++ b/src/java.desktop/share/classes/java/awt/image/RGBImageFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,6 +65,11 @@ import java.awt.image.ColorModel;
  * @author      Jim Graham
  */
 public abstract class RGBImageFilter extends ImageFilter {
+
+    /**
+     * Constructor for subclasses to call.
+     */
+    protected RGBImageFilter() {}
 
     /**
      * The {@code ColorModel} to be replaced by

--- a/src/java.desktop/share/classes/java/awt/image/VolatileImage.java
+++ b/src/java.desktop/share/classes/java/awt/image/VolatileImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,6 +132,11 @@ import java.awt.Transparency;
  */
 public abstract class VolatileImage extends Image implements Transparency
 {
+
+    /**
+     * Constructor for subclasses to call.
+     */
+    protected VolatileImage() {}
 
     // Return codes for validate() method
 

--- a/src/java.desktop/share/classes/javax/print/PrintServiceLookup.java
+++ b/src/java.desktop/share/classes/javax/print/PrintServiceLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,11 @@ import sun.awt.AppContext;
  * {@code checkPrintJobAccess()} method denies access.
  */
 public abstract class PrintServiceLookup {
+
+    /**
+     * Constructor for subclasses to call.
+     */
+    protected PrintServiceLookup() {}
 
     /**
      * Contains a lists of services.

--- a/src/java.desktop/share/classes/javax/print/ServiceUI.java
+++ b/src/java.desktop/share/classes/javax/print/ServiceUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,11 @@ import sun.print.SunAlternateMedia;
  * packages.
  */
 public class ServiceUI {
+
+    /**
+     * Constructs a {@code ServiceUI}.
+     */
+    public ServiceUI() {}
 
     /**
      * Presents a dialog to the user for selecting a print service (printer). It

--- a/src/java.desktop/share/classes/javax/print/ServiceUIFactory.java
+++ b/src/java.desktop/share/classes/javax/print/ServiceUIFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,11 @@ package javax.print;
  * </pre>
  */
 public abstract class ServiceUIFactory {
+
+    /**
+     * Constructor for subclasses to call.
+     */
+    protected ServiceUIFactory() {}
 
     /**
      * Denotes a UI implemented as a Swing component. The value of the string is

--- a/src/java.desktop/share/classes/javax/print/event/PrintJobAdapter.java
+++ b/src/java.desktop/share/classes/javax/print/event/PrintJobAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,11 @@ package javax.print.event;
  * methods you need, rather than all of the methods.
  */
 public abstract class PrintJobAdapter implements PrintJobListener {
+
+    /**
+     * Constructor for subclasses to call.
+     */
+    protected PrintJobAdapter() {}
 
     /**
      * Called to notify the client that data has been successfully transferred


### PR DESCRIPTION
This issue relates to JDK-8250639 '☂ Address reliance on default constructors in the java.desktop module'. The changes address the reliance on default constructors by adding in basic constructors in the following classes:

- java.awt.Image
- java.awt.PrintJob
- java.awt.font.GlyphVector
- java.awt.font.LayoutPath
- java.awt.font.LineMetrics
- java.awt.image.AbstractMultiResolutionImage
- java.awt.image.BufferStrategy
- java.awt.image.ImageFilter
- java.awt.image.RGBImageFilter
- java.awt.image.VolatileImage
- javax.print.PrintServiceLookup
- javax.print.ServiceUI
- javax.print.ServiceUIFactory
- javax.print.StreamPrintServiceFactory
- javax.print.event.PrintJobAdapter

specdiff: http://cr.openjdk.java.net/~ccleary/issues/webrevs-store/8250855/webrevs/webrev.02/specdiff/overview-summary.html
csr: https://bugs.openjdk.java.net/browse/JDK-8252495
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8250855](https://bugs.openjdk.java.net/browse/JDK-8250855): Address reliance on default constructors in the Java 2D APIs    


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/152/head:pull/152`
`$ git checkout pull/152`
