### PR TITLE
8252196: ZGC: TestUncommit.java fails due to "Exception: Uncommitted too fast" again(2)

### DIFF
--- a/test/hotspot/jtreg/gc/z/TestUncommit.java
+++ b/test/hotspot/jtreg/gc/z/TestUncommit.java
@@ -68,12 +68,12 @@ public class TestUncommit {
 
     private static void test(int objectSize) throws Exception {
         final var beforeAlloc = capacity();
+        final var timeBeforeAlloc = System.nanoTime();
 
         // Allocate memory
         log("Allocating");
         allocate(objectSize);
 
-        final var timeAfterAlloc = System.nanoTime();
         final var afterAlloc = capacity();
 
         // Reclaim memory
@@ -87,7 +87,7 @@ public class TestUncommit {
 
         log("Uncommit started");
         final var timeUncommitStart = System.nanoTime();
-        final var actualDelay = (timeUncommitStart - timeAfterAlloc) / 1_000_000;
+        final var actualDelay = (timeUncommitStart - timeBeforeAlloc) / 1_000_000;
 
         log("Waiting for uncommit to complete");
         while (capacity() > beforeAlloc) {


### PR DESCRIPTION
This test has failed a few times because the timeAfterAlloc timestamp (the time when uncommit can start to happen) is taken at the wrong place. We should take this timestamp before we call allocate(), since the allocation could cause ZPageCache::_last_commit to be set, which will dictate when uncommit can happen. This PR moves and renames timeAfterAlloc accordingly.

Testing: gc/z/TestUncommit.java executed multiple times on all platforms.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252196](https://bugs.openjdk.java.net/browse/JDK-8252196): ZGC: TestUncommit.java fails due to "Exception: Uncommitted too fast" again(2)


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/179/head:pull/179`
`$ git checkout pull/179`
