### PR TITLE
8252921: NMT overwrite memory type for region assert when building dynamic archive

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1337,9 +1337,6 @@ void NonJavaThread::post_run() {
   JFR_ONLY(Jfr::on_thread_exit(this);)
   remove_from_the_list();
   unregister_thread_stack_with_NMT();
-  set_stack_base(NULL);
-  set_stack_size(0);
-
   // Ensure thread-local-storage is cleared before termination.
   Thread::clear_thread_current();
 }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -364,6 +364,10 @@ void Thread::record_stack_base_and_size() {
 void Thread::register_thread_stack_with_NMT() {
   MemTracker::record_thread_stack(stack_end(), stack_size());
 }
+
+void Thread::unregister_thread_stack_with_NMT() {
+  MemTracker::release_thread_stack(stack_end(), stack_size());
+}
 #endif // INCLUDE_NMT
 
 void Thread::call_run() {
@@ -402,6 +406,7 @@ void Thread::call_run() {
 
   // Perform <ChildClass> tear-down actions
   DEBUG_ONLY(_run_state = POST_RUN;)
+
   this->post_run();
 
   // Note: at this point the thread object may already have deleted itself,
@@ -428,19 +433,6 @@ Thread::~Thread() {
   if (barrier_set != NULL) {
     barrier_set->on_thread_destroy(this);
   }
-
-  // stack_base can be NULL if the thread is never started or exited before
-  // record_stack_base_and_size called. Although, we would like to ensure
-  // that all started threads do call record_stack_base_and_size(), there is
-  // not proper way to enforce that.
-#if INCLUDE_NMT
-  if (_stack_base != NULL) {
-    MemTracker::release_thread_stack(stack_end(), stack_size());
-#ifdef ASSERT
-    set_stack_base(NULL);
-#endif
-  }
-#endif // INCLUDE_NMT
 
   // deallocate data structures
   delete resource_area();
@@ -1345,6 +1337,10 @@ void NonJavaThread::pre_run() {
 void NonJavaThread::post_run() {
   JFR_ONLY(Jfr::on_thread_exit(this);)
   remove_from_the_list();
+  unregister_thread_stack_with_NMT();
+  set_stack_base(NULL);
+  set_stack_size(0);
+
   // Ensure thread-local-storage is cleared before termination.
   Thread::clear_thread_current();
 }
@@ -2018,6 +2014,7 @@ void JavaThread::thread_main_inner() {
 // Shared teardown for all JavaThreads
 void JavaThread::post_run() {
   this->exit(false);
+  this->unregister_thread_stack_with_NMT();
   // Defer deletion to here to ensure 'this' is still referenceable in call_run
   // for any shared tear-down.
   this->smr_delete();

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -406,7 +406,6 @@ void Thread::call_run() {
 
   // Perform <ChildClass> tear-down actions
   DEBUG_ONLY(_run_state = POST_RUN;)
-
   this->post_run();
 
   // Note: at this point the thread object may already have deleted itself,

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -759,11 +759,7 @@ protected:
 
  public:
   // Stack overflow support
-  address stack_base() const {
-    assert(_stack_base  != NULL || Thread::current() != this, "Sanity check");
-    return _stack_base;
-  }
-
+  address stack_base() const           { assert(_stack_base  != NULL, "Sanity check"); return _stack_base; }
   void    set_stack_base(address base) { _stack_base = base; }
   size_t  stack_size() const           { return _stack_size; }
   void    set_stack_size(size_t size)  { _stack_size = size; }

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -759,7 +759,7 @@ protected:
 
  public:
   // Stack overflow support
-  address stack_base() const           { assert(_stack_base  != NULL, "Sanity check"); return _stack_base; }
+  address stack_base() const           { assert(_stack_base != NULL,"Sanity check"); return _stack_base; }
   void    set_stack_base(address base) { _stack_base = base; }
   size_t  stack_size() const           { return _stack_size; }
   void    set_stack_size(size_t size)  { _stack_size = size; }

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -759,7 +759,11 @@ protected:
 
  public:
   // Stack overflow support
-  address stack_base() const           { return _stack_base; }
+  address stack_base() const {
+    assert(_stack_base  != NULL || Thread::current() != this, "Sanity check");
+    return _stack_base;
+  }
+  
   void    set_stack_base(address base) { _stack_base = base; }
   size_t  stack_size() const           { return _stack_size; }
   void    set_stack_size(size_t size)  { _stack_size = size; }

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -763,7 +763,7 @@ protected:
     assert(_stack_base  != NULL || Thread::current() != this, "Sanity check");
     return _stack_base;
   }
-  
+
   void    set_stack_base(address base) { _stack_base = base; }
   size_t  stack_size() const           { return _stack_size; }
   void    set_stack_size(size_t size)  { _stack_size = size; }

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -759,13 +759,14 @@ protected:
 
  public:
   // Stack overflow support
-  address stack_base() const           { assert(_stack_base != NULL,"Sanity check"); return _stack_base; }
+  address stack_base() const           { return _stack_base; }
   void    set_stack_base(address base) { _stack_base = base; }
   size_t  stack_size() const           { return _stack_size; }
   void    set_stack_size(size_t size)  { _stack_size = size; }
   address stack_end()  const           { return stack_base() - stack_size(); }
   void    record_stack_base_and_size();
   void    register_thread_stack_with_NMT() NOT_NMT_RETURN;
+  void    unregister_thread_stack_with_NMT() NOT_NMT_RETURN;
 
   int     lgrp_id() const        { return _lgrp_id; }
   void    set_lgrp_id(int value) { _lgrp_id = value; }

--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -351,7 +351,7 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
     // os::reserve_memory() -> pd_reserve_memory() -> os::reserve_memory()
     // See JDK-8198226.
     if (reserved_rgn->same_region(base_addr, size) &&
-        reserved_rgn->flag() == flag) {
+        (reserved_rgn->flag() == flag || reserved_rgn->flag() == mtNone)) {
       reserved_rgn->set_call_stack(stack);
       reserved_rgn->set_flag(flag);
       return true;

--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -347,7 +347,11 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
     VirtualMemorySummary::record_reserved_memory(size, flag);
     return _reserved_regions->add(rgn) != NULL;
   } else {
-    if (reserved_rgn->same_region(base_addr, size)) {
+    // Deal with recursive reservation
+    // os::reserve_memory() -> pd_reserve_memory() -> os::reserve_memory()
+    // See JDK-8198226.
+    if (reserved_rgn->same_region(base_addr, size) &&
+        reserved_rgn->flag() == flag) {
       reserved_rgn->set_call_stack(stack);
       reserved_rgn->set_flag(flag);
       return true;


### PR DESCRIPTION
Thread stack is currently unregistered with NMT in Thread's destructor. Apparently, only Java thread invokes destructor before thread exits. 
For NonJavaThread, e.g. ConcurrentGCThread, thread may exit while its "Thread" object continues alive, therefore, its thread stack is still "alive" from NMT perspective. Once thread exits, the virtual memory for the thread stack can be reserved again, that confused NMT.

The solution is to move thread stack unregistration code to post_run() method.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252921](https://bugs.openjdk.java.net/browse/JDK-8252921): NMT overwrite memory type for region assert when building dynamic archive


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**) ⚠️ Review applies to f4fbe38b70352407271ccb537c772a415ba3ad1b
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/185/head:pull/185`
`$ git checkout pull/185`
