### PR TITLE
8253148: Fix terminology in align_down comment

### DIFF
--- a/src/hotspot/share/utilities/align.hpp
+++ b/src/hotspot/share/utilities/align.hpp
@@ -60,8 +60,8 @@ constexpr bool is_aligned(T size, A alignment) {
 
 template<typename T, typename A, ENABLE_IF(std::is_integral<T>::value)>
 constexpr T align_down(T size, A alignment) {
-  // Convert mask to T before lognot.  Otherwise, if alignment is unsigned
-  // and smaller than T, the result of the lognot will be zero-extended
+  // Convert mask to T before logical_not.  Otherwise, if alignment is unsigned
+  // and smaller than T, the result of the logical_not will be zero-extended
   // by integral promotion, and upper bits of size will be discarded.
   T result = size & ~T(alignment_mask(alignment));
   assert(is_aligned(result, alignment),


### PR DESCRIPTION
Please review this trivial terminology change in a comment.  This was supposed to be part of JDK-8247910, but I forgot to push this comment change before integrating.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253148](https://bugs.openjdk.java.net/browse/JDK-8253148): Fix terminology in align_down comment


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/166/head:pull/166`
`$ git checkout pull/166`
