### PR TITLE
8253222: Shenandoah: unused AlwaysTrueClosure after JDK-8246591

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
@@ -209,7 +209,6 @@ void ShenandoahRootScanner::roots_do(uint worker_id, OopClosure* oops, CLDClosur
           "Expect class unloading when Shenandoah cycle is running");
   assert(clds != NULL, "Only possible with CLD closure");
 
-  AlwaysTrueClosure always_true;
   ShenandoahParallelOopsDoThreadClosure tc_cl(oops, code, tc);
 
   ResourceMark rm;


### PR DESCRIPTION
Static analysis shows the AlwaysTrueClosure is not needed in `ShenandoahRootScanner::roots_do` after JDK-8246591.

Testing: Linux x86_64 tier1_gc_shenandoah
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253222](https://bugs.openjdk.java.net/browse/JDK-8253222): Shenandoah: unused AlwaysTrueClosure after JDK-8246591


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/201/head:pull/201`
`$ git checkout pull/201`
