### PR TITLE
JDK-8253239: Disable VS warning C4307

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -134,6 +134,9 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
 
       WARNINGS_ENABLE_ALL="-W3"
       DISABLED_WARNINGS="4800"
+      if test "x$TOOLCHAIN_VERSION" = x2017; then
+        DISABLED_WARNINGS+=" 4307"
+      fi
       ;;
 
     gcc)

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -135,6 +135,7 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
       WARNINGS_ENABLE_ALL="-W3"
       DISABLED_WARNINGS="4800"
       if test "x$TOOLCHAIN_VERSION" = x2017; then
+        # VS2017 incorrectly triggers this warning for constexpr
         DISABLED_WARNINGS+=" 4307"
       fi
       ;;


### PR DESCRIPTION
hello, this fixes the build when using VS2017. VS2019 does not have the issue as far as I know.
failure was 

> ./test/hotspot/gtest/utilities/test_align.cpp(96): error C2220: warning treated as error - no 'object' file generated
> ./test/hotspot/gtest/utilities/test_align.cpp(156): note: see reference to function template instantiation 'void static_test_alignments<T,A>(void)' being compiled
> with
> [
> T=int64_t,
> A=uint8_t
> ]
> ./test/hotspot/gtest/utilities/test_align.cpp(162): note: see reference to function template instantiation 'void test_alignments<int64_t,uint8_t>(void)' being compiled
> ./test/hotspot/gtest/utilities/test_align.cpp(96): warning C4307: '+': integral constant overflow
>
>

This might be related to an issue fixed at least in some versions of VS2019 , that is discussed here :

https://developercommunity.visualstudio.com/content/problem/211134/unsigned-integer-overflows-in-constexpr-functionsa.html

https://bugs.openjdk.java.net/browse/JDK-8253239
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253239](https://bugs.openjdk.java.net/browse/JDK-8253239): Disable VS warning C4307


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/237/head:pull/237`
`$ git checkout pull/237`
