### PR TITLE
8253240: No javadoc for DecimalFormatSymbols.hashCode()

### DIFF
--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -760,7 +760,6 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
     /**
      * Override hashCode.
      */
-    private volatile int hashCode;
     @Override
     public int hashCode() {
         if (hashCode == 0) {
@@ -1147,6 +1146,11 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
     // currency; only the ISO code is serialized.
     private transient Currency currency;
     private transient volatile boolean currencyInitialized;
+
+    /**
+     * Cached hash code
+     */
+    private volatile int hashCode;
 
     // Proclaim JDK 1.1 FCS compatibility
     @java.io.Serial

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -1148,9 +1148,9 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
     private transient volatile boolean currencyInitialized;
 
     /**
-     * Cached hash code
+     * Cached hash code.
      */
-    private volatile int hashCode;
+    private transient volatile int hashCode;
 
     // Proclaim JDK 1.1 FCS compatibility
     @java.io.Serial


### PR DESCRIPTION
Hi,

Please review the fix to the issue wrt missing hashCode() javadoc, which was recently discussed in core-libs ml.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253240](https://bugs.openjdk.java.net/browse/JDK-8253240): No javadoc for DecimalFormatSymbols.hashCode()


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to 3276598e992ebc598150b150041859bebb8a3daf


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/208/head:pull/208`
`$ git checkout pull/208`
