### PR TITLE
8252857: AArch64: Shenandoah C1 CAS is not sequentially consistent

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/c1/shenandoahBarrierSetC1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/c1/shenandoahBarrierSetC1_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2018, 2020, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,8 @@ void LIR_OpShenandoahCompareAndSwap::emit_code(LIR_Assembler* masm) {
     newval = tmp2;
   }
 
-  ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm->masm(), addr, cmpval, newval, /*acquire*/ false, /*release*/ true, /*is_cae*/ false, result);
+  ShenandoahBarrierSet::assembler()->cmpxchg_oop(masm->masm(), addr, cmpval, newval, /*acquire*/ true, /*release*/ true, /*is_cae*/ false, result);
+  __ membar(__ AnyAny);
 }
 
 #undef __

--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -459,22 +459,10 @@ void ShenandoahBarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler
 // from-space, or it refers to the to-space version of an object that
 // is being evacuated out of from-space.
 //
-// By default, this operation has relaxed memory ordering and the value
-// held in the result register following execution of the generated code
-// sequence is 0 to indicate failure of CAS, non-zero to indicate
-// success.  Arguments support variations on this theme:
-//
-//  acquire: Load from addr has acquire semantics.
-//
-//  release: Store to addr has release semantics.
-//
-//  is_cae:  This turns CAS (compare and swap) into CAE (compare and
-//           exchange).  This HotSpot convention is that CAE makes
-//           available to the caller the "failure witness", which is
-//           the value that was stored in memory which did not match
-//           the expected value.  If is_cae, the result is the value
-//           most recently fetched from addr rather than a boolean
-//           success indicator.
+// By default the value held in the result register following execution
+// of the generated code sequence is 0 to indicate failure of CAS,
+// non-zero to indicate success. If is_cae, the result is the value most
+// recently fetched from addr rather than a boolean success indicator.
 //
 // Clobbers rscratch1, rscratch2
 void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,

--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -459,32 +459,15 @@ void ShenandoahBarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler
 // from-space, or it refers to the to-space version of an object that
 // is being evacuated out of from-space.
 //
-// By default, this operation implements sequential consistency and the
-// value held in the result register following execution of the
-// generated code sequence is 0 to indicate failure of CAS, non-zero
-// to indicate success.  Arguments support variations on this theme:
+// By default, this operation has relaxed memory ordering and the value
+// held in the result register following execution of the generated code
+// sequence is 0 to indicate failure of CAS, non-zero to indicate
+// success.  Arguments support variations on this theme:
 //
-//  acquire: Allow relaxation of the memory ordering on CAS from
-//           sequential consistency.  This can be useful when
-//           sequential consistency is not required, such as when
-//           another sequentially consistent operation is already
-//           present in the execution stream.  If acquire, successful
-//           execution has the side effect of assuring that memory
-//           values updated by other threads and "released" will be
-//           visible to any read operations perfomed by this thread
-//           which follow this operation in program order.  This is a
-//           special optimization that should not be enabled by default.
-//  release: Allow relaxation of the memory ordering on CAS from
-//           sequential consistency.  This can be useful when
-//           sequential consistency is not required, such as when
-//           another sequentially consistent operation is already
-//           present in the execution stream.  If release, successful
-//           completion of this operation has the side effect of
-//           assuring that all writes to memory performed by this
-//           thread that precede this operation in program order are
-//           visible to all other threads that subsequently "acquire"
-//           before reading the respective memory values.  This is a
-//           special optimization that should not be enabled by default.
+//  acquire: Load from addr has acquire semantics.
+//
+//  release: Store to addr has release semantics.
+//
 //  is_cae:  This turns CAS (compare and swap) into CAE (compare and
 //           exchange).  This HotSpot convention is that CAE makes
 //           available to the caller the "failure witness", which is
@@ -526,11 +509,10 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
   __ bind (step4);
 
   // Step 4. CAS has failed because the value most recently fetched
-  // from addr (which is now held in tmp1) is no longer the from-space
-  // pointer held in tmp2.  If a different thread replaced the
-  // in-memory value with its equivalent to-space pointer, then CAS
-  // may still be able to succeed.  The value held in the expected
-  // register has not changed.
+  // from addr is no longer the from-space pointer held in tmp2.  If a
+  // different thread replaced the in-memory value with its equivalent
+  // to-space pointer, then CAS may still be able to succeed.  The
+  // value held in the expected register has not changed.
   //
   // It is extremely rare we reach this point.  For this reason, the
   // implementation opts for smaller rather than potentially faster
@@ -603,8 +585,8 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
   // Note that macro implementation of __cmpxchg cannot use same register
   // tmp2 for result and expected since it overwrites result before it
   // compares result with expected.
-  __ cmpxchg(addr, tmp2, new_val, size, acquire, release, false, tmp1);
-  // EQ flag set iff success.  tmp2 holds value fetched.
+  __ cmpxchg(addr, tmp2, new_val, size, acquire, release, false, noreg);
+  // EQ flag set iff success.  tmp2 holds value fetched, tmp1 (rscratch1) clobbered.
 
   // If fetched value did not equal the new expected, this could
   // still be a false negative because some other thread may have


### PR DESCRIPTION
C1 atomic operations are supposed to be sequentially consistent by
default but the variant in the Shenandoah C1 barrier set assembler only
provides a half-barrier when the CAS succeeds. Added a trailing full
barrier and load-acquire to exactly match the non-Shenandoah C1 CAS
implementation. This prevents any memory accesses following the CAS
operation being observed before it.

Also adjusted the documentation for ShenandoahBarrierSetAssembler
::cmpxchg_oop as it currently claims to be sequentially consistent by
default but it's not clear what the "default" values of acquire and
release should be, and the comment for acquire/release implies to me
that setting them to true would relax the ordering guarantees but
actually it's the opposite. I tried to simplify this and make it less
ambiguous.

One other thing I noticed when reading this: the comment

   // Step 4. CAS has failed because the value most recently fetched
   // from addr (which is now held in tmp1) ...

is wrong on non-LSE systems because tmp1 is rscratch1 and that is
clobbered by the call to __ cmpxchg() at the end of step3. Although it
doesn't matter because the value in tmp1 is not used after that point.
Adjusted the comment to clarify this.

Tested hotspot_all_no_apps, jdk_core plus jcstress with -jvmArgs
'-XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:TieredStopAtLevel=1'.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252857](https://bugs.openjdk.java.net/browse/JDK-8252857): AArch64: Shenandoah C1 CAS is not sequentially consistent


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to 4768d96fd82eda6ea4d2c3111964ba3ab273101d
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/280/head:pull/280`
`$ git checkout pull/280`
