### PR TITLE
8251188: Update LDAP tests not to use wildcard addresses

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -889,8 +889,6 @@ sun/tools/jhsdb/BasicLauncherTest.java                          8211767 linux-pp
 
 # jdk_other
 
-com/sun/jndi/ldap/DeadSSLLdapTimeoutTest.java                   8169942 linux-i586,macosx-all,windows-x64
-
 javax/rmi/ssl/SSLSocketParametersTest.sh                        8162906 generic-all
 
 javax/script/Test7.java                                         8239361 generic-all

--- a/test/jdk/com/sun/jndi/ldap/BalancedParentheses.java
+++ b/test/jdk/com/sun/jndi/ldap/BalancedParentheses.java
@@ -24,17 +24,22 @@
 /**
  * @test
  * @bug 6449574
+ * @library /test/lib
  * @summary Invalid ldap filter is accepted and processed
  */
 
 import java.io.*;
 import javax.naming.*;
 import javax.naming.directory.*;
-import java.util.Properties;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Hashtable;
 
 import java.net.Socket;
 import java.net.ServerSocket;
+
+import jdk.test.lib.net.URIBuilder;
 
 public class BalancedParentheses {
     // Should we run the client or server in a separate thread?
@@ -54,7 +59,13 @@ public class BalancedParentheses {
     // If the server prematurely exits, serverReady will be set to true
     // to avoid infinite hangs.
     void doServerSide() throws Exception {
-        ServerSocket serverSock = new ServerSocket(serverPort);
+        // Create unbound server socket
+        ServerSocket serverSock = new ServerSocket();
+
+        // And bind it to the loopback address
+        SocketAddress sockAddr = new InetSocketAddress(
+                InetAddress.getLoopbackAddress(), 0);
+        serverSock.bind(sockAddr);
 
         // signal client, it's ready to accecpt connection
         serverPort = serverSock.getLocalPort();
@@ -106,7 +117,13 @@ public class BalancedParentheses {
         Hashtable<Object, Object> env = new Hashtable<>();
         env.put(Context.INITIAL_CONTEXT_FACTORY,
                                 "com.sun.jndi.ldap.LdapCtxFactory");
-        env.put(Context.PROVIDER_URL, "ldap://localhost:" + serverPort);
+        // Construct the provider URL
+        String providerURL = URIBuilder.newBuilder()
+                .scheme("ldap")
+                .loopback()
+                .port(serverPort)
+                .build().toString();
+        env.put(Context.PROVIDER_URL, providerURL);
         env.put("com.sun.jndi.ldap.read.timeout", "1000");
 
         // env.put(Context.SECURITY_AUTHENTICATION, "simple");

--- a/test/jdk/com/sun/jndi/ldap/DeadSSLSocketFactory.java
+++ b/test/jdk/com/sun/jndi/ldap/DeadSSLSocketFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/*
+ * A custom socket factory used to override the default socket factory and track the LDAP client connection.
+ * Factory can create only one SSLSocket. See the DeadServerTimeoutSSLTest test.
+ */
+public class DeadSSLSocketFactory extends SocketFactory {
+    // Client socket that is used by LDAP connection
+    public static AtomicReference<SSLSocket> firstCreatedSocket = new AtomicReference<>();
+
+    // Boolean to track if connection socket has been opened
+    public static AtomicBoolean isConnectionOpened = new AtomicBoolean(false);
+
+    // Default SSLSocketFactory that will be used for SSL socket creation
+    final SSLSocketFactory factory = (SSLSocketFactory)SSLSocketFactory.getDefault();
+
+    // Create unconnected socket
+    public Socket createSocket() throws IOException {
+        if (!isConnectionOpened.getAndSet(true)) {
+            System.err.println("DeadSSLSocketFactory: Creating unconnected socket");
+            firstCreatedSocket.set((SSLSocket) factory.createSocket());
+            return firstCreatedSocket.get();
+        } else {
+            throw new RuntimeException("DeadSSLSocketFactory only allows creation of one SSL socket");
+        }
+    }
+
+    public DeadSSLSocketFactory() {
+        System.err.println("DeadSSLSocketFactory: Constructor call");
+    }
+
+    public static SocketFactory getDefault() {
+        System.err.println("DeadSSLSocketFactory: acquiring DeadSSLSocketFactory as default socket factory");
+        return new DeadSSLSocketFactory();
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        // Not used by DeadSSLLdapTimeoutTest
+        return factory.createSocket(host, port);
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost,
+                               int localPort) throws IOException {
+        // Not used by DeadSSLLdapTimeoutTest
+        return factory.createSocket(host, port, localHost, localPort);
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        // Not used by DeadSSLLdapTimeoutTest
+        return factory.createSocket(host, port);
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port,
+                               InetAddress localAddress, int localPort) throws IOException {
+        // Not used by DeadSSLLdapTimeoutTest
+        return factory.createSocket(address, port, localAddress, localPort);
+    }
+}
+

--- a/test/jdk/com/sun/jndi/ldap/blits/AddTests/AddNewEntry.java
+++ b/test/jdk/com/sun/jndi/ldap/blits/AddTests/AddNewEntry.java
@@ -27,7 +27,7 @@
  * @summary Verify capability to add a new entry to the directory using the
  *          ADD operation.
  * @modules java.naming/com.sun.jndi.ldap
- * @library ../../lib/ /javax/naming/module/src/test/test/
+ * @library /test/lib ../../lib/ /javax/naming/module/src/test/test/
  * @build LDAPServer LDAPTestUtils
  * @run main/othervm AddNewEntry
  */
@@ -41,19 +41,36 @@ import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.SocketAddress;
 import java.util.Hashtable;
+import jdk.test.lib.net.URIBuilder;
 
 public class AddNewEntry {
 
     public static void main(String[] args) throws Exception {
-        ServerSocket serverSocket = new ServerSocket(0);
+        // Create unbound server socket
+        ServerSocket serverSocket = new ServerSocket();
+
+        // Bind it to the loopback address
+        SocketAddress sockAddr = new InetSocketAddress(
+                InetAddress.getLoopbackAddress(), 0);
+        serverSocket.bind(sockAddr);
+
+        // Construct the provider URL for LDAPTestUtils
+        String providerURL = URIBuilder.newBuilder()
+                .scheme("ldap")
+                .loopback()
+                .port(serverSocket.getLocalPort())
+                .buildUnchecked().toString();
 
         Hashtable<Object, Object> env;
 
         // initialize test
-        env = LDAPTestUtils
-                .initEnv(serverSocket, AddNewEntry.class.getName(), args, true);
+        env = LDAPTestUtils.initEnv(serverSocket, providerURL,
+                         AddNewEntry.class.getName(), args, true);
 
         /* Build attribute set */
         String[] ids = { "objectClass", "sn", "cn", "telephoneNumber", "mail",

--- a/test/jdk/com/sun/jndi/ldap/lib/LDAPTestUtils.java
+++ b/test/jdk/com/sun/jndi/ldap/lib/LDAPTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,12 +50,17 @@ public class LDAPTestUtils {
      * Process command line arguments and return properties in a Hashtable.
      */
     public static Hashtable<Object, Object> initEnv(String testname,
-            String[] args) {
+                                                    String[] args) {
         return initEnv(null, testname, args, false);
     }
 
     public static Hashtable<Object, Object> initEnv(ServerSocket socket,
-            String testname, String[] args, boolean authInfo) {
+                                                    String testname, String[] args, boolean authInfo) {
+        return initEnv(socket, null, testname, args, authInfo);
+    }
+
+    public static Hashtable<Object, Object> initEnv(ServerSocket socket, String providerUrl,
+                                                    String testname, String[] args, boolean authInfo) {
 
         Hashtable<Object, Object> env = new Hashtable<>();
         String root = "o=IMC,c=US";
@@ -103,8 +108,9 @@ public class LDAPTestUtils {
             if (socket != null) {
                 env.put(TEST_LDAP_SERVER_THREAD,
                         startLDAPServer(socket, getCaptureFile(testname)));
-                env.put("java.naming.provider.url",
-                        "ldap://localhost:" + socket.getLocalPort());
+                String url = providerUrl != null ? providerUrl :
+                        "ldap://localhost:" + socket.getLocalPort();
+                env.put("java.naming.provider.url", url);
             } else {
                 // for tests which run against remote server or no server
                 // required


### PR DESCRIPTION
Hi,

Please help to review [JDK-8251188](https://bugs.openjdk.java.net/browse/JDK-8251188) fix which helps to improve LDAP tests stability. The list of changes:
1. Usages of wildcard address have been replaced with loopback address. This change includes addition of `LDAPTestUtils.initEnv` method that takes LDAP provider URL as a parameter.
2. `DeadServerTimeoutSSLTest.java` was also updated to fix the intermittent failures reported by [JDK-8152654 ](https://bugs.openjdk.java.net/browse/JDK-8152654) and [JDK-8169942](https://bugs.openjdk.java.net/browse/JDK-8169942).
Before the fix the failure rate was 1 out of 4 runs. After the fix it was executed 400+ times alongside to other LDAP tests, and showed no failures, and therefore removed from the problem list.

Thank you,
Aleksei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251188](https://bugs.openjdk.java.net/browse/JDK-8251188): Update LDAP tests not to use wildcard addresses


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/252/head:pull/252`
`$ git checkout pull/252`
