### PR TITLE
8253155: Minor cleanups and Javadoc fixes for LdapDnsProvider of java.naming

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/DefaultLdapDnsProvider.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/DefaultLdapDnsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,13 @@
 
 package com.sun.jndi.ldap;
 
-import javax.naming.NamingException;
-import javax.naming.ldap.spi.LdapDnsProvider;
-import javax.naming.ldap.spi.LdapDnsProviderResult;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import javax.naming.NamingException;
+import javax.naming.ldap.spi.LdapDnsProviderResult;
 
 public class DefaultLdapDnsProvider {
 
@@ -82,5 +82,4 @@ public class DefaultLdapDnsProvider {
             return Optional.of(res);
         }
     }
-
 }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapDnsProviderService.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapDnsProviderService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ final class LdapDnsProviderService {
      * subclasses of {@code LdapDnsProvider} then this method will fall back
      * to the {@code DefaultLdapDnsProvider}.
      *
-     * @throws NamingException if the {@code url} in not valid or an error
+     * @throws NamingException if the {@code url} is not valid or an error
      *                         occurred while performing the lookup.
      */
     LdapDnsProviderResult lookupEndpoints(String url, Hashtable<?,?> env)
@@ -110,5 +110,4 @@ final class LdapDnsProviderService {
         }
         return result;
     }
-
 }

--- a/src/java.naming/share/classes/javax/naming/ldap/spi/LdapDnsProvider.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/spi/LdapDnsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,5 +105,4 @@ public abstract class LdapDnsProvider {
      */
     public abstract Optional<LdapDnsProviderResult> lookupEndpoints(
             String url, Map<?,?> env) throws NamingException;
-
 }

--- a/src/java.naming/share/classes/javax/naming/ldap/spi/LdapDnsProviderResult.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/spi/LdapDnsProviderResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.util.List;
  *
  * <p> This class is used by an {@link LdapDnsProvider} to return the result
  * of a DNS lookup for a given LDAP URL. The result consists of a domain name
- * and its associated ldap server endpoints.
+ * and its associated LDAP server endpoints.
  *
  * <p> A {@code null} {@code domainName} is equivalent to and represented
  * by an empty string.
@@ -46,10 +46,10 @@ public final class LdapDnsProviderResult {
 
     /**
      * Construct an LdapDnsProviderResult consisting of a resolved domain name
-     * and the ldap server endpoints that serve the domain.
+     * and the LDAP server endpoints that serve the domain.
      *
      * @param domainName    the resolved domain name; can be null.
-     * @param endpoints     the possibly empty list of resolved ldap server
+     * @param endpoints     the possibly empty list of resolved LDAP server
      *                      endpoints
      *
      * @throws NullPointerException   if {@code endpoints} contains {@code null}
@@ -63,7 +63,7 @@ public final class LdapDnsProviderResult {
     }
 
     /**
-     * Returns the domain name resolved from the ldap URL. This method returns
+     * Returns the domain name resolved from the LDAP URL. This method returns
      * the empty string if the {@code LdapDnsProviderResult} is created with a
      * null domain name.
      *
@@ -75,13 +75,12 @@ public final class LdapDnsProviderResult {
 
     /**
      * Returns the possibly empty list of individual server endpoints resolved
-     * from the ldap URL.
+     * from the LDAP URL.
      *
      * @return  a possibly empty unmodifiable {@link List} containing the
-     *          resolved ldap server endpoints
+     *          resolved LDAP server endpoints
      */
     public List<String> getEndpoints() {
         return endpoints;
     }
-
 }


### PR DESCRIPTION
There are some little flaws in LdapDNSProvider and auxilliary classes, mostly in Javadoc.

In detail:
src/java.naming/share/classes/com/sun/jndi/ldap/DefaultLdapDnsProvider.java: Unnecessary import
src/java.naming/share/classes/com/sun/jndi/ldap/LdapDnsProviderService.java: typo
src/java.naming/share/classes/javax/naming/ldap/spi/LdapDnsProvider.java: Whitespace
src/java.naming/share/classes/javax/naming/ldap/spi/LdapDnsProviderResult.java: Spelling of "ldap" -> should be capitalized
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253155](https://bugs.openjdk.java.net/browse/JDK-8253155): Minor cleanups and Javadoc fixes for LdapDnsProvider of java.naming


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * vtewari - Committer ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/168/head:pull/168`
`$ git checkout pull/168`
