### PR TITLE
8253291: bug7072653.java still failed "Popup window height ... is wrong"

### DIFF
--- a/test/jdk/javax/swing/plaf/basic/BasicComboPopup/7072653/bug7072653.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicComboPopup/7072653/bug7072653.java
@@ -112,6 +112,8 @@ public class bug7072653 {
         combobox.putClientProperty("JComboBox.isPopDown", true);
         frame.getContentPane().add(combobox);
         frame.setVisible(true);
+        robot.delay(3000); // wait some time to stabilize the size of the
+                           // screen insets after the window is shown
         combobox.addPopupMenuListener(new PopupMenuListener() {
             @Override
             public void popupMenuWillBecomeVisible(PopupMenuEvent e) {


### PR DESCRIPTION
Same test as in https://github.com/openjdk/jdk/pull/197 but this time the intermittent problem appears on the small screen.

The test checks that the size of the popup menu is expected, but the problem is that when we show the popup we calculate it based on some initial insets, but when the windows appeared on the screen its icon is added to the dock, if the dock does not have enough space for the new icons, then all icons in it have become smaller and the height of the dock became smaller as well -> the insets are changed -> the test fails.

BTW for the test purpose, it is recommended to make the dock as small as possible.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253291](https://bugs.openjdk.java.net/browse/JDK-8253291): bug7072653.java still failed "Popup window height ... is wrong"


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/264/head:pull/264`
`$ git checkout pull/264`
