### PR TITLE
8253220: Epsilon: clean up unused code/declarations

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonBarrierSet.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonBarrierSet.cpp
@@ -41,7 +41,7 @@ EpsilonBarrierSet::EpsilonBarrierSet() : BarrierSet(
           make_barrier_set_c1<BarrierSetC1>(),
           make_barrier_set_c2<BarrierSetC2>(),
           NULL /* barrier_set_nmethod */,
-          BarrierSet::FakeRtti(BarrierSet::EpsilonBarrierSet)) {};
+          BarrierSet::FakeRtti(BarrierSet::EpsilonBarrierSet)) {}
 
 void EpsilonBarrierSet::on_thread_create(Thread *thread) {
   EpsilonThreadLocalData::create(thread);

--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -46,7 +46,6 @@ jint EpsilonHeap::initialize() {
   _virtual_space.initialize(heap_rs, init_byte_size);
 
   MemRegion committed_region((HeapWord*)_virtual_space.low(),          (HeapWord*)_virtual_space.high());
-  MemRegion  reserved_region((HeapWord*)_virtual_space.low_boundary(), (HeapWord*)_virtual_space.high_boundary());
 
   initialize_reserved_region(heap_rs);
 


### PR DESCRIPTION
Static analysis reports a few instances of unused code.

Testing: Linux x86_64 fastdebug gc/epsilon
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253220](https://bugs.openjdk.java.net/browse/JDK-8253220): Epsilon: clean up unused code/declarations


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/199/head:pull/199`
`$ git checkout pull/199`
