### PR TITLE
8253224: Shenandoah: ShenandoahStrDedupQueue destructor calls virtual num_queues()

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahStrDedupQueue.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahStrDedupQueue.cpp
@@ -50,7 +50,7 @@ ShenandoahStrDedupQueue::ShenandoahStrDedupQueue() :
 
 ShenandoahStrDedupQueue::~ShenandoahStrDedupQueue() {
   MonitorLocker ml(StringDedupQueue_lock, Mutex::_no_safepoint_check_flag);
-  for (size_t index = 0; index < num_queues(); index ++) {
+  for (size_t index = 0; index < num_queues_nv(); index ++) {
     release_buffers(queue_at(index));
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahStrDedupQueue.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahStrDedupQueue.hpp
@@ -99,9 +99,11 @@ public:
   void verify_impl();
 
 protected:
-  size_t num_queues() const { return (_num_producer_queue + 2); }
+  size_t num_queues() const { return num_queues_nv(); }
 
 private:
+  inline size_t num_queues_nv() const { return (_num_producer_queue + 2); }
+
   ShenandoahQueueBuffer* new_buffer();
 
   void release_buffers(ShenandoahQueueBuffer* list);


### PR DESCRIPTION
Static analysis complains that `ShenandoahStrDedupQueue` destructor calls virtual `num_queues()`. We can just do the `_nv` version to make this right. 

Testing: hotspot_gc_shenandoah
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253224](https://bugs.openjdk.java.net/browse/JDK-8253224): Shenandoah: ShenandoahStrDedupQueue destructor calls virtual num_queues()


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/202/head:pull/202`
`$ git checkout pull/202`
