### PR TITLE
8253173: Print heap before and after GC lacks a newline

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -36,6 +36,7 @@
 #include "gc/shared/gcWhen.hpp"
 #include "gc/shared/memAllocator.hpp"
 #include "logging/log.hpp"
+#include "logging/logStream.hpp"
 #include "memory/metaspace.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
@@ -123,14 +124,28 @@ MetaspaceSummary CollectedHeap::create_metaspace_summary() {
 }
 
 void CollectedHeap::print_heap_before_gc() {
-  Universe::print_heap_before_gc();
+  LogTarget(Debug, gc, heap) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    ls.print_cr("Heap before GC invocations=%u (full %u):", total_collections(), total_full_collections());
+    ResourceMark rm;
+    print_on(&ls);
+  }
+
   if (_gc_heap_log != NULL) {
     _gc_heap_log->log_heap_before(this);
   }
 }
 
 void CollectedHeap::print_heap_after_gc() {
-  Universe::print_heap_after_gc();
+  LogTarget(Debug, gc, heap) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    ls.print_cr("Heap after GC invocations=%u (full %u):", total_collections(), total_full_collections());
+    ResourceMark rm;
+    print_on(&ls);
+  }
+
   if (_gc_heap_log != NULL) {
     _gc_heap_log->log_heap_after(this);
   }

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -1031,26 +1031,6 @@ void Universe::print_heap_at_SIGBREAK() {
   }
 }
 
-void Universe::print_heap_before_gc() {
-  LogTarget(Debug, gc, heap) lt;
-  if (lt.is_enabled()) {
-    LogStream ls(lt);
-    ls.print("Heap before GC invocations=%u (full %u):", heap()->total_collections(), heap()->total_full_collections());
-    ResourceMark rm;
-    heap()->print_on(&ls);
-  }
-}
-
-void Universe::print_heap_after_gc() {
-  LogTarget(Debug, gc, heap) lt;
-  if (lt.is_enabled()) {
-    LogStream ls(lt);
-    ls.print("Heap after GC invocations=%u (full %u):", heap()->total_collections(), heap()->total_full_collections());
-    ResourceMark rm;
-    heap()->print_on(&ls);
-  }
-}
-
 void Universe::initialize_verify_flags() {
   verify_flags = 0;
   const char delimiter[] = " ,";

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -357,8 +357,6 @@ class Universe: AllStatic {
   static int  verify_count()       { return _verify_count; }
   static void print_on(outputStream* st);
   static void print_heap_at_SIGBREAK();
-  static void print_heap_before_gc();
-  static void print_heap_after_gc();
 
   // Change the number of dummy objects kept reachable by the full gc dummy
   // array; this should trigger relocation in a sliding compaction collector.


### PR DESCRIPTION
When GC logging was converted to Unified Logging a newline went missing.

```
-  st->print_cr("{Heap before GC invocations=%u (full %u):",
-               heap()->total_collections(),
-               heap()->total_full_collections());
```
vs
```
+  LogHandle(gc, heap) log;
+  if (log.is_trace()) {
+    log.trace("Heap before GC invocations=%u (full %u):", heap()->total_collections(), heap()->total_full_collections());
```
This gives lines like this:
```
GC(29) Heap after GC invocations=30 (full 30): ZHeap           used 20M, capacity 2014M, max capacity 30718M
GC(29)  Metaspace       used 6779K, capacity 6857K, committed 7040K, reserved 1056768K
GC(29)   class space    used 574K, capacity 620K, committed 640K, reserved 1048576K
```
Instead of:
```
GC(29) Heap after GC invocations=30 (full 30):
GC(29)  ZHeap           used 20M, capacity 2014M, max capacity 30718M
GC(29)  Metaspace       used 6779K, capacity 6857K, committed 7040K, reserved 1056768K
GC(29)   class space    used 574K, capacity 620K, committed 640K, reserved 1048576K
```
In our hs_err files we print this with a newline:
```  
st.print_cr("{Heap %s GC invocations=%u (full %u):",
            before ? "before" : "after",
            heap->total_collections(),
            heap->total_full_collections());
```
I propse that we add this missing newline.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253173](https://bugs.openjdk.java.net/browse/JDK-8253173): Print heap before and after GC lacks a newline


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Per Lidén](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/187/head:pull/187`
`$ git checkout pull/187`
