### PR TITLE
8253177: outputStream not declared in markWord.hpp

### DIFF
--- a/src/hotspot/share/oops/markWord.cpp
+++ b/src/hotspot/share/oops/markWord.cpp
@@ -26,6 +26,7 @@
 #include "oops/markWord.hpp"
 #include "runtime/thread.inline.hpp"
 #include "runtime/objectMonitor.hpp"
+#include "utilities/ostream.hpp"
 
 void markWord::print_on(outputStream* st) const {
   if (is_marked()) {  // last bits = 11

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -94,6 +94,7 @@
 class BasicLock;
 class ObjectMonitor;
 class JavaThread;
+class outputStream;
 
 class markWord {
  private:


### PR DESCRIPTION
Hi all,

  can I have reviews for this trivial change that adds outputStream declaration(s) to the markWord files? Apparently they have been missing forever, and in some last-minute testing about some unrelated change the ARM compilers complained about it.

Testing: local compilation, tier1

Thanks,
  Thomas
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253177](https://bugs.openjdk.java.net/browse/JDK-8253177): outputStream not declared in markWord.hpp


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/188/head:pull/188`
`$ git checkout pull/188`
