### PR TITLE
8253000: Remove redundant MAKE_SUBDIR argument

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -112,7 +112,6 @@ $(eval $(call SetupTarget, generate-exported-symbols, \
 $(eval $(call DeclareRecipesForPhase, GENSRC, \
     TARGET_SUFFIX := gensrc-src, \
     FILE_PREFIX := Gensrc, \
-    MAKE_SUBDIR := gensrc, \
     CHECK_MODULES := $(ALL_MODULES), \
 ))
 
@@ -150,7 +149,6 @@ ALL_TARGETS += $(GENSRC_TARGETS)
 $(eval $(call DeclareRecipesForPhase, GENDATA, \
     TARGET_SUFFIX := gendata, \
     FILE_PREFIX := Gendata, \
-    MAKE_SUBDIR := gendata, \
     CHECK_MODULES := $(ALL_MODULES), \
 ))
 
@@ -161,7 +159,6 @@ ALL_TARGETS += $(GENDATA_TARGETS)
 $(eval $(call DeclareRecipesForPhase, COPY, \
     TARGET_SUFFIX := copy, \
     FILE_PREFIX := Copy, \
-    MAKE_SUBDIR := copy, \
     CHECK_MODULES := $(ALL_MODULES), \
 ))
 
@@ -203,7 +200,6 @@ ALL_TARGETS += $(JAVA_TARGETS)
 $(eval $(call DeclareRecipesForPhase, LIBS, \
     TARGET_SUFFIX := libs, \
     FILE_PREFIX := Lib, \
-    MAKE_SUBDIR := lib, \
     CHECK_MODULES := $(ALL_MODULES), \
 ))
 
@@ -216,7 +212,6 @@ ALL_TARGETS += $(LIBS_TARGETS)
 $(eval $(call DeclareRecipesForPhase, STATIC_LIBS, \
     TARGET_SUFFIX := static-libs, \
     FILE_PREFIX := Lib, \
-    MAKE_SUBDIR := lib, \
     CHECK_MODULES := $(ALL_MODULES), \
     EXTRA_ARGS := STATIC_LIBS=true, \
 ))
@@ -228,7 +223,6 @@ ALL_TARGETS += $(STATIC_LIBS_TARGETS)
 $(eval $(call DeclareRecipesForPhase, LAUNCHER, \
     TARGET_SUFFIX := launchers, \
     FILE_PREFIX := Launcher, \
-    MAKE_SUBDIR := launcher, \
     CHECK_MODULES := $(ALL_MODULES), \
 ))
 

--- a/make/MainSupport.gmk
+++ b/make/MainSupport.gmk
@@ -185,7 +185,6 @@ endef
 # Param 1: Name of list to add targets to
 # Named params:
 # TARGET_SUFFIX : Suffix of target to create for recipe
-# MAKE_SUBDIR : Subdir for this build phase
 # FILE_PREFIX : File prefix for this build phase
 # CHECK_MODULES : List of modules to try
 # MULTIPLE_MAKEFILES : Set to true to handle makefiles for the same module and


### PR DESCRIPTION
As part of JDK-8244044, MAKE_SUBDIR is no longer used in DeclareRecipesForPhase inside MakeSupport.gmk.

Therefore, it seems sensible to modify the instances where this is passed to DeclareRecipesForPhase, and to remove references to it from the associated MakeSupport.gmk comment. 

Bug: https://bugs.openjdk.java.net/browse/JDK-8253000

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253000](https://bugs.openjdk.java.net/browse/JDK-8253000): Remove redundant MAKE_SUBDIR argument


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/249/head:pull/249`
`$ git checkout pull/249`
