### PR TITLE
8253641: Missing newline in the printout of certain JFR events

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -442,8 +442,9 @@ public final class PrettyWriter extends EventPrintWriter {
             print(" (");
             print("id = ");
             print(String.valueOf(cl.getId()));
-            println(")");
+            print(")");
         }
+        println(postFix);
     }
 
     private void printJavaFrame(RecordedFrame f, String postFix) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -437,12 +437,14 @@ public final class PrettyWriter extends EventPrintWriter {
     private void printClassLoader(RecordedClassLoader cl, String postFix) {
         // Purposely not printing class loader name to avoid cluttered output
         RecordedClass clazz = cl.getType();
-        print(clazz == null ? "null" : clazz.getName());
         if (clazz != null) {
+            print(clazz.getName());
             print(" (");
             print("id = ");
             print(String.valueOf(cl.getId()));
             print(")");
+        } else {
+            print("null");
         }
         println(postFix);
     }


### PR DESCRIPTION
Trivial fix which adds a missing new line to PrettyWriter::printClassLoader if clazz == null.

PrettyWriter is used for both the jfr CLI tool and also for the impl of the public JFR API behind jdk.jfr.Event::toString().

how to reproduce using JFR CLI:

To generate a JFR dump for testing, simply start HelloWorld.java
```
public class HelloWorld {
    public static void main(String[] args) {System.out.println("hello there");}
}
```
with
`jdk-15+36/bin/java -XX:StartFlightRecording=filename=dump.jfr,dumponexit=true HelloWorld.java`


current result for events where the classLoader field equals null (note: newline missing):

```
jdk-15+36/bin/jfr print --events jdk.ModuleRequire dump.jfr
...
jdk.ModuleRequire {
  startTime = 16:12:43.524
  source = {
    name = "jdk.nio.mapmode"
    version = "15"
    location = "jrt:/jdk.nio.mapmode"
    classLoader = null  }
  requiredModule = {
    name = "java.base"
    version = "15"
    location = "jrt:/java.base"
    classLoader = null  }
}
...
```

after the patch, using same jfr dump and displaying the same event:

```
jdk16/build/linux-x86_64-server-release/jdk/bin/jfr print --events jdk.ModuleRequire dump.jfr
...
jdk.ModuleRequire {
  startTime = 16:12:43.524
  source = {
    name = "jdk.nio.mapmode"
    version = "15"
    location = "jrt:/jdk.nio.mapmode"
    classLoader = null
  }
  requiredModule = {
    name = "java.base"
    version = "15"
    location = "jrt:/java.base"
    classLoader = null
  }
}
...
```

sidenote:

There would be an opportunity to merge the two sequential if-else blocks[1] in printClassLoader over the clazz variable after this patch, but this would obfuscate the actual bug fix, so I decided to omit it. Let me know if I should add that.
[1] https://github.com/mbien/jdk/blob/67750e2b599b3f2a6b814d7bceada785ca4051f9/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java#L440-L448

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253641](https://bugs.openjdk.java.net/browse/JDK-8253641): Missing newline in the printout of certain JFR events


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Contributors
 * Michael Bien `<mbien42@gmail.com>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/248/head:pull/248`
`$ git checkout pull/248`
