### PR TITLE
8252966: CI: Remove KILL_COMPILE_ON_FATAL_ and KILL_COMPILE_ON_ANY macros

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -453,10 +453,10 @@ ciKlass* ciEnv::get_klass_by_name_impl(ciKlass* accessing_klass,
     Klass* kls;
     if (!require_local) {
       kls = SystemDictionary::find_constrained_instance_or_array_klass(sym, loader,
-                                                                       KILL_COMPILE_ON_FATAL_(fail_type));
+                                                                       CHECK_AND_CLEAR_(fail_type));
     } else {
       kls = SystemDictionary::find_instance_or_array_klass(sym, loader, domain,
-                                                           KILL_COMPILE_ON_FATAL_(fail_type));
+                                                           CHECK_AND_CLEAR_(fail_type));
     }
     found_klass = kls;
   }

--- a/src/hotspot/share/ci/ciField.cpp
+++ b/src/hotspot/share/ci/ciField.cpp
@@ -400,7 +400,7 @@ bool ciField::will_link(ciMethod* accessing_method,
                      _name->get_symbol(), _signature->get_symbol(),
                      methodHandle(THREAD, accessing_method->get_Method()));
   fieldDescriptor result;
-  LinkResolver::resolve_field(result, link_info, bc, false, KILL_COMPILE_ON_FATAL_(false));
+  LinkResolver::resolve_field(result, link_info, bc, false, CHECK_AND_CLEAR_(false));
 
   // update the hit-cache, unless there is a problem with memory scoping:
   if (accessing_method->holder()->is_shared() || !is_shared()) {

--- a/src/hotspot/share/ci/ciUtilities.inline.hpp
+++ b/src/hotspot/share/ci/ciUtilities.inline.hpp
@@ -66,27 +66,4 @@
 #define GUARDED_VM_QUICK_ENTRY(action)      \
   {if (IS_IN_VM) { action } else { VM_QUICK_ENTRY_MARK; { action }}}
 
-// Redefine this later.
-#define KILL_COMPILE_ON_FATAL_(result)           \
-  THREAD);                                       \
-  if (HAS_PENDING_EXCEPTION) {                   \
-    if (PENDING_EXCEPTION->klass() ==            \
-        SystemDictionary::ThreadDeath_klass()) { \
-      /* Kill the compilation. */                \
-      fatal("unhandled ci exception");           \
-      return (result);                           \
-    }                                            \
-    CLEAR_PENDING_EXCEPTION;                     \
-    return (result);                             \
-  }                                              \
-  (void)(0
-
-#define KILL_COMPILE_ON_ANY                      \
-  THREAD);                                       \
-  if (HAS_PENDING_EXCEPTION) {                   \
-    fatal("unhandled ci exception");             \
-    CLEAR_PENDING_EXCEPTION;                     \
-  }                                              \
-(void)(0
-
 #endif // SHARE_CI_CIUTILITIES_INLINE_HPP


### PR DESCRIPTION
Remove the `KILL_COMPILE_ON_FATAL_` and `KILL_COMPILE_ON_ANY` macros, replacing uses of `KILL_COMPILE_ON_FATAL_` with `CHECK_AND_CLEAR_`. Unlike `KILL_COMPILE_ON_FATAL_`, `CHECK_AND_CLEAR_` ignores `ThreadDeath` exceptions, which compiler threads should not receive anyway.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252966](https://bugs.openjdk.java.net/browse/JDK-8252966): CI: Remove KILL_COMPILE_ON_FATAL_ and KILL_COMPILE_ON_ANY macros


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/191/head:pull/191`
`$ git checkout pull/191`
