### PR TITLE
8253314: precompiled.hpp missing from vmIntrinsics.cpp

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "precompiled.hpp"
 #include "classfile/vmIntrinsics.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "compiler/compilerDirectives.hpp"


### PR DESCRIPTION
Sorry, please review yet another trivial fix for build breakage.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253314](https://bugs.openjdk.java.net/browse/JDK-8253314): precompiled.hpp missing from vmIntrinsics.cpp


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/231/head:pull/231`
`$ git checkout pull/231`
