### PR TITLE
8253147: The javax/swing/JPopupMenu/7154841/bug7154841.java fail on big screens

### DIFF
--- a/test/jdk/java/awt/ColorClass/AlphaColorTest.java
+++ b/test/jdk/java/awt/ColorClass/AlphaColorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,8 +84,8 @@ public class AlphaColorTest extends Component {
         Color color = new Color(255, 255, 255, 127);
         frame.add("Center", new AlphaColorTest(color));
         frame.setUndecorated(true);
-        frame.setLocationRelativeTo(null);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 }

--- a/test/jdk/javax/swing/JPopupMenu/7154841/bug7154841.java
+++ b/test/jdk/javax/swing/JPopupMenu/7154841/bug7154841.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ public class bug7154841 {
 
     private static void initAndShowUI() {
         popupMenu = new JPopupMenu();
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 400; i++) {
             JRadioButtonMenuItem item = new JRadioButtonMenuItem(" Test " + i);
             item.addMouseMotionListener(new MouseMotionAdapter() {
                 @Override


### PR DESCRIPTION
This test creates a big popup menu and assumes that 100 popup items overlap the screen height, but on some big screens more items should be added. + small cleanup
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253147](https://bugs.openjdk.java.net/browse/JDK-8253147): The javax/swing/JPopupMenu/7154841/bug7154841.java fail on big screens


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/165/head:pull/165`
`$ git checkout pull/165`
