### PR TITLE
8253270: Limit fastdebug inlining in G1 evacuation

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -43,6 +43,7 @@
 // tripping over compiler limits (which may be bugs, but nevertheless
 // need to be taken into consideration).  A side benefit of limiting
 // inlining is that we get more call frames that might aid debugging.
+// And the fastdebug compile time for this file is much reduced.
 // Explicit NOINLINE to block ATTRIBUTE_FLATTENing.
 #define MAYBE_INLINE_EVACUATION NOT_DEBUG(inline) DEBUG_ONLY(NOINLINE)
 

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -36,6 +36,15 @@
 #include "oops/access.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/prefetch.inline.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/macros.hpp"
+
+// In fastdebug builds the code size can get out of hand, potentially
+// tripping over compiler limits (which may be bugs, but nevertheless
+// need to be taken into consideration).  A side benefit of limiting
+// inlining is that we get more call frames that might aid debugging.
+// Explicit NOINLINE to block ATTRIBUTE_FLATTENing.
+#define MAYBE_INLINE_EVACUATION NOT_DEBUG(inline) DEBUG_ONLY(NOINLINE)
 
 G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
                                            G1RedirtyCardsQueueSet* rdcqs,
@@ -155,7 +164,9 @@ void G1ParScanThreadState::verify_task(ScannerTask task) const {
 }
 #endif // ASSERT
 
-template <class T> void G1ParScanThreadState::do_oop_evac(T* p) {
+template <class T>
+MAYBE_INLINE_EVACUATION
+void G1ParScanThreadState::do_oop_evac(T* p) {
   // Reference should not be NULL here as such are never pushed to the task queue.
   oop obj = RawAccess<IS_NOT_NULL>::oop_load(p);
 
@@ -194,6 +205,7 @@ template <class T> void G1ParScanThreadState::do_oop_evac(T* p) {
   }
 }
 
+MAYBE_INLINE_EVACUATION
 void G1ParScanThreadState::do_partial_array(PartialArrayScanTask task) {
   oop from_obj = task.to_source_array();
 
@@ -243,6 +255,7 @@ void G1ParScanThreadState::do_partial_array(PartialArrayScanTask task) {
   to_obj_array->oop_iterate_range(&_scanner, start, end);
 }
 
+MAYBE_INLINE_EVACUATION
 void G1ParScanThreadState::dispatch_task(ScannerTask task) {
   verify_task(task);
   if (task.is_narrow_oop_ptr()) {
@@ -388,6 +401,7 @@ void G1ParScanThreadState::undo_allocation(G1HeapRegionAttr dest_attr,
 
 // Private inline function, for direct internal use and providing the
 // implementation of the public not-inline function.
+MAYBE_INLINE_EVACUATION
 oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const region_attr,
                                                     oop const old,
                                                     markWord const old_mark) {

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -156,7 +156,7 @@ public:
   size_t flush(size_t* surviving_young_words);
 
 private:
-  inline void do_partial_array(PartialArrayScanTask task);
+  void do_partial_array(PartialArrayScanTask task);
 
   HeapWord* allocate_copy_slow(G1HeapRegionAttr* dest_attr,
                                oop old,
@@ -169,14 +169,14 @@ private:
                        size_t word_sz,
                        uint node_index);
 
-  inline oop do_copy_to_survivor_space(G1HeapRegionAttr region_attr,
-                                       oop obj,
-                                       markWord old_mark);
+  oop do_copy_to_survivor_space(G1HeapRegionAttr region_attr,
+                                oop obj,
+                                markWord old_mark);
 
   // This method is applied to the fields of the objects that have just been copied.
-  template <class T> inline void do_oop_evac(T* p);
+  template <class T> void do_oop_evac(T* p);
 
-  inline void dispatch_task(ScannerTask task);
+  void dispatch_task(ScannerTask task);
 
   // Tries to allocate word_sz in the PLAB of the next "generation" after trying to
   // allocate into dest. Previous_plab_refill_failed indicates whether previous


### PR DESCRIPTION
Please review this change to G1 evacuation to prevent inlining of some functions in debug (particularly, fastdebug) builds. This reduces the size of the generated code to stay away from limits encountered with gcc when compiling for aarch64.  As a side benefit, this adds more call frames that might be helpful with debugging.

Testing: tier1
Verified expected inlining on linux-x64 and linux-aarch64 in both release and fastdebug builds.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253270](https://bugs.openjdk.java.net/browse/JDK-8253270): Limit fastdebug inlining in G1 evacuation


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 25f8ded446447bb3c889cc98bc55d1b9678f4ad2
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/220/head:pull/220`
`$ git checkout pull/220`
