### PR TITLE
8253392: remove PhaseCCP_DCE declaration

### DIFF
--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -69,7 +69,6 @@ class PhaseGVN;
 class PhaseIterGVN;
 class PhaseRegAlloc;
 class PhaseCCP;
-class PhaseCCP_DCE;
 class PhaseOutput;
 class RootNode;
 class relocInfo;


### PR DESCRIPTION
hello, reviewers, 
May I ask to review this trivial patch? 
it's a clean-up. The forward declaration of PhaseCCP_DCE is not useful.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253392](https://bugs.openjdk.java.net/browse/JDK-8253392): remove PhaseCCP_DCE declaration


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/277/head:pull/277`
`$ git checkout pull/277`
