### PR TITLE
8253261: Disable CDS full module graph until JDK-8253081 is fixed

### DIFF
--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -1488,6 +1488,8 @@ MapArchiveResult MetaspaceShared::map_archives(FileMapInfo* static_mapinfo, File
           // map_heap_regions() compares the current narrow oop and klass encodings
           // with the archived ones, so it must be done after all encodings are determined.
           static_mapinfo->map_heap_regions();
+
+          disable_full_module_graph(); // Disabled temporarily for JDK-8253081
         }
       });
     log_info(cds)("optimized module handling: %s", MetaspaceShared::use_optimized_module_handling() ? "enabled" : "disabled");

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -82,6 +82,7 @@ gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
 
 # :hotspot_runtime
 
+runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java 8253081 generic-all
 runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
 runtime/ReservedStack/ReservedStackTest.java 8231031 generic-all
 containers/docker/TestMemoryAwareness.java 8250984 linux-5.4.0-1019-oracle


### PR DESCRIPTION
Please review this trivial patch.

[JDK-8244778](https://bugs.openjdk.java.net/browse/JDK-8244778) (Archive full module graph in CDS) is causing failures in GC ([JDK-8253081](https://bugs.openjdk.java.net/browse/JDK-8253081))

This patch disables the *use* of the CDS module graph at run time, which seems to avoid the GC problems. The module graph is still being archived into CDS, but that seems to be harmless.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253261](https://bugs.openjdk.java.net/browse/JDK-8253261): Disable CDS full module graph until JDK-8253081 is fixed


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/213/head:pull/213`
`$ git checkout pull/213`
