### PR TITLE
8253262: Allocate in DumpRegion is not thread safe

### DIFF
--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -151,6 +151,7 @@ Mutex*   CDSClassFileStream_lock      = NULL;
 #endif
 Mutex*   DumpTimeTable_lock           = NULL;
 Mutex*   CDSLambda_lock               = NULL;
+Mutex*   DumpRegion_lock              = NULL;
 #endif // INCLUDE_CDS
 
 #if INCLUDE_JVMCI
@@ -346,6 +347,7 @@ void mutex_init() {
 #endif
   def(DumpTimeTable_lock           , PaddedMutex  , leaf - 1,    true,  _safepoint_check_never);
   def(CDSLambda_lock               , PaddedMutex  , leaf,        true,  _safepoint_check_never);
+  def(DumpRegion_lock              , PaddedMutex  , leaf,        true,  _safepoint_check_never);
 #endif // INCLUDE_CDS
 
 #if INCLUDE_JVMCI

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -130,6 +130,7 @@ extern Mutex*   CDSClassFileStream_lock;         // FileMapInfo::open_stream_for
 #endif
 extern Mutex*   DumpTimeTable_lock;              // SystemDictionaryShared::find_or_allocate_info_for
 extern Mutex*   CDSLambda_lock;                  // SystemDictionaryShared::get_shared_lambda_proxy_class
+extern Mutex*   DumpRegion_lock;                 // Symbol::operator new(size_t sz, int len)
 #endif // INCLUDE_CDS
 #if INCLUDE_JFR
 extern Mutex*   JfrStacktrace_lock;              // used to guard access to the JFR stacktrace table


### PR DESCRIPTION
At CDS dump, the symbols are allocated from _dump_region (DumpRegion) which is global, and not thread safe when  executed in JavaThread. Add a lock DumpRegoin_lock to guard symbol allocation from it.  

Tests: tier1-4
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253262](https://bugs.openjdk.java.net/browse/JDK-8253262): Allocate in DumpRegion is not thread safe


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/216/head:pull/216`
`$ git checkout pull/216`
