### PR TITLE
8253412: Unsupported GC options passed in JAVA_TOOL_OPTIONS are silently ignored

### DIFF
--- a/src/hotspot/share/gc/shared/gcConfig.cpp
+++ b/src/hotspot/share/gc/shared/gcConfig.cpp
@@ -79,7 +79,7 @@ SHENANDOAHGC_ONLY_ARG(IncludedGC(UseShenandoahGC,    CollectedHeap::Shenandoah, 
   for (const IncludedGC* var = &IncludedGCs[0]; var < &IncludedGCs[ARRAY_SIZE(IncludedGCs)]; var++)
 
 #define FAIL_IF_SELECTED(option, enabled)                                   \
-  if (option == enabled && FLAG_IS_CMDLINE(option)) {                       \
+  if (option == enabled && !FLAG_IS_DEFAULT(option)) {                      \
     vm_exit_during_initialization(enabled ?                                 \
                                   "Option -XX:+" #option " not supported" : \
                                   "Option -XX:-" #option " not supported"); \

--- a/src/hotspot/share/gc/shared/gcConfig.cpp
+++ b/src/hotspot/share/gc/shared/gcConfig.cpp
@@ -78,23 +78,21 @@ SHENANDOAHGC_ONLY_ARG(IncludedGC(UseShenandoahGC,    CollectedHeap::Shenandoah, 
 #define FOR_EACH_INCLUDED_GC(var)                                            \
   for (const IncludedGC* var = &IncludedGCs[0]; var < &IncludedGCs[ARRAY_SIZE(IncludedGCs)]; var++)
 
-#define FAIL_IF_SELECTED(option, enabled)                                   \
-  if (option == enabled && !FLAG_IS_DEFAULT(option)) {                      \
-    vm_exit_during_initialization(enabled ?                                 \
-                                  "Option -XX:+" #option " not supported" : \
-                                  "Option -XX:-" #option " not supported"); \
+#define FAIL_IF_SELECTED(option)                                            \
+  if (option) {                                                             \
+    vm_exit_during_initialization("Option -XX:+" #option " not supported"); \
   }
 
 GCArguments* GCConfig::_arguments = NULL;
 bool GCConfig::_gc_selected_ergonomically = false;
 
 void GCConfig::fail_if_non_included_gc_is_selected() {
-  NOT_EPSILONGC(   FAIL_IF_SELECTED(UseEpsilonGC,       true));
-  NOT_G1GC(        FAIL_IF_SELECTED(UseG1GC,            true));
-  NOT_PARALLELGC(  FAIL_IF_SELECTED(UseParallelGC,      true));
-  NOT_SERIALGC(    FAIL_IF_SELECTED(UseSerialGC,        true));
-  NOT_SHENANDOAHGC(FAIL_IF_SELECTED(UseShenandoahGC,    true));
-  NOT_ZGC(         FAIL_IF_SELECTED(UseZGC,             true));
+  NOT_EPSILONGC(   FAIL_IF_SELECTED(UseEpsilonGC));
+  NOT_G1GC(        FAIL_IF_SELECTED(UseG1GC));
+  NOT_PARALLELGC(  FAIL_IF_SELECTED(UseParallelGC));
+  NOT_SERIALGC(    FAIL_IF_SELECTED(UseSerialGC));
+  NOT_SHENANDOAHGC(FAIL_IF_SELECTED(UseShenandoahGC));
+  NOT_ZGC(         FAIL_IF_SELECTED(UseZGC));
 }
 
 void GCConfig::select_gc_ergonomically() {


### PR DESCRIPTION
See the reproducer in the bug itself. I think that happens because GCConfig checks only for FLAG_IS_CMDLINE, which is only from cmdline-originated flags. In this case, the flag comes from the environment variable. Maybe checking for `!FLAG_IS_DEFAULT` is better, as it captures all non-default origins. 

But them, instead of checking for `FLAG_IS_CMDLINE`, I think we can rely on the fact that all `Use*GC` options are `false` by default. So if any of such flags is `true`, it means something had selected the GC. This allows for some further simplification of the macro (although I am not sure if it was intended to be ever used to check `-XX:-*` flags).

Attention @pliden.

Testing:
 - [x] Ad-hoc reproducer now passes
 - [x] Linux x86_64 fastdebug tier1
 - [x] Linux x86_64 fastdebug tier2
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253412](https://bugs.openjdk.java.net/browse/JDK-8253412): Unsupported GC options passed in JAVA_TOOL_OPTIONS are silently ignored


### Reviewers
 * [Per Lidén](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/282/head:pull/282`
`$ git checkout pull/282`
