### PR TITLE
8253284: Zero OrderAccess barrier mappings are incorrect

### DIFF
--- a/src/hotspot/os_cpu/bsd_zero/orderAccess_bsd_zero.hpp
+++ b/src/hotspot/os_cpu/bsd_zero/orderAccess_bsd_zero.hpp
@@ -28,6 +28,8 @@
 
 // Included in orderAccess.hpp header file.
 
+#if defined(ARM)   // ----------------------------------------------------
+
 /*
  * ARM Kernel helper for memory barrier.
  * Using __asm __volatile ("":::"memory") does not work reliable on ARM

--- a/src/hotspot/os_cpu/linux_zero/orderAccess_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/orderAccess_linux_zero.hpp
@@ -28,7 +28,7 @@
 
 // Included in orderAccess.hpp header file.
 
-#ifdef ARM
+#if defined(ARM)   // ----------------------------------------------------
 
 /*
  * ARM Kernel helper for memory barrier.
@@ -39,14 +39,10 @@
 typedef void (__kernel_dmb_t) (void);
 #define __kernel_dmb (*(__kernel_dmb_t *) 0xffff0fa0)
 
-#define FULL_MEM_BARRIER __kernel_dmb()
 #define LIGHT_MEM_BARRIER __kernel_dmb()
+#define FULL_MEM_BARRIER  __kernel_dmb()
 
-#else // ARM
-
-#define FULL_MEM_BARRIER __sync_synchronize()
-
-#ifdef PPC
+#elif defined(PPC) // ----------------------------------------------------
 
 #ifdef __NO_LWSYNC__
 #define LIGHT_MEM_BARRIER __asm __volatile ("sync":::"memory")
@@ -54,21 +50,21 @@ typedef void (__kernel_dmb_t) (void);
 #define LIGHT_MEM_BARRIER __asm __volatile ("lwsync":::"memory")
 #endif
 
-#else // PPC
+#define FULL_MEM_BARRIER  __sync_synchronize()
 
-#ifdef ALPHA
-
-#define LIGHT_MEM_BARRIER __sync_synchronize()
-
-#else // ALPHA
+#elif defined(X86) // ----------------------------------------------------
 
 #define LIGHT_MEM_BARRIER __asm __volatile ("":::"memory")
+#define FULL_MEM_BARRIER  __sync_synchronize()
 
-#endif // ALPHA
+#else              // ----------------------------------------------------
 
-#endif // PPC
+// Default to strongest barriers for correctness.
 
-#endif // ARM
+#define LIGHT_MEM_BARRIER __sync_synchronize()
+#define FULL_MEM_BARRIER  __sync_synchronize()
+
+#endif             // ----------------------------------------------------
 
 // Note: What is meant by LIGHT_MEM_BARRIER is a barrier which is sufficient
 // to provide TSO semantics, i.e. StoreStore | LoadLoad | LoadStore.


### PR DESCRIPTION
There are some jcstress failures with AArch64 Zero. It seems because to happen because `orderAccess_linux_zero.hpp` defaults to compiler-only barriers for most OrderAccess::* calls. We need to defer to the strongest barriers by default. 

The code also needs some rearrangement to make the mappings clear.

jcstress seems to capture the bug, and seems to pass when bug is fixed. Since this is `zero`, we want only the interpreter (compiler configs would be excessive). Release builds capture more samples.

```
$ wget https://builds.shipilev.net/jcstress/jcstress-tests-all-20200917.jar
$ build/linux-x86_64-server-release/images/jdk/bin/java -jar jcstress-tests-all-20200917.jar --jvmArgs "-Xint" 
```

Testing:
 - [x] x86_64 Linux zero release jcstress run
 - [x] x86_64 MacOS zero release jcstress run
 - [x] AArch64 Linux zero release jcstress run
 - [x] PPC Linux zero release jcstress run
 - [x] SKIPPED: ARM32 Linux zero release jcstress run (it would seem ARM32 is broken already: JDK-8253464)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253284](https://bugs.openjdk.java.net/browse/JDK-8253284): Zero OrderAccess barrier mappings are incorrect


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/224/head:pull/224`
`$ git checkout pull/224`
