### PR TITLE
8245309: Re-examine use of ThreadLocalCoders in sun.net.www.ParseUtil

### DIFF
--- a/src/java.base/share/classes/sun/net/www/ParseUtil.java
+++ b/src/java.base/share/classes/sun/net/www/ParseUtil.java
@@ -178,8 +178,8 @@ public final class ParseUtil {
         ByteBuffer bb = ByteBuffer.allocate(n);
         CharBuffer cb = CharBuffer.allocate(n);
         CharsetDecoder dec = UTF_8.INSTANCE.newDecoder()
-                .onMalformedInput(CodingErrorAction.REPLACE)
-                .onUnmappableCharacter(CodingErrorAction.REPLACE);
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
 
         char c = s.charAt(0);
         for (int i = 0; i < n;) {

--- a/src/java.base/share/classes/sun/net/www/ParseUtil.java
+++ b/src/java.base/share/classes/sun/net/www/ParseUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,10 +34,10 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 
-import sun.nio.cs.ThreadLocalCoders;
 import sun.nio.cs.UTF_8;
 
 /**
@@ -177,9 +177,9 @@ public final class ParseUtil {
         StringBuilder sb = new StringBuilder(n);
         ByteBuffer bb = ByteBuffer.allocate(n);
         CharBuffer cb = CharBuffer.allocate(n);
-        CharsetDecoder dec = ThreadLocalCoders.decoderFor(UTF_8.INSTANCE)
-            .onMalformedInput(CodingErrorAction.REPORT)
-            .onUnmappableCharacter(CodingErrorAction.REPORT);
+        CharsetDecoder dec = UTF_8.INSTANCE.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPLACE)
+                .onUnmappableCharacter(CodingErrorAction.REPLACE);
 
         char c = s.charAt(0);
         for (int i = 0; i < n;) {
@@ -451,6 +451,7 @@ public final class ParseUtil {
     private static String quote(String s, long lowMask, long highMask) {
         int n = s.length();
         StringBuilder sb = null;
+        CharsetEncoder encoder = null;
         boolean allowNonASCII = ((lowMask & L_ESCAPED) != 0);
         for (int i = 0; i < s.length(); i++) {
             char c = s.charAt(i);
@@ -468,11 +469,14 @@ public final class ParseUtil {
             } else if (allowNonASCII
                        && (Character.isSpaceChar(c)
                            || Character.isISOControl(c))) {
+                if (encoder == null) {
+                    encoder = UTF_8.INSTANCE.newEncoder();
+                }
                 if (sb == null) {
                     sb = new StringBuilder();
                     sb.append(s, 0, i);
                 }
-                appendEncoded(sb, c);
+                appendEncoded(encoder, sb, c);
             } else {
                 if (sb != null)
                     sb.append(c);
@@ -494,11 +498,11 @@ public final class ParseUtil {
                && match(s.charAt(pos + 2), L_HEX, H_HEX);
     }
 
-    private static void appendEncoded(StringBuilder sb, char c) {
+    private static void appendEncoded(CharsetEncoder encoder,
+                                      StringBuilder sb, char c) {
         ByteBuffer bb = null;
         try {
-            bb = ThreadLocalCoders.encoderFor(UTF_8.INSTANCE)
-                .encode(CharBuffer.wrap("" + c));
+            bb = encoder.encode(CharBuffer.wrap("" + c));
         } catch (CharacterCodingException x) {
             assert false;
         }

--- a/test/micro/org/openjdk/bench/java/net/ThreadLocalParseUtil.java
+++ b/test/micro/org/openjdk/bench/java/net/ThreadLocalParseUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.net;
+
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.invoke.MethodType.methodType;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(value = 1, warmups = 0, jvmArgsAppend = "--add-exports=java.base/sun.net.www=ALL-UNNAMED")
+public class ThreadLocalParseUtil {
+
+    private static URL url;
+    private static MethodHandles.Lookup LOOKUP;
+    private static MethodHandle MH_DECODE;
+    private static MethodHandle MH_TO_URI;
+
+    @Setup
+    public void setup() throws Exception {
+        LOOKUP = MethodHandles.lookup();
+        url = new URL("https://example.com/xyz/abc/def?query=#30");
+        Class<?> c = Class.forName("sun.net.www.ParseUtil");
+        MH_DECODE = LOOKUP.findStatic(c, "decode", methodType(String.class, String.class));
+        MH_TO_URI = LOOKUP.findStatic(c, "toURI", methodType(URI.class, URL.class));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public String decodeTest() throws Throwable {
+        return (String) MH_DECODE.invokeExact("/xyz/\u00A0\u00A0");
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public URI appendEncodedTest() throws Throwable {
+        return (URI) MH_TO_URI.invokeExact(url);
+    }
+}

--- a/test/micro/org/openjdk/bench/java/net/ThreadLocalParseUtil.java
+++ b/test/micro/org/openjdk/bench/java/net/ThreadLocalParseUtil.java
@@ -47,16 +47,15 @@ import static java.lang.invoke.MethodType.methodType;
 @Fork(value = 1, jvmArgsAppend = "--add-exports=java.base/sun.net.www=ALL-UNNAMED")
 public class ThreadLocalParseUtil {
 
-    private static final MethodHandles.Lookup LOOKUP;
     private static final MethodHandle MH_DECODE;
     private static final MethodHandle MH_TO_URI;
 
     static {
+        final MethodHandles.Lookup lookup = MethodHandles.lookup();
         try {
-            LOOKUP = MethodHandles.lookup();
             Class<?> c = Class.forName("sun.net.www.ParseUtil");
-            MH_DECODE = LOOKUP.findStatic(c, "decode", methodType(String.class, String.class));
-            MH_TO_URI = LOOKUP.findStatic(c, "toURI", methodType(URI.class, URL.class));
+            MH_DECODE = lookup.findStatic(c, "decode", methodType(String.class, String.class));
+            MH_TO_URI = lookup.findStatic(c, "toURI", methodType(URI.class, URL.class));
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
             throw new ExceptionInInitializerError(e);
         }


### PR DESCRIPTION
Replaced the use of ThreadLocalCoders with regular non-caching CharsetEncoder and added a benchmark to confirm that there is no performance impact.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8245309](https://bugs.openjdk.java.net/browse/JDK-8245309): Re-examine use of ThreadLocalCoders in sun.net.www.ParseUtil


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to d7542872b41f5f959fb0b458dc8feb5961867115
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/170/head:pull/170`
`$ git checkout pull/170`
