### PR TITLE
8252998: ModuleWrapper.gmk doesn't consult include path

### DIFF
--- a/make/ModuleWrapper.gmk
+++ b/make/ModuleWrapper.gmk
@@ -39,7 +39,7 @@ include MakeBase.gmk
 TARGETS :=
 
 # Include the file being wrapped.
-include modules/$(MODULE)/$(MAKEFILE_PREFIX).gmk
+include $(MAKEFILE_PREFIX).gmk
 
 # Setup copy rules from the modules directories to the jdk image directory.
 ifeq ($(call isTargetOs, windows), true)


### PR DESCRIPTION
A change made to ModuleWrapper.gmk as part of JDK-8244044 means that an included makefile is found in the current directory, so Make doesn't check the include dirs for overriding gmk files.

Recommend a minor, partial reversion of this changeset to ensure any override files are included instead. 

Bug: https://bugs.openjdk.java.net/browse/JDK-8252998

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252998](https://bugs.openjdk.java.net/browse/JDK-8252998): ModuleWrapper.gmk doesn't consult include path


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/250/head:pull/250`
`$ git checkout pull/250`
