### PR TITLE
8251548 Remove unnecessary explicit initialization of volatile variables in security-libs code

### DIFF
--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -219,7 +219,7 @@ public class KeyStore {
     private KeyStoreSpi keyStoreSpi;
 
     // Has this keystore been initialized (loaded)?
-    private boolean initialized = false;
+    private boolean initialized;
 
     /**
      * A marker interface for {@code KeyStore}
@@ -264,7 +264,7 @@ public class KeyStore {
         private final char[] password;
         private final String protectionAlgorithm;
         private final AlgorithmParameterSpec protectionParameters;
-        private volatile boolean destroyed = false;
+        private volatile boolean destroyed;
 
         /**
          * Creates a password parameter.

--- a/src/java.base/share/classes/java/util/ListResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ListResourceBundle.java
@@ -206,5 +206,5 @@ public abstract class ListResourceBundle extends ResourceBundle {
         lookup = temp;
     }
 
-    private volatile Map<String,Object> lookup = null;
+    private volatile Map<String,Object> lookup;
 }

--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -126,7 +126,7 @@ public final class Subject implements java.io.Serializable {
      *
      * @serial
      */
-    private volatile boolean readOnly = false;
+    private volatile boolean readOnly;
 
     private static final int PRINCIPAL_SET = 1;
     private static final int PUB_CREDENTIAL_SET = 2;

--- a/src/java.base/share/classes/sun/security/provider/AbstractDrbg.java
+++ b/src/java.base/share/classes/sun/security/provider/AbstractDrbg.java
@@ -71,7 +71,7 @@ public abstract class AbstractDrbg {
 
     // Common working status
 
-    private boolean instantiated = false;
+    private boolean instantiated;
 
     /**
      * Reseed counter of a DRBG instance. A mechanism should increment it
@@ -80,7 +80,7 @@ public abstract class AbstractDrbg {
      *
      * Volatile, will be used in a double checked locking.
      */
-    protected volatile int reseedCounter = 0;
+    protected volatile int reseedCounter;
 
     // Mech features. If not same as below, must be redefined in constructor.
 

--- a/src/java.base/share/classes/sun/security/ssl/DTLSOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/DTLSOutputRecord.java
@@ -36,7 +36,7 @@ import sun.security.ssl.SSLCipher.SSLWriteCipher;
  */
 final class DTLSOutputRecord extends OutputRecord implements DTLSRecord {
 
-    private DTLSFragmenter fragmenter = null;
+    private DTLSFragmenter fragmenter;
 
     int                 writeEpoch;
 
@@ -44,7 +44,7 @@ final class DTLSOutputRecord extends OutputRecord implements DTLSRecord {
     Authenticator       prevWriteAuthenticator;
     SSLWriteCipher      prevWriteCipher;
 
-    private volatile boolean isCloseWaiting = false;
+    private volatile boolean isCloseWaiting;
 
     DTLSOutputRecord(HandshakeHash handshakeHash) {
         super(handshakeHash, SSLWriteCipher.nullDTlsWriteCipher());

--- a/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
@@ -102,11 +102,11 @@ abstract class HandshakeContext implements ConnectionContext {
     boolean                                 isResumption;
     SSLSessionImpl                          resumingSession;
     // Session is using stateless resumption
-    boolean                                 statelessResumption = false;
+    boolean                                 statelessResumption;
 
     final Queue<Map.Entry<Byte, ByteBuffer>> delegatedActions;
-    volatile boolean                        taskDelegated = false;
-    volatile Exception                      delegatedThrown = null;
+    volatile boolean                        taskDelegated;
+    volatile Exception                      delegatedThrown;
 
     ProtocolVersion                         negotiatedProtocol;
     CipherSuite                             negotiatedCipherSuite;

--- a/src/java.base/share/classes/sun/security/ssl/SSLEngineOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLEngineOutputRecord.java
@@ -37,11 +37,11 @@ import sun.security.ssl.SSLCipher.SSLWriteCipher;
  */
 final class SSLEngineOutputRecord extends OutputRecord implements SSLRecord {
 
-    private HandshakeFragment fragmenter = null;
-    private boolean isTalkingToV2 = false;      // SSLv2Hello
-    private ByteBuffer v2ClientHello = null;    // SSLv2Hello
+    private HandshakeFragment fragmenter;
+    private boolean isTalkingToV2;      // SSLv2Hello
+    private ByteBuffer v2ClientHello;    // SSLv2Hello
 
-    private volatile boolean isCloseWaiting = false;
+    private volatile boolean isCloseWaiting;
 
     SSLEngineOutputRecord(HandshakeHash handshakeHash) {
         super(handshakeHash, SSLWriteCipher.nullTlsWriteCipher());

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -83,8 +83,8 @@ public final class SSLSocketImpl
 
     private String                  peerHost;
     private boolean                 autoClose;
-    private boolean                 isConnected = false;
-    private volatile boolean        tlsIsClosed = false;
+    private boolean                 isConnected;
+    private volatile boolean        tlsIsClosed;
 
     private final ReentrantLock     socketLock = new ReentrantLock();
     private final ReentrantLock     handshakeLock = new ReentrantLock();


### PR DESCRIPTION
Hello,

is it possible to have a code review for the changes proposed in JDK-8251548 (originally contributed via https://mail.openjdk.java.net/pipermail/security-dev/2020-June/022137.html)?

Sean Mullan has created an issue and web-review and can sponsor the patch as soos as it gets properly reviewed.

The issue itself is a continuation of changes merged into java.base before as:

- https://bugs.openjdk.java.net/browse/JDK-6736490
- https://bugs.openjdk.java.net/browse/JDK-8035284
- https://bugs.openjdk.java.net/browse/JDK-8145680

As Doug Lea claims in http://cs.oswego.edu/pipermail/concurrency-interest/2015-December/014770.html

> there is never any reason to explicitly initialize fields to 0/0.0/false/null

so I believe this patch is harmless as well as previous ones.

Issue: https://bugs.openjdk.java.net/browse/JDK-8251548
Webrev: https://cr.openjdk.java.net/~mullan/webrevs/8251548/

Thanks,
Sergey Tsypanov
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251548](https://bugs.openjdk.java.net/browse/JDK-8251548): Remove unnecessary explicit initialization of volatile variables in security-libs code


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/218/head:pull/218`
`$ git checkout pull/218`
