### PR TITLE
8250668 : Clean up method_oop names in adlc

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -614,8 +614,8 @@ alloc_class chunk3(RFLAGS);
 // Several register classes are automatically defined based upon information in
 // this architecture description.
 // 1) reg_class inline_cache_reg           ( /* as def'd in frame section */ )
-// 2) reg_class compiler_method_oop_reg    ( /* as def'd in frame section */ )
-// 2) reg_class interpreter_method_oop_reg ( /* as def'd in frame section */ )
+// 2) reg_class compiler_method_reg        ( /* as def'd in frame section */ )
+// 2) reg_class interpreter_method_reg     ( /* as def'd in frame section */ )
 // 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //
 
@@ -4049,8 +4049,8 @@ frame %{
   // Inline Cache Register or Method for I2C.
   inline_cache_reg(R12);
 
-  // Method Oop Register when calling interpreter.
-  interpreter_method_oop_reg(R12);
+  // Method Register when calling interpreter.
+  interpreter_method_reg(R12);
 
   // Number of stack slots consumed by locking an object
   sync_stack_slots(2);
@@ -5619,9 +5619,9 @@ operand inline_cache_RegP(iRegP reg)
   interface(REG_INTER);
 %}
 
-operand interpreter_method_oop_RegP(iRegP reg)
+operand interpreter_method_RegP(iRegP reg)
 %{
-  constraint(ALLOC_IN_RC(method_reg)); // interpreter_method_oop_reg
+  constraint(ALLOC_IN_RC(method_reg)); // interpreter_method_reg
   match(reg);
   match(iRegPNoSp);
   op_cost(0);

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -1667,7 +1667,7 @@ frame %{
   // These two registers define part of the calling convention
   // between compiled code and the interpreter.
   inline_cache_reg(R_Ricklass);          // Inline Cache Register or Method* for I2C
-  interpreter_method_oop_reg(R_Rmethod); // Method Oop Register when calling interpreter
+  interpreter_method_reg(R_Rmethod);     // Method Register when calling interpreter
 
   // Optional: name the operand used by cisc-spilling to access [stack_pointer + offset]
   cisc_spilling_operand_name(indOffset);
@@ -2527,7 +2527,7 @@ operand inline_cache_regP(iRegP reg) %{
   interface(REG_INTER);
 %}
 
-operand interpreter_method_oop_regP(iRegP reg) %{
+operand interpreter_method_regP(iRegP reg) %{
   constraint(ALLOC_IN_RC(Rmethod_regP));
   match(reg);
   format %{ %}

--- a/src/hotspot/cpu/arm/arm_32.ad
+++ b/src/hotspot/cpu/arm/arm_32.ad
@@ -196,7 +196,7 @@ alloc_class chunk2(APSR, FPSCR);
 // Several register classes are automatically defined based upon information in
 // this architecture description.
 // 1) reg_class inline_cache_reg           ( as defined in frame section )
-// 2) reg_class interpreter_method_oop_reg ( as defined in frame section )
+// 2) reg_class interpreter_method_reg     ( as defined in frame section )
 // 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //
 

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -535,8 +535,8 @@ alloc_class chunk4 (
 // information in this architecture description.
 
 // 1) reg_class inline_cache_reg           ( as defined in frame section )
-// 2) reg_class compiler_method_oop_reg    ( as defined in frame section )
-// 2) reg_class interpreter_method_oop_reg ( as defined in frame section )
+// 2) reg_class compiler_method_reg        ( as defined in frame section )
+// 2) reg_class interpreter_method_reg     ( as defined in frame section )
 // 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //
 
@@ -3863,8 +3863,8 @@ frame %{
   // Inline Cache Register or method for I2C.
   inline_cache_reg(R19); // R19_method
 
-  // Method Oop Register when calling interpreter.
-  interpreter_method_oop_reg(R19); // R19_method
+  // Method Register when calling interpreter.
+  interpreter_method_reg(R19); // R19_method
 
   // Optional: name the operand used by cisc-spilling to access
   // [stack_pointer + offset].
@@ -4773,15 +4773,15 @@ operand inline_cache_regP(iRegPdst reg) %{
   interface(REG_INTER);
 %}
 
-operand compiler_method_oop_regP(iRegPdst reg) %{
-  constraint(ALLOC_IN_RC(rscratch1_bits64_reg)); // compiler_method_oop_reg
+operand compiler_method_regP(iRegPdst reg) %{
+  constraint(ALLOC_IN_RC(rscratch1_bits64_reg)); // compiler_method_reg
   match(reg);
   format %{ %}
   interface(REG_INTER);
 %}
 
-operand interpreter_method_oop_regP(iRegPdst reg) %{
-  constraint(ALLOC_IN_RC(r19_bits64_reg)); // interpreter_method_oop_reg
+operand interpreter_method_regP(iRegPdst reg) %{
+  constraint(ALLOC_IN_RC(r19_bits64_reg)); // interpreter_method_reg
   match(reg);
   format %{ %}
   interface(REG_INTER);

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -1258,7 +1258,7 @@ void LIR_Assembler::emit_static_call_stub() {
 
   __ relocate(static_stub_Relocation::spec(call_pc));
 
-  // See also Matcher::interpreter_method_oop_reg().
+  // See also Matcher::interpreter_method_reg().
   AddressLiteral meta = __ allocate_metadata_address(NULL);
   bool success = __ load_const_from_toc(Z_method, meta);
 

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -278,8 +278,8 @@ alloc_class chunk2(
 // information in this architecture description.
 
 // 1) reg_class inline_cache_reg           (as defined in frame section)
-// 2) reg_class compiler_method_oop_reg    (as defined in frame section)
-// 2) reg_class interpreter_method_oop_reg (as defined in frame section)
+// 2) reg_class compiler_method_reg        (as defined in frame section)
+// 2) reg_class interpreter_method_reg     (as defined in frame section)
 // 3) reg_class stack_slots(/* one chunk of stack-based "registers" */)
 
 // Integer Register Classes
@@ -2468,10 +2468,10 @@ frame %{
   // interpreter_arg_ptr_reg(Z_R6);
 
   // Temporary in compiled entry-points
-  // compiler_method_oop_reg(Z_R1);//Z_R1_scratch
+  // compiler_method_reg(Z_R1);//Z_R1_scratch
 
-  // Method Oop Register when calling interpreter
-  interpreter_method_oop_reg(Z_R9);//Z_method
+  // Method Register when calling interpreter
+  interpreter_method_reg(Z_R9);//Z_method
 
   // Optional: name the operand used by cisc-spilling to access
   // [stack_pointer + offset].
@@ -3536,15 +3536,15 @@ operand inline_cache_regP(iRegP reg) %{
   interface(REG_INTER);
 %}
 
-operand compiler_method_oop_regP(iRegP reg) %{
-  constraint(ALLOC_IN_RC(z_r1_RegP)); // compiler_method_oop_reg
+operand compiler_method_regP(iRegP reg) %{
+  constraint(ALLOC_IN_RC(z_r1_RegP)); // compiler_method_reg
   match(reg);
   format %{ %}
   interface(REG_INTER);
 %}
 
-operand interpreter_method_oop_regP(iRegP reg) %{
-  constraint(ALLOC_IN_RC(z_r9_regP)); // interpreter_method_oop_reg
+operand interpreter_method_regP(iRegP reg) %{
+  constraint(ALLOC_IN_RC(z_r9_regP)); // interpreter_method_reg
   match(reg);
   format %{ %}
   interface(REG_INTER);

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -131,8 +131,8 @@ alloc_class chunk0( ECX,   EBX,   EBP,   EDI,   EAX,   EDX,   ESI, ESP,
 // Several register classes are automatically defined based upon information in
 // this architecture description.
 // 1) reg_class inline_cache_reg           ( /* as def'd in frame section */ )
-// 2) reg_class compiler_method_oop_reg    ( /* as def'd in frame section */ )
-// 2) reg_class interpreter_method_oop_reg ( /* as def'd in frame section */ )
+// 2) reg_class compiler_method_reg        ( /* as def'd in frame section */ )
+// 2) reg_class interpreter_method_reg     ( /* as def'd in frame section */ )
 // 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //
 // Class for no registers (empty set).
@@ -1931,7 +1931,7 @@ encode %{
 //   enc_class Java_Interpreter_Call (label labl) %{    // JAVA INTERPRETER CALL
 //     // int ic_reg     = Matcher::inline_cache_reg();
 //     // int ic_encode  = Matcher::_regEncode[ic_reg];
-//     // int imo_reg    = Matcher::interpreter_method_oop_reg();
+//     // int imo_reg    = Matcher::interpreter_method_reg();
 //     // int imo_encode = Matcher::_regEncode[imo_reg];
 //
 //     // // Interpreter expects method_ptr in EBX, currently a callee-saved register,
@@ -3194,7 +3194,7 @@ frame %{
   // These three registers define part of the calling convention
   // between compiled code and the interpreter.
   inline_cache_reg(EAX);                // Inline Cache Register
-  interpreter_method_oop_reg(EBX);      // Method Oop Register when calling interpreter
+  interpreter_method_reg(EBX);          // Method Register when calling interpreter
 
   // Optional: name the operand used by cisc-spilling to access [stack_pointer + offset]
   cisc_spilling_operand_name(indOffset32);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -161,8 +161,8 @@ alloc_class chunk0(R10,         R10_H,
 // Several register classes are automatically defined based upon information in
 // this architecture description.
 // 1) reg_class inline_cache_reg           ( /* as def'd in frame section */ )
-// 2) reg_class compiler_method_oop_reg    ( /* as def'd in frame section */ )
-// 2) reg_class interpreter_method_oop_reg ( /* as def'd in frame section */ )
+// 2) reg_class compiler_method_reg        ( /* as def'd in frame section */ )
+// 2) reg_class interpreter_method_reg     ( /* as def'd in frame section */ )
 // 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //
 
@@ -2743,7 +2743,7 @@ frame
   // These three registers define part of the calling convention
   // between compiled code and the interpreter.
   inline_cache_reg(RAX);                // Inline Cache Register
-  interpreter_method_oop_reg(RBX);      // Method Oop Register when
+  interpreter_method_reg(RBX);          // Method Register when
                                         // calling interpreter
 
   // Optional: name the operand used by cisc-spilling to access

--- a/src/hotspot/share/adlc/adlparse.cpp
+++ b/src/hotspot/share/adlc/adlparse.cpp
@@ -1002,7 +1002,11 @@ void ADLParser::frame_parse(void) {
         skipws();
       }
       if (strcmp(token,"interpreter_method_oop_reg")==0) {
-        interpreter_method_oop_parse(frame, false);
+        parse_err(WARN, "Using obsolete Token, interpreter_method_oop_reg");
+        skipws();
+      }
+      if (strcmp(token,"interpreter_method_reg")==0) {
+        interpreter_method_parse(frame, false);
       }
       if (strcmp(token,"cisc_spilling_operand_name")==0) {
         cisc_spilling_operand_name_parse(frame, false);
@@ -1130,9 +1134,9 @@ void ADLParser::inline_cache_parse(FrameForm *frame, bool native) {
   frame->_inline_cache_reg = parse_one_arg("inline cache reg entry");
 }
 
-//------------------------------interpreter_method_oop_parse------------------
-void ADLParser::interpreter_method_oop_parse(FrameForm *frame, bool native) {
-  frame->_interpreter_method_oop_reg = parse_one_arg("method reg entry");
+//------------------------------interpreter_method_parse------------------
+void ADLParser::interpreter_method_parse(FrameForm *frame, bool native) {
+  frame->_interpreter_method_reg = parse_one_arg("method reg entry");
 }
 
 //------------------------------cisc_spilling_operand_parse---------------------

--- a/src/hotspot/share/adlc/adlparse.hpp
+++ b/src/hotspot/share/adlc/adlparse.hpp
@@ -115,7 +115,7 @@ protected:
   void interpreter_frame_pointer_parse(FrameForm *frame, bool native);
   void inline_cache_parse(FrameForm *frame, bool native);
   void interpreter_arg_ptr_parse(FrameForm *frame, bool native);
-  void interpreter_method_oop_parse(FrameForm *frame, bool native);
+  void interpreter_method_parse(FrameForm *frame, bool native);
   void cisc_spilling_operand_name_parse(FrameForm *frame, bool native);
   void stack_alignment_parse(FrameForm *frame);
   void return_addr_parse(FrameForm *frame, bool native);

--- a/src/hotspot/share/adlc/formsopt.hpp
+++ b/src/hotspot/share/adlc/formsopt.hpp
@@ -336,7 +336,7 @@ public:
   // Public Data
   char *_sync_stack_slots;
   char *_inline_cache_reg;
-  char *_interpreter_method_oop_reg;
+  char *_interpreter_method_reg;
   char *_interpreter_frame_pointer_reg;
   char *_cisc_spilling_operand_name;
   char *_frame_pointer;

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -4192,12 +4192,12 @@ void ArchDesc::buildFrameMethods(FILE *fp_cpp) {
   fprintf(fp_cpp,"int Matcher::inline_cache_reg_encode() {");
   fprintf(fp_cpp," return _regEncode[inline_cache_reg()]; }\n\n");
 
-  // Interpreter's Method Oop Register, mask definition, and encoding
-  fprintf(fp_cpp,"OptoReg::Name Matcher::interpreter_method_oop_reg() {");
+  // Interpreter's Method Register, mask definition, and encoding
+  fprintf(fp_cpp,"OptoReg::Name Matcher::interpreter_method_reg() {");
   fprintf(fp_cpp," return OptoReg::Name(%s_num); }\n\n",
-          _frame->_interpreter_method_oop_reg);
-  fprintf(fp_cpp,"int Matcher::interpreter_method_oop_reg_encode() {");
-  fprintf(fp_cpp," return _regEncode[interpreter_method_oop_reg()]; }\n\n");
+          _frame->_interpreter_method_reg);
+  fprintf(fp_cpp,"int Matcher::interpreter_method_reg_encode() {");
+  fprintf(fp_cpp," return _regEncode[interpreter_method_reg()]; }\n\n");
 
   // Interpreter's Frame Pointer Register, mask definition, and encoding
   fprintf(fp_cpp,"OptoReg::Name Matcher::interpreter_frame_pointer_reg() {");

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -495,7 +495,7 @@ class ConstantPool : public Metadata {
   // a String entry.
   // This can happen if the user patches a live
   // object into a CONSTANT_String entry of an unsafe anonymous class.
-  // Method oops internally created for method handles may also
+  // Methods internally created for method handles may also
   // use pseudo-strings to link themselves to related metaobjects.
 
   bool is_pseudo_string_at(int which);

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -415,12 +415,12 @@ public:
   // The Method-klass-holder may be passed in the inline_cache_reg
   // and then expanded into the inline_cache_reg and a method_ptr register
 
-  static OptoReg::Name  interpreter_method_oop_reg();
-  static int            interpreter_method_oop_reg_encode();
+  static OptoReg::Name  interpreter_method_reg();
+  static int            interpreter_method_reg_encode();
 
-  static OptoReg::Name  compiler_method_oop_reg();
-  static const RegMask &compiler_method_oop_reg_mask();
-  static int            compiler_method_oop_reg_encode();
+  static OptoReg::Name  compiler_method_reg();
+  static const RegMask &compiler_method_reg_mask();
+  static int            compiler_method_reg_encode();
 
   // Interpreter's Frame Pointer Register
   static OptoReg::Name  interpreter_frame_pointer_reg();

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -338,9 +338,9 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   volatile_nonstatic_field(ConstantPoolCacheEntry,      _f2,                                  intx)                                  \
   volatile_nonstatic_field(ConstantPoolCacheEntry,      _flags,                               intx)                                  \
                                                                                                                                      \
-  /********************************/                                                                                                 \
-  /* MethodOop-related structures */                                                                                                 \
-  /********************************/                                                                                                 \
+  /*****************************/                                                                                                    \
+  /* Method related structures */                                                                                                    \
+  /*****************************/                                                                                                    \
                                                                                                                                      \
   nonstatic_field(CheckedExceptionElement,     class_cp_index,                                u2)                                    \
   nonstatic_field(LocalVariableTableElement,   start_bci,                                     u2)                                    \
@@ -1284,9 +1284,9 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
                                                                           \
   declare_toplevel_type(OopHandle)                                        \
                                                                           \
-  /*************************************/                                 \
-  /* MethodOop-related data structures */                                 \
-  /*************************************/                                 \
+  /**********************************/                                    \
+  /* Method related data structures */                                    \
+  /**********************************/                                    \
                                                                           \
   declare_toplevel_type(CheckedExceptionElement)                          \
   declare_toplevel_type(LocalVariableTableElement)                        \


### PR DESCRIPTION
Relates to: https://bugs.openjdk.java.net/browse/JDK-8250668
Tested on: x86_64 {windows, linux, os x} x {jdk-tier1-part1..3, hotspot-tier1-gc}
Follow up from this thread: https://mail.openjdk.java.net/pipermail/hotspot-compiler-dev/2020-September/039846.html

Rename occurrences of 'method_oop' under `src/` to just `method'.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250668](https://bugs.openjdk.java.net/browse/JDK-8250668): Clean up method_oop names in adlc


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Aditya Mandaleeka](https://openjdk.java.net/census#adityam) (@adityamandaleeka - Author)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/164/head:pull/164`
`$ git checkout pull/164`
