### PR TITLE
8220483: Calendar.setTime(Date date) throws NPE with Date date = null

### DIFF
--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -1796,8 +1796,10 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * @param date the given Date.
      * @see #getTime()
      * @see #setTimeInMillis(long)
+     * @throws NullPointerException if {@code date} is {@code null}
      */
     public final void setTime(Date date) {
+        Objects.requireNonNull(date, "date must not be null");
         setTimeInMillis(date.getTime());
     }
 


### PR DESCRIPTION
Hi,

Please review this simple doc fix.

/issue add 8220483
/csr needed
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8220483](https://bugs.openjdk.java.net/browse/JDK-8220483): Calendar.setTime(Date date) throws NPE with Date date = null


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/159/head:pull/159`
`$ git checkout pull/159`
