### PR TITLE
8252311: AArch64: save two words in itable lookup stub

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1004,27 +1004,22 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
   // }
   Label search, found_method;
 
-  for (int peel = 1; peel >= 0; peel--) {
-    ldr(method_result, Address(scan_temp, itableOffsetEntry::interface_offset_in_bytes()));
-    cmp(intf_klass, method_result);
-
-    if (peel) {
-      br(Assembler::EQ, found_method);
-    } else {
-      br(Assembler::NE, search);
-      // (invert the test to fall through to found_method...)
-    }
-
-    if (!peel)  break;
-
-    bind(search);
-
-    // Check that the previous entry is non-null.  A null entry means that
-    // the receiver class doesn't implement the interface, and wasn't the
-    // same as when the caller was compiled.
-    cbz(method_result, L_no_such_interface);
+  ldr(method_result, Address(scan_temp, itableOffsetEntry::interface_offset_in_bytes()));
+  cmp(intf_klass, method_result);
+  br(Assembler::EQ, found_method);
+  bind(search);
+  // Check that the previous entry is non-null.  A null entry means that
+  // the receiver class doesn't implement the interface, and wasn't the
+  // same as when the caller was compiled.
+  cbz(method_result, L_no_such_interface);
+  if (itableOffsetEntry::interface_offset_in_bytes() != 0) {
     add(scan_temp, scan_temp, scan_step);
+    ldr(method_result, Address(scan_temp, itableOffsetEntry::interface_offset_in_bytes()));
+  } else {
+    ldr(method_result, Address(pre(scan_temp, scan_step)));
   }
+  cmp(intf_klass, method_result);
+  br(Assembler::NE, search);
 
   bind(found_method);
 


### PR DESCRIPTION
The change was reviewed on hotspot-compiler-dev, but I missed the time to complete 
the commit to the mercural repo. Can I get it approved once again?

Issue: [JDK-8252311](https://bugs.openjdk.java.net/browse/JDK-8252311)

Description:
The interface method lookup stub becomes hot when interface calls
are performed frequently. The stub assembly code can be made
shorter (132->124 bytes) by using a pre-increment instruction variant.

Review by Andrew Dinn && Andrew Haley:
http://mail.openjdk.java.net/pipermail/hotspot-compiler-dev/2020-September/039818.html
http://mail.openjdk.java.net/pipermail/hotspot-compiler-dev/2020-September/039833.html

For the reference, benchmark scores with higher iteration number:
```
Neoverse                              Cnt   Score     Error  ->    Score   Error   Units
InvokeInterface.bench                  25  6163.804 ±  5.116 -> 6303.035 ± 5.450  ops/ms
InvokeInterface.bench:L1-icache-loads   5   305.408 ±  1.895 ->  272.891 ± 0.750    #/op
InvokeInterface.bench:iTLB-loads        5   221.755 ±  0.990 ->  207.635 ± 0.566    #/op
InvokeInterface.bench:instructions      5  1035.468 ±  2.701 ->  953.466 ± 1.667    #/op 
```
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252311](https://bugs.openjdk.java.net/browse/JDK-8252311): AArch64: save two words in itable lookup stub


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/189/head:pull/189`
`$ git checkout pull/189`
