### PR TITLE
8253050: jfr disassemble command processes --max-chunks incorrectly

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Disassemble.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Disassemble.java
@@ -182,19 +182,13 @@ final class Disassemble extends Command {
         long fileSize = sizes.get(0);
         for (int i = 1; i < sizes.size(); i++) {
             long size = sizes.get(i);
-            if (fileSize + size > maxSize) {
+            if (fileSize + size > maxSize || chunks == maxChunks) {
                 reduced.add(fileSize);
                 chunks = 1;
                 fileSize = size;
                 continue;
             }
             fileSize += size;
-            if (chunks == maxChunks) {
-                reduced.add(fileSize);
-                fileSize = 0;
-                chunks = 1;
-                continue;
-            }
             chunks++;
         }
         if (fileSize != 0) {


### PR DESCRIPTION
The problem is caused by Disassemble.combineChunkSizes() implementation that checks maxChunks after incrementation of fileSize, therefore the first output file has extra chunk.

Testing:
jdk/jdk/jfr/*
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253050](https://bugs.openjdk.java.net/browse/JDK-8253050): jfr disassemble command processes --max-chunks incorrectly


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/205/head:pull/205`
`$ git checkout pull/205`
