### PR TITLE
8248352: [TEST_BUG] Test test/jdk/java/awt/font/TextLayout/ArabicDiacriticTest.java can leave frame open

### DIFF
--- a/test/jdk/java/awt/font/TextLayout/ArabicDiacriticTest.java
+++ b/test/jdk/java/awt/font/TextLayout/ArabicDiacriticTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,8 @@
  */
 
 /* @test
- * @key headful
  * @summary verify Arab Diacritic Positioning
- * @bug 8168759
+ * @bug 8168759 8248352
  */
 
 import java.awt.Font;
@@ -46,19 +45,18 @@ public class ArabicDiacriticTest {
     static final String STR1 = "\u0644\u0639\u064e\u0629";
     static final String STR2 = "\u0644\u0639\u0629";
 
-    static JFrame frame;
     static final String FONT = "DejaVu Sans";
 
-    public static void main(String args[]) throws Exception {
-        showText(); // for a human
+    public static void main(String[] args) throws Exception {
+        if ((args.length > 0) && (args[0].equals("-show"))) {
+            showText(); // for a human
+        }
         measureText(); // for the test harness
-        Thread.sleep(5000);
-        frame.dispose();
     }
 
     static void showText() {
         SwingUtilities.invokeLater(() -> {
-            frame = new JFrame();
+            JFrame frame = new JFrame();
             JLabel label = new JLabel(SAMPLE);
             Font font = new Font(FONT, Font.PLAIN, 36);
             label.setFont(font);


### PR DESCRIPTION
Hello All,

Could you please review a TEST_BUG fix for the JDK 16?

Bug: https://bugs.openjdk.java.net/browse/JDK-8248352

Problem description: The test test/jdk/java/awt/font/TextLayout/ArabicDiacriticTest.java can potentially leave the frame open if it fails. If it were not for the frame, the test could be headless. So probably, we can remove the call to showText() from the test and make it headless..

Fix: An argument is added to the test. If "-show" is passed, the test will show UI for visual inspection.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248352](https://bugs.openjdk.java.net/browse/JDK-8248352): [TEST_BUG] Test test/jdk/java/awt/font/TextLayout/ArabicDiacriticTest.java can leave frame open


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/255/head:pull/255`
`$ git checkout pull/255`
