### PR TITLE
8253313: xmlstream.hpp missing from vmIntrinsics.cpp

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -25,6 +25,7 @@
 #include "classfile/vmIntrinsics.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "compiler/compilerDirectives.hpp"
+#include "utilities/xmlstream.hpp"
 
 // These are flag-matching functions:
 inline bool match_F_R(jshort flags) {


### PR DESCRIPTION
Please review this quick/trivial fix for for build breakage.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253313](https://bugs.openjdk.java.net/browse/JDK-8253313): xmlstream.hpp missing from vmIntrinsics.cpp


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/230/head:pull/230`
`$ git checkout pull/230`
