### PR TITLE
8253219: Epsilon: clean up unnecessary includes

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
@@ -28,7 +28,6 @@
 #include "gc/shared/gcArguments.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
-#include "runtime/vm_version.hpp"
 #include "utilities/macros.hpp"
 
 size_t EpsilonArguments::conservative_max_heap_alignment() {

--- a/src/hotspot/share/gc/epsilon/epsilonMonitoringSupport.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonMonitoringSupport.cpp
@@ -26,8 +26,6 @@
 #include "gc/epsilon/epsilonMonitoringSupport.hpp"
 #include "gc/epsilon/epsilonHeap.hpp"
 #include "gc/shared/generationCounters.hpp"
-#include "memory/allocation.hpp"
-#include "memory/allocation.inline.hpp"
 #include "memory/metaspaceCounters.hpp"
 #include "memory/resourceArea.hpp"
 #include "services/memoryService.hpp"

--- a/src/hotspot/share/gc/epsilon/epsilonMonitoringSupport.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonMonitoringSupport.cpp
@@ -26,6 +26,7 @@
 #include "gc/epsilon/epsilonMonitoringSupport.hpp"
 #include "gc/epsilon/epsilonHeap.hpp"
 #include "gc/shared/generationCounters.hpp"
+#include "memory/allocation.hpp"
 #include "memory/metaspaceCounters.hpp"
 #include "memory/resourceArea.hpp"
 #include "services/memoryService.hpp"


### PR DESCRIPTION
Static analysis shows a few #include statements in gc/epsilon that are not needed.

Testing: Linux x86_64 {release, fastdebug, slowdebug} x {+PCH, -PCH}
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253219](https://bugs.openjdk.java.net/browse/JDK-8253219): Epsilon: clean up unnecessary includes


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to f6db93d1c4667313cd168b433b3c838e52d408b3
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/198/head:pull/198`
`$ git checkout pull/198`
