### PR TITLE
8253285: Some java/util/StringJoiner tests do not explicitly specify required -XX:+CompactStrings

### DIFF
--- a/test/jdk/java/util/StringJoiner/MergeTest.java
+++ b/test/jdk/java/util/StringJoiner/MergeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary test  StringJoiner::merge
  * @modules java.base/jdk.internal.util
  * @requires os.maxMemory > 4G
- * @run testng/othervm -Xmx4g MergeTest
+ * @run testng/othervm -Xmx4g -XX:+CompactStrings MergeTest
  */
 
 import java.util.StringJoiner;

--- a/test/jdk/java/util/StringJoiner/StringJoinerTest.java
+++ b/test/jdk/java/util/StringJoiner/StringJoinerTest.java
@@ -26,7 +26,7 @@
  * @summary tests StringJoinerTest
  * @modules java.base/jdk.internal.util
  * @requires os.maxMemory > 4G
- * @run testng/othervm -Xmx4g StringJoinerTest
+ * @run testng/othervm -Xmx4g -XX:+CompactStrings StringJoinerTest
  * @author Jim Gish
  */
 import java.util.ArrayList;


### PR DESCRIPTION
Signed-off-by: Andrew Leonard <andrew_m_leonard@uk.ibm.com>
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253285](https://bugs.openjdk.java.net/browse/JDK-8253285): Some java/util/StringJoiner tests do not explicitly specify required -XX:+CompactStrings


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/223/head:pull/223`
`$ git checkout pull/223`
