### PR TITLE
8253034: Update symbol generation to accomodate Git as the SCM

### DIFF
--- a/make/scripts/generate-symbol-data.sh
+++ b/make/scripts/generate-symbol-data.sh
@@ -63,7 +63,7 @@ if [ ! -f symbols ] ; then
     exit 1
 fi;
 
-if [ "`git status -s .`x" != "x" ] ; then
+if [ "`git status --porcelain=v1 .`x" != "x" ] ; then
     echo "The make/data/symbols directory contains local changes!" >&2
     exit 1
 fi;

--- a/make/scripts/generate-symbol-data.sh
+++ b/make/scripts/generate-symbol-data.sh
@@ -63,7 +63,7 @@ if [ ! -f symbols ] ; then
     exit 1
 fi;
 
-if [ "`hg status .`x" != "x" ] ; then
+if [ "`git status -s .`x" != "x" ] ; then
     echo "The make/data/symbols directory contains local changes!" >&2
     exit 1
 fi;


### PR DESCRIPTION
The symbol generation script assumed Mercurial was being used as the SCM. This should now be updated to Git.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253034](https://bugs.openjdk.java.net/browse/JDK-8253034): Update symbol generation to accomodate Git as the SCM


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 2910def1fd84c2b47a38626f131a1a16b88e989e
 * [Aditya Mandaleeka](https://openjdk.java.net/census#adityam) (@adityamandaleeka - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/161/head:pull/161`
`$ git checkout pull/161`
