### PR TITLE
8253348: Remove unimplemented JNIHandles::initialize

### DIFF
--- a/src/hotspot/share/runtime/jniHandles.hpp
+++ b/src/hotspot/share/runtime/jniHandles.hpp
@@ -99,9 +99,6 @@ class JNIHandles : AllStatic {
   static void destroy_weak_global(jobject handle);
   static bool is_global_weak_cleared(jweak handle); // Test jweak without resolution
 
-  // Initialization
-  static void initialize();
-
   // Debugging
   static void print_on(outputStream* st);
   static void print();


### PR DESCRIPTION
Seems to be a left-over from JDK-8227053 that removed the definition, but left the declaration behind.

Testing:
  - [x] Linux x86_64 fastdebug build
  - [x] Text search for `JNIHandles::initialize` in `src/hotspot`
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253348](https://bugs.openjdk.java.net/browse/JDK-8253348): Remove unimplemented JNIHandles::initialize


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/243/head:pull/243`
`$ git checkout pull/243`
