### PR TITLE
8253350: Remove unimplemented SharedRuntime::clean_*_entry

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -356,10 +356,6 @@ class SharedRuntime: AllStatic {
 
   static Method* extract_attached_method(vframeStream& vfst);
 
-  static address clean_virtual_call_entry();
-  static address clean_opt_virtual_call_entry();
-  static address clean_static_call_entry();
-
 #if defined(X86) && defined(COMPILER1)
   // For Object.hashCode, System.identityHashCode try to pull hashCode from object header if available.
   static void inline_check_hashcode_from_object_header(MacroAssembler* masm, const methodHandle& method, Register obj_reg, Register result);


### PR DESCRIPTION
Their existence seems to predate OpenJDK. There are no uses, no definitions.

Testing:
  - [x] Linux x86_64 fastdebug build
  - [x] Text searches for `clean_*_entry` in `src/hotspot`
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253350](https://bugs.openjdk.java.net/browse/JDK-8253350): Remove unimplemented SharedRuntime::clean_*_entry


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/245/head:pull/245`
`$ git checkout pull/245`
