### PR TITLE
8253278: Refactor/cleanup oopDesc::*_klass_addr

### DIFF
--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -145,11 +145,11 @@ bool oopDesc::has_klass_gap() {
 
 void* oopDesc::load_klass_raw(oop obj) {
   if (UseCompressedClassPointers) {
-    narrowKlass narrow_klass = *(obj->compressed_klass_addr());
+    narrowKlass narrow_klass = obj->_metadata._compressed_klass;
     if (narrow_klass == 0) return NULL;
     return (void*)CompressedKlassPointers::decode_raw(narrow_klass);
   } else {
-    return *(void**)(obj->klass_addr());
+    return obj->_metadata._klass;
   }
 }
 

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -78,13 +78,9 @@ class oopDesc {
   inline Klass* klass() const;
   inline Klass* klass_or_null() const;
   inline Klass* klass_or_null_acquire() const;
-  static inline Klass** klass_addr(HeapWord* mem);
-  static inline narrowKlass* compressed_klass_addr(HeapWord* mem);
-  inline Klass** klass_addr();
-  inline narrowKlass* compressed_klass_addr();
 
   inline void set_klass(Klass* k);
-  static inline void release_set_klass(HeapWord* mem, Klass* klass);
+  static inline void release_set_klass(HeapWord* mem, Klass* k);
 
   // For klass field compression
   inline int klass_gap() const;

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -126,13 +126,12 @@ void oopDesc::set_klass(Klass* k) {
 void oopDesc::release_set_klass(HeapWord* mem, Klass* k) {
   assert(Universe::is_bootstrapping() || (k != NULL && k->is_klass()), "incorrect Klass");
 
-  char* raw_mem = (char*)mem;
+  char* raw_mem = ((char*)mem + klass_offset_in_bytes());
   if (UseCompressedClassPointers) {
-    narrowKlass* addr = (narrowKlass*)(raw_mem + klass_offset_in_bytes());
-    Atomic::release_store(addr, CompressedKlassPointers::encode_not_null(k));
+    Atomic::release_store((narrowKlass*)raw_mem,
+                          CompressedKlassPointers::encode_not_null(k));
   } else {
-    Klass** addr = (Klass**)(raw_mem + klass_offset_in_bytes());
-    Atomic::release_store(addr, k);
+    Atomic::release_store((Klass**)raw_mem, k);
   }
 }
 

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -115,7 +115,6 @@ Klass* oopDesc::klass_or_null_acquire() const {
 
 void oopDesc::set_klass(Klass* k) {
   assert(Universe::is_bootstrapping() || (k != NULL && k->is_klass()), "incorrect Klass");
-
   if (UseCompressedClassPointers) {
     _metadata._compressed_klass = CompressedKlassPointers::encode_not_null(k);
   } else {
@@ -125,7 +124,6 @@ void oopDesc::set_klass(Klass* k) {
 
 void oopDesc::release_set_klass(HeapWord* mem, Klass* k) {
   assert(Universe::is_bootstrapping() || (k != NULL && k->is_klass()), "incorrect Klass");
-
   char* raw_mem = ((char*)mem + klass_offset_in_bytes());
   if (UseCompressedClassPointers) {
     Atomic::release_store((narrowKlass*)raw_mem,

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -113,54 +113,28 @@ Klass* oopDesc::klass_or_null_acquire() const {
   }
 }
 
-Klass** oopDesc::klass_addr(HeapWord* mem) {
-  // Only used internally and with CMS and will not work with
-  // UseCompressedOops
-  assert(!UseCompressedClassPointers, "only supported with uncompressed klass pointers");
-  ByteSize offset = byte_offset_of(oopDesc, _metadata._klass);
-  return (Klass**) (((char*)mem) + in_bytes(offset));
-}
-
-narrowKlass* oopDesc::compressed_klass_addr(HeapWord* mem) {
-  assert(UseCompressedClassPointers, "only called by compressed klass pointers");
-  ByteSize offset = byte_offset_of(oopDesc, _metadata._compressed_klass);
-  return (narrowKlass*) (((char*)mem) + in_bytes(offset));
-}
-
-Klass** oopDesc::klass_addr() {
-  return klass_addr((HeapWord*)this);
-}
-
-narrowKlass* oopDesc::compressed_klass_addr() {
-  return compressed_klass_addr((HeapWord*)this);
-}
-
-#define CHECK_SET_KLASS(k)                                                \
-  do {                                                                    \
-    assert(Universe::is_bootstrapping() || k != NULL, "NULL Klass");      \
-    assert(Universe::is_bootstrapping() || k->is_klass(), "not a Klass"); \
-  } while (0)
-
 void oopDesc::set_klass(Klass* k) {
-  CHECK_SET_KLASS(k);
+  assert(Universe::is_bootstrapping() || (k != NULL && k->is_klass()), "incorrect Klass");
+
   if (UseCompressedClassPointers) {
-    *compressed_klass_addr() = CompressedKlassPointers::encode_not_null(k);
+    _metadata._compressed_klass = CompressedKlassPointers::encode_not_null(k);
   } else {
-    *klass_addr() = k;
+    _metadata._klass = k;
   }
 }
 
-void oopDesc::release_set_klass(HeapWord* mem, Klass* klass) {
-  CHECK_SET_KLASS(klass);
+void oopDesc::release_set_klass(HeapWord* mem, Klass* k) {
+  assert(Universe::is_bootstrapping() || (k != NULL && k->is_klass()), "incorrect Klass");
+
+  char* raw_mem = (char*)mem;
   if (UseCompressedClassPointers) {
-    Atomic::release_store(compressed_klass_addr(mem),
-                          CompressedKlassPointers::encode_not_null(klass));
+    narrowKlass* addr = (narrowKlass*)(raw_mem + klass_offset_in_bytes());
+    Atomic::release_store(addr, CompressedKlassPointers::encode_not_null(k));
   } else {
-    Atomic::release_store(klass_addr(mem), klass);
+    Klass** addr = (Klass**)(raw_mem + klass_offset_in_bytes());
+    Atomic::release_store(addr, k);
   }
 }
-
-#undef CHECK_SET_KLASS
 
 int oopDesc::klass_gap() const {
   return *(int*)(((intptr_t)this) + klass_gap_offset_in_bytes());


### PR DESCRIPTION
Right now this one has the comment mentioning CMS:

```
Klass** oopDesc::klass_addr(HeapWord* mem) {
  // Only used internally and with CMS and will not work with
  // UseCompressedOops
  assert(!UseCompressedClassPointers, "only supported with uncompressed klass pointers");
  ByteSize offset = byte_offset_of(oopDesc, _metadata._klass);
  return (Klass**) (((char*)mem) + in_bytes(offset));
}
```

But that is not true, it is used on the generic paths.

The rest are the snowballing changes: 
 - in `load_klass_raw` and `set_klass`: `compressed_klass_addr` and `klass_addr` are used where the direct access to `_metadata` can be done, avoiding these methods
 - the leftover use is in `set_klass_release`, where we can simplify things by inlining `_addr` methods directly
 - `CHECK_SET_KLASS` macro seems too much ceremony for just two asserts

Note that new code uses the universal `klass_offset_in_bytes`, that is technically `offset_of(..., _metadata._klass)`. This is different from the previous code, but it matches what other code is doing -- it trusts that both `_metadata._klass` and `_metadata._compressed_klass` are on the same offsets. I thought to add a very paranoid assert there, but decided not to.

Testing: 
  - [x] Linux x86_64 fastdebug hotspot_gc_shenandoah
  - [x] Linux x86_64 release hotspot_gc_shenandoah
  - [x] Linux x86_64 fastdebug tier1
  - [x] Linux x86_64 fastdebug tier2
  - [x] Linux x86_64 fastdebug tier1, -XX:+UseShenandoahGC
  - [x] Linux x86_64 fastdebug tier2, -XX:+UseShenandoahGC
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253278](https://bugs.openjdk.java.net/browse/JDK-8253278): Refactor/cleanup oopDesc::*_klass_addr


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/221/head:pull/221`
`$ git checkout pull/221`
