### PR TITLE
8252739: Deflater.setDictionary(byte[], int off, int len) ignores the starting offset for the dictionary

### DIFF
--- a/src/java.base/share/native/libzip/Deflater.c
+++ b/src/java.base/share/native/libzip/Deflater.c
@@ -105,7 +105,7 @@ Java_java_util_zip_Deflater_setDictionary(JNIEnv *env, jclass cls, jlong addr,
     Bytef *buf = (*env)->GetPrimitiveArrayCritical(env, b, 0);
     if (buf == NULL) /* out of memory */
         return;
-    res = deflateSetDictionary(jlong_to_ptr(addr), buf, len);
+    res = deflateSetDictionary(jlong_to_ptr(addr), buf + off, len);
     (*env)->ReleasePrimitiveArrayCritical(env, b, buf, 0);
     checkSetDictionaryResult(env, addr, res);
 }

--- a/test/jdk/java/util/zip/DeflaterDictionaryTests.java
+++ b/test/jdk/java/util/zip/DeflaterDictionaryTests.java
@@ -22,6 +22,7 @@
  */
 
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
@@ -30,6 +31,7 @@ import java.util.zip.Deflater;
 import java.util.zip.Inflater;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertThrows;
 
 /**
  * @test
@@ -48,19 +50,48 @@ public class DeflaterDictionaryTests {
     private static final int DICTIONARY_LENGTH = 3;
 
     /**
+     * DataProvider with offsets which should be valid for setDictionary
+     *
+     * @return valid offset values
+     */
+    @DataProvider(name = "validDictionaryOffsets")
+    protected Object[][] validDictionaryOffsets() {
+        return new Object[][]{
+                {0},
+                {DICTIONARY_OFFSET},
+                {DICTIONARY_LENGTH}
+        };
+    }
+
+    /**
+     * DataProvider with  invalid offsets for setDictionary
+     *
+     * @return invalid offset values
+     */
+    @DataProvider(name = "invalidDictionaryOffsets")
+    protected Object[][] invalidDictionaryOffsets() {
+        return new Object[][]{
+                {-1},
+                {DICTIONARY_LENGTH + 2},
+                {DICTIONARY.length()}
+        };
+    }
+
+    /**
      * Validate that an offset can be used with Deflater::setDictionary
      *
+     * @param dictionary_offset offset value to be used
      * @throws Exception if an error occurs
      */
-    @Test
-    public void testByteArray() throws Exception {
+    @Test(dataProvider = "validDictionaryOffsets")
+    public void testByteArray(int dictionary_offset) throws Exception {
         byte[] input = SRC_DATA.getBytes(UTF_8);
         byte[] output = new byte[RESULT_SIZE];
         Deflater deflater = new Deflater();
         Inflater inflater = new Inflater();
         try {
             // Compress the bytes
-            deflater.setDictionary(DICTIONARY.getBytes(UTF_8), DICTIONARY_OFFSET, DICTIONARY_LENGTH);
+            deflater.setDictionary(DICTIONARY.getBytes(UTF_8), dictionary_offset, DICTIONARY_LENGTH);
             deflater.setInput(input);
             deflater.finish();
             int compressedDataLength = deflater.deflate(output, 0, output.length, Deflater.NO_FLUSH);
@@ -75,7 +106,7 @@ public class DeflaterDictionaryTests {
             int resultLength = inflater.inflate(result);
             if (inflater.needsDictionary()) {
                 System.out.println("Specifying Dictionary");
-                inflater.setDictionary(DICTIONARY.getBytes(UTF_8), DICTIONARY_OFFSET, DICTIONARY_LENGTH);
+                inflater.setDictionary(DICTIONARY.getBytes(UTF_8), dictionary_offset, DICTIONARY_LENGTH);
                 resultLength = inflater.inflate(result);
             } else {
                 System.out.println("Did not need to use a Dictionary");
@@ -188,6 +219,30 @@ public class DeflaterDictionaryTests {
 
             Assert.assertEquals(SRC_DATA.length(), resultLength);
             Assert.assertEquals(input, Arrays.copyOf(result, resultLength));
+        } finally {
+            // Release Resources
+            deflater.end();
+            inflater.end();
+        }
+    }
+
+    /**
+     * Validate that an invalid offset used with setDictionary will
+     * throw an Exception
+     *
+     * @param dictionary_offset offset value to be used
+     */
+    @Test(dataProvider = "invalidDictionaryOffsets")
+    public void testInvalidOffsets(int dictionary_offset) {
+        byte[] dictionary = DICTIONARY.getBytes(UTF_8);
+
+        Deflater deflater = new Deflater();
+        Inflater inflater = new Inflater();
+        try {
+            assertThrows(ArrayIndexOutOfBoundsException.class, () ->
+                    deflater.setDictionary(dictionary, dictionary_offset, DICTIONARY_LENGTH));
+            assertThrows(ArrayIndexOutOfBoundsException.class, () ->
+                    inflater.setDictionary(dictionary, dictionary_offset, DICTIONARY_LENGTH));
         } finally {
             // Release Resources
             deflater.end();

--- a/test/jdk/java/util/zip/DeflaterDictionaryTests.java
+++ b/test/jdk/java/util/zip/DeflaterDictionaryTests.java
@@ -41,115 +41,115 @@ public class DeflaterDictionaryTests {
     // Output buffer size
     private static final int RESULT_SIZE = 1024;
     // Data to compress
-    private static final String SRC_DATA = "Welcome to US Open;"
-            +"Welcome to US Open;"
-            +"Welcome to US Open;"
-            +"Welcome to US Open;"
-            +"Welcome to US Open;"
-            +"Welcome to US Open;";
+    private static final String SRC_DATA = "Welcome to the US Open;".repeat(6);
     // Dictionary to be used
     private static final String DICTIONARY = "US Open";
     private static final int DICTIONARY_OFFSET = 1;
     private static final int DICTIONARY_LENGTH = 3;
 
-
     /**
      * Validate that an offset can be used with Deflater::setDictionary
+     *
      * @throws Exception if an error occurs
      */
     @Test
-    public void ByteArrayTest() throws Exception {
+    public void testByteArray() throws Exception {
         byte[] input = SRC_DATA.getBytes(UTF_8);
         byte[] output = new byte[RESULT_SIZE];
-        // Compress the bytes
         Deflater deflater = new Deflater();
-        deflater.setDictionary(DICTIONARY.getBytes(UTF_8), DICTIONARY_OFFSET, DICTIONARY_LENGTH);
-        deflater.setInput(input);
-        deflater.finish();
-        int compressedDataLength = deflater.deflate(output,0 , output.length, Deflater.NO_FLUSH);
-        System.out.printf("Deflater::getTotalOut:%s, Deflater::getAdler: %s," +
-                        " compressed length: %s%n", deflater.getTotalOut(),
-                deflater.getTotalOut(), compressedDataLength);
-        deflater.finished();
-
-        // Decompress the bytes
         Inflater inflater = new Inflater();
-        inflater.setInput(output, 0, compressedDataLength);
-        byte[] result = new byte[RESULT_SIZE];
-        int resultLength = inflater.inflate(result);
-        if(inflater.needsDictionary()) {
-            System.out.println("Specifying Dictionary");
-            inflater.setDictionary(DICTIONARY.getBytes(UTF_8), DICTIONARY_OFFSET, DICTIONARY_LENGTH);
-            resultLength = inflater.inflate(result);
-        } else {
-            System.out.println("Did not need to use a Dictionary");
+        try {
+            // Compress the bytes
+            deflater.setDictionary(DICTIONARY.getBytes(UTF_8), DICTIONARY_OFFSET, DICTIONARY_LENGTH);
+            deflater.setInput(input);
+            deflater.finish();
+            int compressedDataLength = deflater.deflate(output, 0, output.length, Deflater.NO_FLUSH);
+            System.out.printf("Deflater::getTotalOut:%s, Deflater::getAdler: %s," +
+                            " compressed length: %s%n", deflater.getTotalOut(),
+                    deflater.getTotalOut(), compressedDataLength);
+            deflater.finished();
+
+            // Decompress the bytes
+            inflater.setInput(output, 0, compressedDataLength);
+            byte[] result = new byte[RESULT_SIZE];
+            int resultLength = inflater.inflate(result);
+            if (inflater.needsDictionary()) {
+                System.out.println("Specifying Dictionary");
+                inflater.setDictionary(DICTIONARY.getBytes(UTF_8), DICTIONARY_OFFSET, DICTIONARY_LENGTH);
+                resultLength = inflater.inflate(result);
+            } else {
+                System.out.println("Did not need to use a Dictionary");
+            }
+            inflater.finished();
+            System.out.printf("Inflater::getAdler:%s, length: %s%n",
+                    inflater.getAdler(), resultLength);
+
+            Assert.assertEquals(SRC_DATA.length(), resultLength);
+            Assert.assertEquals(input, Arrays.copyOf(result, resultLength));
+        } finally {
+            // Release Resources
+            deflater.end();
+            inflater.end();
         }
-        inflater.finished();
-        System.out.printf("Inflater::getAdler:%s, length: %s%n",
-                inflater.getAdler(), resultLength);
-
-        Assert.assertEquals(SRC_DATA.length(), resultLength);
-        Assert.assertEquals(input, Arrays.copyOf(result, resultLength));
-
-        // Release Resources
-        deflater.end();
-        inflater.end();
     }
 
     /**
      * Validate that a ByteBuffer can be used with Deflater::setDictionary
+     *
      * @throws Exception if an error occurs
      */
     @Test
-    public void testByteBufferWrap() throws Exception {
+    public void testHeapByteBuffer() throws Exception {
         byte[] input = SRC_DATA.getBytes(UTF_8);
         byte[] output = new byte[RESULT_SIZE];
-        // Compress the bytes
         ByteBuffer dictDef = ByteBuffer.wrap(DICTIONARY.getBytes(UTF_8), DICTIONARY_OFFSET, DICTIONARY_LENGTH);
         ByteBuffer dictInf = ByteBuffer.wrap(DICTIONARY.getBytes(UTF_8), DICTIONARY_OFFSET, DICTIONARY_LENGTH);
         Deflater deflater = new Deflater();
-        deflater.setDictionary(dictDef);
-        deflater.setInput(input);
-        deflater.finish();
-        int compressedDataLength = deflater.deflate(output,0 , output.length, Deflater.NO_FLUSH);
-        System.out.printf("Deflater::getTotalOut:%s, Deflater::getAdler: %s," +
-                        " compressed length: %s%n", deflater.getTotalOut(),
-                deflater.getTotalOut(), compressedDataLength);
-        deflater.finished();
-
-        // Decompress the bytes
         Inflater inflater = new Inflater();
-        inflater.setInput(output, 0, compressedDataLength);
-        byte[] result = new byte[RESULT_SIZE];
-        int resultLength = inflater.inflate(result);
-        if(inflater.needsDictionary()) {
-            System.out.println("Specifying Dictionary");
-            inflater.setDictionary(dictInf);
-            resultLength = inflater.inflate(result);
-        } else {
-            System.out.println("Did not need to use a Dictionary");
+        try {
+            // Compress the bytes
+            deflater.setDictionary(dictDef);
+            deflater.setInput(input);
+            deflater.finish();
+            int compressedDataLength = deflater.deflate(output, 0, output.length, Deflater.NO_FLUSH);
+            System.out.printf("Deflater::getTotalOut:%s, Deflater::getAdler: %s," +
+                            " compressed length: %s%n", deflater.getTotalOut(),
+                    deflater.getTotalOut(), compressedDataLength);
+            deflater.finished();
+
+            // Decompress the bytes
+            inflater.setInput(output, 0, compressedDataLength);
+            byte[] result = new byte[RESULT_SIZE];
+            int resultLength = inflater.inflate(result);
+            if (inflater.needsDictionary()) {
+                System.out.println("Specifying Dictionary");
+                inflater.setDictionary(dictInf);
+                resultLength = inflater.inflate(result);
+            } else {
+                System.out.println("Did not need to use a Dictionary");
+            }
+            inflater.finished();
+            System.out.printf("Inflater::getAdler:%s, length: %s%n",
+                    inflater.getAdler(), resultLength);
+
+            Assert.assertEquals(SRC_DATA.length(), resultLength);
+            Assert.assertEquals(input, Arrays.copyOf(result, resultLength));
+        } finally {
+            // Release Resources
+            deflater.end();
+            inflater.end();
         }
-        inflater.finished();
-        System.out.printf("Inflater::getAdler:%s, length: %s%n",
-                inflater.getAdler(), resultLength);
-
-        Assert.assertEquals(SRC_DATA.length(), resultLength);
-        Assert.assertEquals(input, Arrays.copyOf(result, resultLength));
-
-        // Release Resources
-        deflater.end();
-        inflater.end();
     }
 
     /**
      * Validate that ByteBuffer::allocateDirect can be used with Deflater::setDictionary
+     *
      * @throws Exception if an error occurs
      */
     @Test
     public void testByteBufferDirect() throws Exception {
         byte[] input = SRC_DATA.getBytes(UTF_8);
         byte[] output = new byte[RESULT_SIZE];
-        // Compress the bytes
         ByteBuffer dictDef = ByteBuffer.allocateDirect(DICTIONARY.length());
         ByteBuffer dictInf = ByteBuffer.allocateDirect(DICTIONARY.length());
         dictDef.put(DICTIONARY.getBytes(UTF_8));
@@ -159,36 +159,39 @@ public class DeflaterDictionaryTests {
         dictInf.position(DICTIONARY_OFFSET);
         dictInf.limit(DICTIONARY_LENGTH);
         Deflater deflater = new Deflater();
-        deflater.setDictionary(dictDef.slice());
-        deflater.setInput(input);
-        deflater.finish();
-        int compressedDataLength = deflater.deflate(output,0 , output.length, Deflater.NO_FLUSH);
-        System.out.printf("Deflater::getTotalOut:%s, Deflater::getAdler: %s," +
-                        " compressed length: %s%n", deflater.getTotalOut(),
-                deflater.getTotalOut(), compressedDataLength);
-        deflater.finished();
-
-        // Decompress the bytes
         Inflater inflater = new Inflater();
-        inflater.setInput(output, 0, compressedDataLength);
-        byte[] result = new byte[RESULT_SIZE];
-        int resultLength = inflater.inflate(result);
-        if(inflater.needsDictionary()){
-            System.out.println("Specifying Dictionary");
-            inflater.setDictionary(dictInf.slice());
-            resultLength = inflater.inflate(result);
-        } else {
-            System.out.println("Did not need to use a Dictionary");
+        try {
+            // Compress the bytes
+            deflater.setDictionary(dictDef.slice());
+            deflater.setInput(input);
+            deflater.finish();
+            int compressedDataLength = deflater.deflate(output, 0, output.length, Deflater.NO_FLUSH);
+            System.out.printf("Deflater::getTotalOut:%s, Deflater::getAdler: %s," +
+                            " compressed length: %s%n", deflater.getTotalOut(),
+                    deflater.getTotalOut(), compressedDataLength);
+            deflater.finished();
+
+            // Decompress the bytes
+            inflater.setInput(output, 0, compressedDataLength);
+            byte[] result = new byte[RESULT_SIZE];
+            int resultLength = inflater.inflate(result);
+            if (inflater.needsDictionary()) {
+                System.out.println("Specifying Dictionary");
+                inflater.setDictionary(dictInf.slice());
+                resultLength = inflater.inflate(result);
+            } else {
+                System.out.println("Did not need to use a Dictionary");
+            }
+            inflater.finished();
+            System.out.printf("Inflater::getAdler:%s, length: %s%n",
+                    inflater.getAdler(), resultLength);
+
+            Assert.assertEquals(SRC_DATA.length(), resultLength);
+            Assert.assertEquals(input, Arrays.copyOf(result, resultLength));
+        } finally {
+            // Release Resources
+            deflater.end();
+            inflater.end();
         }
-        inflater.finished();
-        System.out.printf("Inflater::getAdler:%s, length: %s%n",
-                inflater.getAdler(), resultLength);
-
-        Assert.assertEquals(SRC_DATA.length(), resultLength);
-        Assert.assertEquals(input, Arrays.copyOf(result, resultLength));
-
-        // Release Resources
-        deflater.end();
-        inflater.end();
     }
 }

--- a/test/jdk/java/util/zip/DeflaterDictionaryTests.java
+++ b/test/jdk/java/util/zip/DeflaterDictionaryTests.java
@@ -49,6 +49,9 @@ public class DeflaterDictionaryTests {
             +"Welcome to US Open;";
     // Dictionary to be used
     private static final String DICTIONARY = "US Open";
+    private static final int DICTIONARY_OFFSET = 1;
+    private static final int DICTIONARY_LENGTH = 3;
+
 
     /**
      * Validate that an offset can be used with Deflater::setDictionary
@@ -60,7 +63,7 @@ public class DeflaterDictionaryTests {
         byte[] output = new byte[RESULT_SIZE];
         // Compress the bytes
         Deflater deflater = new Deflater();
-        deflater.setDictionary(DICTIONARY.getBytes(UTF_8), 1, 3);
+        deflater.setDictionary(DICTIONARY.getBytes(UTF_8), DICTIONARY_OFFSET, DICTIONARY_LENGTH);
         deflater.setInput(input);
         deflater.finish();
         int compressedDataLength = deflater.deflate(output,0 , output.length, Deflater.NO_FLUSH);
@@ -76,7 +79,7 @@ public class DeflaterDictionaryTests {
         int resultLength = inflater.inflate(result);
         if(inflater.needsDictionary()) {
             System.out.println("Specifying Dictionary");
-            inflater.setDictionary(DICTIONARY.getBytes(UTF_8), 1, 3);
+            inflater.setDictionary(DICTIONARY.getBytes(UTF_8), DICTIONARY_OFFSET, DICTIONARY_LENGTH);
             resultLength = inflater.inflate(result);
         } else {
             System.out.println("Did not need to use a Dictionary");
@@ -102,8 +105,8 @@ public class DeflaterDictionaryTests {
         byte[] input = SRC_DATA.getBytes(UTF_8);
         byte[] output = new byte[RESULT_SIZE];
         // Compress the bytes
-        ByteBuffer dictDef = ByteBuffer.wrap(DICTIONARY.getBytes(UTF_8), 1, 3);
-        ByteBuffer dictInf = ByteBuffer.wrap(DICTIONARY.getBytes(UTF_8), 1, 3);
+        ByteBuffer dictDef = ByteBuffer.wrap(DICTIONARY.getBytes(UTF_8), DICTIONARY_OFFSET, DICTIONARY_LENGTH);
+        ByteBuffer dictInf = ByteBuffer.wrap(DICTIONARY.getBytes(UTF_8), DICTIONARY_OFFSET, DICTIONARY_LENGTH);
         Deflater deflater = new Deflater();
         deflater.setDictionary(dictDef);
         deflater.setInput(input);
@@ -149,10 +152,14 @@ public class DeflaterDictionaryTests {
         // Compress the bytes
         ByteBuffer dictDef = ByteBuffer.allocateDirect(DICTIONARY.length());
         ByteBuffer dictInf = ByteBuffer.allocateDirect(DICTIONARY.length());
-        dictDef.put(DICTIONARY.getBytes(UTF_8), 1, 3);
-        dictInf.put(DICTIONARY.getBytes(UTF_8), 1, 3);
+        dictDef.put(DICTIONARY.getBytes(UTF_8));
+        dictInf.put(DICTIONARY.getBytes(UTF_8));
+        dictDef.position(DICTIONARY_OFFSET);
+        dictDef.limit(DICTIONARY_LENGTH);
+        dictInf.position(DICTIONARY_OFFSET);
+        dictInf.limit(DICTIONARY_LENGTH);
         Deflater deflater = new Deflater();
-        deflater.setDictionary(dictDef);
+        deflater.setDictionary(dictDef.slice());
         deflater.setInput(input);
         deflater.finish();
         int compressedDataLength = deflater.deflate(output,0 , output.length, Deflater.NO_FLUSH);
@@ -168,7 +175,7 @@ public class DeflaterDictionaryTests {
         int resultLength = inflater.inflate(result);
         if(inflater.needsDictionary()){
             System.out.println("Specifying Dictionary");
-            inflater.setDictionary(dictInf);
+            inflater.setDictionary(dictInf.slice());
             resultLength = inflater.inflate(result);
         } else {
             System.out.println("Did not need to use a Dictionary");

--- a/test/jdk/java/util/zip/DeflaterDictionaryTests.java
+++ b/test/jdk/java/util/zip/DeflaterDictionaryTests.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * @test
+ * @bug 8252739
+ * @summary Verify Deflater.setDictionary(dictionary, offset, length) uses the offset
+ * @run testng/othervm DeflaterDictionaryTests
+ */
+public class DeflaterDictionaryTests {
+    // Output buffer size
+    private static final int RESULT_SIZE = 1024;
+    // Data to compress
+    private static final String SRC_DATA = "Welcome to US Open;"
+            +"Welcome to US Open;"
+            +"Welcome to US Open;"
+            +"Welcome to US Open;"
+            +"Welcome to US Open;"
+            +"Welcome to US Open;";
+    // Dictionary to be used
+    private static final String DICTIONARY = "US Open";
+
+    /**
+     * Validate that an offset can be used with Deflater::setDictionary
+     * @throws Exception if an error occurs
+     */
+    @Test
+    public void ByteArrayTest() throws Exception {
+        byte[] input = SRC_DATA.getBytes(UTF_8);
+        byte[] output = new byte[RESULT_SIZE];
+        // Compress the bytes
+        Deflater deflater = new Deflater();
+        deflater.setDictionary(DICTIONARY.getBytes(UTF_8), 1, 3);
+        deflater.setInput(input);
+        deflater.finish();
+        int compressedDataLength = deflater.deflate(output,0 , output.length, Deflater.NO_FLUSH);
+        System.out.printf("Deflater::getTotalOut:%s, Deflater::getAdler: %s," +
+                        " compressed length: %s%n", deflater.getTotalOut(),
+                deflater.getTotalOut(), compressedDataLength);
+        deflater.finished();
+
+        // Decompress the bytes
+        Inflater inflater = new Inflater();
+        inflater.setInput(output, 0, compressedDataLength);
+        byte[] result = new byte[RESULT_SIZE];
+        int resultLength = inflater.inflate(result);
+        if(inflater.needsDictionary()) {
+            System.out.println("Specifying Dictionary");
+            inflater.setDictionary(DICTIONARY.getBytes(UTF_8), 1, 3);
+            resultLength = inflater.inflate(result);
+        } else {
+            System.out.println("Did not need to use a Dictionary");
+        }
+        inflater.finished();
+        System.out.printf("Inflater::getAdler:%s, length: %s%n",
+                inflater.getAdler(), resultLength);
+
+        Assert.assertEquals(SRC_DATA.length(), resultLength);
+        Assert.assertEquals(input, Arrays.copyOf(result, resultLength));
+
+        // Release Resources
+        deflater.end();
+        inflater.end();
+    }
+
+    /**
+     * Validate that a ByteBuffer can be used with Deflater::setDictionary
+     * @throws Exception if an error occurs
+     */
+    @Test
+    public void testByteBufferWrap() throws Exception {
+        byte[] input = SRC_DATA.getBytes(UTF_8);
+        byte[] output = new byte[RESULT_SIZE];
+        // Compress the bytes
+        ByteBuffer dictDef = ByteBuffer.wrap(DICTIONARY.getBytes(UTF_8));
+        ByteBuffer dictInf = ByteBuffer.wrap(DICTIONARY.getBytes(UTF_8));
+        Deflater deflater = new Deflater();
+        deflater.setDictionary(dictDef);
+        deflater.setInput(input);
+        deflater.finish();
+        int compressedDataLength = deflater.deflate(output,0 , output.length, Deflater.NO_FLUSH);
+        System.out.printf("Deflater::getTotalOut:%s, Deflater::getAdler: %s," +
+                        " compressed length: %s%n", deflater.getTotalOut(),
+                deflater.getTotalOut(), compressedDataLength);
+        deflater.finished();
+
+        // Decompress the bytes
+        Inflater inflater = new Inflater();
+        inflater.setInput(output, 0, compressedDataLength);
+        byte[] result = new byte[RESULT_SIZE];
+        int resultLength = inflater.inflate(result);
+        if(inflater.needsDictionary()) {
+            System.out.println("Specifying Dictionary");
+            inflater.setDictionary(dictInf);
+            resultLength = inflater.inflate(result);
+        } else {
+            System.out.println("Did not need to use a Dictionary");
+        }
+        inflater.finished();
+        System.out.printf("Inflater::getAdler:%s, length: %s%n",
+                inflater.getAdler(), resultLength);
+
+        Assert.assertEquals(SRC_DATA.length(), resultLength);
+        Assert.assertEquals(input, Arrays.copyOf(result, resultLength));
+
+        // Release Resources
+        deflater.end();
+        inflater.end();
+    }
+
+    /**
+     * Validate that ByteBuffer::allocateDirect can be used with Deflater::setDictionary
+     * @throws Exception if an error occurs
+     */
+    @Test
+    public void testByteBufferDirect() throws Exception {
+        byte[] input = SRC_DATA.getBytes(UTF_8);
+        byte[] output = new byte[RESULT_SIZE];
+        // Compress the bytes
+        ByteBuffer dictDef = ByteBuffer.allocateDirect(DICTIONARY.length());
+        ByteBuffer dictInf = ByteBuffer.allocateDirect(DICTIONARY.length());
+        Deflater deflater = new Deflater();
+        deflater.setDictionary(dictDef);
+        deflater.setInput(input);
+        deflater.finish();
+        int compressedDataLength = deflater.deflate(output,0 , output.length, Deflater.NO_FLUSH);
+        System.out.printf("Deflater::getTotalOut:%s, Deflater::getAdler: %s," +
+                        " compressed length: %s%n", deflater.getTotalOut(),
+                deflater.getTotalOut(), compressedDataLength);
+        deflater.finished();
+
+        // Decompress the bytes
+        Inflater inflater = new Inflater();
+        inflater.setInput(output, 0, compressedDataLength);
+        byte[] result = new byte[RESULT_SIZE];
+        int resultLength = inflater.inflate(result);
+        if(inflater.needsDictionary()){
+            System.out.println("Specifying Dictionary");
+            inflater.setDictionary(dictInf);
+            resultLength = inflater.inflate(result);
+        } else {
+            System.out.println("Did not need to use a Dictionary");
+        }
+        inflater.finished();
+        System.out.printf("Inflater::getAdler:%s, length: %s%n",
+                inflater.getAdler(), resultLength);
+
+        Assert.assertEquals(SRC_DATA.length(), resultLength);
+        Assert.assertEquals(input, Arrays.copyOf(result, resultLength));
+
+        // Release Resources
+        deflater.end();
+        inflater.end();
+    }
+}

--- a/test/jdk/java/util/zip/DeflaterDictionaryTests.java
+++ b/test/jdk/java/util/zip/DeflaterDictionaryTests.java
@@ -102,8 +102,8 @@ public class DeflaterDictionaryTests {
         byte[] input = SRC_DATA.getBytes(UTF_8);
         byte[] output = new byte[RESULT_SIZE];
         // Compress the bytes
-        ByteBuffer dictDef = ByteBuffer.wrap(DICTIONARY.getBytes(UTF_8));
-        ByteBuffer dictInf = ByteBuffer.wrap(DICTIONARY.getBytes(UTF_8));
+        ByteBuffer dictDef = ByteBuffer.wrap(DICTIONARY.getBytes(UTF_8), 1, 3);
+        ByteBuffer dictInf = ByteBuffer.wrap(DICTIONARY.getBytes(UTF_8), 1, 3);
         Deflater deflater = new Deflater();
         deflater.setDictionary(dictDef);
         deflater.setInput(input);
@@ -149,6 +149,8 @@ public class DeflaterDictionaryTests {
         // Compress the bytes
         ByteBuffer dictDef = ByteBuffer.allocateDirect(DICTIONARY.length());
         ByteBuffer dictInf = ByteBuffer.allocateDirect(DICTIONARY.length());
+        dictDef.put(DICTIONARY.getBytes(UTF_8), 1, 3);
+        dictInf.put(DICTIONARY.getBytes(UTF_8), 1, 3);
         Deflater deflater = new Deflater();
         deflater.setDictionary(dictDef);
         deflater.setInput(input);


### PR DESCRIPTION
Hi all,

Please review the fix  for JDK-8252739 which addresses an issue introduced by https://bugs.openjdk.java.net/browse/JDK-8225189, where Deflater.c ignored the offset specified by Deflater.setDictionary.

Mach5 jdk-tier1, jdk-tier2, jdk-tier3 runs cleanly as well as the java/util/zip and java/util/jar JCK tests.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252739](https://bugs.openjdk.java.net/browse/JDK-8252739): Deflater.setDictionary(byte[], int off, int len) ignores the starting offset for the dictionary


### Reviewers
 * [Uwe Schindler](https://openjdk.java.net/census#uschindler) (@uschindler - Author) ⚠️ Review applies to aac03e3e8d4ef4a7ca1a8e715b4ec62a68e08d35
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/269/head:pull/269`
`$ git checkout pull/269`
