### PR TITLE
8253207: enable problemlists jcheck's check

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -3,7 +3,7 @@ project=jdk
 jbs=JDK
 
 [checks]
-error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace
+error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists
 
 [repository]
 tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)
@@ -28,3 +28,6 @@ role=committer
 
 [checks "issues"]
 pattern=^([124-8][0-9]{6}): (\S.*)$
+
+[checks "problemlists"]
+dirs=test/jdk|test/langtools|test/lib-test|test/hotspot/jtreg|test/jaxp


### PR DESCRIPTION
problemlists[[1]] check verifies that there are no problem-list entries w/ the bug-id used in the commit message.

[1]: https://github.com/openjdk/skara/pull/518
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253207](https://bugs.openjdk.java.net/browse/JDK-8253207): enable problemlists jcheck's check


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/196/head:pull/196`
`$ git checkout pull/196`
