### PR TITLE
8253015: Aarch64: Move linux code out from generic CPU feature detection

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5271,7 +5271,7 @@ void MacroAssembler::cache_wb(Address line) {
   assert(line.offset() == 0, "offset should be 0");
   // would like to assert this
   // assert(line._ext.shift == 0, "shift should be zero");
-  if (VM_Version::supports_dcpop()) {
+  if (VM_Version::features() & VM_Version::CPU_DCPOP) {
     // writeback using clear virtual address to point of persistence
     dc(Assembler::CVAP, line.base());
   } else {

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -37,110 +37,26 @@
 
 #include OS_HEADER_INLINE(os)
 
-#include <asm/hwcap.h>
-#include <sys/auxv.h>
-#include <sys/prctl.h>
-
-#ifndef HWCAP_AES
-#define HWCAP_AES   (1<<3)
-#endif
-
-#ifndef HWCAP_PMULL
-#define HWCAP_PMULL (1<<4)
-#endif
-
-#ifndef HWCAP_SHA1
-#define HWCAP_SHA1  (1<<5)
-#endif
-
-#ifndef HWCAP_SHA2
-#define HWCAP_SHA2  (1<<6)
-#endif
-
-#ifndef HWCAP_CRC32
-#define HWCAP_CRC32 (1<<7)
-#endif
-
-#ifndef HWCAP_ATOMICS
-#define HWCAP_ATOMICS (1<<8)
-#endif
-
-#ifndef HWCAP_SHA512
-#define HWCAP_SHA512 (1 << 21)
-#endif
-
-#ifndef HWCAP_SVE
-#define HWCAP_SVE (1 << 22)
-#endif
-
-#ifndef HWCAP2_SVE2
-#define HWCAP2_SVE2 (1 << 1)
-#endif
-
-#ifndef PR_SVE_GET_VL
-// For old toolchains which do not have SVE related macros defined.
-#define PR_SVE_SET_VL   50
-#define PR_SVE_GET_VL   51
-#endif
-
 int VM_Version::_cpu;
 int VM_Version::_model;
 int VM_Version::_model2;
 int VM_Version::_variant;
 int VM_Version::_revision;
 int VM_Version::_stepping;
-bool VM_Version::_dcpop;
+
+int VM_Version::_zva_length;
+int VM_Version::_dcache_line_size;
+int VM_Version::_icache_line_size;
 int VM_Version::_initial_sve_vector_length;
-VM_Version::PsrInfo VM_Version::_psr_info   = { 0, };
 
-static BufferBlob* stub_blob;
-static const int stub_size = 550;
-
-extern "C" {
-  typedef void (*getPsrInfo_stub_t)(void*);
-}
-static getPsrInfo_stub_t getPsrInfo_stub = NULL;
-
-
-class VM_Version_StubGenerator: public StubCodeGenerator {
- public:
-
-  VM_Version_StubGenerator(CodeBuffer *c) : StubCodeGenerator(c) {}
-
-  address generate_getPsrInfo() {
-    StubCodeMark mark(this, "VM_Version", "getPsrInfo_stub");
-#   define __ _masm->
-    address start = __ pc();
-
-    // void getPsrInfo(VM_Version::PsrInfo* psr_info);
-
-    address entry = __ pc();
-
-    __ enter();
-
-    __ get_dczid_el0(rscratch1);
-    __ strw(rscratch1, Address(c_rarg0, in_bytes(VM_Version::dczid_el0_offset())));
-
-    __ get_ctr_el0(rscratch1);
-    __ strw(rscratch1, Address(c_rarg0, in_bytes(VM_Version::ctr_el0_offset())));
-
-    __ leave();
-    __ ret(lr);
-
-#   undef __
-
-    return start;
-  }
-};
-
-void VM_Version::get_processor_features() {
+void VM_Version::initialize() {
   _supports_cx8 = true;
   _supports_atomic_getset4 = true;
   _supports_atomic_getadd4 = true;
   _supports_atomic_getset8 = true;
   _supports_atomic_getadd8 = true;
 
-  getPsrInfo_stub(&_psr_info);
+  get_os_cpu_info();
 
   int dcache_line = VM_Version::dcache_line_size();
 
@@ -182,45 +98,12 @@ void VM_Version::get_processor_features() {
     SoftwarePrefetchHintDistance &= ~7;
   }
 
-  uint64_t auxv = getauxval(AT_HWCAP);
-  uint64_t auxv2 = getauxval(AT_HWCAP2);
-
-  char buf[512];
-
-  _features = auxv;
-
-  int cpu_lines = 0;
-  if (FILE *f = fopen("/proc/cpuinfo", "r")) {
-    // need a large buffer as the flags line may include lots of text
-    char buf[1024], *p;
-    while (fgets(buf, sizeof (buf), f) != NULL) {
-      if ((p = strchr(buf, ':')) != NULL) {
-        long v = strtol(p+1, NULL, 0);
-        if (strncmp(buf, "CPU implementer", sizeof "CPU implementer" - 1) == 0) {
-          _cpu = v;
-          cpu_lines++;
-        } else if (strncmp(buf, "CPU variant", sizeof "CPU variant" - 1) == 0) {
-          _variant = v;
-        } else if (strncmp(buf, "CPU part", sizeof "CPU part" - 1) == 0) {
-          if (_model != v)  _model2 = _model;
-          _model = v;
-        } else if (strncmp(buf, "CPU revision", sizeof "CPU revision" - 1) == 0) {
-          _revision = v;
-        } else if (strncmp(buf, "flags", sizeof("flags") - 1) == 0) {
-          if (strstr(p+1, "dcpop")) {
-            _dcpop = true;
-          }
-        }
-      }
-    }
-    fclose(f);
-  }
 
   if (os::supports_map_sync()) {
     // if dcpop is available publish data cache line flush size via
     // generic field, otherwise let if default to zero thereby
     // disabling writeback
-    if (_dcpop) {
+    if (_features & CPU_DCPOP) {
       _data_cache_line_flush_size = dcache_line;
     }
   }
@@ -301,30 +184,31 @@ void VM_Version::get_processor_features() {
   }
 
   if (_cpu == CPU_ARM && (_model == 0xd07 || _model2 == 0xd07)) _features |= CPU_STXR_PREFETCH;
-  // If an olde style /proc/cpuinfo (cpu_lines == 1) then if _model is an A57 (0xd07)
+  // If an olde style /proc/cpuinfo (cores == 1) then if _model is an A57 (0xd07)
   // we assume the worst and assume we could be on a big little system and have
   // undisclosed A53 cores which we could be swapped to at any stage
-  if (_cpu == CPU_ARM && cpu_lines == 1 && _model == 0xd07) _features |= CPU_A53MAC;
+  if (_cpu == CPU_ARM && os::processor_count() == 1 && _model == 0xd07) _features |= CPU_A53MAC;
 
+  char buf[512];
   sprintf(buf, "0x%02x:0x%x:0x%03x:%d", _cpu, _variant, _model, _revision);
   if (_model2) sprintf(buf+strlen(buf), "(0x%03x)", _model2);
-  if (auxv & HWCAP_ASIMD) strcat(buf, ", simd");
-  if (auxv & HWCAP_CRC32) strcat(buf, ", crc");
-  if (auxv & HWCAP_AES)   strcat(buf, ", aes");
-  if (auxv & HWCAP_SHA1)  strcat(buf, ", sha1");
-  if (auxv & HWCAP_SHA2)  strcat(buf, ", sha256");
-  if (auxv & HWCAP_SHA512) strcat(buf, ", sha512");
-  if (auxv & HWCAP_ATOMICS) strcat(buf, ", lse");
-  if (auxv & HWCAP_SVE) strcat(buf, ", sve");
-  if (auxv2 & HWCAP2_SVE2) strcat(buf, ", sve2");
+  if (_features & CPU_ASIMD) strcat(buf, ", simd");
+  if (_features & CPU_CRC32) strcat(buf, ", crc");
+  if (_features & CPU_AES)   strcat(buf, ", aes");
+  if (_features & CPU_SHA1)  strcat(buf, ", sha1");
+  if (_features & CPU_SHA2)  strcat(buf, ", sha256");
+  if (_features & CPU_SHA512) strcat(buf, ", sha512");
+  if (_features & CPU_LSE) strcat(buf, ", lse");
+  if (_features & CPU_SVE) strcat(buf, ", sve");
+  if (_features & CPU_SVE2) strcat(buf, ", sve2");
 
   _features_string = os::strdup(buf);
 
   if (FLAG_IS_DEFAULT(UseCRC32)) {
-    UseCRC32 = (auxv & HWCAP_CRC32) != 0;
+    UseCRC32 = (_features & CPU_CRC32) != 0;
   }
 
-  if (UseCRC32 && (auxv & HWCAP_CRC32) == 0) {
+  if (UseCRC32 && (_features & CPU_CRC32) == 0) {
     warning("UseCRC32 specified, but not supported on this CPU");
     FLAG_SET_DEFAULT(UseCRC32, false);
   }
@@ -338,7 +222,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
   }
 
-  if (auxv & HWCAP_ATOMICS) {
+  if (_features & CPU_LSE) {
     if (FLAG_IS_DEFAULT(UseLSE))
       FLAG_SET_DEFAULT(UseLSE, true);
   } else {
@@ -348,7 +232,7 @@ void VM_Version::get_processor_features() {
     }
   }
 
-  if (auxv & HWCAP_AES) {
+  if (_features & CPU_AES) {
     UseAES = UseAES || FLAG_IS_DEFAULT(UseAES);
     UseAESIntrinsics =
         UseAESIntrinsics || (UseAES && FLAG_IS_DEFAULT(UseAESIntrinsics));
@@ -376,7 +260,7 @@ void VM_Version::get_processor_features() {
     UseCRC32Intrinsics = true;
   }
 
-  if (auxv & HWCAP_CRC32) {
+  if (_features & CPU_CRC32) {
     if (FLAG_IS_DEFAULT(UseCRC32CIntrinsics)) {
       FLAG_SET_DEFAULT(UseCRC32CIntrinsics, true);
     }
@@ -394,7 +278,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseMD5Intrinsics, false);
   }
 
-  if (auxv & (HWCAP_SHA1 | HWCAP_SHA2)) {
+  if (_features & (CPU_SHA1 | CPU_SHA2)) {
     if (FLAG_IS_DEFAULT(UseSHA)) {
       FLAG_SET_DEFAULT(UseSHA, true);
     }
@@ -403,7 +287,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA, false);
   }
 
-  if (UseSHA && (auxv & HWCAP_SHA1)) {
+  if (UseSHA && (_features & CPU_SHA1)) {
     if (FLAG_IS_DEFAULT(UseSHA1Intrinsics)) {
       FLAG_SET_DEFAULT(UseSHA1Intrinsics, true);
     }
@@ -412,7 +296,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA1Intrinsics, false);
   }
 
-  if (UseSHA && (auxv & HWCAP_SHA2)) {
+  if (UseSHA && (_features & CPU_SHA2)) {
     if (FLAG_IS_DEFAULT(UseSHA256Intrinsics)) {
       FLAG_SET_DEFAULT(UseSHA256Intrinsics, true);
     }
@@ -421,7 +305,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA256Intrinsics, false);
   }
 
-  if (UseSHA && (auxv & HWCAP_SHA512)) {
+  if (UseSHA && (_features & CPU_SHA512)) {
     // Do not auto-enable UseSHA512Intrinsics until it has been fully tested on hardware
     // if (FLAG_IS_DEFAULT(UseSHA512Intrinsics)) {
       // FLAG_SET_DEFAULT(UseSHA512Intrinsics, true);
@@ -435,7 +319,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA, false);
   }
 
-  if (auxv & HWCAP_PMULL) {
+  if (_features & CPU_PMULL) {
     if (FLAG_IS_DEFAULT(UseGHASHIntrinsics)) {
       FLAG_SET_DEFAULT(UseGHASHIntrinsics, true);
     }
@@ -456,12 +340,12 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseBlockZeroing, false);
   }
 
-  if (auxv & HWCAP_SVE) {
+  if (_features & CPU_SVE) {
     if (FLAG_IS_DEFAULT(UseSVE)) {
-      FLAG_SET_DEFAULT(UseSVE, (auxv2 & HWCAP2_SVE2) ? 2 : 1);
+      FLAG_SET_DEFAULT(UseSVE, (_features & CPU_SVE2) ? 2 : 1);
     }
     if (UseSVE > 0) {
-      _initial_sve_vector_length = prctl(PR_SVE_GET_VL);
+      _initial_sve_vector_length = get_current_sve_vector_length();
     }
   } else if (UseSVE > 0) {
     warning("UseSVE specified, but not supported on current CPU. Disabling SVE.");
@@ -509,11 +393,9 @@ void VM_Version::get_processor_features() {
       warning("SVE does not support vector length less than 16 bytes. Disabling SVE.");
       UseSVE = 0;
     } else if ((MaxVectorSize % 16) == 0 && is_power_of_2(MaxVectorSize)) {
-      int new_vl = prctl(PR_SVE_SET_VL, MaxVectorSize);
+      int new_vl = set_and_get_current_sve_vector_lenght(MaxVectorSize);
       _initial_sve_vector_length = new_vl;
-      // If MaxVectorSize is larger than system largest supported SVE vector length, above prctl()
-      // call will set task vector length to the system largest supported value. So, we also update
-      // MaxVectorSize to that largest supported value.
+      // Update MaxVectorSize to the largest supported value.
       if (new_vl < 0) {
         vm_exit_during_initialization(
           err_msg("Current system does not support SVE vector length for MaxVectorSize: %d",
@@ -554,22 +436,6 @@ void VM_Version::get_processor_features() {
     AlignVector = AvoidUnalignedAccesses;
   }
 #endif
-}
-
-void VM_Version::initialize() {
-  ResourceMark rm;
-
-  stub_blob = BufferBlob::create("getPsrInfo_stub", stub_size);
-  if (stub_blob == NULL) {
-    vm_exit_during_initialization("Unable to allocate getPsrInfo_stub");
-  }
-
-  CodeBuffer c(stub_blob);
-  VM_Version_StubGenerator g(&c);
-  getPsrInfo_stub = CAST_TO_FN_PTR(getPsrInfo_stub_t,
-                                   g.generate_getPsrInfo());
-
-  get_processor_features();
 
   UNSUPPORTED_OPTION(CriticalJNINatives);
 }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -24,13 +24,9 @@
  */
 
 #include "precompiled.hpp"
-#include "asm/macroAssembler.hpp"
-#include "asm/macroAssembler.inline.hpp"
-#include "memory/resourceArea.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
-#include "runtime/stubCodeGenerator.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/formatBuffer.hpp"
 #include "utilities/macros.hpp"

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -40,15 +40,20 @@ protected:
   static int _variant;
   static int _revision;
   static int _stepping;
-  static bool _dcpop;
+
+  static int _zva_length;
+  static int _dcache_line_size;
+  static int _icache_line_size;
   static int _initial_sve_vector_length;
 
-  struct PsrInfo {
-    uint32_t dczid_el0;
-    uint32_t ctr_el0;
-  };
-  static PsrInfo _psr_info;
-  static void get_processor_features();
+  // Read additional info using OS-specific interfaces
+  static void get_os_cpu_info();
+
+  // Sets the SVE length and returns a new actual value or negative on error.
+  // If the len is larger than the system largest supported SVE vector length,
+  // the function sets the largest supported value.
+  static int set_and_get_current_sve_vector_lenght(int len);
+  static int get_current_sve_vector_length();
 
 public:
   // Initialization
@@ -98,8 +103,13 @@ public:
     CPU_SHA2         = (1<<6),
     CPU_CRC32        = (1<<7),
     CPU_LSE          = (1<<8),
-    CPU_STXR_PREFETCH= (1 << 29),
-    CPU_A53MAC       = (1 << 30),
+    CPU_DCPOP        = (1<<16),
+    CPU_SHA512       = (1<<21),
+    CPU_SVE          = (1<<22),
+    // flags above must follow Linux HWCAP
+    CPU_SVE2         = (1<<28),
+    CPU_STXR_PREFETCH= (1<<29),
+    CPU_A53MAC       = (1<<30),
   };
 
   static int cpu_family()                     { return _cpu; }
@@ -107,26 +117,17 @@ public:
   static int cpu_model2()                     { return _model2; }
   static int cpu_variant()                    { return _variant; }
   static int cpu_revision()                   { return _revision; }
-  static bool supports_dcpop()                { return _dcpop; }
-  static int get_initial_sve_vector_length()  { return _initial_sve_vector_length; };
-  static ByteSize dczid_el0_offset() { return byte_offset_of(PsrInfo, dczid_el0); }
-  static ByteSize ctr_el0_offset()   { return byte_offset_of(PsrInfo, ctr_el0); }
-  static bool is_zva_enabled() {
-    // Check the DZP bit (bit 4) of dczid_el0 is zero
-    // and block size (bit 0~3) is not zero.
-    return ((_psr_info.dczid_el0 & 0x10) == 0 &&
-            (_psr_info.dczid_el0 & 0xf) != 0);
-  }
+
+  static bool is_zva_enabled() { return 0 <= _zva_length; }
   static int zva_length() {
     assert(is_zva_enabled(), "ZVA not available");
-    return 4 << (_psr_info.dczid_el0 & 0xf);
+    return _zva_length;
   }
-  static int icache_line_size() {
-    return (1 << (_psr_info.ctr_el0 & 0x0f)) * 4;
-  }
-  static int dcache_line_size() {
-    return (1 << ((_psr_info.ctr_el0 >> 16) & 0x0f)) * 4;
-  }
+
+  static int icache_line_size() { return _icache_line_size; }
+  static int dcache_line_size() { return _dcache_line_size; }
+  static int get_initial_sve_vector_length()  { return _initial_sve_vector_length; };
+
   static bool supports_fast_class_init_checks() { return true; }
 };
 

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -27,3 +27,140 @@
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
 
+#include <asm/hwcap.h>
+#include <sys/auxv.h>
+#include <sys/prctl.h>
+
+#ifndef HWCAP_AES
+#define HWCAP_AES   (1<<3)
+#endif
+
+#ifndef HWCAP_PMULL
+#define HWCAP_PMULL (1<<4)
+#endif
+
+#ifndef HWCAP_SHA1
+#define HWCAP_SHA1  (1<<5)
+#endif
+
+#ifndef HWCAP_SHA2
+#define HWCAP_SHA2  (1<<6)
+#endif
+
+#ifndef HWCAP_CRC32
+#define HWCAP_CRC32 (1<<7)
+#endif
+
+#ifndef HWCAP_ATOMICS
+#define HWCAP_ATOMICS (1<<8)
+#endif
+
+#ifndef HWCAP_DCPOP
+#define HWCAP_DCPOP (1<<16)
+#endif
+
+#ifndef HWCAP_SHA512
+#define HWCAP_SHA512 (1 << 21)
+#endif
+
+#ifndef HWCAP_SVE
+#define HWCAP_SVE (1 << 22)
+#endif
+
+#ifndef HWCAP2_SVE2
+#define HWCAP2_SVE2 (1 << 1)
+#endif
+
+#ifndef PR_SVE_GET_VL
+// For old toolchains which do not have SVE related macros defined.
+#define PR_SVE_SET_VL   50
+#define PR_SVE_GET_VL   51
+#endif
+
+int VM_Version::get_current_sve_vector_length() {
+  assert(_features & CPU_SVE, "should not call this");
+  return prctl(PR_SVE_GET_VL);
+}
+
+int VM_Version::set_and_get_current_sve_vector_lenght(int length) {
+  assert(_features & CPU_SVE, "should not call this");
+  int new_length = prctl(PR_SVE_SET_VL, length);
+  return new_length;
+}
+
+void VM_Version::get_os_cpu_info() {
+
+  uint64_t auxv = getauxval(AT_HWCAP);
+  uint64_t auxv2 = getauxval(AT_HWCAP2);
+
+  static_assert(CPU_FP      == HWCAP_FP);
+  static_assert(CPU_ASIMD   == HWCAP_ASIMD);
+  static_assert(CPU_EVTSTRM == HWCAP_EVTSTRM);
+  static_assert(CPU_AES     == HWCAP_AES);
+  static_assert(CPU_PMULL   == HWCAP_PMULL);
+  static_assert(CPU_SHA1    == HWCAP_SHA1);
+  static_assert(CPU_SHA2    == HWCAP_SHA2);
+  static_assert(CPU_CRC32   == HWCAP_CRC32);
+  static_assert(CPU_LSE     == HWCAP_ATOMICS);
+  static_assert(CPU_DCPOP   == HWCAP_DCPOP);
+  static_assert(CPU_SHA512  == HWCAP_SHA512);
+  static_assert(CPU_SVE     == HWCAP_SVE);
+  _features = auxv & (
+      HWCAP_FP      |
+      HWCAP_ASIMD   |
+      HWCAP_EVTSTRM |
+      HWCAP_AES     |
+      HWCAP_PMULL   |
+      HWCAP_SHA1    |
+      HWCAP_SHA2    |
+      HWCAP_CRC32   |
+      HWCAP_ATOMICS |
+      HWCAP_DCPOP   |
+      HWCAP_SHA512  |
+      HWCAP_SVE);
+
+  if (auxv2 & HWCAP2_SVE2) _features |= CPU_SVE2;
+
+  uint64_t ctr_el0;
+  uint64_t dczid_el0;
+  __asm__ (
+    "mrs %0, CTR_EL0\n"
+    "mrs %1, DCZID_EL0\n"
+    : "=r"(ctr_el0), "=r"(dczid_el0)
+  );
+
+  _icache_line_size = (1 << (ctr_el0 & 0x0f)) * 4;
+  _dcache_line_size = (1 << ((ctr_el0 >> 16) & 0x0f)) * 4;
+
+  if (!(dczid_el0 & 0x10)) {
+    _zva_length = 4 << (dczid_el0 & 0xf);
+  }
+
+  int cpu_lines = 0;
+  if (FILE *f = fopen("/proc/cpuinfo", "r")) {
+    // need a large buffer as the flags line may include lots of text
+    char buf[1024], *p;
+    while (fgets(buf, sizeof (buf), f) != NULL) {
+      if ((p = strchr(buf, ':')) != NULL) {
+        long v = strtol(p+1, NULL, 0);
+        if (strncmp(buf, "CPU implementer", sizeof "CPU implementer" - 1) == 0) {
+          _cpu = v;
+          cpu_lines++;
+        } else if (strncmp(buf, "CPU variant", sizeof "CPU variant" - 1) == 0) {
+          _variant = v;
+        } else if (strncmp(buf, "CPU part", sizeof "CPU part" - 1) == 0) {
+          if (_model != v)  _model2 = _model;
+          _model = v;
+        } else if (strncmp(buf, "CPU revision", sizeof "CPU revision" - 1) == 0) {
+          _revision = v;
+        } else if (strncmp(buf, "flags", sizeof("flags") - 1) == 0) {
+          if (strstr(p+1, "dcpop")) {
+            guarantee(_features & CPU_DCPOP, "dcpop availability should be consistent");
+          }
+        }
+      }
+    }
+    fclose(f);
+  }
+  guarantee(cpu_lines == os::processor_count(), "core count should be consistent");
+}

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -723,7 +723,7 @@
 #ifdef AARCH64
 
 #define VM_STRUCTS_CPU(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field, nonproduct_nonstatic_field, c2_nonstatic_field, unchecked_c1_static_field, unchecked_c2_static_field) \
-  static_field(VM_Version, _psr_info.dczid_el0, uint32_t)               \
+  static_field(VM_Version, _zva_length, int)                            \
   volatile_nonstatic_field(JavaFrameAnchor, _last_Java_fp, intptr_t*)
 
 #define VM_INT_CONSTANTS_CPU(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant) \

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -719,7 +719,8 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigAccess {
     // ARMv8-A architecture reference manual D12.2.35 Data Cache Zero ID register says:
     // * BS, bits [3:0] indicate log2 of the DC ZVA block size in (4-byte) words.
     // * DZP, bit [4] of indicates whether use of DC ZVA instruction is prohibited.
-    public final int psrInfoDczidValue = getFieldValue("VM_Version::_psr_info.dczid_el0", Integer.class, "uint32_t", 0x10, (JVMCI ? jvmciGE(JVMCI_19_3_b04) : (JDK == 14 || JDK == 15)) && osArch.equals("aarch64"));
+    public final int psrInfoDczidValue = getFieldValue("VM_Version::_psr_info.dczid_el0", Integer.class, "uint32_t", 0x10,
+                    (JVMCI ? jvmciGE(JVMCI_19_3_b04) : (JDK == 14 || JDK == 15)) && osArch.equals("aarch64"));
 
     public final int zvaLength = getFieldValue("VM_Version::_zva_length", Integer.class, "int", 0, JDK >= 16 && osArch.equals("aarch64"));
 

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -719,7 +719,9 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigAccess {
     // ARMv8-A architecture reference manual D12.2.35 Data Cache Zero ID register says:
     // * BS, bits [3:0] indicate log2 of the DC ZVA block size in (4-byte) words.
     // * DZP, bit [4] of indicates whether use of DC ZVA instruction is prohibited.
-    public final int psrInfoDczidValue = getFieldValue("VM_Version::_psr_info.dczid_el0", Integer.class, "uint32_t", 0x10, (JVMCI ? jvmciGE(JVMCI_19_3_b04) : JDK >= 14) && osArch.equals("aarch64"));
+    public final int psrInfoDczidValue = getFieldValue("VM_Version::_psr_info.dczid_el0", Integer.class, "uint32_t", 0x10, (JVMCI ? jvmciGE(JVMCI_19_3_b04) : (JDK == 14 || JDK == 15)) && osArch.equals("aarch64"));
+
+    public final int zvaLength = getFieldValue("VM_Version::_zva_length", Integer.class, "int", 0, JDK >= 16 && osArch.equals("aarch64"));
 
     // FIXME This is only temporary until the GC code is changed.
     public final boolean inlineContiguousAllocationSupported = getFieldValue("CompilerToVM::Data::_supports_inline_contig_alloc", Boolean.class);


### PR DESCRIPTION
Please review a change to remove Linux-specific code from hotspot/cpu/aarch64.

The change is made to prepare for non-linux aarch64 platforms. 

vm_version no longer contains any "raw" values that were obtained directly from the platform registers. Some of them may be unavailable on certain architectures, like `ctr_el0` is not available on windows [1].

Few opportunities to improve linux code were taken:
1. `HWCAP_` flags now explicitly mapped to `CPU_`
2. `_dcpop` boolean was replaced with `CPU_DCPOP`
3. Code generation to get the platform register values was replaced with inline assembly. There is no a code buffer allocation anymore.

Graal-related changes: https://github.com/oracle/graal/pull/2861

Testing:
* local hotspot tier1
* looking at detected features
* looking at debug output for `isDcZvaProhibited` and `zvaLength` values in Graal (not committed) -- have not changed
* looking at the results of `./graal-compiler-micro-benchmarks.jar -p size=128,256,512,1024,2048,4096,8192,16384,32768,65536,131072 ArrayAllocationBenchmark.arrayAllocate` (https://github.com/oracle/graal/commit/dcb4506e4da05db74e8b4007e2845458e8c555e2) -- the benchmark is noisy in my environment, probably too many threads are used. Manually compared iterations, there is no regression spotted.

[1] https://mail.openjdk.java.net/pipermail/aarch64-port-dev/2020-September/009690.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253015](https://bugs.openjdk.java.net/browse/JDK-8253015): Aarch64: Move linux code out from generic CPU feature detection


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/154/head:pull/154`
`$ git checkout pull/154`
