### PR TITLE
8253028: SA core file tests still time out on OSX with "java.io.IOException: App waiting timeout"

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
@@ -45,7 +45,7 @@ import jtreg.SkippedException;
  * @summary Test clhsdb pmap command on a core file
  * @requires vm.hasSA
  * @library /test/lib
- * @run main/othervm/timeout=240 ClhsdbPmap true
+ * @run main/othervm/timeout=480 ClhsdbPmap true
  */
 
 public class ClhsdbPmap {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
@@ -45,7 +45,7 @@ import jtreg.SkippedException;
  * @summary Test clhsdb pstack command on a core file
  * @requires vm.hasSA
  * @library /test/lib
- * @run main/othervm/timeout=240 ClhsdbPstack true
+ * @run main/othervm/timeout=480 ClhsdbPstack true
  */
 
 public class ClhsdbPstack {

--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -92,7 +92,7 @@ public class LingeredApp {
     protected Process appProcess;
     protected OutputBuffer output;
     protected static final int appWaitTime = 100;
-    protected static final int appCoreWaitTime = 240;
+    protected static final int appCoreWaitTime = 480;
     protected final String lockFileName;
 
     protected boolean forceCrash = false; // set true to force a crash and core file


### PR DESCRIPTION
Some SA core file testing requires longer timeouts since core files can on occasion take a very long time to produce on OSX.

I'd like to treat this as a trival change.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253028](https://bugs.openjdk.java.net/browse/JDK-8253028): SA core file tests still time out on OSX with "java.io.IOException: App waiting timeout"


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/192/head:pull/192`
`$ git checkout pull/192`
