### PR TITLE
8253167: ARM32 builds fail after JDK-8247910

### DIFF
--- a/src/hotspot/cpu/arm/globalDefinitions_arm.hpp
+++ b/src/hotspot/cpu/arm/globalDefinitions_arm.hpp
@@ -55,11 +55,4 @@ const bool HaveVFP = true;
 #define AD_MD_HPP              "adfiles/ad_arm_32.hpp"
 #define C1_LIRGENERATOR_MD_HPP "c1_LIRGenerator_arm.hpp"
 
-#ifdef TARGET_COMPILER_gcc
-#ifdef ARM32
-#undef BREAKPOINT
-#define BREAKPOINT __asm__ volatile ("bkpt")
-#endif
-#endif
-
 #endif // CPU_ARM_GLOBALDEFINITIONS_ARM_HPP

--- a/src/hotspot/share/utilities/breakpoint.hpp
+++ b/src/hotspot/share/utilities/breakpoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,17 +24,6 @@
 
 #ifndef SHARE_UTILITIES_BREAKPOINT_HPP
 #define SHARE_UTILITIES_BREAKPOINT_HPP
-
-// Provide BREAKPOINT macro for requesting stop in the debugger.
-
-// We presently only have one non-default definition, so it's not
-// worth going through the COMPILER_HEADER() dispatch, with all
-// non-visCPP files being empty.
-#ifdef TARGET_COMPILER_visCPP
-#ifndef _WIN64
-#define BREAKPOINT __asm { int 3 }
-#endif // _WIN64
-#endif //  TARGET_COMPILER_visCPP
 
 // If no more specific definition provided, default to calling a
 // function that is defined per-platform.  See also os::breakpoint().


### PR DESCRIPTION
Please review this fix for a build failure for arm32.

nconstexpr functions cannot contain asm statements (until C++20), even if
not executed by a constexpr invocation. This means assert (for example)
can't be used in a constexpr function on arm32, because of the
implementation of the BREAKPOINT macro as an asm statement for linux-arm.

The current arm32 implementation is from JDK-8077648: "ARM: BREAKPOINT is
wrong for thumb", which is a Confidential bug about Oracle's old closed
source arm32 port. That port was open sourced by JDK-8168503: "JEP 297:
Unified arm32/arm64 Port". The discussion of JDK-8077648 suggested making
the arm32 port be like nearly all others. That is, have BREAKPOINT expand to
a call to ::breakpoint(), with any empty body for that function and a
comment that one should use a debugger to set a breakpoint there.

This change takes that alternative approach.

The same problem likely exists for win32, which also implements BREAKPOINT
as an asm statement. However, I don't have the infrastructure to do a win32
build to demonstrate that. But I'm making a similar change there on spec.

Note that the Windows implementation of ::breakpoint() ultimately calls the
DebugBreak Win32 library function. That should work for the windows-x86 port
too.

I don't know why we have that difference of some platforms having an
affirmative platform-specific breakpoint operation in place while others
require a debugger to set one, but that difference already exists. This
change does move arm32 from the former to the latter camp though. I'm
guessing that won't matter; if it does then we'll need to conditionalize the
body of ::breakpoint().

There may be some further cleanup that could be done after this change.
We don't really need the BREAKPOINT macro anymore, and could just
use ::breakpoint() directly.  But I think that's out of scope for dealing
with the build failure(s).

Testing:
build linux-arm.
tier1 for Oracle supported platforms.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8253167](https://bugs.openjdk.java.net/browse/JDK-8253167): ARM32 builds fail after JDK-8247910
 * [JDK-8213483](https://bugs.openjdk.java.net/browse/JDK-8213483): ARM32: runtime/ErrorHandling/ShowRegistersOnAssertTest.java jtreg test fail


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)
 * bulasevich - Committer ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/259/head:pull/259`
`$ git checkout pull/259`
