### PR TITLE
8253361: Shenandoah: runtime barrier does not honor ShenandoahSelfFixing flag

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
@@ -204,7 +204,7 @@ oop ShenandoahBarrierSet::load_reference_barrier_native_impl(oop obj, T* load_ad
   }
 
   oop fwd = load_reference_barrier_not_null(obj);
-  if (load_addr != NULL && fwd != obj) {
+  if (ShenandoahSelfFixing && load_addr != NULL && fwd != obj) {
     // Since we are here and we know the load address, update the reference.
     ShenandoahHeap::cas_oop(fwd, load_addr, obj);
   }


### PR DESCRIPTION
ShenandoahSelfFixing flag is currently only honored by C2, not runtime barrier. Runtime barrier should check the check too.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253361](https://bugs.openjdk.java.net/browse/JDK-8253361): Shenandoah: runtime barrier does not honor ShenandoahSelfFixing flag


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/257/head:pull/257`
`$ git checkout pull/257`
