### PR TITLE
8252997: Null-proofing for linker_md.c

### DIFF
--- a/src/jdk.jdwp.agent/unix/native/libjdwp/linker_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/linker_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,10 +49,11 @@ static void dll_build_name(char* buffer, size_t buflen,
     *buffer = '\0';
 
     paths_copy = jvmtiAllocate((int)strlen(paths) + 1);
-    strcpy(paths_copy, paths);
     if (paths_copy == NULL) {
         return;
     }
+
+    strcpy(paths_copy, paths);
 
     next_token = NULL;
     path = strtok_r(paths_copy, PATH_SEPARATOR, &next_token);

--- a/src/jdk.jdwp.agent/windows/native/libjdwp/linker_md.c
+++ b/src/jdk.jdwp.agent/windows/native/libjdwp/linker_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,10 +46,11 @@ static void dll_build_name(char* buffer, size_t buflen,
     *buffer = '\0';
 
     paths_copy = jvmtiAllocate((int)strlen(paths) + 1);
-    strcpy(paths_copy, paths);
     if (paths_copy == NULL) {
         return;
     }
+
+    strcpy(paths_copy, paths);
 
     next_token = NULL;
     path = strtok_s(paths_copy, PATH_SEPARATOR, &next_token);


### PR DESCRIPTION
In the platform-specific implementations of linker_md.c, we see the dll_build_name methods begin with a call to jvmtiAllocate.

We then appear to rush ahead and try to use that variable without checking for a null.

I propose moving the null check to the point *before* we try to use that variable, to avoid any possible SEGV. 

Bug link: https://bugs.openjdk.java.net/browse/JDK-8252997

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252997](https://bugs.openjdk.java.net/browse/JDK-8252997): Null-proofing for linker_md.c


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/246/head:pull/246`
`$ git checkout pull/246`
