### PR TITLE
8252100: NumberOverflow in class MemoryCache

### DIFF
--- a/src/java.desktop/share/classes/javax/imageio/stream/MemoryCache.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/MemoryCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -333,7 +333,7 @@ class MemoryCache {
         }
 
         long index = pos/BUFFER_LENGTH;
-        int offset = (int)pos % BUFFER_LENGTH;
+        int offset = (int)(pos % BUFFER_LENGTH);
         while (len > 0) {
             int nbytes = Math.min(len, BUFFER_LENGTH - offset);
             byte[] buf = getCacheBlock(index++);


### PR DESCRIPTION
Number overflow in javax/imageio/stream/MemoryCache.java
I tried to reproduce the issue but was not able to create stream or BufferedImage of such a large size because of array size limitations. Submitter has mentioned simple fix for overflow which has solved his issue. I have verified the fix by running jtreg and compatibility tests and there are no failures.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252100](https://bugs.openjdk.java.net/browse/JDK-8252100): NumberOverflow in class MemoryCache


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/182/head:pull/182`
`$ git checkout pull/182`
