### PR TITLE
8247251: Assert (_pcs_length == 0 || last_pc()->pc_offset() < pc_offs…

### DIFF
--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.core/src/org/graalvm/compiler/core/gen/LIRCompilerBackend.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.core/src/org/graalvm/compiler/core/gen/LIRCompilerBackend.java
@@ -79,7 +79,7 @@ public class LIRCompilerBackend {
     public static <T extends CompilationResult> void emitBackEnd(StructuredGraph graph, Object stub, ResolvedJavaMethod installedCodeOwner, Backend backend, T compilationResult,
                     CompilationResultBuilderFactory factory, RegisterConfig registerConfig, LIRSuites lirSuites) {
         DebugContext debug = graph.getDebug();
-        try (DebugContext.Scope s = debug.scope("BackEnd", graph.getLastSchedule()); DebugCloseable a = BackEnd.start(debug)) {
+        try (DebugContext.Scope s = debug.scope("BackEnd", graph, graph.getLastSchedule()); DebugCloseable a = BackEnd.start(debug)) {
             LIRGenerationResult lirGen = null;
             lirGen = emitLIR(backend, graph, stub, registerConfig, lirSuites);
             try (DebugContext.Scope s2 = debug.scope("CodeGen", lirGen, lirGen.getLIR())) {

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/ArrayCopyIntrinsificationTest.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/ArrayCopyIntrinsificationTest.java
@@ -28,14 +28,15 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import org.graalvm.compiler.api.directives.GraalDirectives;
 import org.graalvm.compiler.core.test.GraalCompilerTest;
 import org.graalvm.compiler.graph.Node;
-import org.graalvm.compiler.replacements.arraycopy.ArrayCopySnippets;
 import org.graalvm.compiler.nodes.DirectCallTargetNode;
 import org.graalvm.compiler.nodes.Invoke;
 import org.graalvm.compiler.nodes.LoweredCallTargetNode;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.compiler.replacements.arraycopy.ArrayCopySnippets;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -369,5 +370,23 @@ public class ArrayCopyIntrinsificationTest extends GraalCompilerTest {
         }
         test("objectArraycopyCatchArrayStoreException", longSource, 4, integerDest, 2, 3);
         test("objectArraycopyCatchArrayIndexException", new Integer[128], 0, new Integer[128], Integer.MAX_VALUE, 1);
+    }
+
+    @Test
+    public void testArraycopyDeoptWithSideEffect() {
+        ArgSupplier s = () -> new int[4];
+        int[] b = new int[]{1, 1, 1, 1};
+        int[] c = new int[]{2, 2, 2, 2};
+        test("arraycopyAndDeopt", s, b, c);
+    }
+
+    public static int[] arraycopyAndDeopt(int[] a, int[] b, int[] c) {
+        if (a[0] == 0) {
+            System.arraycopy(b, 0, a, 0, b.length);
+            GraalDirectives.deoptimize();
+        } else {
+            System.arraycopy(c, 0, a, 0, b.length);
+        }
+        return a;
     }
 }

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/HotSpotGraalCompiler.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/HotSpotGraalCompiler.java
@@ -235,13 +235,13 @@ public class HotSpotGraalCompiler implements GraalJVMCICompiler, Cancellable {
         return result;
     }
 
-    public CompilationResult compile(ResolvedJavaMethod method,
+    public CompilationResult compile(StructuredGraph graph,
+                    ResolvedJavaMethod method,
                     int entryBCI,
                     boolean useProfilingInfo,
                     boolean shouldRetainLocalVariables,
                     CompilationIdentifier compilationId,
                     DebugContext debug) {
-        StructuredGraph graph = createGraph(method, entryBCI, useProfilingInfo, compilationId, debug.getOptions(), debug);
         CompilationResult result = new CompilationResult(compilationId);
         return compileHelper(CompilationResultBuilderFactory.Default, result, graph, method, entryBCI, useProfilingInfo, shouldRetainLocalVariables, debug.getOptions());
     }

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/SnippetFrameStateAssignment.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/SnippetFrameStateAssignment.java
@@ -216,13 +216,20 @@ public class SnippetFrameStateAssignment {
                     afterCount++;
                 }
             }
+            NodeStateAssignment selected = null;
             if (invalidCount > 0) {
-                stateMapping.put(loop, NodeStateAssignment.INVALID);
+                selected = NodeStateAssignment.INVALID;
             } else {
                 if (afterCount > 0) {
-                    stateMapping.put(loop, NodeStateAssignment.AFTER_BCI);
+                    selected = NodeStateAssignment.AFTER_BCI;
                 } else {
-                    stateMapping.put(loop, NodeStateAssignment.BEFORE_BCI);
+                    selected = NodeStateAssignment.BEFORE_BCI;
+                }
+            }
+            stateMapping.put(loop, selected);
+            if (selected != initialState) {
+                for (LoopExitNode exit : loop.loopExits()) {
+                    loopInfo.exitStates.put(exit, selected);
                 }
             }
             return loopInfo.exitStates;

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/arraycopy/ArrayCopyCallNode.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/arraycopy/ArrayCopyCallNode.java
@@ -51,6 +51,7 @@ import org.graalvm.compiler.nodes.calc.AddNode;
 import org.graalvm.compiler.nodes.calc.IntegerConvertNode;
 import org.graalvm.compiler.nodes.calc.LeftShiftNode;
 import org.graalvm.compiler.nodes.extended.ForeignCallNode;
+import org.graalvm.compiler.nodes.memory.AbstractMemoryCheckpoint;
 import org.graalvm.compiler.nodes.memory.MemoryAccess;
 import org.graalvm.compiler.nodes.memory.MemoryKill;
 import org.graalvm.compiler.nodes.memory.SingleMemoryKill;
@@ -67,7 +68,7 @@ import jdk.vm.ci.meta.MetaAccessProvider;
 import jdk.vm.ci.meta.PrimitiveConstant;
 
 @NodeInfo(allowedUsageTypes = {Memory}, cycles = CYCLES_UNKNOWN, size = SIZE_UNKNOWN)
-public final class ArrayCopyCallNode extends FixedWithNextNode implements Lowerable, SingleMemoryKill, MemoryAccess, Canonicalizable {
+public final class ArrayCopyCallNode extends AbstractMemoryCheckpoint implements Lowerable, SingleMemoryKill, MemoryAccess, Canonicalizable {
 
     public static final NodeClass<ArrayCopyCallNode> TYPE = NodeClass.create(ArrayCopyCallNode.class);
     @Input protected ValueNode src;
@@ -212,6 +213,11 @@ public final class ArrayCopyCallNode extends FixedWithNextNode implements Lowera
     @Override
     public LocationIdentity getKilledLocationIdentity() {
         return killedLocationIdentity;
+    }
+
+    @Override
+    public boolean hasSideEffect() {
+        return !killedLocationIdentity.isInit();
     }
 
     @NodeIntrinsic(hasSideEffect = true)


### PR DESCRIPTION
Fix frame state recording for System.arraycopy() intrinsic. This is port of Graal fix:
https://github.com/oracle/graal/commit/438a7cb0257

Graal unit test ArrayCopyIntrinsificationTest.java is updated to catch this case.

I ran tier1 and tier3-graal testing. I also ran CodeCacheInfoOnCompilation/Test.java and c2/Test6603011.java jtreg tests 100 times in Mach5 and got 6 failures with latest JDK. With fix tests passed.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247251](https://bugs.openjdk.java.net/browse/JDK-8247251): Assert '(_pcs_length == 0 || last_pc()->pc_offset() < pc_offset) failed: must specify a new, larger pc offset' failure ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Tom Rodriguez](https://openjdk.java.net/census#never) (@tkrodriguez - **Reviewer**)


### Contributors
 * Tom Rodriguez `<never@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/272/head:pull/272`
`$ git checkout pull/272`
