### PR TITLE
8253345: Remove unimplemented Arguments::lookup_logging_aliases

### DIFF
--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -478,7 +478,6 @@ class Arguments : AllStatic {
   // Return the "real" name for option arg if arg is an alias, and print a warning if arg is deprecated.
   // Return NULL if the arg has expired.
   static const char* handle_aliases_and_deprecation(const char* arg, bool warn);
-  static bool lookup_logging_aliases(const char* arg, char* buffer);
   static AliasedLoggingFlag catch_logging_aliases(const char* name, bool on);
 
   static char*  SharedArchivePath;


### PR DESCRIPTION
Renamed with JDK-8146800, but old declaration was left behind.

Testing:

 - [x] Linux x86_64 fastdebug build
 - [x] Text search for lookup_logging_aliases in src/
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253345](https://bugs.openjdk.java.net/browse/JDK-8253345): Remove unimplemented Arguments::lookup_logging_aliases


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/241/head:pull/241`
`$ git checkout pull/241`
