### PR TITLE
8253303  G1: Move static initialization of G1FromCardCache to a proper location

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1682,9 +1682,11 @@ jint G1CollectedHeap::initialize() {
   // The G1FromCardCache reserves card with value 0 as "invalid", so the heap must not
   // start within the first card.
   guarantee(heap_rs.base() >= (char*)G1CardTable::card_size, "Java heap must not start within the first card.");
+  G1FromCardCache::initialize(max_reserved_regions());
   // Also create a G1 rem set.
   _rem_set = new G1RemSet(this, _card_table, _hot_card_cache);
   _rem_set->initialize(max_reserved_regions());
+
 
   size_t max_cards_per_region = ((size_t)1 << (sizeof(CardIdx_t)*BitsPerByte-1)) - 1;
   guarantee(HeapRegion::CardsPerRegion > 0, "make sure it's initialized");

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1687,7 +1687,6 @@ jint G1CollectedHeap::initialize() {
   _rem_set = new G1RemSet(this, _card_table, _hot_card_cache);
   _rem_set->initialize(max_reserved_regions());
 
-
   size_t max_cards_per_region = ((size_t)1 << (sizeof(CardIdx_t)*BitsPerByte-1)) - 1;
   guarantee(HeapRegion::CardsPerRegion > 0, "make sure it's initialized");
   guarantee(HeapRegion::CardsPerRegion < max_cards_per_region,

--- a/src/hotspot/share/gc/g1/g1FromCardCache.hpp
+++ b/src/hotspot/share/gc/g1/g1FromCardCache.hpp
@@ -54,6 +54,13 @@ private:
   // This means that the heap must not contain card zero.
   static const uintptr_t InvalidCard = 0;
 
+  // Gives an approximation on how many threads can be expected to add records to
+  // a remembered set in parallel. This is used for sizing the G1FromCardCache to
+  // decrease performance losses due to data structure sharing.
+  // Examples for quantities that influence this value are the maximum number of
+  // mutator threads, maximum number of concurrent refinement or GC threads.
+  static uint num_par_rem_sets();
+
 public:
   static void clear(uint region_idx);
 
@@ -79,7 +86,7 @@ public:
     _cache[region_idx][worker_id] = val;
   }
 
-  static void initialize(uint num_par_rem_sets, uint max_reserved_regions);
+  static void initialize(uint max_reserved_regions);
 
   static void invalidate(uint start_idx, size_t num_regions);
 

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -38,6 +38,7 @@
 #include "gc/g1/g1RootClosures.hpp"
 #include "gc/g1/g1RemSet.hpp"
 #include "gc/g1/g1SharedDirtyCardQueue.hpp"
+#include "gc/g1/g1_globals.hpp"
 #include "gc/g1/heapRegion.inline.hpp"
 #include "gc/g1/heapRegionManager.inline.hpp"
 #include "gc/g1/heapRegionRemSet.inline.hpp"
@@ -481,12 +482,7 @@ G1RemSet::~G1RemSet() {
   delete _scan_state;
 }
 
-uint G1RemSet::num_par_rem_sets() {
-  return G1DirtyCardQueueSet::num_par_ids() + G1ConcurrentRefine::max_num_threads() + MAX2(ConcGCThreads, ParallelGCThreads);
-}
-
 void G1RemSet::initialize(uint max_reserved_regions) {
-  G1FromCardCache::initialize(num_par_rem_sets(), max_reserved_regions);
   _scan_state->initialize(max_reserved_regions);
 }
 

--- a/src/hotspot/share/gc/g1/g1RemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.hpp
@@ -70,12 +70,6 @@ private:
 public:
 
   typedef CardTable::CardValue CardValue;
-  // Gives an approximation on how many threads can be expected to add records to
-  // a remembered set in parallel. This can be used for sizing data structures to
-  // decrease performance losses due to data structure sharing.
-  // Examples for quantities that influence this value are the maximum number of
-  // mutator threads, maximum number of concurrent refinement or GC threads.
-  static uint num_par_rem_sets();
 
   // Initialize data that depends on the heap size being known.
   void initialize(uint max_reserved_regions);


### PR DESCRIPTION
in src/hotspot/share/gc/g1/g1RemSet.cpp:

 488 void G1RemSet::initialize(uint max_reserved_regions) {
 489 G1FromCardCache::initialize(num_par_rem_sets(), max_reserved_regions);
 490 _scan_state->initialize(max_reserved_regions);
 491 }

the static initialization is piggy-backed to G1RemSet instance initialization which is rather bad style. Fortunately there is only one G1RemSet instance and that method is only called once so no functional issue. 

This change moves the initialization call, and after a bit of analysis move some more related code to more appropriate places.

Testing: local compilation, jtreg gc/g1, tier1-3 passed
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253303](https://bugs.openjdk.java.net/browse/JDK-8253303): G1: Move static initialization of G1FromCardCache to a proper location


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author) ⚠️ Review applies to d327a515d6f1018c85efaede4e35563ed305ae62
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to d327a515d6f1018c85efaede4e35563ed305ae62


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/247/head:pull/247`
`$ git checkout pull/247`
