### PR TITLE
8253332: ZGC: Make heap views reservation platform independent

### DIFF
--- a/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
+++ b/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
@@ -33,19 +33,21 @@ void ZVirtualMemoryManager::initialize_os() {
   // Does nothing
 }
 
-uintptr_t ZVirtualMemoryManager::os_reserve(uintptr_t addr, size_t size) {
+bool ZVirtualMemoryManager::os_reserve(uintptr_t addr, size_t size) {
   const uintptr_t res = (uintptr_t)mmap((void*)addr, size, PROT_NONE, MAP_ANONYMOUS|MAP_PRIVATE|MAP_NORESERVE, -1, 0);
   if (res == (uintptr_t)MAP_FAILED) {
     // Failed to reserve memory
-    return 0;
+    return false;
   }
 
   if (res != addr) {
     // Failed to reserve memory at the requested address
     munmap((void*)res, size);
+    return false;
   }
 
-  return res;
+  // Success
+  return true;
 }
 
 void ZVirtualMemoryManager::os_unreserve(uintptr_t addr, size_t size) {

--- a/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
+++ b/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
@@ -42,7 +42,7 @@ uintptr_t ZVirtualMemoryManager::os_reserve(uintptr_t addr, size_t size) {
 
   if (res != addr) {
     // Failed to reserve memory at the requested address
-    os_unreserve(res, size);
+    munmap((void*)res, size);
   }
 
   return res;

--- a/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
@@ -116,34 +116,10 @@ void ZVirtualMemoryManager::initialize_os() {
   _manager.register_callbacks(callbacks);
 }
 
-bool ZVirtualMemoryManager::reserve_contiguous_platform(uintptr_t start, size_t size) {
-  assert(is_aligned(size, ZGranuleSize), "Must be granule aligned");
+uintptr_t ZVirtualMemoryManager::os_reserve(uintptr_t addr, size_t size) {
+  return ZMapper::reserve(addr, size);
+}
 
-  // Reserve address views
-  const uintptr_t marked0 = ZAddress::marked0(start);
-  const uintptr_t marked1 = ZAddress::marked1(start);
-  const uintptr_t remapped = ZAddress::remapped(start);
-
-  // Reserve address space
-  if (ZMapper::reserve(marked0, size) != marked0) {
-    return false;
-  }
-
-  if (ZMapper::reserve(marked1, size) != marked1) {
-    ZMapper::unreserve(marked0, size);
-    return false;
-  }
-
-  if (ZMapper::reserve(remapped, size) != remapped) {
-    ZMapper::unreserve(marked0, size);
-    ZMapper::unreserve(marked1, size);
-    return false;
-  }
-
-  // Register address views with native memory tracker
-  nmt_reserve(marked0, size);
-  nmt_reserve(marked1, size);
-  nmt_reserve(remapped, size);
-
-  return true;
+void ZVirtualMemoryManager::os_unreserve(uintptr_t addr, size_t size) {
+  ZMapper::unreserve(addr, size);
 }

--- a/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
@@ -116,8 +116,11 @@ void ZVirtualMemoryManager::initialize_os() {
   _manager.register_callbacks(callbacks);
 }
 
-uintptr_t ZVirtualMemoryManager::os_reserve(uintptr_t addr, size_t size) {
-  return ZMapper::reserve(addr, size);
+bool ZVirtualMemoryManager::os_reserve(uintptr_t addr, size_t size) {
+  uintptr_t res = ZMapper::reserve(addr, size);
+
+  assert(res == addr || res == NULL, "Should not reserve other memory than requested");
+  return res == addr;
 }
 
 void ZVirtualMemoryManager::os_unreserve(uintptr_t addr, size_t size) {

--- a/src/hotspot/share/gc/z/zVirtualMemory.cpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.cpp
@@ -23,12 +23,13 @@
 
 #include "precompiled.hpp"
 #include "gc/shared/gcLogPrecious.hpp"
+#include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zAddressSpaceLimit.hpp"
 #include "gc/z/zGlobals.hpp"
 #include "gc/z/zVirtualMemory.inline.hpp"
 #include "services/memTracker.hpp"
-#include "utilities/debug.hpp"
 #include "utilities/align.hpp"
+#include "utilities/debug.hpp"
 
 ZVirtualMemoryManager::ZVirtualMemoryManager(size_t max_capacity) :
     _manager(),
@@ -62,9 +63,7 @@ size_t ZVirtualMemoryManager::reserve_discontiguous(uintptr_t start, size_t size
 
   assert(is_aligned(size, ZGranuleSize), "Misaligned");
 
-  if (reserve_contiguous_platform(start, size)) {
-    // Make the address range free
-    _manager.free(start, size);
+  if (reserve_contiguous(start, size)) {
     return size;
   }
 
@@ -99,16 +98,56 @@ size_t ZVirtualMemoryManager::reserve_discontiguous(size_t size) {
   return reserved;
 }
 
+bool ZVirtualMemoryManager::reserve_contiguous_inner(uintptr_t start, size_t size) {
+  assert(is_aligned(size, ZGranuleSize), "Must be granule aligned");
+
+  // Reserve address views
+  const uintptr_t marked0 = ZAddress::marked0(start);
+  const uintptr_t marked1 = ZAddress::marked1(start);
+  const uintptr_t remapped = ZAddress::remapped(start);
+
+  // Reserve address space
+  if (os_reserve(marked0, size) != marked0) {
+    return false;
+  }
+
+  if (os_reserve(marked1, size) != marked1) {
+    os_unreserve(marked0, size);
+    return false;
+  }
+
+  if (os_reserve(remapped, size) != remapped) {
+    os_unreserve(marked0, size);
+    os_unreserve(marked1, size);
+    return false;
+  }
+
+  // Register address views with native memory tracker
+  nmt_reserve(ZAddress::marked0(start), size);
+  nmt_reserve(ZAddress::marked1(start), size);
+  nmt_reserve(ZAddress::remapped(start), size);
+
+  return true;
+}
+
+bool ZVirtualMemoryManager::reserve_contiguous(uintptr_t start, size_t size) {
+  if (reserve_contiguous_inner(start, size)) {
+    // Make the address range free
+    _manager.free(start, size);
+
+    return true;
+  }
+
+  return false;
+}
+
 bool ZVirtualMemoryManager::reserve_contiguous(size_t size) {
   // Allow at most 8192 attempts spread evenly across [0, ZAddressOffsetMax)
   const size_t unused = ZAddressOffsetMax - size;
   const size_t increment = MAX2(align_up(unused / 8192, ZGranuleSize), ZGranuleSize);
 
   for (size_t start = 0; start + size <= ZAddressOffsetMax; start += increment) {
-    if (reserve_contiguous_platform(start, size)) {
-      // Make the address range free
-      _manager.free(start, size);
-
+    if (reserve_contiguous(start, size)) {
       // Success
       return true;
     }

--- a/src/hotspot/share/gc/z/zVirtualMemory.cpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.cpp
@@ -107,16 +107,16 @@ bool ZVirtualMemoryManager::reserve_contiguous_inner(uintptr_t start, size_t siz
   const uintptr_t remapped = ZAddress::remapped(start);
 
   // Reserve address space
-  if (os_reserve(marked0, size) != marked0) {
+  if (!os_reserve(marked0, size)) {
     return false;
   }
 
-  if (os_reserve(marked1, size) != marked1) {
+  if (!os_reserve(marked1, size)) {
     os_unreserve(marked0, size);
     return false;
   }
 
-  if (os_reserve(remapped, size) != remapped) {
+  if (!os_reserve(remapped, size)) {
     os_unreserve(marked0, size);
     os_unreserve(marked1, size);
     return false;

--- a/src/hotspot/share/gc/z/zVirtualMemory.cpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.cpp
@@ -98,7 +98,7 @@ size_t ZVirtualMemoryManager::reserve_discontiguous(size_t size) {
   return reserved;
 }
 
-bool ZVirtualMemoryManager::reserve_contiguous_inner(uintptr_t start, size_t size) {
+bool ZVirtualMemoryManager::reserve_contiguous(uintptr_t start, size_t size) {
   assert(is_aligned(size, ZGranuleSize), "Must be granule aligned");
 
   // Reserve address views
@@ -127,18 +127,10 @@ bool ZVirtualMemoryManager::reserve_contiguous_inner(uintptr_t start, size_t siz
   nmt_reserve(marked1, size);
   nmt_reserve(remapped, size);
 
+  // Make the address range free
+  _manager.free(start, size);
+
   return true;
-}
-
-bool ZVirtualMemoryManager::reserve_contiguous(uintptr_t start, size_t size) {
-  if (reserve_contiguous_inner(start, size)) {
-    // Make the address range free
-    _manager.free(start, size);
-
-    return true;
-  }
-
-  return false;
 }
 
 bool ZVirtualMemoryManager::reserve_contiguous(size_t size) {

--- a/src/hotspot/share/gc/z/zVirtualMemory.cpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.cpp
@@ -123,9 +123,9 @@ bool ZVirtualMemoryManager::reserve_contiguous_inner(uintptr_t start, size_t siz
   }
 
   // Register address views with native memory tracker
-  nmt_reserve(ZAddress::marked0(start), size);
-  nmt_reserve(ZAddress::marked1(start), size);
-  nmt_reserve(ZAddress::remapped(start), size);
+  nmt_reserve(marked0, size);
+  nmt_reserve(marked1, size);
+  nmt_reserve(remapped, size);
 
   return true;
 }

--- a/src/hotspot/share/gc/z/zVirtualMemory.hpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.hpp
@@ -55,7 +55,6 @@ private:
   bool os_reserve(uintptr_t addr, size_t size);
   void os_unreserve(uintptr_t addr, size_t size);
 
-  bool reserve_contiguous_inner(uintptr_t start, size_t size);
   bool reserve_contiguous(uintptr_t start, size_t size);
   bool reserve_contiguous(size_t size);
   size_t reserve_discontiguous(uintptr_t start, size_t size, size_t min_range);

--- a/src/hotspot/share/gc/z/zVirtualMemory.hpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.hpp
@@ -52,8 +52,8 @@ private:
 
   // OS specific implementation
   void initialize_os();
-  uintptr_t os_reserve(uintptr_t start, size_t size);
-  void os_unreserve(uintptr_t start, size_t size);
+  bool os_reserve(uintptr_t addr, size_t size);
+  void os_unreserve(uintptr_t addr, size_t size);
 
   bool reserve_contiguous_inner(uintptr_t start, size_t size);
   bool reserve_contiguous(uintptr_t start, size_t size);

--- a/src/hotspot/share/gc/z/zVirtualMemory.hpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.hpp
@@ -50,9 +50,13 @@ private:
   ZMemoryManager _manager;
   bool           _initialized;
 
+  // OS specific implementation
   void initialize_os();
+  uintptr_t os_reserve(uintptr_t start, size_t size);
+  void os_unreserve(uintptr_t start, size_t size);
 
-  bool reserve_contiguous_platform(uintptr_t start, size_t size);
+  bool reserve_contiguous_inner(uintptr_t start, size_t size);
+  bool reserve_contiguous(uintptr_t start, size_t size);
   bool reserve_contiguous(size_t size);
   size_t reserve_discontiguous(uintptr_t start, size_t size, size_t min_range);
   size_t reserve_discontiguous(size_t size);


### PR DESCRIPTION
ZVirtualMemoryManager::reserve_contiguous_platform tries to reserve three views of a given address range. The posix and windows versions are more or less duplicates, with calls to platform dependent versions of reserve/unreserve functions.

I'd like to clean this up in preparation of an alternative implementation for heap memory allocation on Windows.

I choose to prefix the OS dependent functions with os_. For consistency, initialize_os should have been renamed as well, but the plan is to change that in a separate patch that splits that function into two, so I skipped it for now.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253332](https://bugs.openjdk.java.net/browse/JDK-8253332): ZGC: Make heap views reservation platform independent


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to bb10b9c2ed6804998f6a13857922dd7a919f398b
 * [Per Lidén](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/236/head:pull/236`
`$ git checkout pull/236`
