### PR TITLE
8249142: java/awt/FontClass/CreateFont/DeleteFont.sh is unstable

### DIFF
--- a/test/jdk/java/awt/FontClass/CreateFont/DeleteFont.java
+++ b/test/jdk/java/awt/FontClass/CreateFont/DeleteFont.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,8 +21,11 @@
  * questions.
  */
 
-import java.io.*;
-import java.awt.*;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.awt.Font;
 
 public class DeleteFont {
 
@@ -55,19 +58,22 @@ public class DeleteFont {
         if (!gotException) {
             throw new RuntimeException("No expected IOException");
         }
-        badRead(-2, Font.TRUETYPE_FONT);
-        badRead(8193, Font.TRUETYPE_FONT);
 
-        badRead(-2, Font.TYPE1_FONT);
-        badRead(8193, Font.TYPE1_FONT);
+        badRead(-2, 16, Font.TYPE1_FONT);
+        badRead(8193, 14, Font.TYPE1_FONT);
+
+        badRead(-2, 12, Font.TRUETYPE_FONT);
+        badRead(8193, 10, Font.TRUETYPE_FONT);
 
         // Make sure GC has a chance to clean up before we exit.
         System.gc(); System.gc();
+        Thread.sleep(5000);
+        System.gc(); System.gc();
     }
 
-    static void badRead(final int retval, int fontType) {
+    static void badRead(final int retval, final int multiple, int fontType) {
         int num = 2;
-        byte[] buff = new byte[16*8192]; // Multiple of 8192 is important.
+        byte[] buff = new byte[multiple*8192]; // Multiple of 8192 is important.
         for (int ct=0; ct<num; ++ct) {
             try {
                 Font.createFont(

--- a/test/jdk/java/awt/FontClass/CreateFont/DeleteFont.sh
+++ b/test/jdk/java/awt/FontClass/CreateFont/DeleteFont.sh
@@ -20,7 +20,8 @@
 # questions.
 
 # @test
-# @bug 6189812 6380357 6632886
+# @bug 6189812 6380357 6632886 8249142
+# @key intermittent
 # @summary Verify that temporary font files are deleted on exit.
 
 if [ -z "${TESTSRC}" ]; then


### PR DESCRIPTION
This test is being marked intermittent, although at the same time I am trying to make it less likely to fail.
However since we have a known issue around NIO mmap'd files not being directly unmappable, the
deletes the font system make may be stymied on Windows. So marking it intermittent is probably for the best
One other thing is that I changed it so that the tmp files created are now of different sizes so we can now
tell which createFont() call resulted in the font that can't be deleted. If it is always the Type 1 fonts then
that will be good evidence it is mmap that is the problem.
We likely need to stop using mmap for this reason.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249142](https://bugs.openjdk.java.net/browse/JDK-8249142): java/awt/FontClass/CreateFont/DeleteFont.sh is unstable


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/256/head:pull/256`
`$ git checkout pull/256`
