### PR TITLE
8252722: More Swing plaf APIs that rely on default constructors

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicBorders.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicBorders.java
@@ -48,6 +48,11 @@ import sun.swing.SwingUtilities2;
 public class BasicBorders {
 
     /**
+     * Constructs a {@code BasicBorders}.
+     */
+    public BasicBorders() {}
+
+    /**
      * Returns a border instance for a {@code JButton}.
      *
      * @return a border instance for a {@code JButton}
@@ -473,6 +478,11 @@ public class BasicBorders {
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     public static class MarginBorder extends AbstractBorder implements UIResource {
+        /**
+         * Constructs a {@code MarginBorder}.
+         */
+        public MarginBorder() {}
+
         public Insets getBorderInsets(Component c, Insets insets)       {
             Insets margin = null;
             //

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicButtonUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicButtonUI.java
@@ -77,6 +77,11 @@ public class BasicButtonUI extends ButtonUI{
     //          Create PLAF
     // ********************************
     /**
+     * Constructs a {@code BasicButtonUI}.
+     */
+    public BasicButtonUI() {}
+
+    /**
      * Returns an instance of {@code BasicButtonUI}.
      *
      * @param c a component

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicCheckBoxMenuItemUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicCheckBoxMenuItemUI.java
@@ -40,6 +40,11 @@ import javax.swing.plaf.*;
 public class BasicCheckBoxMenuItemUI extends BasicMenuItemUI {
 
     /**
+     * Constructs a {@code BasicCheckBoxMenuItemUI}.
+     */
+    public BasicCheckBoxMenuItemUI() {}
+
+    /**
      * Constructs a new instance of {@code BasicCheckBoxMenuItemUI}.
      *
      * @param c a component

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicCheckBoxUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicCheckBoxUI.java
@@ -61,6 +61,11 @@ public class BasicCheckBoxUI extends BasicRadioButtonUI {
     // ********************************
 
     /**
+     * Constructs a {@code BasicCheckBoxUI}.
+     */
+    public BasicCheckBoxUI() {}
+
+    /**
      * Returns an instance of {@code BasicCheckBoxUI}.
      *
      * @param b a component

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicColorChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicColorChooserUI.java
@@ -78,6 +78,11 @@ public class BasicColorChooserUI extends ColorChooserUI
     private Handler handler;
 
     /**
+     * Constructs a {@code BasicColorChooserUI}.
+     */
+    public BasicColorChooserUI() {}
+
+    /**
      * Returns a new instance of {@code BasicColorChooserUI}.
      *
      * @param c a component
@@ -383,6 +388,11 @@ public class BasicColorChooserUI extends ColorChooserUI
      * Instantiate it only within subclasses of {@code BasicColorChooserUI}.
      */
     public class PropertyHandler implements PropertyChangeListener {
+        /**
+         * Constructs a {@code PropertyHandler}.
+         */
+        public PropertyHandler() {}
+
         public void propertyChange(PropertyChangeEvent e) {
             getHandler().propertyChange(e);
         }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxEditor.java
@@ -176,5 +176,9 @@ public class BasicComboBoxEditor implements ComboBoxEditor,FocusListener {
     @SuppressWarnings("serial") // Same-version serialization only
     public static class UIResource extends BasicComboBoxEditor
     implements javax.swing.plaf.UIResource {
+        /**
+         * Constructs a {@code UIResource}.
+         */
+        public UIResource() {}
     }
 }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxRenderer.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxRenderer.java
@@ -145,5 +145,9 @@ implements ListCellRenderer<Object>, Serializable {
      */
     @SuppressWarnings("serial") // Same-version serialization only
     public static class UIResource extends BasicComboBoxRenderer implements javax.swing.plaf.UIResource {
+        /**
+         * Constructs a {@code UIResource}.
+         */
+        public UIResource() {}
     }
 }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxUI.java
@@ -617,6 +617,11 @@ public class BasicComboBoxUI extends ComboBoxUI {
      * <code>BasicComboBoxUI</code>.
      */
     public class FocusHandler implements FocusListener {
+        /**
+         * Constructs a {@code FocusHandler}.
+         */
+        public FocusHandler() {}
+
         public void focusGained( FocusEvent e ) {
             getHandler().focusGained(e);
         }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxUI.java
@@ -232,6 +232,11 @@ public class BasicComboBoxUI extends ComboBoxUI {
      */
     protected Insets padding;
 
+    /**
+     * Constructs a {@code BasicComboBoxUI}.
+     */
+    public BasicComboBoxUI() {}
+
     // Used for calculating the default size.
     private static ListCellRenderer<Object> getDefaultListCellRenderer() {
         @SuppressWarnings("unchecked")
@@ -592,6 +597,11 @@ public class BasicComboBoxUI extends ComboBoxUI {
      * <code>BasicComboBoxUI</code>.
      */
     public class KeyHandler extends KeyAdapter {
+        /**
+         * Constructs a {@code KeyHandler}.
+         */
+        public KeyHandler() {}
+
         @Override
         public void keyPressed( KeyEvent e ) {
             getHandler().keyPressed(e);
@@ -627,6 +637,11 @@ public class BasicComboBoxUI extends ComboBoxUI {
      * @see #createListDataListener
      */
     public class ListDataHandler implements ListDataListener {
+        /**
+         * Constructs a {@code ListDataHandler}.
+         */
+        public ListDataHandler() {}
+
         public void contentsChanged( ListDataEvent e ) {
             getHandler().contentsChanged(e);
         }
@@ -651,6 +666,11 @@ public class BasicComboBoxUI extends ComboBoxUI {
      * @see #createItemListener
      */
     public class ItemHandler implements ItemListener {
+        /**
+         * Constructs a {@code ItemHandler}.
+         */
+        public ItemHandler() {}
+
         // This class used to implement behavior which is now redundant.
         public void itemStateChanged(ItemEvent e) {}
     }
@@ -670,6 +690,11 @@ public class BasicComboBoxUI extends ComboBoxUI {
      * @see #createPropertyChangeListener
      */
     public class PropertyChangeHandler implements PropertyChangeListener {
+        /**
+         * Constructs a {@code PropertyChangeHandler}.
+         */
+        public PropertyChangeHandler() {}
+
         public void propertyChange(PropertyChangeEvent e) {
             getHandler().propertyChange(e);
         }
@@ -697,6 +722,11 @@ public class BasicComboBoxUI extends ComboBoxUI {
      * <code>BasicComboBoxUI</code>.
      */
     public class ComboBoxLayoutManager implements LayoutManager {
+        /**
+         * Constructs a {@code ComboBoxLayoutManager}.
+         */
+        public ComboBoxLayoutManager() {}
+
         public void addLayoutComponent(String name, Component comp) {}
 
         public void removeLayoutComponent(Component comp) {}

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboPopup.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboPopup.java
@@ -734,6 +734,11 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      */
     protected class InvocationMouseHandler extends MouseAdapter {
         /**
+         * Constructor for subclasses to call.
+         */
+        protected InvocationMouseHandler() {}
+
+        /**
          * Responds to mouse-pressed events on the combo box.
          *
          * @param e the mouse-press event to be handled
@@ -758,6 +763,11 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      * list if it is dragging over the list.
      */
     protected class InvocationMouseMotionHandler extends MouseMotionAdapter {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected InvocationMouseMotionHandler() {}
+
         public void mouseDragged( MouseEvent e ) {
             getHandler().mouseDragged(e);
         }
@@ -771,6 +781,10 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      * BasicComboBoxUI ActionMap/InputMap methods.
      */
     public class InvocationKeyHandler extends KeyAdapter {
+        /**
+         * Constructs a {@code InvocationKeyHandler}.
+         */
+        public InvocationKeyHandler() {}
         public void keyReleased( KeyEvent e ) {}
     }
 
@@ -780,6 +794,10 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      * override.
      */
     protected class ListSelectionHandler implements ListSelectionListener {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected ListSelectionHandler() {}
         public void valueChanged( ListSelectionEvent e ) {}
     }
 
@@ -793,6 +811,10 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      * @see #createItemListener
      */
     public class ListDataHandler implements ListDataListener {
+        /**
+         * Constructs a {@code ListDataHandler}.
+         */
+        public ListDataHandler() {}
         public void contentsChanged( ListDataEvent e ) {}
 
         public void intervalAdded( ListDataEvent e ) {
@@ -806,6 +828,10 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      * This listener hides the popup when the mouse is released in the list.
      */
     protected class ListMouseHandler extends MouseAdapter {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected ListMouseHandler() {}
         public void mousePressed( MouseEvent e ) {
         }
         public void mouseReleased(MouseEvent anEvent) {
@@ -818,6 +844,10 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      * The selection change is not committed to the model, this is for user feedback only.
      */
     protected class ListMouseMotionHandler extends MouseMotionAdapter {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected ListMouseMotionHandler() {}
         public void mouseMoved( MouseEvent anEvent ) {
             getHandler().mouseMoved(anEvent);
         }
@@ -828,6 +858,10 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      * combo box.
      */
     protected class ItemHandler implements ItemListener {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected ItemHandler() {}
         public void itemStateChanged( ItemEvent e ) {
             getHandler().itemStateChanged(e);
         }
@@ -844,6 +878,10 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      * @see #createPropertyChangeListener
      */
     protected class PropertyChangeHandler implements PropertyChangeListener {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected PropertyChangeHandler() {}
         public void propertyChange( PropertyChangeEvent e ) {
             getHandler().propertyChange(e);
         }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboPopup.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboPopup.java
@@ -734,7 +734,7 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      */
     protected class InvocationMouseHandler extends MouseAdapter {
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code InvocationMouseHandler}.
          */
         protected InvocationMouseHandler() {}
 
@@ -764,7 +764,7 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      */
     protected class InvocationMouseMotionHandler extends MouseMotionAdapter {
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code InvocationMouseMotionHandler}.
          */
         protected InvocationMouseMotionHandler() {}
 
@@ -782,7 +782,7 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      */
     public class InvocationKeyHandler extends KeyAdapter {
         /**
-         * Constructs a {@code InvocationKeyHandler}.
+         * Constructs an {@code InvocationKeyHandler}.
          */
         public InvocationKeyHandler() {}
         public void keyReleased( KeyEvent e ) {}
@@ -795,7 +795,7 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      */
     protected class ListSelectionHandler implements ListSelectionListener {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code ListSelectionHandler}.
          */
         protected ListSelectionHandler() {}
         public void valueChanged( ListSelectionEvent e ) {}
@@ -829,7 +829,7 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      */
     protected class ListMouseHandler extends MouseAdapter {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code ListMouseHandler}.
          */
         protected ListMouseHandler() {}
         public void mousePressed( MouseEvent e ) {
@@ -845,9 +845,10 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      */
     protected class ListMouseMotionHandler extends MouseMotionAdapter {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code ListMouseMotionHandler}.
          */
         protected ListMouseMotionHandler() {}
+
         public void mouseMoved( MouseEvent anEvent ) {
             getHandler().mouseMoved(anEvent);
         }
@@ -859,7 +860,7 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      */
     protected class ItemHandler implements ItemListener {
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code ItemHandler}.
          */
         protected ItemHandler() {}
         public void itemStateChanged( ItemEvent e ) {
@@ -879,7 +880,7 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
      */
     protected class PropertyChangeHandler implements PropertyChangeListener {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code PropertyChangeHandler}.
          */
         protected PropertyChangeHandler() {}
         public void propertyChange( PropertyChangeEvent e ) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDesktopIconUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDesktopIconUI.java
@@ -243,6 +243,11 @@ public class BasicDesktopIconUI extends DesktopIconUI {
         int __x, __y;
         Rectangle startingBounds;
 
+        /**
+         * Constructs a {@code MouseInputHandler}.
+         */
+        public MouseInputHandler() {}
+
         public void mouseReleased(MouseEvent e) {
             _x = 0;
             _y = 0;

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDesktopPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDesktopPaneUI.java
@@ -679,7 +679,7 @@ public class BasicDesktopPaneUI extends DesktopPaneUI {
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class OpenAction extends AbstractAction {
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code OpenAction}.
          */
         protected OpenAction() {}
         public void actionPerformed(ActionEvent evt) {
@@ -698,7 +698,7 @@ public class BasicDesktopPaneUI extends DesktopPaneUI {
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class CloseAction extends AbstractAction {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code CloseAction}.
          */
         protected CloseAction() {}
         public void actionPerformed(ActionEvent evt) {
@@ -721,7 +721,7 @@ public class BasicDesktopPaneUI extends DesktopPaneUI {
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class MinimizeAction extends AbstractAction {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code MinimizeAction}.
          */
         protected MinimizeAction() {}
         public void actionPerformed(ActionEvent evt) {
@@ -744,7 +744,7 @@ public class BasicDesktopPaneUI extends DesktopPaneUI {
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class MaximizeAction extends AbstractAction {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code MaximizeAction}.
          */
         protected MaximizeAction() {}
         public void actionPerformed(ActionEvent evt) {
@@ -767,7 +767,7 @@ public class BasicDesktopPaneUI extends DesktopPaneUI {
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class NavigateAction extends AbstractAction {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code NavigateAction}.
          */
         protected NavigateAction() {}
         public void actionPerformed(ActionEvent evt) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDesktopPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDesktopPaneUI.java
@@ -678,6 +678,10 @@ public class BasicDesktopPaneUI extends DesktopPaneUI {
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class OpenAction extends AbstractAction {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected OpenAction() {}
         public void actionPerformed(ActionEvent evt) {
             JDesktopPane dp = (JDesktopPane)evt.getSource();
             SHARED_ACTION.setState(dp, Actions.RESTORE);
@@ -693,6 +697,10 @@ public class BasicDesktopPaneUI extends DesktopPaneUI {
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class CloseAction extends AbstractAction {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected CloseAction() {}
         public void actionPerformed(ActionEvent evt) {
             JDesktopPane dp = (JDesktopPane)evt.getSource();
             SHARED_ACTION.setState(dp, Actions.CLOSE);
@@ -712,6 +720,10 @@ public class BasicDesktopPaneUI extends DesktopPaneUI {
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class MinimizeAction extends AbstractAction {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected MinimizeAction() {}
         public void actionPerformed(ActionEvent evt) {
             JDesktopPane dp = (JDesktopPane)evt.getSource();
             SHARED_ACTION.setState(dp, Actions.MINIMIZE);
@@ -731,6 +743,10 @@ public class BasicDesktopPaneUI extends DesktopPaneUI {
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class MaximizeAction extends AbstractAction {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected MaximizeAction() {}
         public void actionPerformed(ActionEvent evt) {
             JDesktopPane dp = (JDesktopPane)evt.getSource();
             SHARED_ACTION.setState(dp, Actions.MAXIMIZE);
@@ -750,6 +766,10 @@ public class BasicDesktopPaneUI extends DesktopPaneUI {
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class NavigateAction extends AbstractAction {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected NavigateAction() {}
         public void actionPerformed(ActionEvent evt) {
             JDesktopPane dp = (JDesktopPane)evt.getSource();
             dp.selectFrame(true);

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
@@ -757,6 +757,12 @@ public class BasicFileChooserUI extends FileChooserUI {
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
+
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected SelectionListener() {}
+
         /** {@inheritDoc} */
         public void valueChanged(ListSelectionEvent e) {
             getHandler().valueChanged(e);
@@ -1325,6 +1331,11 @@ public class BasicFileChooserUI extends FileChooserUI {
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class CancelSelectionAction extends AbstractAction {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected CancelSelectionAction() {}
+
         /** {@inheritDoc} */
         public void actionPerformed(ActionEvent e) {
             getFileChooser().cancelSelection();
@@ -1336,6 +1347,11 @@ public class BasicFileChooserUI extends FileChooserUI {
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class UpdateAction extends AbstractAction {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected UpdateAction() {}
+
         /** {@inheritDoc} */
         public void actionPerformed(ActionEvent e) {
             JFileChooser fc = getFileChooser();

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
@@ -759,7 +759,7 @@ public class BasicFileChooserUI extends FileChooserUI {
         // class calls into the Handler.
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code SelectionListener}.
          */
         protected SelectionListener() {}
 
@@ -1332,7 +1332,7 @@ public class BasicFileChooserUI extends FileChooserUI {
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class CancelSelectionAction extends AbstractAction {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code CancelSelectionAction}.
          */
         protected CancelSelectionAction() {}
 
@@ -1348,7 +1348,7 @@ public class BasicFileChooserUI extends FileChooserUI {
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class UpdateAction extends AbstractAction {
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code UpdateAction}.
          */
         protected UpdateAction() {}
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFormattedTextFieldUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFormattedTextFieldUI.java
@@ -35,6 +35,11 @@ import javax.swing.plaf.ComponentUI;
  */
 public class BasicFormattedTextFieldUI extends BasicTextFieldUI {
     /**
+     * Constructs a {@code BasicFormattedTextFieldUI}.
+     */
+    public BasicFormattedTextFieldUI() {}
+
+    /**
      * Creates a UI for a JFormattedTextField.
      *
      * @param c the formatted text field

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicGraphicsUtils.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicGraphicsUtils.java
@@ -52,6 +52,11 @@ public class BasicGraphicsUtils
     private static final Insets ETCHED_INSETS = new Insets(2, 2, 2, 2);
 
     /**
+     * Constructs a {@code BasicGraphicsUtils}.
+     */
+    public BasicGraphicsUtils() {}
+
+    /**
      * Draws an etched rectangle.
      *
      * @param g an instance of {@code Graphics}

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicHTML.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicHTML.java
@@ -47,6 +47,11 @@ import sun.swing.SwingUtilities2;
 public class BasicHTML {
 
     /**
+     * Constructs a {@code BasicHTML}.
+     */
+    public BasicHTML() {}
+
+    /**
      * Create an html renderer for the given component and
      * string of html.
      *

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicIconFactory.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicIconFactory.java
@@ -62,6 +62,11 @@ public class BasicIconFactory implements Serializable
     private static Icon menuArrowIcon;
 
     /**
+     * Constructs a {@code BasicIconFactory}.
+     */
+    public BasicIconFactory() {}
+
+    /**
      * Returns a menu item check icon.
      *
      * @return a menu item check icon

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicInternalFrameTitlePane.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicInternalFrameTitlePane.java
@@ -723,6 +723,11 @@ public class BasicInternalFrameTitlePane extends JComponent
      * Instantiate it only within subclasses of <code>Foo</code>.
      */
     public class PropertyChangeHandler implements PropertyChangeListener {
+        /**
+         * Constructs a {@code PropertyChangeHandler}.
+         */
+        public PropertyChangeHandler() {}
+
         // NOTE: This class exists only for backward compatibility. All
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
@@ -741,6 +746,11 @@ public class BasicInternalFrameTitlePane extends JComponent
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
+        /**
+         * Constructs a {@code TitlePaneLayout}.
+         */
+        public TitlePaneLayout() {}
+
         public void addLayoutComponent(String name, Component c) {
             getHandler().addLayoutComponent(name, c);
         }
@@ -930,6 +940,10 @@ public class BasicInternalFrameTitlePane extends JComponent
      */
     @SuppressWarnings("deprecation")
     public class SystemMenuBar extends JMenuBar {
+        /**
+         * Constructs a {@code SystemMenuBar}.
+         */
+        public SystemMenuBar() {}
         public boolean isFocusTraversable() { return false; }
         public void requestFocus() {}
         public void paint(Graphics g) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicInternalFrameUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicInternalFrameUI.java
@@ -647,6 +647,10 @@ public class BasicInternalFrameUI extends InternalFrameUI
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
         /**
+         * Constructs a {@code InternalFramePropertyChangeListener}.
+         */
+        public InternalFramePropertyChangeListener() {}
+        /**
          * Detects changes in state from the JInternalFrame and handles
          * actions.
          */
@@ -663,6 +667,11 @@ public class BasicInternalFrameUI extends InternalFrameUI
     // its functionality has been moved into Handler. If you need to add
     // new functionality add it to the Handler, but make sure this
     // class calls into the Handler.
+    /**
+     * Constructs a {@code InternalFrameLayout}.
+     */
+    public InternalFrameLayout() {}
+
       /**
        * {@inheritDoc}
        */
@@ -841,6 +850,11 @@ public class BasicInternalFrameUI extends InternalFrameUI
         private boolean discardRelease = false;
 
         int resizeCornerSize = 16;
+
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected BorderListener() {}
 
         public void mouseClicked(MouseEvent e) {
             if(e.getClickCount() > 1 && e.getSource() == getNorthPane()) {
@@ -1305,6 +1319,11 @@ public class BasicInternalFrameUI extends InternalFrameUI
       // its functionality has been moved into Handler. If you need to add
       // new functionality add it to the Handler, but make sure this
       // class calls into the Handler.
+      /**
+       * Constructor for subclasses to call.
+       */
+      protected ComponentHandler() {}
+
       /** Invoked when a JInternalFrame's parent's size changes. */
       public void componentResized(ComponentEvent e) {
           getHandler().componentResized(e);
@@ -1347,6 +1366,11 @@ public class BasicInternalFrameUI extends InternalFrameUI
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected GlassPaneDispatcher() {}
+
         /**
          * {@inheritDoc}
          */
@@ -1414,6 +1438,11 @@ public class BasicInternalFrameUI extends InternalFrameUI
       // its functionality has been moved into Handler. If you need to add
       // new functionality add it to the Handler, but make sure this
       // class calls into the Handler.
+      /**
+       * Constructor for subclasses to call.
+       */
+      protected BasicInternalFrameListener() {}
+
         /**
          * {@inheritDoc}
          */

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicInternalFrameUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicInternalFrameUI.java
@@ -647,7 +647,7 @@ public class BasicInternalFrameUI extends InternalFrameUI
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
         /**
-         * Constructs a {@code InternalFramePropertyChangeListener}.
+         * Constructs an {@code InternalFramePropertyChangeListener}.
          */
         public InternalFramePropertyChangeListener() {}
         /**
@@ -668,7 +668,7 @@ public class BasicInternalFrameUI extends InternalFrameUI
     // new functionality add it to the Handler, but make sure this
     // class calls into the Handler.
     /**
-     * Constructs a {@code InternalFrameLayout}.
+     * Constructs an {@code InternalFrameLayout}.
      */
     public InternalFrameLayout() {}
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicInternalFrameUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicInternalFrameUI.java
@@ -852,7 +852,7 @@ public class BasicInternalFrameUI extends InternalFrameUI
         int resizeCornerSize = 16;
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code BorderListener}.
          */
         protected BorderListener() {}
 
@@ -1320,7 +1320,7 @@ public class BasicInternalFrameUI extends InternalFrameUI
       // new functionality add it to the Handler, but make sure this
       // class calls into the Handler.
       /**
-       * Constructor for subclasses to call.
+       * Constructs a {@code ComponentHandler}.
        */
       protected ComponentHandler() {}
 
@@ -1367,7 +1367,7 @@ public class BasicInternalFrameUI extends InternalFrameUI
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code GlassPaneDispatcher}.
          */
         protected GlassPaneDispatcher() {}
 
@@ -1439,7 +1439,7 @@ public class BasicInternalFrameUI extends InternalFrameUI
       // new functionality add it to the Handler, but make sure this
       // class calls into the Handler.
       /**
-       * Constructor for subclasses to call.
+       * Constructs a {@code BasicInternalFrameListener}.
        */
       protected BasicInternalFrameListener() {}
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
@@ -928,6 +928,11 @@ public class BasicMenuItemUI extends MenuItemUI
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
 
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected MouseInputHandler() {}
+
         /** {@inheritDoc} */
         public void mouseClicked(MouseEvent e) {
             getHandler().mouseClicked(e);

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
@@ -929,7 +929,7 @@ public class BasicMenuItemUI extends MenuItemUI
         // class calls into the Handler.
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code MouseInputHandler}.
          */
         protected MouseInputHandler() {}
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuUI.java
@@ -370,6 +370,11 @@ public class BasicMenuUI extends BasicMenuItemUI
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
 
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected MouseInputHandler() {}
+
         public void mouseClicked(MouseEvent e) {
             getHandler().mouseClicked(e);
         }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuUI.java
@@ -371,7 +371,7 @@ public class BasicMenuUI extends BasicMenuItemUI
         // class calls into the Handler.
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code MouseInputHandler}.
          */
         protected MouseInputHandler() {}
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
@@ -1177,7 +1177,7 @@ public class BasicScrollBarUI
      */
     protected class ModelListener implements ChangeListener {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code ModelListener}.
          */
         protected ModelListener() {}
 
@@ -1206,7 +1206,7 @@ public class BasicScrollBarUI
         private transient int direction = +1;
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code TrackListener}.
          */
         protected TrackListener() {}
 
@@ -1509,7 +1509,7 @@ public class BasicScrollBarUI
         boolean handledEvent;
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code ArrowButtonListener}.
          */
         protected ArrowButtonListener() {}
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
@@ -1176,6 +1176,11 @@ public class BasicScrollBarUI
      * A listener to listen for model changes.
      */
     protected class ModelListener implements ChangeListener {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected ModelListener() {}
+
         public void stateChanged(ChangeEvent e) {
             if (!useCachedValue) {
                 scrollBarValue = scrollbar.getValue();
@@ -1199,6 +1204,11 @@ public class BasicScrollBarUI
         /** Current mouse y position */
         protected transient int currentMouseY;
         private transient int direction = +1;
+
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected TrackListener() {}
 
         /** {@inheritDoc} */
         public void mouseReleased(MouseEvent e)
@@ -1497,6 +1507,11 @@ public class BasicScrollBarUI
         // we need to make sure we don't fire under both conditions.
         // (keyfocus on scrollbars causes action without mousePress
         boolean handledEvent;
+
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected ArrowButtonListener() {}
 
         public void mousePressed(MouseEvent e)          {
             if(!scrollbar.isEnabled()) { return; }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollPaneUI.java
@@ -624,6 +624,11 @@ public class BasicScrollPaneUI
         // class calls into the Handler.
 
         /**
+         * Constructor for subclasses to call.
+         */
+        protected MouseWheelHandler() {}
+
+        /**
          * Called when the mouse wheel is rotated while over a
          * JScrollPane.
          *

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollPaneUI.java
@@ -624,7 +624,7 @@ public class BasicScrollPaneUI
         // class calls into the Handler.
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code MouseWheelHandler}.
          */
         protected MouseWheelHandler() {}
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -553,7 +553,7 @@ public class BasicSplitPaneDivider extends Container
             implements MouseMotionListener
     {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code MouseHandler}.
          */
         protected MouseHandler() {}
 
@@ -961,7 +961,7 @@ public class BasicSplitPaneDivider extends Container
     protected class DividerLayout implements LayoutManager
     {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code DividerLayout}.
          */
         protected DividerLayout() {}
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -553,6 +553,11 @@ public class BasicSplitPaneDivider extends Container
             implements MouseMotionListener
     {
         /**
+         * Constructor for subclasses to call.
+         */
+        protected MouseHandler() {}
+
+        /**
          * Starts the dragging session by creating the appropriate instance
          * of DragController.
          */
@@ -955,6 +960,11 @@ public class BasicSplitPaneDivider extends Container
      */
     protected class DividerLayout implements LayoutManager
     {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected DividerLayout() {}
+
         public void layoutContainer(Container c) {
             if (leftButton != null && rightButton != null &&
                 c == BasicSplitPaneDivider.this) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneUI.java
@@ -714,6 +714,11 @@ public class BasicSplitPaneUI extends SplitPaneUI
      */
     public class PropertyHandler implements PropertyChangeListener
     {
+        /**
+         * Constructs a {@code PropertyHandler}.
+         */
+        public PropertyHandler() {}
+
         // NOTE: This class exists only for backward compatibility. All
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
@@ -766,6 +771,11 @@ public class BasicSplitPaneUI extends SplitPaneUI
      */
     public class KeyboardUpLeftHandler implements ActionListener
     {
+        /**
+         * Constructs a {@code KeyboardUpLeftHandler}.
+         */
+        public KeyboardUpLeftHandler() {}
+
         public void actionPerformed(ActionEvent ev) {
             if (dividerKeyboardResize) {
                 splitPane.setDividerLocation(Math.max(0,getDividerLocation
@@ -861,6 +871,11 @@ public class BasicSplitPaneUI extends SplitPaneUI
      */
     public class KeyboardResizeToggleHandler implements ActionListener
     {
+        /**
+         * Constructs a {@code KeyboardResizeToggleHandler}.
+         */
+        public KeyboardResizeToggleHandler() {}
+
         public void actionPerformed(ActionEvent ev) {
             if (!dividerKeyboardResize) {
                 splitPane.requestFocus();

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
@@ -211,6 +211,11 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
 // UI creation
 
     /**
+     * Constructs a {@code BasicTabbedPaneUI}.
+     */
+    public BasicTabbedPaneUI() {}
+
+    /**
      * Create a UI.
      * @param c a component
      * @return a UI
@@ -2657,6 +2662,10 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
      * Instantiate it only within subclasses of BasicTabbedPaneUI.
      */
     public class TabbedPaneLayout implements LayoutManager {
+        /**
+         * Constructs a {@code TabbedPaneLayout}.
+         */
+        public TabbedPaneLayout() {}
 
         public void addLayoutComponent(String name, Component comp) {}
 
@@ -4195,6 +4204,11 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
      * Instantiate it only within subclasses of BasicTabbedPaneUI.
      */
     public class PropertyChangeHandler implements PropertyChangeListener {
+        /**
+         * Constructs a {@code PropertyChangeHandler}.
+         */
+        public PropertyChangeHandler() {}
+
         // NOTE: This class exists only for backward compatibility. All
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
@@ -4209,6 +4223,11 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
      * Instantiate it only within subclasses of BasicTabbedPaneUI.
      */
     public class TabSelectionHandler implements ChangeListener {
+        /**
+         * Constructs a {@code TabSelectionHandler}.
+         */
+        public TabSelectionHandler() {}
+
         // NOTE: This class exists only for backward compatibility. All
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
@@ -4223,6 +4242,11 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
      * Instantiate it only within subclasses of BasicTabbedPaneUI.
      */
     public class MouseHandler extends MouseAdapter {
+        /**
+         * Constructs a {@code MouseHandler}.
+         */
+        public MouseHandler() {}
+
         // NOTE: This class exists only for backward compatibility. All
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
@@ -4241,6 +4265,11 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
+        /**
+         * Constructs a {@code FocusHandler}.
+         */
+        public FocusHandler() {}
+
         public void focusGained(FocusEvent e) {
             getHandler().focusGained(e);
         }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableHeaderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableHeaderUI.java
@@ -70,6 +70,11 @@ public class BasicTableHeaderUI extends TableHeaderUI {
     // The column that should be highlighted when the table header has the focus.
     private int selectedColumnIndex = 0; // Read ONLY via getSelectedColumnIndex!
 
+    /**
+     * Constructs a {@code BasicTableHeaderUI}.
+     */
+    public BasicTableHeaderUI() {}
+
     private static FocusListener focusListener = new FocusListener() {
         public void focusGained(FocusEvent e) {
             repaintHeader(e.getSource());
@@ -103,6 +108,11 @@ public class BasicTableHeaderUI extends TableHeaderUI {
 
         private int mouseXOffset;
         private Cursor otherCursor = resizeCursor;
+
+        /**
+         * Constructs a {@code MouseInputHandler}.
+         */
+        public MouseInputHandler() {}
 
         public void mouseClicked(MouseEvent e) {
             if (!header.isEnabled()) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
@@ -96,6 +96,11 @@ public class BasicTableUI extends TableUI
      */
     private boolean isFileList = false;
 
+    /**
+     * Constructs a {@code BasicTableUI}.
+     */
+    public BasicTableUI() {}
+
 //
 //  Helper class for keyboard actions
 //
@@ -760,6 +765,11 @@ public class BasicTableUI extends TableUI
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
+        /**
+         * Constructs a {@code KeyHandler}.
+         */
+        public KeyHandler() {}
+
         public void keyPressed(KeyEvent e) {
             getHandler().keyPressed(e);
         }
@@ -786,6 +796,11 @@ public class BasicTableUI extends TableUI
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
+        /**
+         * Constructs a {@code FocusHandler}.
+         */
+        public FocusHandler() {}
+
         public void focusGained(FocusEvent e) {
             getHandler().focusGained(e);
         }
@@ -808,6 +823,11 @@ public class BasicTableUI extends TableUI
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
+        /**
+         * Constructs a {@code MouseInputHandler}.
+         */
+        public MouseInputHandler() {}
+
         public void mouseClicked(MouseEvent e) {
             getHandler().mouseClicked(e);
         }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -1371,12 +1371,22 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
     /**
      * Default implementation of the interface {@code Caret}.
      */
-    public static class BasicCaret extends DefaultCaret implements UIResource {}
+    public static class BasicCaret extends DefaultCaret implements UIResource {
+        /**
+         * Constructs a {@code BasicCaret}.
+         */
+        public BasicCaret() {}
+    }
 
     /**
      * Default implementation of the interface {@code Highlighter}.
      */
-    public static class BasicHighlighter extends DefaultHighlighter implements UIResource {}
+    public static class BasicHighlighter extends DefaultHighlighter implements UIResource {
+        /**
+         * Constructs a {@code BasicHighlighter}.
+         */
+        public BasicHighlighter() {}
+    }
 
     static class BasicCursor extends Cursor implements UIResource {
         BasicCursor(int type) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicToggleButtonUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicToggleButtonUI.java
@@ -53,6 +53,11 @@ public class BasicToggleButtonUI extends BasicButtonUI {
     // ********************************
 
     /**
+     * Constructs a {@code BasicToggleButtonUI}.
+     */
+    public BasicToggleButtonUI() {}
+
+    /**
      * Returns an instance of {@code BasicToggleButtonUI}.
      *
      * @param b a component

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicToolBarSeparatorUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicToolBarSeparatorUI.java
@@ -46,6 +46,11 @@ import javax.swing.plaf.basic.BasicSeparatorUI;
 public class BasicToolBarSeparatorUI extends BasicSeparatorUI
 {
     /**
+     * Constructs a {@code BasicToolBarSeparatorUI}.
+     */
+    public BasicToolBarSeparatorUI() {}
+
+    /**
      * Returns a new instance of {@code BasicToolBarSeparatorUI}.
      *
      * @param c a component

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicToolBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicToolBarUI.java
@@ -167,6 +167,11 @@ public class BasicToolBarUI extends ToolBarUI implements SwingConstants
     private static String FOCUSED_COMP_INDEX = "JToolBar.focusedCompIndex";
 
     /**
+     * Constructs a {@code BasicToolBarUI}.
+     */
+    public BasicToolBarUI() {}
+
+    /**
      * Constructs a new instance of {@code BasicToolBarUI}.
      *
      * @param c a component
@@ -1408,6 +1413,11 @@ public class BasicToolBarUI extends ToolBarUI implements SwingConstants
      * The class listens for window events.
      */
     protected class FrameListener extends WindowAdapter {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected FrameListener() {}
+
         public void windowClosing(WindowEvent w) {
             if (toolBar.isFloatable()) {
                 if (dragWindow != null)
@@ -1450,6 +1460,11 @@ public class BasicToolBarUI extends ToolBarUI implements SwingConstants
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected ToolBarContListener() {}
+
         public void componentAdded( ContainerEvent e )  {
             getHandler().componentAdded(e);
         }
@@ -1468,6 +1483,11 @@ public class BasicToolBarUI extends ToolBarUI implements SwingConstants
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected ToolBarFocusListener() {}
+
         public void focusGained( FocusEvent e ) {
             getHandler().focusGained(e);
             }
@@ -1485,6 +1505,11 @@ public class BasicToolBarUI extends ToolBarUI implements SwingConstants
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected PropertyListener() {}
+
         public void propertyChange( PropertyChangeEvent e ) {
             getHandler().propertyChange(e);
             }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicToolBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicToolBarUI.java
@@ -1414,7 +1414,7 @@ public class BasicToolBarUI extends ToolBarUI implements SwingConstants
      */
     protected class FrameListener extends WindowAdapter {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code FrameListener}.
          */
         protected FrameListener() {}
 
@@ -1461,7 +1461,7 @@ public class BasicToolBarUI extends ToolBarUI implements SwingConstants
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code ToolBarContListener}.
          */
         protected ToolBarContListener() {}
 
@@ -1484,7 +1484,7 @@ public class BasicToolBarUI extends ToolBarUI implements SwingConstants
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code ToolBarFocusListener}.
          */
         protected ToolBarFocusListener() {}
 
@@ -1506,7 +1506,7 @@ public class BasicToolBarUI extends ToolBarUI implements SwingConstants
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code PropertyListener}.
          */
         protected PropertyListener() {}
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
@@ -3335,6 +3335,11 @@ public class BasicTreeUI extends TreeUI
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
 
+        /**
+         * Constructs a {@code SelectionModelPropertyChangeHandler}.
+         */
+        public SelectionModelPropertyChangeHandler() {}
+
         public void propertyChange(PropertyChangeEvent event) {
             getHandler().propertyChange(event);
         }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
@@ -2905,6 +2905,11 @@ public class BasicTreeUI extends TreeUI
         // class calls into the Handler.
 
         /**
+         * Constructs a {@code TreeExpansionHandler}.
+         */
+        public TreeExpansionHandler() {}
+
+        /**
          * Called whenever an item in the tree has been expanded.
          */
         public void treeExpanded(TreeExpansionEvent event) {
@@ -2930,6 +2935,11 @@ public class BasicTreeUI extends TreeUI
         protected Timer                timer;
         /** ScrollBar that is being adjusted. */
         protected JScrollBar           scrollBar;
+
+        /**
+         * Constructs a {@code ComponentHandler}.
+         */
+        public ComponentHandler() {}
 
         public void componentMoved(ComponentEvent e) {
             if(timer == null) {
@@ -3008,6 +3018,11 @@ public class BasicTreeUI extends TreeUI
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
 
+        /**
+         * Constructs a {@code TreeModelHandler}.
+         */
+        public TreeModelHandler() {}
+
         public void treeNodesChanged(TreeModelEvent e) {
             getHandler().treeNodesChanged(e);
         }
@@ -3038,6 +3053,11 @@ public class BasicTreeUI extends TreeUI
         // class calls into the Handler.
 
         /**
+         * Constructs a {@code TreeSelectionHandler}.
+         */
+        public TreeSelectionHandler() {}
+
+        /**
          * Messaged when the selection changes in the tree we're displaying
          * for.  Stops editing, messages super and displays the changed paths.
          */
@@ -3057,6 +3077,11 @@ public class BasicTreeUI extends TreeUI
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
+
+        /**
+         * Constructs a {@code CellEditorHandler}.
+         */
+        public CellEditorHandler() {}
 
         /** Messaged when editing has stopped in the tree. */
         public void editingStopped(ChangeEvent e) {
@@ -3092,6 +3117,11 @@ public class BasicTreeUI extends TreeUI
         protected boolean            isKeyDown;
 
         /**
+         * Constructs a {@code KeyHandler}.
+         */
+        public KeyHandler() {}
+
+        /**
          * Invoked when a key has been typed.
          *
          * Moves the keyboard focus to the first element
@@ -3124,6 +3154,11 @@ public class BasicTreeUI extends TreeUI
         // class calls into the Handler.
 
         /**
+         * Constructs a {@code FocusHandler}.
+         */
+        public FocusHandler() {}
+
+        /**
          * Invoked when focus is activated on the tree we're in, redraws the
          * lead row.
          */
@@ -3149,6 +3184,11 @@ public class BasicTreeUI extends TreeUI
     // This returns locations that don't include any Insets.
     public class NodeDimensionsHandler extends
                  AbstractLayoutCache.NodeDimensions {
+        /**
+         * Constructs a {@code NodeDimensionsHandler}.
+         */
+        public NodeDimensionsHandler() {}
+
         /**
          * Responsible for getting the size of a particular node.
          */
@@ -3230,6 +3270,11 @@ public class BasicTreeUI extends TreeUI
         // class calls into the Handler.
 
         /**
+         * Constructs a {@code MouseHandler}.
+         */
+        public MouseHandler() {}
+
+        /**
          * Invoked when a mouse button has been pressed on a component.
          */
         public void mousePressed(MouseEvent e) {
@@ -3266,6 +3311,11 @@ public class BasicTreeUI extends TreeUI
         // its functionality has been moved into Handler. If you need to add
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
+
+        /**
+         * Constructs a {@code PropertyChangeHandler}.
+         */
+        public PropertyChangeHandler() {}
 
         public void propertyChange(PropertyChangeEvent event) {
             getHandler().propertyChange(event);

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicViewportUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicViewportUI.java
@@ -44,6 +44,11 @@ public class BasicViewportUI extends ViewportUI {
     private static ViewportUI viewportUI;
 
     /**
+     * Constructs a {@code BasicViewportUI}.
+     */
+    public BasicViewportUI() {}
+
+    /**
      * Returns an instance of {@code BasicViewportUI}.
      *
      * @param c a component

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
@@ -587,7 +587,7 @@ public class MetalFileChooserUI extends BasicFileChooserUI {
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class FileRenderer extends DefaultListCellRenderer  {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code FileRenderer}.
          */
         protected FileRenderer() {}
     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
@@ -586,6 +586,10 @@ public class MetalFileChooserUI extends BasicFileChooserUI {
     @Deprecated(since = "9")
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     protected class FileRenderer extends DefaultListCellRenderer  {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected FileRenderer() {}
     }
 
     public void uninstallUI(JComponent c) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalSliderUI.java
@@ -181,7 +181,7 @@ public class MetalSliderUI extends BasicSliderUI {
      */
     protected class MetalPropertyListener extends BasicSliderUI.PropertyChangeHandler {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code MetalPropertyListener}.
          */
         protected MetalPropertyListener() {}
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalSliderUI.java
@@ -180,6 +180,11 @@ public class MetalSliderUI extends BasicSliderUI {
      * {@code PropertyListener} for {@code JSlider.isFilled}.
      */
     protected class MetalPropertyListener extends BasicSliderUI.PropertyChangeHandler {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected MetalPropertyListener() {}
+
         public void propertyChange( PropertyChangeEvent e ) {  // listen for slider fill
             super.propertyChange( e );
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalToolBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalToolBarUI.java
@@ -86,6 +86,11 @@ public class MetalToolBarUI extends BasicToolBarUI
     private JMenuBar lastMenuBar;
 
     /**
+     * Constructs a {@code MetalToolBarUI}.
+     */
+    public MetalToolBarUI() {}
+
+    /**
      * Registers the specified component.
      */
     static synchronized void register(JComponent c) {
@@ -361,13 +366,23 @@ public class MetalToolBarUI extends BasicToolBarUI
      * No longer used. The class cannot be removed for compatibility reasons.
      */
     protected class MetalContainerListener
-        extends BasicToolBarUI.ToolBarContListener {}
+        extends BasicToolBarUI.ToolBarContListener {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected MetalContainerListener() {}
+    }
 
     /**
      * No longer used. The class cannot be removed for compatibility reasons.
      */
     protected class MetalRolloverListener
-        extends BasicToolBarUI.PropertyListener {}
+        extends BasicToolBarUI.PropertyListener {
+        /**
+         * Constructor for subclasses to call.
+         */
+        protected MetalRolloverListener() {}
+    }
 
     /**
      * {@code DockingListener} for {@code MetalToolBarUI}.

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalToolBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalToolBarUI.java
@@ -368,7 +368,7 @@ public class MetalToolBarUI extends BasicToolBarUI
     protected class MetalContainerListener
         extends BasicToolBarUI.ToolBarContListener {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code MetalContainerListener}.
          */
         protected MetalContainerListener() {}
     }
@@ -379,7 +379,7 @@ public class MetalToolBarUI extends BasicToolBarUI
     protected class MetalRolloverListener
         extends BasicToolBarUI.PropertyListener {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code MetalRolloverListener}.
          */
         protected MetalRolloverListener() {}
     }


### PR DESCRIPTION
Please review a fix for issue where it was seen that several classes in plaf package rely on default constructors as part of their public API.

It's to be noted that "A no-arg public constructor is generated by the compiler for a class if it does not declare an
explicit constructor. While convenient, this is inappropriate for many kinds of formal classes, both because the
constructor will have no javadoc and because the constructor may be unintended."

For the JDK, classes intended to be used outside of the JDK, public classes in exported packages, should not rely on
default constructors.

Proposed fix is to add explicit public no-arg constructors for public classes and protected no-arg constructor for
protected classes for javax.swing module

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252722](https://bugs.openjdk.java.net/browse/JDK-8252722): More Swing plaf APIs that rely on default constructors


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to 2b6273bfbb8d26d8b66b12e93e41a93f7708d059


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/251/head:pull/251`
`$ git checkout pull/251`
