### PR TITLE
8253317: The "com/apple/eawt" is missed in the "othervm.dirs" config option

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -18,7 +18,7 @@ keys=2d dnd headful i18n intermittent printer randomness jfr
 
 # Tests that must run in othervm mode
 othervm.dirs=java/awt java/beans javax/accessibility javax/imageio javax/sound javax/swing javax/print \
-com/apple/laf com/sun/java/accessibility com/sun/java/swing sanity/client demo/jfc \
+com/apple/laf com/apple/eawt com/sun/java/accessibility com/sun/java/swing sanity/client demo/jfc \
 javax/management sun/awt sun/java2d javax/xml/jaxp/testng/validation java/lang/ProcessHandle
 
 # Tests that cannot run concurrently


### PR DESCRIPTION
The list of client test groups in "TEST.groups" is synchronized with the list of othervm.dirs in "TEST.ROOT"
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253317](https://bugs.openjdk.java.net/browse/JDK-8253317): The "com/apple/eawt" is missed in the "othervm.dirs" config option


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/233/head:pull/233`
`$ git checkout pull/233`
