### PR TITLE
7151826: [TEST_BUG] [macosx] The test javax/swing/JPopupMenu/4966112/bug4966112.java not for mac

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -777,7 +777,6 @@ javax/swing/JFileChooser/8062561/bug8062561.java 8196466 linux-all,macosx-all
 javax/swing/JInternalFrame/Test6325652.java 8224977 macosx-all
 javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java 8225045 linux-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
-javax/swing/JPopupMenu/4966112/bug4966112.java 8064915 macosx-all
 javax/swing/MultiUIDefaults/Test6860438.java 8198391 generic-all
 javax/swing/UITest/UITest.java 8198392 generic-all
 javax/swing/plaf/basic/BasicComboBoxEditor/Test8015336.java 8198394 generic-all

--- a/test/jdk/javax/swing/JPopupMenu/4966112/bug4966112.java
+++ b/test/jdk/javax/swing/JPopupMenu/4966112/bug4966112.java
@@ -48,6 +48,7 @@ public class bug4966112 {
     private static volatile JFileChooser filec;
     private static int buttonMask;
     private static Robot robot;
+    private static boolean isAquaFileChooser;
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
@@ -95,14 +96,15 @@ public class bug4966112 {
             throw new RuntimeException("Popup was not shown on spinner");
         }
 
-        if (System.getProperty("os.name").startsWith("Mac")) {
-            return;
-        }
-
         // Test File Chooser
         createAndShowFileChooser();
         robot.waitForIdle();
 
+        if (System.getProperty("os.name").startsWith("Mac")) {
+            isAquaFileChooser = true;
+        } else {
+            isAquaFileChooser = false;
+        }
         clickMouse(filec);
         robot.waitForIdle();
 
@@ -113,6 +115,7 @@ public class bug4966112 {
         robot.waitForIdle();
         closeFrame();
 
+        isAquaFileChooser = false;
         if (!shown) {
             throw new RuntimeException("Popup was not shown on filechooser");
         }
@@ -150,7 +153,11 @@ public class bug4966112 {
             public void run() {
                 Point p = c.getLocationOnScreen();
                 Dimension size = c.getSize();
-                result[0] = new Point(p.x + size.width / 2, p.y + size.height / 2);
+                if (isAquaFileChooser){
+                    result[0] = new Point(p.x + size.width / 2, p.y + 5);
+                } else {
+                    result[0] = new Point(p.x + size.width / 2, p.y + size.height / 2);
+                }
             }
         });
 

--- a/test/jdk/javax/swing/JPopupMenu/4966112/bug4966112.java
+++ b/test/jdk/javax/swing/JPopupMenu/4966112/bug4966112.java
@@ -31,11 +31,27 @@
  * @author Alexander Zuev
  * @run main bug4966112
  */
-import javax.swing.*;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JSpinner;
+import javax.swing.JSplitPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.event.PopupMenuListener;
 import javax.swing.event.PopupMenuEvent;
-import java.awt.*;
-import java.awt.event.*;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Robot;
+import java.awt.Point;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 
 public class bug4966112 {
 
@@ -100,7 +116,7 @@ public class bug4966112 {
         createAndShowFileChooser();
         robot.waitForIdle();
 
-        if (System.getProperty("os.name").startsWith("Mac")) {
+        if ((UIManager.getLookAndFeel().getID()).equals("Aqua")) {
             isAquaFileChooser = true;
         } else {
             isAquaFileChooser = false;
@@ -153,7 +169,7 @@ public class bug4966112 {
             public void run() {
                 Point p = c.getLocationOnScreen();
                 Dimension size = c.getSize();
-                if (isAquaFileChooser){
+                if (isAquaFileChooser) {
                     result[0] = new Point(p.x + size.width / 2, p.y + 5);
                 } else {
                     result[0] = new Point(p.x + size.width / 2, p.y + size.height / 2);

--- a/test/jdk/javax/swing/JPopupMenu/4966112/bug4966112.java
+++ b/test/jdk/javax/swing/JPopupMenu/4966112/bug4966112.java
@@ -131,7 +131,6 @@ public class bug4966112 {
         robot.waitForIdle();
         closeFrame();
 
-        isAquaFileChooser = false;
         if (!shown) {
             throw new RuntimeException("Popup was not shown on filechooser");
         }

--- a/test/jdk/javax/swing/JPopupMenu/4966112/bug4966112.java
+++ b/test/jdk/javax/swing/JPopupMenu/4966112/bug4966112.java
@@ -95,6 +95,10 @@ public class bug4966112 {
             throw new RuntimeException("Popup was not shown on spinner");
         }
 
+        if (System.getProperty("os.name").startsWith("Mac")) {
+            return;
+        }
+
         // Test File Chooser
         createAndShowFileChooser();
         robot.waitForIdle();


### PR DESCRIPTION
The test test/jdk/javax/swing/JPopupMenu/4966112/bug4966112.java fails for Mac OS X 
with the error message Popup was not shown on FileChooser.

Popup doesn't appear for JFileChooser in MAC OS X platform so 
skipping this test for Mac OS X.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-7151826](https://bugs.openjdk.java.net/browse/JDK-7151826): [TEST_BUG] [macosx] The test javax/swing/JPopupMenu/4966112/bug4966112.java not for mac


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/204/head:pull/204`
`$ git checkout pull/204`
