### PR TITLE
8253206: Enforce whitespace checking for additional source files

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -14,7 +14,7 @@ version=0
 domain=openjdk.org
 
 [checks "whitespace"]
-files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java
+files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java|.*\.cc|.*\.hh|.*\.m|.*\.mm
 
 [checks "merge"]
 message=Merge


### PR DESCRIPTION
This adds the following extensions to the list of source files that git jcheck will check for whitespace errors:

```
 .cc, .hh, .m, .mm
```

All files with the above extensions are now white-space clean after the fix for [JDK-8240487](https://bugs.openjdk.java.net/browse/JDK-8240487). This will help them stay that way.

I just integrated a similar fix to `jfx` (with a few more source extensions that aren't relevant for the JDK) in [JDK-8240499](https://bugs.openjdk.java.net/browse/JDK-8240499).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253206](https://bugs.openjdk.java.net/browse/JDK-8253206): Enforce whitespace checking for additional source files


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/195/head:pull/195`
`$ git checkout pull/195`
