### PR TITLE
8231591: [TESTBUG] Create additional two phase jpackage tests

### DIFF
--- a/src/jdk.incubator.jpackage/linux/classes/jdk/incubator/jpackage/internal/DesktopIntegration.java
+++ b/src/jdk.incubator.jpackage/linux/classes/jdk/incubator/jpackage/internal/DesktopIntegration.java
@@ -135,9 +135,8 @@ final class DesktopIntegration {
                 createDataForDesktopFile(params));
 
         // Read launchers information from predefine app image
-        if (initAppImageLaunchers && launchers.isEmpty() &&
+        if (launchers.isEmpty() &&
                 PREDEFINED_APP_IMAGE.fetchFrom(params) != null) {
-            initAppImageLaunchers = false;
             List<String> launcherPaths = AppImageFile.getLauncherNames(
                     PREDEFINED_APP_IMAGE.fetchFrom(params), params);
             if (!launcherPaths.isEmpty()) {
@@ -149,7 +148,7 @@ final class DesktopIntegration {
                         launcherPath);
                 launcherParams = AddLauncherArguments.merge(params, launcherParams,
                     ICON.getID(), ICON_PNG.getID(), ADD_LAUNCHERS.getID(),
-                    FILE_ASSOCIATIONS.getID());
+                    FILE_ASSOCIATIONS.getID(), PREDEFINED_APP_IMAGE.getID());
                 launchers.add(launcherParams);
             }
         }
@@ -546,7 +545,6 @@ final class DesktopIntegration {
 
     private final List<LinuxFileAssociation> associations;
 
-    private static boolean initAppImageLaunchers = true;
     private final List<Map<String, ? super Object>> launchers;
 
     private final OverridableResource iconResource;

--- a/src/jdk.incubator.jpackage/linux/classes/jdk/incubator/jpackage/internal/DesktopIntegration.java
+++ b/src/jdk.incubator.jpackage/linux/classes/jdk/incubator/jpackage/internal/DesktopIntegration.java
@@ -134,6 +134,7 @@ final class DesktopIntegration {
         desktopFileData = Collections.unmodifiableMap(
                 createDataForDesktopFile(params));
 
+        nestedIntegrations = new ArrayList<>();
         // Read launchers information from predefine app image
         if (launchers.isEmpty() &&
                 PREDEFINED_APP_IMAGE.fetchFrom(params) != null) {
@@ -149,17 +150,17 @@ final class DesktopIntegration {
                 launcherParams = AddLauncherArguments.merge(params, launcherParams,
                     ICON.getID(), ICON_PNG.getID(), ADD_LAUNCHERS.getID(),
                     FILE_ASSOCIATIONS.getID(), PREDEFINED_APP_IMAGE.getID());
-                launchers.add(launcherParams);
+                nestedIntegrations.add(new DesktopIntegration(thePackage,
+                        launcherParams, params));
             }
-        }
-
-        nestedIntegrations = new ArrayList<>();
-        for (var launcherParams : launchers) {
-            launcherParams = AddLauncherArguments.merge(params, launcherParams,
-                    ICON.getID(), ICON_PNG.getID(), ADD_LAUNCHERS.getID(),
-                    FILE_ASSOCIATIONS.getID());
-            nestedIntegrations.add(new DesktopIntegration(thePackage,
-                    launcherParams, params));
+        } else {
+            for (var launcherParams : launchers) {
+                launcherParams = AddLauncherArguments.merge(params, launcherParams,
+                        ICON.getID(), ICON_PNG.getID(), ADD_LAUNCHERS.getID(),
+                        FILE_ASSOCIATIONS.getID());
+                nestedIntegrations.add(new DesktopIntegration(thePackage,
+                        launcherParams, params));
+            }
         }
     }
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/AdditionalLauncher.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/AdditionalLauncher.java
@@ -111,6 +111,7 @@ public final class AdditionalLauncher {
     }
 
     public void applyTo(PackageTest test) {
+        test.addLauncherName(name);
         test.addInitializer(this::initialize);
         test.addInstallVerifier(this::verify);
     }

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/AdditionalLauncher.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/AdditionalLauncher.java
@@ -211,7 +211,7 @@ public final class AdditionalLauncher {
         verifier.applyTo(cmd);
     }
 
-    public void verify(JPackageCommand cmd) throws IOException {
+    private void verify(JPackageCommand cmd) throws IOException {
         verifyIcon(cmd);
 
         Path launcherPath = cmd.appLauncherPath(name);
@@ -231,44 +231,6 @@ public final class AdditionalLauncher {
                 .ofNullable(javaOptions)
                 .orElseGet(() -> List.of(cmd.getAllArgumentValues("--java-options"))))
         .executeAndVerifyOutput();
-    }
-
-    public void verifyPackageInstalled(JPackageCommand cmd) {
-        final String formatString;
-        if (cmd.isPackageUnpacked()) {
-            formatString = "Verify unpacked: %s";
-        } else {
-            formatString = "Verify installed: %s";
-        }
-        TKit.trace(String.format(formatString, cmd.getPrintableCommandLine()));
-
-        if (!cmd.isRuntime()) {
-            if (PackageType.WINDOWS.contains(cmd.packageType())
-                    && !cmd.isPackageUnpacked(
-                            "Not verifying desktop integration")) {
-                new WindowsHelper.DesktopIntegrationVerifier(cmd, name);
-            }
-        }
-    }
-
-    public void verifyPackageUninstalled(JPackageCommand cmd) {
-        TKit.trace(String.format("Verify uninstalled: %s",
-                cmd.getPrintableCommandLine()));
-        if (!cmd.isRuntime()) {
-            TKit.assertPathExists(cmd.appLauncherPath(), false);
-
-            if (PackageType.WINDOWS.contains(cmd.packageType())) {
-                new WindowsHelper.DesktopIntegrationVerifier(cmd, name);
-            }
-        }
-
-        Path appInstallDir = cmd.appInstallationDirectory();
-        if (TKit.isLinux() && Path.of("/").equals(appInstallDir)) {
-            ApplicationLayout appLayout = cmd.appLayout();
-            TKit.assertPathExists(appLayout.runtimeDirectory(), false);
-        } else {
-            TKit.assertPathExists(appInstallDir, false);
-        }
     }
 
     private List<String> javaOptions;

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
@@ -556,7 +556,7 @@ public final class PackageTest extends RunnablePackageTest {
                 if (PackageType.WINDOWS.contains(cmd.packageType())
                         && !cmd.isPackageUnpacked(
                                 "Not verifying desktop integration")) {
-                    new WindowsHelper.DesktopIntegrationVerifier(cmd);
+                    new WindowsHelper.DesktopIntegrationVerifier(cmd, null);
                 }
             }
             cmd.assertAppLayout();
@@ -571,7 +571,7 @@ public final class PackageTest extends RunnablePackageTest {
                 TKit.assertPathExists(cmd.appLauncherPath(), false);
 
                 if (PackageType.WINDOWS.contains(cmd.packageType())) {
-                    new WindowsHelper.DesktopIntegrationVerifier(cmd);
+                    new WindowsHelper.DesktopIntegrationVerifier(cmd, null);
                 }
             }
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
@@ -317,6 +317,11 @@ public final class PackageTest extends RunnablePackageTest {
         return this;
     }
 
+    public PackageTest addLauncherName(String name) {
+        launchersName.add(name);
+        return this;
+    }
+
     public final static class Group extends RunnablePackageTest {
         public Group(PackageTest... tests) {
             handlers = Stream.of(tests)
@@ -556,7 +561,12 @@ public final class PackageTest extends RunnablePackageTest {
                 if (PackageType.WINDOWS.contains(cmd.packageType())
                         && !cmd.isPackageUnpacked(
                                 "Not verifying desktop integration")) {
+                    // Check main launcher
                     new WindowsHelper.DesktopIntegrationVerifier(cmd, null);
+                    // Check additional launchers
+                    launchersName.forEach(name -> {
+                        new WindowsHelper.DesktopIntegrationVerifier(cmd, name);
+                    });
                 }
             }
             cmd.assertAppLayout();
@@ -571,7 +581,12 @@ public final class PackageTest extends RunnablePackageTest {
                 TKit.assertPathExists(cmd.appLauncherPath(), false);
 
                 if (PackageType.WINDOWS.contains(cmd.packageType())) {
+                    // Check main launcher
                     new WindowsHelper.DesktopIntegrationVerifier(cmd, null);
+                    // Check additional launchers
+                    launchersName.forEach(name -> {
+                        new WindowsHelper.DesktopIntegrationVerifier(cmd, name);
+                    });
                 }
             }
 
@@ -618,6 +633,7 @@ public final class PackageTest extends RunnablePackageTest {
     private Map<PackageType, Handler> handlers;
     private Set<String> namedInitializers;
     private Map<PackageType, PackageHandlers> packageHandlers;
+    private final List<String> launchersName = new ArrayList();
 
     private final static File BUNDLE_OUTPUT_DIR;
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
@@ -318,7 +318,7 @@ public final class PackageTest extends RunnablePackageTest {
     }
 
     public PackageTest addLauncherName(String name) {
-        launchersName.add(name);
+        launcherNames.add(name);
         return this;
     }
 
@@ -564,7 +564,7 @@ public final class PackageTest extends RunnablePackageTest {
                     // Check main launcher
                     new WindowsHelper.DesktopIntegrationVerifier(cmd, null);
                     // Check additional launchers
-                    launchersName.forEach(name -> {
+                    launcherNames.forEach(name -> {
                         new WindowsHelper.DesktopIntegrationVerifier(cmd, name);
                     });
                 }
@@ -584,7 +584,7 @@ public final class PackageTest extends RunnablePackageTest {
                     // Check main launcher
                     new WindowsHelper.DesktopIntegrationVerifier(cmd, null);
                     // Check additional launchers
-                    launchersName.forEach(name -> {
+                    launcherNames.forEach(name -> {
                         new WindowsHelper.DesktopIntegrationVerifier(cmd, name);
                     });
                 }
@@ -633,7 +633,7 @@ public final class PackageTest extends RunnablePackageTest {
     private Map<PackageType, Handler> handlers;
     private Set<String> namedInitializers;
     private Map<PackageType, PackageHandlers> packageHandlers;
-    private final List<String> launchersName = new ArrayList();
+    private final List<String> launcherNames = new ArrayList();
 
     private final static File BUNDLE_OUTPUT_DIR;
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -137,7 +137,7 @@ public class WindowsHelper {
         DesktopIntegrationVerifier(JPackageCommand cmd, String name) {
             cmd.verifyIsOfType(PackageType.WINDOWS);
             this.cmd = cmd;
-            this.name = name;
+            this.name = (name == null ? cmd.name() : name);
             verifyStartMenuShortcut();
             verifyDesktopShortcut();
             verifyFileAssociationsRegistry();
@@ -160,7 +160,7 @@ public class WindowsHelper {
         }
 
         private Path desktopShortcutPath() {
-            return Path.of((name == null ? cmd.name() : name) + ".lnk");
+            return Path.of(name + ".lnk");
         }
 
         private void verifyShortcut(Path path, boolean exists) {
@@ -201,8 +201,7 @@ public class WindowsHelper {
 
         private Path startMenuShortcutPath() {
             return Path.of(cmd.getArgumentValue("--win-menu-group",
-                    () -> "Unknown"), (name == null ? cmd.name() : name)
-                            + ".lnk");
+                    () -> "Unknown"), name + ".lnk");
         }
 
         private void verifyStartMenuShortcut(Path shortcutsRoot, boolean exists) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -134,16 +134,17 @@ public class WindowsHelper {
 
     static class DesktopIntegrationVerifier {
 
-        DesktopIntegrationVerifier(JPackageCommand cmd) {
+        DesktopIntegrationVerifier(JPackageCommand cmd, String name) {
             cmd.verifyIsOfType(PackageType.WINDOWS);
             this.cmd = cmd;
+            this.name = name;
             verifyStartMenuShortcut();
             verifyDesktopShortcut();
             verifyFileAssociationsRegistry();
         }
 
         private void verifyDesktopShortcut() {
-            boolean appInstalled = cmd.appLauncherPath().toFile().exists();
+            boolean appInstalled = cmd.appLauncherPath(name).toFile().exists();
             if (cmd.hasArgument("--win-shortcut")) {
                 if (isUserLocalInstall(cmd)) {
                     verifyUserLocalDesktopShortcut(appInstalled);
@@ -159,7 +160,7 @@ public class WindowsHelper {
         }
 
         private Path desktopShortcutPath() {
-            return Path.of(cmd.name() + ".lnk");
+            return Path.of((name == null ? cmd.name() : name) + ".lnk");
         }
 
         private void verifyShortcut(Path path, boolean exists) {
@@ -183,7 +184,7 @@ public class WindowsHelper {
         }
 
         private void verifyStartMenuShortcut() {
-            boolean appInstalled = cmd.appLauncherPath().toFile().exists();
+            boolean appInstalled = cmd.appLauncherPath(name).toFile().exists();
             if (cmd.hasArgument("--win-menu")) {
                 if (isUserLocalInstall(cmd)) {
                     verifyUserLocalStartMenuShortcut(appInstalled);
@@ -200,7 +201,8 @@ public class WindowsHelper {
 
         private Path startMenuShortcutPath() {
             return Path.of(cmd.getArgumentValue("--win-menu-group",
-                    () -> "Unknown"), cmd.name() + ".lnk");
+                    () -> "Unknown"), (name == null ? cmd.name() : name)
+                            + ".lnk");
         }
 
         private void verifyStartMenuShortcut(Path shortcutsRoot, boolean exists) {
@@ -228,7 +230,7 @@ public class WindowsHelper {
         }
 
         private void verifyFileAssociationsRegistry(Path faFile) {
-            boolean appInstalled = cmd.appLauncherPath().toFile().exists();
+            boolean appInstalled = cmd.appLauncherPath(name).toFile().exists();
             try {
                 TKit.trace(String.format(
                         "Get file association properties from [%s] file",
@@ -279,6 +281,7 @@ public class WindowsHelper {
         }
 
         private final JPackageCommand cmd;
+        private final String name;
     }
 
     private static String queryRegistryValue(String keyPath, String valueName) {

--- a/test/jdk/tools/jpackage/share/MultiLauncherTwoPhaseTest.java
+++ b/test/jdk/tools/jpackage/share/MultiLauncherTwoPhaseTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import jdk.jpackage.test.AdditionalLauncher;
+import jdk.jpackage.test.PackageTest;
+import jdk.jpackage.test.PackageType;
+import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.JPackageCommand;
+
+/**
+ * Test multiple launchers in two phases. First test creates app image and then
+ * creates installer from this image. Output of the test should be
+ * MultiLauncherTwoPhaseTest*.* installer. The output installer should be basic
+ * installer with 3 launcher MultiLauncherTwoPhaseTest, bar and foo. On Windows
+ * we should have start menu integration under MultiLauncherTwoPhaseTest and
+ * desktop shortcuts for all 3 launchers. Linux should also create shortcuts for
+ * all launchers.
+ */
+
+/*
+ * @test
+ * @summary Multiple launchers in two phases
+ * @library ../helpers
+ * @library /test/lib
+ * @key jpackagePlatformPackage
+ * @build jdk.jpackage.test.*
+ * @modules jdk.incubator.jpackage/jdk.incubator.jpackage.internal
+ * @run main/othervm/timeout=360 -Xmx512m MultiLauncherTwoPhaseTest
+ */
+
+public class MultiLauncherTwoPhaseTest {
+
+    public static void main(String[] args) throws Exception {
+        TKit.run(args, () -> {
+            Path appimageOutput = TKit.workDir().resolve("appimage");
+
+            JPackageCommand appImageCmd = JPackageCommand.helloAppImage()
+                    .setArgumentValue("--dest", appimageOutput);
+
+            AdditionalLauncher launcher1 = new AdditionalLauncher("bar");
+            launcher1.setDefaultArguments().applyTo(appImageCmd);
+
+            AdditionalLauncher launcher2 = new AdditionalLauncher("foo");
+            launcher2.applyTo(appImageCmd);
+
+            PackageTest packageTest = new PackageTest()
+                    .addRunOnceInitializer(() -> appImageCmd.execute())
+                    .addBundleDesktopIntegrationVerifier(true)
+                    .addInitializer(cmd -> {
+                        cmd.addArguments("--app-image", appImageCmd.outputBundle());
+                        cmd.removeArgumentWithValue("--input");
+                    })
+                    .forTypes(PackageType.WINDOWS)
+                    .addInitializer(cmd -> {
+                        cmd.addArguments("--win-shortcut", "--win-menu",
+                                "--win-menu-group", "MultiLauncherTwoPhaseTest");
+                    })
+                    .addInstallVerifier(cmd -> {
+                        launcher1.verify(cmd);
+                        launcher1.verifyPackageInstalled(cmd);
+                        launcher2.verify(cmd);
+                        launcher2.verifyPackageInstalled(cmd);
+                    })
+                    .forTypes(PackageType.LINUX)
+                    .addInitializer(cmd -> {
+                        cmd.addArguments("--linux-shortcut");
+                    })
+                    .addInstallVerifier(cmd -> {
+                        launcher1.verify(cmd);
+                        launcher1.verifyPackageInstalled(cmd);
+                        launcher2.verify(cmd);
+                        launcher2.verifyPackageInstalled(cmd);
+                    });
+
+            packageTest.run();
+        });
+    }
+}

--- a/test/jdk/tools/jpackage/share/MultiLauncherTwoPhaseTest.java
+++ b/test/jdk/tools/jpackage/share/MultiLauncherTwoPhaseTest.java
@@ -22,10 +22,12 @@
  */
 
 import java.nio.file.Path;
+import java.io.IOException;
 import jdk.jpackage.test.AdditionalLauncher;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
 import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.JPackageCommand;
 
 /**
@@ -46,54 +48,45 @@ import jdk.jpackage.test.JPackageCommand;
  * @key jpackagePlatformPackage
  * @build jdk.jpackage.test.*
  * @modules jdk.incubator.jpackage/jdk.incubator.jpackage.internal
- * @run main/othervm/timeout=360 -Xmx512m MultiLauncherTwoPhaseTest
+ * @compile MultiLauncherTwoPhaseTest.java
+ * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=MultiLauncherTwoPhaseTest
  */
 
 public class MultiLauncherTwoPhaseTest {
 
-    public static void main(String[] args) throws Exception {
-        TKit.run(args, () -> {
-            Path appimageOutput = TKit.workDir().resolve("appimage");
+    @Test
+    public static void test() throws IOException {
+        Path appimageOutput = TKit.createTempDirectory("appimage");
 
-            JPackageCommand appImageCmd = JPackageCommand.helloAppImage()
-                    .setArgumentValue("--dest", appimageOutput);
+        JPackageCommand appImageCmd = JPackageCommand.helloAppImage()
+                .setArgumentValue("--dest", appimageOutput);
 
-            AdditionalLauncher launcher1 = new AdditionalLauncher("bar");
-            launcher1.setDefaultArguments().applyTo(appImageCmd);
+        AdditionalLauncher launcher1 = new AdditionalLauncher("bar");
+        launcher1.setDefaultArguments().applyTo(appImageCmd);
 
-            AdditionalLauncher launcher2 = new AdditionalLauncher("foo");
-            launcher2.applyTo(appImageCmd);
+        AdditionalLauncher launcher2 = new AdditionalLauncher("foo");
+        launcher2.applyTo(appImageCmd);
 
-            PackageTest packageTest = new PackageTest()
-                    .addRunOnceInitializer(() -> appImageCmd.execute())
-                    .addBundleDesktopIntegrationVerifier(true)
-                    .addInitializer(cmd -> {
-                        cmd.addArguments("--app-image", appImageCmd.outputBundle());
-                        cmd.removeArgumentWithValue("--input");
-                    })
-                    .forTypes(PackageType.WINDOWS)
-                    .addInitializer(cmd -> {
-                        cmd.addArguments("--win-shortcut", "--win-menu",
-                                "--win-menu-group", "MultiLauncherTwoPhaseTest");
-                    })
-                    .addInstallVerifier(cmd -> {
-                        launcher1.verify(cmd);
-                        launcher1.verifyPackageInstalled(cmd);
-                        launcher2.verify(cmd);
-                        launcher2.verifyPackageInstalled(cmd);
-                    })
-                    .forTypes(PackageType.LINUX)
-                    .addInitializer(cmd -> {
-                        cmd.addArguments("--linux-shortcut");
-                    })
-                    .addInstallVerifier(cmd -> {
-                        launcher1.verify(cmd);
-                        launcher1.verifyPackageInstalled(cmd);
-                        launcher2.verify(cmd);
-                        launcher2.verifyPackageInstalled(cmd);
-                    });
+        PackageTest packageTest = new PackageTest()
+                .addLauncherName("bar") // Add launchers name for verification
+                .addLauncherName("foo")
+                .addRunOnceInitializer(() -> appImageCmd.execute())
+                .addBundleDesktopIntegrationVerifier(true)
+                .addInitializer(cmd -> {
+                    cmd.addArguments("--app-image", appImageCmd.outputBundle());
+                    cmd.removeArgumentWithValue("--input");
+                })
+                .forTypes(PackageType.WINDOWS)
+                .addInitializer(cmd -> {
+                    cmd.addArguments("--win-shortcut", "--win-menu",
+                            "--win-menu-group", "MultiLauncherTwoPhaseTest");
+                })
+                .forTypes(PackageType.LINUX)
+                .addInitializer(cmd -> {
+                    cmd.addArguments("--linux-shortcut");
+                });
 
-            packageTest.run();
-        });
+        packageTest.run();
     }
 }


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8231591

- Added MultiLauncherTwoPhaseTest which uses predefine app image with multiple launcher and tests to make sure installer will create shortcuts for all launchers.
- Fixed Linux DesktopIntegration to create shortcuts for additional launcher if we using pre-define app image.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8231591](https://bugs.openjdk.java.net/browse/JDK-8231591): [TESTBUG] Create additional two phase jpackage tests


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/263/head:pull/263`
`$ git checkout pull/263`
