### PR TITLE
8253226: Shenandoah: remove unimplemented ShenandoahStrDedupQueue::verify

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahStrDedupQueue.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahStrDedupQueue.hpp
@@ -111,8 +111,6 @@ private:
   bool pop_candidate(oop& obj);
 
   void set_producer_buffer(ShenandoahQueueBuffer* buf, size_t queue_id);
-
-  void verify(ShenandoahQueueBuffer* head);
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHSTRDEDUPQUEUE_HPP


### PR DESCRIPTION
`ShenandoahStrDedupQueue` defers to super-class that in turn calls `verify_impl()`. `verify()` is left unused and unimplemented. Static analysis complains about it.

Testing: Linux x86_64 fastdebug tier1_gc_shenandoah
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253226](https://bugs.openjdk.java.net/browse/JDK-8253226): Shenandoah: remove unimplemented ShenandoahStrDedupQueue::verify


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/203/head:pull/203`
`$ git checkout pull/203`
