### PR TITLE
8253349: Remove unimplemented SharedRuntime::native_method_throw_unsupported_operation_exception_entry

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -266,7 +266,6 @@ class SharedRuntime: AllStatic {
 
   // To be used as the entry point for unresolved native methods.
   static address native_method_throw_unsatisfied_link_error_entry();
-  static address native_method_throw_unsupported_operation_exception_entry();
 
   static oop retrieve_receiver(Symbol* sig, frame caller);
 


### PR DESCRIPTION
The definition was removed in JDK-7196277 (confidential): https://github.com/openjdk/jdk/commit/149097fbb751155cba49de38f8da5b39635198af

Declaration was left behind.

Testing:
  - [x] Linux x86_64 fastdebug build
  - [x] Text search for `native_method_throw_unsupported_operation_exception_entry` in `src/hotspot`
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253349](https://bugs.openjdk.java.net/browse/JDK-8253349): Remove unimplemented SharedRuntime::native_method_throw_unsupported_operation_exception_entry


### Reviewers
 * [Aditya Mandaleeka](https://openjdk.java.net/census#adityam) (@adityamandaleeka - Author)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/244/head:pull/244`
`$ git checkout pull/244`
