### PR TITLE
8253253: Binutils tar ball extension update to gz

### DIFF
--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -125,7 +125,7 @@ else
 endif
 
 GCC := http://ftp.gnu.org/pub/gnu/gcc/$(gcc_ver)/$(gcc_ver).tar.xz
-BINUTILS := http://ftp.gnu.org/pub/gnu/binutils/$(binutils_ver).tar.xz
+BINUTILS := http://ftp.gnu.org/pub/gnu/binutils/$(binutils_ver).tar.gz
 CCACHE := https://github.com/ccache/ccache/releases/download/v$(ccache_ver)/ccache-$(ccache_ver).tar.xz
 MPFR := https://www.mpfr.org/${mpfr_ver}/${mpfr_ver}.tar.bz2
 GMP := http://ftp.gnu.org/pub/gnu/gmp/${gmp_ver}.tar.bz2


### PR DESCRIPTION
Our infra team found this error when building DevKit with GCC 4.9.2. The binutils version is 2.25, and an *.xz doesn't exist on https://ftp.gnu.org/pub/gnu/binutils.  Hence, we would like to submit a PR to update *.xz to *.gz.

We have confirmed that *.gz exists for all binutil version.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253253](https://bugs.openjdk.java.net/browse/JDK-8253253): Binutils tar ball extension update to gz


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/162/head:pull/162`
`$ git checkout pull/162`
