### PR TITLE
8252041: G1: Fix incorrect uses of HeapRegionManager::max_length

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1677,21 +1677,21 @@ jint G1CollectedHeap::initialize() {
   // 6843694 - ensure that the maximum region index can fit
   // in the remembered set structures.
   const uint max_region_idx = (1U << (sizeof(RegionIdx_t)*BitsPerByte-1)) - 1;
-  guarantee((max_regions() - 1) <= max_region_idx, "too many regions");
+  guarantee((max_reserved_regions() - 1) <= max_region_idx, "too many regions");
 
   // The G1FromCardCache reserves card with value 0 as "invalid", so the heap must not
   // start within the first card.
   guarantee(heap_rs.base() >= (char*)G1CardTable::card_size, "Java heap must not start within the first card.");
   // Also create a G1 rem set.
   _rem_set = new G1RemSet(this, _card_table, _hot_card_cache);
-  _rem_set->initialize(max_regions());
+  _rem_set->initialize(max_reserved_regions());
 
   size_t max_cards_per_region = ((size_t)1 << (sizeof(CardIdx_t)*BitsPerByte-1)) - 1;
   guarantee(HeapRegion::CardsPerRegion > 0, "make sure it's initialized");
   guarantee(HeapRegion::CardsPerRegion < max_cards_per_region,
             "too many cards per region");
 
-  FreeRegionList::set_unrealistically_long_length(max_expandable_regions() + 1);
+  FreeRegionList::set_unrealistically_long_length(max_regions() + 1);
 
   _bot = new G1BlockOffsetTable(reserved(), bot_storage);
 
@@ -1713,7 +1713,7 @@ jint G1CollectedHeap::initialize() {
   _numa->set_region_info(HeapRegion::GrainBytes, page_size);
 
   // Create the G1ConcurrentMark data structure and thread.
-  // (Must do this late, so that "max_regions" is defined.)
+  // (Must do this late, so that "max_[reserved_]regions" is defined.)
   _cm = new G1ConcurrentMark(this, prev_bitmap_storage, next_bitmap_storage);
   _cm_thread = _cm->cm_thread();
 
@@ -1765,7 +1765,7 @@ jint G1CollectedHeap::initialize() {
 
   _preserved_marks_set.init(ParallelGCThreads);
 
-  _collection_set.initialize(max_regions());
+  _collection_set.initialize(max_reserved_regions());
 
   G1InitLogger::print();
 
@@ -2391,7 +2391,7 @@ size_t G1CollectedHeap::unsafe_max_tlab_alloc(Thread* ignored) const {
 }
 
 size_t G1CollectedHeap::max_capacity() const {
-  return _hrm->max_expandable_length() * HeapRegion::GrainBytes;
+  return max_regions() * HeapRegion::GrainBytes;
 }
 
 void G1CollectedHeap::deduplicate_string(oop str) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -101,7 +101,7 @@ class G1EvacSummary;
 typedef OverflowTaskQueue<ScannerTask, mtGC>           G1ScannerTasksQueue;
 typedef GenericTaskQueueSet<G1ScannerTasksQueue, mtGC> G1ScannerTasksQueueSet;
 
-typedef int RegionIdx_t;   // needs to hold [ 0..max_regions() )
+typedef int RegionIdx_t;   // needs to hold [ 0..max_reserved_regions() )
 typedef int CardIdx_t;     // needs to hold [ 0..CardsPerRegion )
 
 // The G1 STW is alive closure.
@@ -1061,11 +1061,12 @@ public:
   // The current number of regions in the heap.
   uint num_regions() const { return _hrm->length(); }
 
-  // The max number of regions in the heap.
-  uint max_regions() const { return _hrm->max_length(); }
+  // The max number of regions reserved for the heap. Except for static array
+  // sizing purposes you probably want to use max_regions().
+  uint max_reserved_regions() const { return _hrm->reserved_length(); }
 
-  // Max number of regions that can be comitted.
-  uint max_expandable_regions() const { return _hrm->max_expandable_length(); }
+  // Max number of regions that can be committed.
+  uint max_regions() const { return _hrm->max_length(); }
 
   // The number of regions that are completely free.
   uint num_free_regions() const { return _hrm->num_free_regions(); }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -405,8 +405,8 @@ G1ConcurrentMark::G1ConcurrentMark(G1CollectedHeap* g1h,
   _num_concurrent_workers(0),
   _max_concurrent_workers(0),
 
-  _region_mark_stats(NEW_C_HEAP_ARRAY(G1RegionMarkStats, _g1h->max_regions(), mtGC)),
-  _top_at_rebuild_starts(NEW_C_HEAP_ARRAY(HeapWord*, _g1h->max_regions(), mtGC))
+  _region_mark_stats(NEW_C_HEAP_ARRAY(G1RegionMarkStats, _g1h->max_reserved_regions(), mtGC)),
+  _top_at_rebuild_starts(NEW_C_HEAP_ARRAY(HeapWord*, _g1h->max_reserved_regions(), mtGC))
 {
   assert(CGC_lock != NULL, "CGC_lock must be initialized");
 
@@ -462,8 +462,8 @@ void G1ConcurrentMark::reset() {
     _tasks[i]->reset(_next_mark_bitmap);
   }
 
-  uint max_regions = _g1h->max_regions();
-  for (uint i = 0; i < max_regions; i++) {
+  uint max_reserved_regions = _g1h->max_reserved_regions();
+  for (uint i = 0; i < max_reserved_regions; i++) {
     _top_at_rebuild_starts[i] = NULL;
     _region_mark_stats[i].clear();
   }
@@ -518,8 +518,8 @@ void G1ConcurrentMark::reset_marking_for_restart() {
   if (has_overflown()) {
     _global_mark_stack.expand();
 
-    uint max_regions = _g1h->max_regions();
-    for (uint i = 0; i < max_regions; i++) {
+    uint max_reserved_regions = _g1h->max_reserved_regions();
+    for (uint i = 0; i < max_reserved_regions; i++) {
       _region_mark_stats[i].clear_during_overflow();
     }
   }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -182,13 +182,13 @@ inline size_t G1CMTask::scan_objArray(objArrayOop obj, MemRegion mr) {
 }
 
 inline HeapWord* G1ConcurrentMark::top_at_rebuild_start(uint region) const {
-  assert(region < _g1h->max_regions(), "Tried to access TARS for region %u out of bounds", region);
+  assert(region < _g1h->max_reserved_regions(), "Tried to access TARS for region %u out of bounds", region);
   return _top_at_rebuild_starts[region];
 }
 
 inline void G1ConcurrentMark::update_top_at_rebuild_start(HeapRegion* r) {
   uint const region = r->hrm_index();
-  assert(region < _g1h->max_regions(), "Tried to access TARS for region %u out of bounds", region);
+  assert(region < _g1h->max_reserved_regions(), "Tried to access TARS for region %u out of bounds", region);
   assert(_top_at_rebuild_starts[region] == NULL,
          "TARS for region %u has already been set to " PTR_FORMAT " should be NULL",
          region, p2i(_top_at_rebuild_starts[region]));

--- a/src/hotspot/share/gc/g1/g1FromCardCache.hpp
+++ b/src/hotspot/share/gc/g1/g1FromCardCache.hpp
@@ -38,14 +38,14 @@ private:
   // freeing. I.e. a single clear of a single memory area instead of multiple separate
   // accesses with a large stride per region.
   static uintptr_t** _cache;
-  static uint _max_regions;
+  static uint _max_reserved_regions;
   static size_t _static_mem_size;
 #ifdef ASSERT
   static uint _max_workers;
 
   static void check_bounds(uint worker_id, uint region_idx) {
     assert(worker_id < _max_workers, "Worker_id %u is larger than maximum %u", worker_id, _max_workers);
-    assert(region_idx < _max_regions, "Region_idx %u is larger than maximum %u", region_idx, _max_regions);
+    assert(region_idx < _max_reserved_regions, "Region_idx %u is larger than maximum %u", region_idx, _max_reserved_regions);
   }
 #endif
 
@@ -79,7 +79,7 @@ public:
     _cache[region_idx][worker_id] = val;
   }
 
-  static void initialize(uint num_par_rem_sets, uint max_num_regions);
+  static void initialize(uint num_par_rem_sets, uint max_reserved_regions);
 
   static void invalidate(uint start_idx, size_t num_regions);
 

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -108,7 +108,7 @@ void G1Policy::init(G1CollectedHeap* g1h, G1CollectionSet* collection_set) {
 
   assert(Heap_lock->owned_by_self(), "Locking discipline.");
 
-  _young_gen_sizer->adjust_max_new_size(_g1h->max_expandable_regions());
+  _young_gen_sizer->adjust_max_new_size(_g1h->max_regions());
 
   _free_regions_at_end_of_collection = _g1h->num_free_regions();
 

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -86,7 +86,7 @@
 class G1RemSetScanState : public CHeapObj<mtGC> {
   class G1DirtyRegions;
 
-  size_t _max_regions;
+  size_t _max_reserved_regions;
 
   // Has this region that is part of the regions in the collection set been processed yet.
   typedef bool G1RemsetIterState;
@@ -141,16 +141,16 @@ private:
   class G1DirtyRegions : public CHeapObj<mtGC> {
     uint* _buffer;
     uint _cur_idx;
-    size_t _max_regions;
+    size_t _max_reserved_regions;
 
     bool* _contains;
 
   public:
-    G1DirtyRegions(size_t max_regions) :
-      _buffer(NEW_C_HEAP_ARRAY(uint, max_regions, mtGC)),
+    G1DirtyRegions(size_t max_reserved_regions) :
+      _buffer(NEW_C_HEAP_ARRAY(uint, max_reserved_regions, mtGC)),
       _cur_idx(0),
-      _max_regions(max_regions),
-      _contains(NEW_C_HEAP_ARRAY(bool, max_regions, mtGC)) {
+      _max_reserved_regions(max_reserved_regions),
+      _contains(NEW_C_HEAP_ARRAY(bool, max_reserved_regions, mtGC)) {
 
       reset();
     }
@@ -164,7 +164,7 @@ private:
 
     void reset() {
       _cur_idx = 0;
-      ::memset(_contains, false, _max_regions * sizeof(bool));
+      ::memset(_contains, false, _max_reserved_regions * sizeof(bool));
     }
 
     uint size() const { return _cur_idx; }
@@ -273,7 +273,7 @@ private:
 
 public:
   G1RemSetScanState() :
-    _max_regions(0),
+    _max_reserved_regions(0),
     _collection_set_iter_state(NULL),
     _card_table_scan_state(NULL),
     _scan_chunks_per_region(get_chunks_per_region(HeapRegion::LogOfHRGrainBytes)),
@@ -293,16 +293,16 @@ public:
     FREE_C_HEAP_ARRAY(HeapWord*, _scan_top);
   }
 
-  void initialize(size_t max_regions) {
+  void initialize(size_t max_reserved_regions) {
     assert(_collection_set_iter_state == NULL, "Must not be initialized twice");
-    _max_regions = max_regions;
-    _collection_set_iter_state = NEW_C_HEAP_ARRAY(G1RemsetIterState, max_regions, mtGC);
-    _card_table_scan_state = NEW_C_HEAP_ARRAY(uint, max_regions, mtGC);
-    _num_total_scan_chunks = max_regions * _scan_chunks_per_region;
+    _max_reserved_regions = max_reserved_regions;
+    _collection_set_iter_state = NEW_C_HEAP_ARRAY(G1RemsetIterState, max_reserved_regions, mtGC);
+    _card_table_scan_state = NEW_C_HEAP_ARRAY(uint, max_reserved_regions, mtGC);
+    _num_total_scan_chunks = max_reserved_regions * _scan_chunks_per_region;
     _region_scan_chunks = NEW_C_HEAP_ARRAY(bool, _num_total_scan_chunks, mtGC);
 
     _scan_chunks_shift = (uint8_t)log2_intptr(HeapRegion::CardsPerRegion / _scan_chunks_per_region);
-    _scan_top = NEW_C_HEAP_ARRAY(HeapWord*, max_regions, mtGC);
+    _scan_top = NEW_C_HEAP_ARRAY(HeapWord*, max_reserved_regions, mtGC);
   }
 
   void prepare() {
@@ -310,20 +310,20 @@ public:
     // regions currently not available or free. Since regions might
     // become used during the collection these values must be valid
     // for those regions as well.
-    for (size_t i = 0; i < _max_regions; i++) {
+    for (size_t i = 0; i < _max_reserved_regions; i++) {
       reset_region_claim((uint)i);
       clear_scan_top((uint)i);
     }
 
-    _all_dirty_regions = new G1DirtyRegions(_max_regions);
-    _next_dirty_regions = new G1DirtyRegions(_max_regions);
+    _all_dirty_regions = new G1DirtyRegions(_max_reserved_regions);
+    _next_dirty_regions = new G1DirtyRegions(_max_reserved_regions);
   }
 
   void prepare_for_merge_heap_roots() {
     _all_dirty_regions->merge(_next_dirty_regions);
 
     _next_dirty_regions->reset();
-    for (size_t i = 0; i < _max_regions; i++) {
+    for (size_t i = 0; i < _max_reserved_regions; i++) {
       _card_table_scan_state[i] = 0;
     }
 
@@ -416,7 +416,7 @@ public:
   // Attempt to claim the given region in the collection set for iteration. Returns true
   // if this call caused the transition from Unclaimed to Claimed.
   inline bool claim_collection_set_region(uint region) {
-    assert(region < _max_regions, "Tried to access invalid region %u", region);
+    assert(region < _max_reserved_regions, "Tried to access invalid region %u", region);
     if (_collection_set_iter_state[region]) {
       return false;
     }
@@ -424,12 +424,12 @@ public:
   }
 
   bool has_cards_to_scan(uint region) {
-    assert(region < _max_regions, "Tried to access invalid region %u", region);
+    assert(region < _max_reserved_regions, "Tried to access invalid region %u", region);
     return _card_table_scan_state[region] < HeapRegion::CardsPerRegion;
   }
 
   uint claim_cards_to_scan(uint region, uint increment) {
-    assert(region < _max_regions, "Tried to access invalid region %u", region);
+    assert(region < _max_reserved_regions, "Tried to access invalid region %u", region);
     return Atomic::fetch_and_add(&_card_table_scan_state[region], increment);
   }
 
@@ -485,9 +485,9 @@ uint G1RemSet::num_par_rem_sets() {
   return G1DirtyCardQueueSet::num_par_ids() + G1ConcurrentRefine::max_num_threads() + MAX2(ConcGCThreads, ParallelGCThreads);
 }
 
-void G1RemSet::initialize(uint max_regions) {
-  G1FromCardCache::initialize(num_par_rem_sets(), max_regions);
-  _scan_state->initialize(max_regions);
+void G1RemSet::initialize(uint max_reserved_regions) {
+  G1FromCardCache::initialize(num_par_rem_sets(), max_reserved_regions);
+  _scan_state->initialize(max_reserved_regions);
 }
 
 // Helper class to scan and detect ranges of cards that need to be scanned on the

--- a/src/hotspot/share/gc/g1/g1RemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.hpp
@@ -78,7 +78,7 @@ public:
   static uint num_par_rem_sets();
 
   // Initialize data that depends on the heap size being known.
-  void initialize(uint max_regions);
+  void initialize(uint max_reserved_regions);
 
   G1RemSet(G1CollectedHeap* g1h,
            G1CardTable* ct,

--- a/src/hotspot/share/gc/g1/heapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.cpp
@@ -85,11 +85,11 @@ HeapRegionManager* HeapRegionManager::create_manager(G1CollectedHeap* heap) {
 }
 
 void HeapRegionManager::initialize(G1RegionToSpaceMapper* heap_storage,
-                               G1RegionToSpaceMapper* prev_bitmap,
-                               G1RegionToSpaceMapper* next_bitmap,
-                               G1RegionToSpaceMapper* bot,
-                               G1RegionToSpaceMapper* cardtable,
-                               G1RegionToSpaceMapper* card_counts) {
+                                   G1RegionToSpaceMapper* prev_bitmap,
+                                   G1RegionToSpaceMapper* next_bitmap,
+                                   G1RegionToSpaceMapper* bot,
+                                   G1RegionToSpaceMapper* cardtable,
+                                   G1RegionToSpaceMapper* card_counts) {
   _allocated_heapregions_length = 0;
 
   _heap_mapper = heap_storage;
@@ -184,7 +184,8 @@ HeapRegion* HeapRegionManager::new_heap_region(uint hrm_index) {
 
 void HeapRegionManager::commit_regions(uint index, size_t num_regions, WorkGang* pretouch_gang) {
   guarantee(num_regions > 0, "Must commit more than zero regions");
-  guarantee(_num_committed + num_regions <= max_length(), "Cannot commit more than the maximum amount of regions");
+  guarantee(num_regions <= available(),
+            "Cannot commit more than the maximum amount of regions");
 
   _num_committed += (uint)num_regions;
 
@@ -321,16 +322,19 @@ void HeapRegionManager::expand_exact(uint start, uint num_regions, WorkGang* pre
 
 uint HeapRegionManager::expand_on_preferred_node(uint preferred_index) {
   uint expand_candidate = UINT_MAX;
-  for (uint i = 0; i < max_length(); i++) {
-    if (is_available(i)) {
-      // Already in use continue
-      continue;
-    }
-    // Always save the candidate so we can expand later on.
-    expand_candidate = i;
-    if (is_on_preferred_index(expand_candidate, preferred_index)) {
-      // We have found a candidate on the preffered node, break.
-      break;
+
+  if (available() >= 1) {
+    for (uint i = 0; i < reserved_length(); i++) {
+      if (is_available(i)) {
+        // Already in use continue
+        continue;
+      }
+      // Always save the candidate so we can expand later on.
+      expand_candidate = i;
+      if (is_on_preferred_index(expand_candidate, preferred_index)) {
+        // We have found a candidate on the preferred node, break.
+        break;
+      }
     }
   }
 
@@ -397,14 +401,18 @@ uint HeapRegionManager::find_contiguous_in_free_list(uint num_regions) {
     range_start = _available_map.get_next_one_offset(range_end);
     range_end = _available_map.get_next_zero_offset(range_start);
     candidate = find_contiguous_in_range((uint) range_start, (uint) range_end, num_regions);
-  } while (candidate == G1_NO_HRM_INDEX && range_end < max_length());
+  } while (candidate == G1_NO_HRM_INDEX && range_end < reserved_length());
 
   return candidate;
 }
 
 uint HeapRegionManager::find_contiguous_allow_expand(uint num_regions) {
+  // Check if we can actually satisfy the allocation.
+  if (num_regions > available()) {
+    return G1_NO_HRM_INDEX;
+  }
   // Find any candidate.
-  return find_contiguous_in_range(0, max_length(), num_regions);
+  return find_contiguous_in_range(0, reserved_length(), num_regions);
 }
 
 HeapRegion* HeapRegionManager::next_region_in_heap(const HeapRegion* r) const {
@@ -420,7 +428,7 @@ HeapRegion* HeapRegionManager::next_region_in_heap(const HeapRegion* r) const {
 }
 
 void HeapRegionManager::iterate(HeapRegionClosure* blk) const {
-  uint len = max_length();
+  uint len = reserved_length();
 
   for (uint i = 0; i < len; i++) {
     if (!is_available(i)) {
@@ -436,13 +444,13 @@ void HeapRegionManager::iterate(HeapRegionClosure* blk) const {
 }
 
 HeapRegionRange HeapRegionManager::find_unavailable_from_idx(uint index) const {
-  guarantee(index <= max_length(), "checking");
+  guarantee(index <= reserved_length(), "checking");
 
   // Find first unavailable region from offset.
   BitMap::idx_t start = _available_map.get_next_zero_offset(index);
   if (start == _available_map.size()) {
     // No unavailable regions found.
-    return HeapRegionRange(max_length(), max_length());
+    return HeapRegionRange(reserved_length(), reserved_length());
   }
 
   // The end of the range is the next available region.
@@ -452,6 +460,8 @@ HeapRegionRange HeapRegionManager::find_unavailable_from_idx(uint index) const {
   assert(!_available_map.at(end - 1), "Last region (" SIZE_FORMAT ") in range is not unavailable", end - 1);
   assert(end == _available_map.size() || _available_map.at(end), "Region (" SIZE_FORMAT ") is not available", end);
 
+  // Shrink returned range to number of regions left to commit if necessary.
+  end = MIN2(start + available(), end);
   return HeapRegionRange((uint) start, (uint) end);
 }
 
@@ -459,7 +469,7 @@ uint HeapRegionManager::find_highest_free(bool* expanded) {
   // Loop downwards from the highest region index, looking for an
   // entry which is either free or not yet committed.  If not yet
   // committed, expand_at that index.
-  uint curr = max_length() - 1;
+  uint curr = reserved_length() - 1;
   while (true) {
     HeapRegion *hr = _regions.get_by_index(curr);
     if (hr == NULL || !is_available(curr)) {
@@ -611,9 +621,12 @@ void HeapRegionManager::verify() {
   guarantee(length() <= _allocated_heapregions_length,
             "invariant: _length: %u _allocated_length: %u",
             length(), _allocated_heapregions_length);
-  guarantee(_allocated_heapregions_length <= max_length(),
+  guarantee(_allocated_heapregions_length <= reserved_length(),
             "invariant: _allocated_length: %u _max_length: %u",
-            _allocated_heapregions_length, max_length());
+            _allocated_heapregions_length, reserved_length());
+  guarantee(_num_committed <= max_length(),
+            "invariant: _num_committed: %u max_regions: %u",
+            _num_committed, max_length());
 
   bool prev_committed = true;
   uint num_committed = 0;
@@ -640,7 +653,7 @@ void HeapRegionManager::verify() {
     prev_committed = true;
     prev_end = hr->end();
   }
-  for (uint i = _allocated_heapregions_length; i < max_length(); i++) {
+  for (uint i = _allocated_heapregions_length; i < reserved_length(); i++) {
     guarantee(_regions.get_by_index(i) == NULL, "invariant i: %u", i);
   }
 
@@ -693,7 +706,7 @@ public:
       AbstractGangTask("G1 Rebuild Free List Task"),
       _hrm(hrm),
       _worker_freelists(NEW_C_HEAP_ARRAY(FreeRegionList, num_workers, mtGC)),
-      _worker_chunk_size((_hrm->max_length() + num_workers - 1) / num_workers),
+      _worker_chunk_size((_hrm->reserved_length() + num_workers - 1) / num_workers),
       _num_workers(num_workers) {
     for (uint worker = 0; worker < _num_workers; worker++) {
       ::new (&_worker_freelists[worker]) FreeRegionList("Appendable Worker Free List");
@@ -718,7 +731,7 @@ public:
     EventGCPhaseParallel event;
 
     uint start = worker_id * _worker_chunk_size;
-    uint end = MIN2(start + _worker_chunk_size, _hrm->max_length());
+    uint end = MIN2(start + _worker_chunk_size, _hrm->reserved_length());
 
     // If start is outside the heap, this worker has nothing to do.
     if (start > end) {

--- a/src/hotspot/share/gc/g1/heapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.hpp
@@ -73,13 +73,14 @@ class HeapRegionRange : public StackObj {
 // region we retain the HeapRegion to be able to re-use it in the
 // future (in case we recommit it).
 //
-// We keep track of three lengths:
+// We keep track of four lengths:
 //
 // * _num_committed (returned by length()) is the number of currently
 //   committed regions. These may not be contiguous.
 // * _allocated_heapregions_length (not exposed outside this class) is the
 //   number of regions+1 for which we have HeapRegions.
-// * max_length() returns the maximum number of regions the heap can have.
+// * max_length() returns the maximum number of regions the heap may commit.
+// * max_reserved_length() returns the maximum number of regions the heap has reserved.
 //
 
 class HeapRegionManager: public CHeapObj<mtGC> {
@@ -94,7 +95,7 @@ class HeapRegionManager: public CHeapObj<mtGC> {
   // for allocation.
   CHeapBitMap _available_map;
 
-   // The number of regions committed in the heap.
+  // The number of regions committed in the heap.
   uint _num_committed;
 
   // Internal only. The highest heap region +1 we allocated a HeapRegion instance for.
@@ -124,7 +125,7 @@ class HeapRegionManager: public CHeapObj<mtGC> {
 
   // Finds the next sequence of unavailable regions starting at the given index. Returns the
   // sequence found as a HeapRegionRange. If no regions can be found, both start and end of
-  // the returned range is equal to max_regions().
+  // the returned range is equal to max_reserved_length().
   HeapRegionRange find_unavailable_from_idx(uint index) const;
   // Finds the next sequence of empty regions starting from start_idx, going backwards in
   // the heap. Returns the length of the sequence found. If this value is zero, no
@@ -240,17 +241,17 @@ public:
     return num_free_regions() * HeapRegion::GrainBytes;
   }
 
-  // Return the number of available (uncommitted) regions.
+  // Return the number of regions available (uncommitted) regions.
   uint available() const { return max_length() - length(); }
 
   // Return the number of regions that have been committed in the heap.
   uint length() const { return _num_committed; }
 
-  // Return the maximum number of regions in the heap.
-  uint max_length() const { return (uint)_regions.length(); }
+  // The number of regions reserved for the heap.
+  uint reserved_length() const { return (uint)_regions.length(); }
 
   // Return maximum number of regions that heap can expand to.
-  virtual uint max_expandable_length() const { return (uint)_regions.length(); }
+  virtual uint max_length() const { return reserved_length(); }
 
   MemoryUsage get_auxiliary_data_memory_usage() const;
 
@@ -267,7 +268,7 @@ public:
   // this.
   virtual uint expand_at(uint start, uint num_regions, WorkGang* pretouch_workers);
 
-  // Try to expand on the given node index.
+  // Try to expand on the given node index, returning the index of the new region.
   virtual uint expand_on_preferred_node(uint node_index);
 
   HeapRegion* next_region_in_heap(const HeapRegion* r) const;

--- a/src/hotspot/share/gc/g1/heapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.hpp
@@ -80,7 +80,7 @@ class HeapRegionRange : public StackObj {
 // * _allocated_heapregions_length (not exposed outside this class) is the
 //   number of regions+1 for which we have HeapRegions.
 // * max_length() returns the maximum number of regions the heap may commit.
-// * max_reserved_length() returns the maximum number of regions the heap has reserved.
+// * reserved_length() returns the maximum number of regions the heap has reserved.
 //
 
 class HeapRegionManager: public CHeapObj<mtGC> {
@@ -125,7 +125,7 @@ class HeapRegionManager: public CHeapObj<mtGC> {
 
   // Finds the next sequence of unavailable regions starting at the given index. Returns the
   // sequence found as a HeapRegionRange. If no regions can be found, both start and end of
-  // the returned range is equal to max_reserved_length().
+  // the returned range is equal to reserved_length().
   HeapRegionRange find_unavailable_from_idx(uint index) const;
   // Finds the next sequence of empty regions starting from start_idx, going backwards in
   // the heap. Returns the length of the sequence found. If this value is zero, no

--- a/src/hotspot/share/gc/g1/heapRegionManager.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.inline.hpp
@@ -62,7 +62,7 @@ inline HeapRegion* HeapRegionManager::next_region_in_humongous(HeapRegion* hr) c
   assert(is_available(index), "pre-condition");
   assert(hr->is_humongous(), "next_region_in_humongous should only be called for a humongous region.");
   index++;
-  if (index < max_length() && is_available(index) && at(index)->is_continues_humongous()) {
+  if (index < reserved_length() && is_available(index) && at(index)->is_continues_humongous()) {
     return at(index);
   } else {
     return NULL;

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
@@ -267,7 +267,7 @@ PerRegionTable* OtherRegionsTable::delete_region_table(size_t& added_by_deleted)
     _coarse_map.at_put(max_hrm_index, true);
   } else {
     // This will lazily initialize an uninitialized bitmap
-    _coarse_map.reinitialize(G1CollectedHeap::heap()->max_regions());
+    _coarse_map.reinitialize(G1CollectedHeap::heap()->max_reserved_regions());
     assert(!_coarse_map.at(max_hrm_index), "No coarse entries");
     _coarse_map.at_put(max_hrm_index, true);
     // Release store guarantees that the bitmap has initialized before any

--- a/src/hotspot/share/gc/g1/heterogeneousHeapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/heterogeneousHeapRegionManager.hpp
@@ -124,7 +124,7 @@ public:
   virtual HeapRegion* allocate_humongous_allow_expand(uint num_regions);
 
   // Return maximum number of regions that heap can expand to.
-  uint max_expandable_length() const;
+  uint max_length() const;
 
   // Override. Expand in nv-dimm.
   uint expand_by(uint num_regions, WorkGang* pretouch_workers);


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes some uses of HeapRegionManager::max_regions()/max_expandable_regions() in our code to use the correct variant?

HeapRegionManager::max_length gives the absolute maximum number of regions reserved for the heap based on the reservation.

HeapRegionmanager::max_expandable_regions() returns the maximum number of regions the heap can grow to (can be committed).

Typically they are exchangeable, but if the reservation is larger than what -Xmx allows (like when file-mapping old gen), this is not the case, and causes assertions. In some cases the existing region manager code could (if it reserved more than -Xmx) give back more than -Xmx allows.

Testing: tier1-5.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252041](https://bugs.openjdk.java.net/browse/JDK-8252041): G1: Fix incorrect uses of HeapRegionManager::max_length


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 54673e954efaafcc411cc4bfb0f62a91e94fd989
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/178/head:pull/178`
`$ git checkout pull/178`
