### PR TITLE
8253397: Ensure LogTag types are sorted

### DIFF
--- a/src/hotspot/share/logging/logTag.cpp
+++ b/src/hotspot/share/logging/logTag.cpp
@@ -26,7 +26,6 @@
 #include "utilities/stringUtils.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/ostream.hpp"
-#include "utilities/quickSort.hpp"
 
 const char* LogTag::_name[] = {
   "", // __NO_TAG
@@ -60,28 +59,30 @@ LogTagType LogTag::fuzzy_match(const char *str) {
   return match;
 }
 
-static int cmp_logtag(LogTagType a, LogTagType b) {
-  return strcmp(LogTag::name(a), LogTag::name(b));
-}
-
-static const size_t sorted_tagcount = LogTag::Count - 1; // Not counting _NO_TAG
-static LogTagType sorted_tags[sorted_tagcount];
-
-class TagSorter {
- public:
-  TagSorter() {
-    for (size_t i = 1; i < LogTag::Count; i++) {
-      sorted_tags[i - 1] = static_cast<LogTagType>(i);
-    }
-    QuickSort::sort(sorted_tags, sorted_tagcount, cmp_logtag, true);
-  }
-};
-
-static TagSorter tagsorter; // Sorts tags during static initialization
-
 void LogTag::list_tags(outputStream* out) {
-  for (size_t i = 0; i < sorted_tagcount; i++) {
-    out->print("%s %s", (i == 0 ? "" : ","), _name[sorted_tags[i]]);
+  for (size_t i = 1; i < LogTag::Count; i++) { // Not including __NO_TAG
+    out->print("%s %s", (i == 1 ? "" : ","), _name[static_cast<LogTagType>(i)]);
   }
   out->cr();
 }
+
+#ifdef ASSERT
+class LogTagTypeChecker {
+ public:
+  LogTagTypeChecker() {
+    assert(LogTagType::__NO_TAG == static_cast<LogTagType>(0), "First tag should be __NO_TAG");
+
+    // assert the LogTag type enum is sorted
+    for (size_t i = 1; i < LogTag::Count - 1; i++) {
+      const char* a = LogTag::name(static_cast<LogTagType>(i));
+      const char* b = LogTag::name(static_cast<LogTagType>(i + 1));
+
+      assert(strcmp(a, b) < 0,
+          "LogTag type not in alphabetical order at index %zu: %s should be after %s",
+          i, a, b);
+    }
+  }
+};
+
+static LogTagTypeChecker logtagtypechecker; // Assert LogTag tags are set up as expected during static initialization
+#endif // ASSERT

--- a/src/hotspot/share/logging/logTag.cpp
+++ b/src/hotspot/share/logging/logTag.cpp
@@ -27,7 +27,7 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/ostream.hpp"
 
-const char* LogTag::_name[] = {
+const char* const LogTag::_name[] = {
   "", // __NO_TAG
 #define LOG_TAG(name) #name,
   LOG_TAG_LIST

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -228,7 +228,7 @@ class LogTag : public AllStatic {
   static void list_tags(outputStream* out);
 
  private:
-  static const char* _name[];
+  static const char* const _name[];
 };
 
 typedef LogTag::type LogTagType;

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -27,15 +27,16 @@
 #include "memory/allocation.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-// List of available logging tags. New tags should be added here.
+// List of available logging tags. New tags should be added here, in
+// alphabetical order.
 // (The tags 'all', 'disable' and 'help' are special tags that can
 // not be used in log calls, and should not be listed below.)
 #define LOG_TAG_LIST \
   LOG_TAG(add) \
   LOG_TAG(age) \
   LOG_TAG(alloc) \
-  LOG_TAG(aot) \
   LOG_TAG(annotation) \
+  LOG_TAG(aot) \
   LOG_TAG(arguments) \
   LOG_TAG(attach) \
   LOG_TAG(barrier) \
@@ -53,8 +54,8 @@
   LOG_TAG(compaction) \
   LOG_TAG(compilation) \
   LOG_TAG(condy) \
-  LOG_TAG(constraints) \
   LOG_TAG(constantpool) \
+  LOG_TAG(constraints) \
   LOG_TAG(container) \
   LOG_TAG(coops) \
   LOG_TAG(cpu) \
@@ -101,10 +102,11 @@
   LOG_TAG(marking) \
   LOG_TAG(membername) \
   LOG_TAG(memops) \
-  LOG_TAG(methodcomparator) \
   LOG_TAG(metadata) \
   LOG_TAG(metaspace) \
+  LOG_TAG(methodcomparator) \
   LOG_TAG(methodhandles) \
+  LOG_TAG(mirror) \
   LOG_TAG(mmu) \
   LOG_TAG(module) \
   LOG_TAG(monitorinflation) \
@@ -123,27 +125,27 @@
   LOG_TAG(os) \
   LOG_TAG(owner) \
   LOG_TAG(pagesize) \
+  LOG_TAG(parser) \
   LOG_TAG(patch) \
   LOG_TAG(path) \
   LOG_TAG(perf) \
   LOG_TAG(periodic) \
   LOG_TAG(phases) \
   LOG_TAG(plab) \
+  LOG_TAG(preorder)  /* Trace all classes loaded in order referenced (not loaded) */ \
   LOG_TAG(preview)   /* Trace loading of preview feature types */ \
   LOG_TAG(primitivewrappers) \
   LOG_TAG(promotion) \
-  LOG_TAG(preorder) /* Trace all classes loaded in order referenced (not loaded) */ \
   LOG_TAG(protectiondomain) /* "Trace protection domain verification" */ \
-  LOG_TAG(ref) \
+  LOG_TAG(ptrqueue) \
+  LOG_TAG(purge) \
+  LOG_TAG(record) \
   LOG_TAG(redefine) \
+  LOG_TAG(ref) \
   LOG_TAG(refine) \
   LOG_TAG(region) \
   LOG_TAG(reloc) \
   LOG_TAG(remset) \
-  LOG_TAG(parser) \
-  LOG_TAG(ptrqueue) \
-  LOG_TAG(purge) \
-  LOG_TAG(record) \
   LOG_TAG(resolve) \
   LOG_TAG(safepoint) \
   LOG_TAG(sampling) \
@@ -151,6 +153,7 @@
   LOG_TAG(sealed) \
   LOG_TAG(setting) \
   LOG_TAG(smr) \
+  LOG_TAG(stackmap) \
   LOG_TAG(stacktrace) \
   LOG_TAG(stackwalk) \
   LOG_TAG(start) \
@@ -160,24 +163,22 @@
   LOG_TAG(streaming) \
   LOG_TAG(stringdedup) \
   LOG_TAG(stringtable) \
-  LOG_TAG(symboltable) \
-  LOG_TAG(stackmap) \
   LOG_TAG(subclass) \
   LOG_TAG(survivor) \
   LOG_TAG(sweep) \
+  LOG_TAG(symboltable) \
   LOG_TAG(system) \
   LOG_TAG(table) \
   LOG_TAG(task) \
   DEBUG_ONLY(LOG_TAG(test)) \
   LOG_TAG(thread) \
-  LOG_TAG(tlab) \
   LOG_TAG(time) \
   LOG_TAG(timer) \
+  LOG_TAG(tlab) \
   LOG_TAG(tracking) \
-  LOG_TAG(update) \
   LOG_TAG(unload) /* Trace unloading of classes */ \
   LOG_TAG(unshareable) \
-  LOG_TAG(mirror) \
+  LOG_TAG(update) \
   LOG_TAG(verification) \
   LOG_TAG(verify) \
   LOG_TAG(vmmutex) \


### PR DESCRIPTION
- Sort LogTag type enum alphabetically
- Assert that the tags are sorted instead of sorting
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253397](https://bugs.openjdk.java.net/browse/JDK-8253397): Ensure LogTag types are sorted


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to af642fb653e177cb45c7c1b32c16b2170884590f
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to af642fb653e177cb45c7c1b32c16b2170884590f
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to af642fb653e177cb45c7c1b32c16b2170884590f


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/274/head:pull/274`
`$ git checkout pull/274`
