### PR TITLE
8253344: Remove unimplemented Arguments::check_gc_consistency

### DIFF
--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -503,8 +503,6 @@ class Arguments : AllStatic {
   // Adjusts the arguments after the OS have adjusted the arguments
   static jint adjust_after_os();
 
-  // Check for consistency in the selection of the garbage collector.
-  static bool check_gc_consistency();        // Check user-selected gc
   // Check consistency or otherwise of VM argument settings
   static bool check_vm_args_consistency();
   // Used by os_solaris


### PR DESCRIPTION
Looks like a leftover from JDK-8199925 that removed the definition, but left the declaration back.

Testing:
  - [x] Linux x86_64 fastdebug build
  - [x] Text search for check_gc_consistency in `src/`
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253344](https://bugs.openjdk.java.net/browse/JDK-8253344): Remove unimplemented Arguments::check_gc_consistency


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/240/head:pull/240`
`$ git checkout pull/240`
