### PR TITLE
8253146: C2: Purge unused MachCallNode::_arg_size field

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -3605,7 +3605,6 @@ encode %{
     call->_tf                = _tf;
     call->_entry_point       = _entry_point;
     call->_cnt               = _cnt;
-    call->_argsize           = _argsize;
     call->_oop_map           = _oop_map;
     call->_jvms              = _jvms;
     call->_jvmadj            = _jvmadj;
@@ -3806,7 +3805,6 @@ encode %{
     call->_tf          = _tf;
     call->_entry_point = _entry_point;
     call->_cnt         = _cnt;
-    call->_argsize     = _argsize;
     call->_oop_map     = _oop_map;
     guarantee(!_jvms, "You must clone the jvms and adapt the offsets by fix_jvms().");
     call->_jvms        = NULL;

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -880,17 +880,14 @@ public:
   const TypeFunc *_tf;        // Function type
   address      _entry_point;  // Address of the method being called
   float        _cnt;          // Estimate of number of times called
-  uint         _argsize;      // Size of argument block on stack
 
   const TypeFunc* tf()        const { return _tf; }
   const address entry_point() const { return _entry_point; }
   const float   cnt()         const { return _cnt; }
-  uint argsize()              const { return _argsize; }
 
   void set_tf(const TypeFunc* tf) { _tf = tf; }
   void set_entry_point(address p) { _entry_point = p; }
   void set_cnt(float c)           { _cnt = c; }
-  void set_argsize(int s)         { _argsize = s; }
 
   MachCallNode() : MachSafePointNode() {
     init_class_id(Class_MachCall);

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -1305,10 +1305,6 @@ MachNode *Matcher::match_sfpt( SafePointNode *sfpt ) {
       if (OptoReg::is_valid(reg2))
         rm->Insert( reg2 );
     } // End of for all arguments
-
-    // Compute number of stack slots needed to restore stack in case of
-    // Pascal-style argument popping.
-    mcall->_argsize = out_arg_limit_per_call - begin_out_arg_area;
   }
 
   // Compute the max stack slot killed by any call.  These will not be


### PR DESCRIPTION
While doing changes in related code, noticed that `MachCallNode::_arg_size` is computed needlessly, taking memory without a good reason. Let's purge it.

Testing: text search for _argsize; Linux x86_64 {release,fastdebug,slowdebug} builds; Linux x86_64 tier1; Linux ppc64 fastdebug build
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253146](https://bugs.openjdk.java.net/browse/JDK-8253146): C2: Purge unused MachCallNode::_arg_size field


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Aditya Mandaleeka](https://openjdk.java.net/census#adityam) (@adityamandaleeka - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/167/head:pull/167`
`$ git checkout pull/167`
