### PR TITLE
8244505: G1 pause time ratio calculation does not consider Remark/Cleanup  pauses

### DIFF
--- a/src/hotspot/share/gc/g1/g1Analytics.cpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.cpp
@@ -98,8 +98,9 @@ G1Analytics::G1Analytics(const G1Predictions* predictor) :
     _short_term_pause_time_ratio(0.0) {
 
   // Seed sequences with initial values.
-  _recent_prev_end_times_for_all_gcs_sec->add(os::elapsedTime());
-  _prev_collection_pause_end_ms = os::elapsedTime() * 1000.0;
+  double time_sec = os::elapsedTime();
+  _recent_prev_end_times_for_all_gcs_sec->add(time_sec);
+  _prev_collection_pause_end_ms = time_sec * 1000.0;
 
   int index = MIN2(ParallelGCThreads - 1, 7u);
 
@@ -151,7 +152,7 @@ void G1Analytics::report_alloc_rate_ms(double alloc_rate) {
 
 void G1Analytics::compute_pause_time_ratios(double end_time_sec, double pause_time_ms) {
   double long_interval_ms = (end_time_sec - oldest_known_gc_end_time_sec()) * 1000.0;
-  _long_term_pause_time_ratio = _recent_gc_times_ms->sum() / long_interval_ms;
+  _long_term_pause_time_ratio = (_recent_gc_times_ms->sum() + pause_time_ms) / long_interval_ms;
   _long_term_pause_time_ratio = clamp(_long_term_pause_time_ratio, 0.0, 1.0);
 
   double short_interval_ms = (end_time_sec - most_recent_gc_end_time_sec()) * 1000.0;
@@ -323,7 +324,6 @@ void G1Analytics::update_recent_gc_times(double end_time_sec,
                                          double pause_time_ms) {
   _recent_gc_times_ms->add(pause_time_ms);
   _recent_prev_end_times_for_all_gcs_sec->add(end_time_sec);
-  _prev_collection_pause_end_ms = end_time_sec * 1000.0;
 }
 
 void G1Analytics::report_concurrent_mark_cleanup_times_ms(double ms) {

--- a/src/hotspot/share/gc/g1/g1Analytics.cpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.cpp
@@ -98,9 +98,8 @@ G1Analytics::G1Analytics(const G1Predictions* predictor) :
     _short_term_pause_time_ratio(0.0) {
 
   // Seed sequences with initial values.
-  double time_sec = os::elapsedTime();
-  _recent_prev_end_times_for_all_gcs_sec->add(time_sec);
-  _prev_collection_pause_end_ms = time_sec * 1000.0;
+  _recent_prev_end_times_for_all_gcs_sec->add(os::elapsedTime());
+  _prev_collection_pause_end_ms = os::elapsedTime() * 1000.0;
 
   int index = MIN2(ParallelGCThreads - 1, 7u);
 

--- a/src/hotspot/share/gc/g1/g1Analytics.cpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.cpp
@@ -151,7 +151,7 @@ void G1Analytics::report_alloc_rate_ms(double alloc_rate) {
 
 void G1Analytics::compute_pause_time_ratios(double end_time_sec, double pause_time_ms) {
   double long_interval_ms = (end_time_sec - oldest_known_gc_end_time_sec()) * 1000.0;
-  _long_term_pause_time_ratio = (_recent_gc_times_ms->sum() + pause_time_ms) / long_interval_ms;
+  _long_term_pause_time_ratio = _recent_gc_times_ms->sum() / long_interval_ms;
   _long_term_pause_time_ratio = clamp(_long_term_pause_time_ratio, 0.0, 1.0);
 
   double short_interval_ms = (end_time_sec - most_recent_gc_end_time_sec()) * 1000.0;

--- a/src/hotspot/share/gc/g1/g1Analytics.hpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.hpp
@@ -114,6 +114,10 @@ public:
     _prev_collection_pause_end_ms += ms;
   }
 
+  void set_prev_collection_pause_end_ms(double ms) {
+    _prev_collection_pause_end_ms = ms;
+  }
+
   void report_concurrent_mark_remark_times_ms(double ms);
   void report_concurrent_mark_cleanup_times_ms(double ms);
   void report_alloc_rate_ms(double alloc_rate);

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -754,8 +754,6 @@ void G1Policy::record_collection_pause_end(double pause_time_ms) {
 
   bool update_stats = should_update_gc_stats();
 
-  record_pause(this_pause, start_time_sec, end_time_sec);
-
   if (is_concurrent_start_pause(this_pause)) {
     record_concurrent_mark_init_end(0.0);
   } else {
@@ -783,6 +781,8 @@ void G1Policy::record_collection_pause_end(double pause_time_ms) {
     double alloc_rate_ms = (double) regions_allocated / app_time_ms;
     _analytics->report_alloc_rate_ms(alloc_rate_ms);
   }
+
+  record_pause(this_pause, start_time_sec, end_time_sec);
 
   if (is_last_young_pause(this_pause)) {
     assert(!is_concurrent_start_pause(this_pause),

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1305,6 +1305,8 @@ G1Policy::PauseKind G1Policy::young_gc_pause_kind() const {
 }
 
 bool G1Policy::should_update_gc_stats() {
+  // Evacuation failures skew the timing too much to be considered for statistics updates.
+  // We make the assumption that these are rare.
   return !_g1h->evacuation_failed();
 }
 

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -529,7 +529,7 @@ void G1Policy::revise_young_list_target_length_if_necessary(size_t rs_length) {
 
   if (rs_length > _rs_length_prediction) {
     // add 10% to avoid having to recalculate often
-    size_t rs_length_prediction = rs_length * 110 / 100;
+    size_t rs_length_prediction = rs_length * 1100 / 1000;
     update_rs_length_prediction(rs_length_prediction);
     update_young_length_bounds(rs_length_prediction);
   }
@@ -660,7 +660,7 @@ void G1Policy::record_collection_pause_start(double start_time_sec) {
   assert(_g1h->collection_set()->verify_young_ages(), "region age verification failed");
 }
 
-void G1Policy::record_concurrent_mark_init_end() {
+void G1Policy::record_concurrent_mark_init_end(double mark_init_elapsed_time_ms) {
   assert(!collector_state()->initiate_conc_mark_if_possible(), "we should have cleared it by now");
   collector_state()->set_in_concurrent_start_gc(false);
 }
@@ -757,7 +757,7 @@ void G1Policy::record_collection_pause_end(double pause_time_ms) {
   record_pause(this_pause, start_time_sec, end_time_sec);
 
   if (is_concurrent_start_pause(this_pause)) {
-    record_concurrent_mark_init_end();
+    record_concurrent_mark_init_end(0.0);
   } else {
     maybe_start_marking();
   }
@@ -1304,7 +1304,7 @@ G1Policy::PauseKind G1Policy::young_gc_pause_kind() const {
   }
 }
 
-void G1Policy::update_pause_time_stats(PauseKind kind, double start_time_sec, double end_time_sec){
+void G1Policy::update_gc_pause_time_ratios(PauseKind kind, double start_time_sec, double end_time_sec){
 
   double pause_time_sec = end_time_sec - start_time_sec;
   double pause_time_ms = pause_time_sec * 1000.0;
@@ -1325,7 +1325,7 @@ void G1Policy::record_pause(PauseKind kind, double start, double end) {
   }
   bool update_stats = !_g1h->evacuation_failed();
   if (update_stats){
-    update_pause_time_stats(kind, start, end);
+    update_gc_pause_time_ratios(kind, start, end);
   }
   // Manage the mutator time tracking from concurrent start to first mixed gc.
   switch (kind) {
@@ -1405,9 +1405,11 @@ uint G1Policy::calc_min_old_cset_length() const {
 
   const size_t region_num = _collection_set->candidates()->num_regions();
   const size_t gc_num = (size_t) MAX2(G1MixedGCCountTarget, (uintx) 1);
-
+  size_t result = region_num / gc_num;
   // emulate ceiling
-  size_t result = (region_num + gc_num -1) / gc_num;
+  if (result * gc_num < region_num) {
+    result += 1;
+  }
   return (uint) result;
 }
 
@@ -1420,9 +1422,11 @@ uint G1Policy::calc_max_old_cset_length() const {
   const G1CollectedHeap* g1h = G1CollectedHeap::heap();
   const size_t region_num = g1h->num_regions();
   const size_t perc = (size_t) G1OldCSetRegionThresholdPercent;
-
+  size_t result = region_num * perc / 100;
   // emulate ceiling
-  size_t result = ((region_num * perc) + 99) / 100;
+  if (100 * result < region_num * perc) {
+    result += 1;
+  }
   return (uint) result;
 }
 

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -285,6 +285,13 @@ private:
   PauseKind young_gc_pause_kind() const;
   // Record the given STW pause with the given start and end times (in s).
   void record_pause(PauseKind kind, double start, double end);
+
+  // Evacuation failures skew the timing too much to be considered for statistics updates.
+  // We make the assumption that these are rare.
+  bool should_update_gc_stats();
+
+  void update_gc_pause_time_ratios(PauseKind kind, double start_sec, double end_sec);
+
   // Indicate that we aborted marking before doing any mixed GCs.
   void abort_time_to_mixed_tracking();
 
@@ -438,8 +445,6 @@ public:
   void print_age_table();
 
   void update_survivors_policy();
-
-  void update_gc_pause_time_ratios(PauseKind kind, double start_sec, double end_sec);
 
   virtual bool force_upgrade_to_full() {
     return false;

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -328,7 +328,7 @@ public:
   virtual void record_full_collection_end();
 
   // Must currently be called while the world is stopped.
-  void record_concurrent_mark_init_end();
+  void record_concurrent_mark_init_end(double mark_init_elapsed_time_ms);
 
   // Record start and end of remark.
   void record_concurrent_mark_remark_start();
@@ -439,7 +439,7 @@ public:
 
   void update_survivors_policy();
 
-  void update_pause_time_stats(PauseKind kind, double start_sec, double end_sec);
+  void update_gc_pause_time_ratios(PauseKind kind, double start_sec, double end_sec);
 
   virtual bool force_upgrade_to_full() {
     return false;

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -328,7 +328,7 @@ public:
   virtual void record_full_collection_end();
 
   // Must currently be called while the world is stopped.
-  void record_concurrent_mark_init_end(double mark_init_elapsed_time_ms);
+  void record_concurrent_mark_init_end();
 
   // Record start and end of remark.
   void record_concurrent_mark_remark_start();
@@ -438,6 +438,8 @@ public:
   void print_age_table();
 
   void update_survivors_policy();
+
+  void update_pause_time_stats(PauseKind kind, double start_sec, double end_sec);
 
   virtual bool force_upgrade_to_full() {
     return false;

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -286,8 +286,6 @@ private:
   // Record the given STW pause with the given start and end times (in s).
   void record_pause(PauseKind kind, double start, double end);
 
-  // Evacuation failures skew the timing too much to be considered for statistics updates.
-  // We make the assumption that these are rare.
   bool should_update_gc_stats();
 
   void update_gc_pause_time_ratios(PauseKind kind, double start_sec, double end_sec);


### PR DESCRIPTION
The computation for long and short term pause time ratios does not include Remark/Cleanup pause times. Isolate updates to _prev_collection_pause_end_ms from update_recent_gc_times(), then have all gc pauses (including Remark/Cleanup) recorded by update_recent_gc_times(). Patch also includes trivial clean ups to g1Policy.* files.
Testing: Tier 1 - 7
Performance testing did not show any significant changes in performance
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244505](https://bugs.openjdk.java.net/browse/JDK-8244505): G1 pause time ratio calculation does not consider Remark/Cleanup pauses


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/183/head:pull/183`
`$ git checkout pull/183`
