### PR TITLE
8253235: JFR.dump does not respect maxage parameter

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
@@ -331,6 +331,8 @@ public final class PlatformRecording implements AutoCloseable {
         clone.setShouldWriteActiveRecordingEvent(false);
         clone.setName(getName());
         clone.setToDisk(true);
+        clone.setMaxAge(getMaxAge());
+        clone.setMaxSize(getMaxSize());
         // We purposely don't clone settings here, since
         // a union a == a
         if (!isToDisk()) {


### PR DESCRIPTION
JFR.dump command creates a clone of the original recording, but maxage and maxsize parameters are not copied to the clone in PlatformRecording.newSnapshotClone().
When PlatformRecording.appendChunk() is called for the clone to append the latest data, trimToAge() and trimToSize() are not performed because maxAge and maxSize are not set.
Therefore the clone sometimes dumps outdated chunks to the disk.

Testing:
jdk/jdk/jfr/*

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253235](https://bugs.openjdk.java.net/browse/JDK-8253235): JFR.dump does not respect maxage parameter


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/239/head:pull/239`
`$ git checkout pull/239`
