### PR TITLE
8253098: Archived full module graph should be disabled if CDS heap cannot be mapped

### DIFF
--- a/src/hotspot/share/memory/filemap.cpp
+++ b/src/hotspot/share/memory/filemap.cpp
@@ -1846,6 +1846,7 @@ void FileMapInfo::map_heap_regions() {
 
   if (!HeapShared::open_archive_heap_region_mapped()) {
     assert(open_archive_heap_ranges == NULL && num_open_archive_heap_ranges == 0, "sanity");
+    MetaspaceShared::disable_full_module_graph();
   }
 }
 


### PR DESCRIPTION
Please review this simple fix -- `MetaspaceShared::use_full_module_graph()` depends on the CDS heap. It should be disabled if the CDS heap cannot be mapped.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253098](https://bugs.openjdk.java.net/browse/JDK-8253098): Disable archived module graph if CDS heap cannot be mapped ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/158/head:pull/158`
`$ git checkout pull/158`
