### PR TITLE
8253125 vmTestbase/nsk/stress/stack/stack017.java timed out

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack017.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack017.java
@@ -41,10 +41,10 @@
  *     See the bug:
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
- * @requires (vm.opt.DeoptimizeALot != true & vm.compMode != "Xcomp")
+ * @requires (vm.opt.DeoptimizeALot != true & vm.compMode != "Xcomp" & vm.pageSize == 4096)
  * @library /vmTestbase
  * @build nsk.share.Terminator
- * @run main/othervm/timeout=900 -Xss448K nsk.stress.stack.stack017 -eager
+ * @run main/othervm/timeout=900 -Xss220K nsk.stress.stack.stack017 -eager
  */
 
 package nsk.stress.stack;


### PR DESCRIPTION
Please review this small change that reduces the amount of thread stack space used by the test in order to reduce the time required to execute it.  Before and after timings showed that the amount of time needed to execute the test dropped significantly with this change.

The changes to this test are similar to the changes done to test stack018.java, and others.

The modified test was run on Linux X64, MacOS, and Windows.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253125](https://bugs.openjdk.java.net/browse/JDK-8253125): vmTestbase/nsk/stress/stack/stack017.java timed out


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/209/head:pull/209`
`$ git checkout pull/209`
