### PR TITLE
8253130: bug7072653.java failed "Popup window height ... is wrong"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -836,7 +836,6 @@ javax/swing/JMenuItem/4171437/bug4171437.java 8233641 macosx-all
 javax/swing/JMenu/4692443/bug4692443.java 8171998 macosx-all
 javax/swing/plaf/synth/7158712/bug7158712.java 8238720 windows-all
 javax/swing/plaf/basic/BasicComboPopup/JComboBoxPopupLocation/JComboBoxPopupLocation.java 8238720 windows-all
-javax/swing/plaf/basic/BasicComboPopup/7072653/bug7072653.java 8238720 windows-all
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all

--- a/test/jdk/javax/swing/plaf/basic/BasicComboPopup/7072653/bug7072653.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicComboPopup/7072653/bug7072653.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,11 +104,11 @@ public class bug7072653 {
 
             @Override
             public int getSize() {
-                return 100;
+                return 400;
             }
         });
 
-        combobox.setMaximumRowCount(100);
+        combobox.setMaximumRowCount(400);
         combobox.putClientProperty("JComboBox.isPopDown", true);
         frame.getContentPane().add(combobox);
         frame.setVisible(true);


### PR DESCRIPTION
One more test which fails on the big screen, the number of items in the popup should be more than 100 to overlap the screen.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253130](https://bugs.openjdk.java.net/browse/JDK-8253130): bug7072653.java failed "Popup window height ... is wrong"


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/197/head:pull/197`
`$ git checkout pull/197`
