### PR TITLE
8253418: ZGC: Use pd_ prefix to denote platform dependent code

### DIFF
--- a/src/hotspot/os/bsd/gc/z/zLargePages_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/z/zLargePages_bsd.cpp
@@ -25,7 +25,7 @@
 #include "gc/z/zLargePages.hpp"
 #include "runtime/globals.hpp"
 
-void ZLargePages::initialize_platform() {
+void ZLargePages::pd_initialize() {
   if (UseLargePages) {
     _state = Explicit;
   } else {

--- a/src/hotspot/os/bsd/gc/z/zNUMA_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/z/zNUMA_bsd.cpp
@@ -24,7 +24,7 @@
 #include "precompiled.hpp"
 #include "gc/z/zNUMA.hpp"
 
-void ZNUMA::initialize_platform() {
+void ZNUMA::pd_initialize() {
   _enabled = false;
 }
 

--- a/src/hotspot/os/linux/gc/z/zLargePages_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zLargePages_linux.cpp
@@ -25,7 +25,7 @@
 #include "gc/z/zLargePages.hpp"
 #include "runtime/globals.hpp"
 
-void ZLargePages::initialize_platform() {
+void ZLargePages::pd_initialize() {
   if (UseLargePages) {
     if (UseTransparentHugePages) {
       _state = Transparent;

--- a/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
@@ -29,7 +29,7 @@
 #include "runtime/os.hpp"
 #include "utilities/debug.hpp"
 
-void ZNUMA::initialize_platform() {
+void ZNUMA::pd_initialize() {
   _enabled = UseNUMA;
 }
 

--- a/src/hotspot/os/posix/gc/z/zInitialize_posix.cpp
+++ b/src/hotspot/os/posix/gc/z/zInitialize_posix.cpp
@@ -24,6 +24,6 @@
 #include "precompiled.hpp"
 #include "gc/z/zInitialize.hpp"
 
-void ZInitialize::initialize_os() {
+void ZInitialize::os_initialize() {
   // Does nothing
 }

--- a/src/hotspot/os/posix/gc/z/zInitialize_posix.cpp
+++ b/src/hotspot/os/posix/gc/z/zInitialize_posix.cpp
@@ -24,6 +24,6 @@
 #include "precompiled.hpp"
 #include "gc/z/zInitialize.hpp"
 
-void ZInitialize::os_initialize() {
+void ZInitialize::pd_initialize() {
   // Does nothing
 }

--- a/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
+++ b/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
@@ -29,7 +29,7 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 
-void ZVirtualMemoryManager::initialize_os() {
+void ZVirtualMemoryManager::os_initialize() {
   // Does nothing
 }
 

--- a/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
+++ b/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
@@ -29,11 +29,11 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 
-void ZVirtualMemoryManager::os_initialize() {
+void ZVirtualMemoryManager::pd_initialize() {
   // Does nothing
 }
 
-bool ZVirtualMemoryManager::os_reserve(uintptr_t addr, size_t size) {
+bool ZVirtualMemoryManager::pd_reserve(uintptr_t addr, size_t size) {
   const uintptr_t res = (uintptr_t)mmap((void*)addr, size, PROT_NONE, MAP_ANONYMOUS|MAP_PRIVATE|MAP_NORESERVE, -1, 0);
   if (res == (uintptr_t)MAP_FAILED) {
     // Failed to reserve memory
@@ -50,7 +50,7 @@ bool ZVirtualMemoryManager::os_reserve(uintptr_t addr, size_t size) {
   return true;
 }
 
-void ZVirtualMemoryManager::os_unreserve(uintptr_t addr, size_t size) {
+void ZVirtualMemoryManager::pd_unreserve(uintptr_t addr, size_t size) {
   const int res = munmap((void*)addr, size);
   assert(res == 0, "Failed to unmap memory");
 }

--- a/src/hotspot/os/windows/gc/z/zInitialize_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zInitialize_windows.cpp
@@ -25,6 +25,6 @@
 #include "gc/z/zInitialize.hpp"
 #include "gc/z/zSyscall_windows.hpp"
 
-void ZInitialize::initialize_os() {
+void ZInitialize::os_initialize() {
   ZSyscall::initialize();
 }

--- a/src/hotspot/os/windows/gc/z/zInitialize_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zInitialize_windows.cpp
@@ -25,6 +25,6 @@
 #include "gc/z/zInitialize.hpp"
 #include "gc/z/zSyscall_windows.hpp"
 
-void ZInitialize::os_initialize() {
+void ZInitialize::pd_initialize() {
   ZSyscall::initialize();
 }

--- a/src/hotspot/os/windows/gc/z/zLargePages_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zLargePages_windows.cpp
@@ -24,6 +24,6 @@
 #include "precompiled.hpp"
 #include "gc/z/zLargePages.hpp"
 
-void ZLargePages::initialize_platform() {
+void ZLargePages::pd_initialize() {
   _state = Disabled;
 }

--- a/src/hotspot/os/windows/gc/z/zNUMA_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zNUMA_windows.cpp
@@ -24,7 +24,7 @@
 #include "precompiled.hpp"
 #include "gc/z/zNUMA.hpp"
 
-void ZNUMA::initialize_platform() {
+void ZNUMA::pd_initialize() {
   _enabled = false;
 }
 

--- a/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
@@ -87,7 +87,7 @@ static void grow_from_back_callback(const ZMemory* area, size_t size) {
   coalesce_into_one_placeholder(area->start(), area->size() + size);
 }
 
-void ZVirtualMemoryManager::initialize_os() {
+void ZVirtualMemoryManager::os_initialize() {
   // Each reserved virtual memory address area registered in _manager is
   // exactly covered by a single placeholder. Callbacks are installed so
   // that whenever a memory area changes, the corresponding placeholder

--- a/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
@@ -87,7 +87,7 @@ static void grow_from_back_callback(const ZMemory* area, size_t size) {
   coalesce_into_one_placeholder(area->start(), area->size() + size);
 }
 
-void ZVirtualMemoryManager::os_initialize() {
+void ZVirtualMemoryManager::pd_initialize() {
   // Each reserved virtual memory address area registered in _manager is
   // exactly covered by a single placeholder. Callbacks are installed so
   // that whenever a memory area changes, the corresponding placeholder
@@ -116,13 +116,13 @@ void ZVirtualMemoryManager::os_initialize() {
   _manager.register_callbacks(callbacks);
 }
 
-bool ZVirtualMemoryManager::os_reserve(uintptr_t addr, size_t size) {
+bool ZVirtualMemoryManager::pd_reserve(uintptr_t addr, size_t size) {
   uintptr_t res = ZMapper::reserve(addr, size);
 
   assert(res == addr || res == NULL, "Should not reserve other memory than requested");
   return res == addr;
 }
 
-void ZVirtualMemoryManager::os_unreserve(uintptr_t addr, size_t size) {
+void ZVirtualMemoryManager::pd_unreserve(uintptr_t addr, size_t size) {
   ZMapper::unreserve(addr, size);
 }

--- a/src/hotspot/share/gc/z/zInitialize.cpp
+++ b/src/hotspot/share/gc/z/zInitialize.cpp
@@ -52,5 +52,5 @@ ZInitialize::ZInitialize(ZBarrierSet* barrier_set) {
   ZLargePages::initialize();
   ZBarrierSet::set_barrier_set(barrier_set);
 
-  os_initialize();
+  pd_initialize();
 }

--- a/src/hotspot/share/gc/z/zInitialize.cpp
+++ b/src/hotspot/share/gc/z/zInitialize.cpp
@@ -52,5 +52,5 @@ ZInitialize::ZInitialize(ZBarrierSet* barrier_set) {
   ZLargePages::initialize();
   ZBarrierSet::set_barrier_set(barrier_set);
 
-  initialize_os();
+  os_initialize();
 }

--- a/src/hotspot/share/gc/z/zInitialize.hpp
+++ b/src/hotspot/share/gc/z/zInitialize.hpp
@@ -30,7 +30,7 @@ class ZBarrierSet;
 
 class ZInitialize {
 private:
-  void os_initialize();
+  void pd_initialize();
 
 public:
   ZInitialize(ZBarrierSet* barrier_set);

--- a/src/hotspot/share/gc/z/zInitialize.hpp
+++ b/src/hotspot/share/gc/z/zInitialize.hpp
@@ -30,7 +30,7 @@ class ZBarrierSet;
 
 class ZInitialize {
 private:
-  void initialize_os();
+  void os_initialize();
 
 public:
   ZInitialize(ZBarrierSet* barrier_set);

--- a/src/hotspot/share/gc/z/zLargePages.cpp
+++ b/src/hotspot/share/gc/z/zLargePages.cpp
@@ -29,7 +29,7 @@
 ZLargePages::State ZLargePages::_state;
 
 void ZLargePages::initialize() {
-  initialize_platform();
+  pd_initialize();
 
   log_info_p(gc, init)("Memory: " JULONG_FORMAT "M", os::physical_memory() / M);
   log_info_p(gc, init)("Large Page Support: %s", to_string());

--- a/src/hotspot/share/gc/z/zLargePages.hpp
+++ b/src/hotspot/share/gc/z/zLargePages.hpp
@@ -36,7 +36,7 @@ private:
 
   static State _state;
 
-  static void initialize_platform();
+  static void pd_initialize();
 
 public:
   static void initialize();

--- a/src/hotspot/share/gc/z/zNUMA.cpp
+++ b/src/hotspot/share/gc/z/zNUMA.cpp
@@ -28,7 +28,7 @@
 bool ZNUMA::_enabled;
 
 void ZNUMA::initialize() {
-  initialize_platform();
+  pd_initialize();
 
   log_info_p(gc, init)("NUMA Support: %s", to_string());
   if (_enabled) {

--- a/src/hotspot/share/gc/z/zNUMA.hpp
+++ b/src/hotspot/share/gc/z/zNUMA.hpp
@@ -30,7 +30,7 @@ class ZNUMA : public AllStatic {
 private:
   static bool _enabled;
 
-  static void initialize_platform();
+  static void pd_initialize();
 
 public:
   static void initialize();

--- a/src/hotspot/share/gc/z/zVirtualMemory.cpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.cpp
@@ -48,8 +48,8 @@ ZVirtualMemoryManager::ZVirtualMemoryManager(size_t max_capacity) :
     return;
   }
 
-  // Initialize OS specific parts
-  os_initialize();
+  // Initialize platform specific parts
+  pd_initialize();
 
   // Successfully initialized
   _initialized = true;
@@ -107,18 +107,18 @@ bool ZVirtualMemoryManager::reserve_contiguous(uintptr_t start, size_t size) {
   const uintptr_t remapped = ZAddress::remapped(start);
 
   // Reserve address space
-  if (!os_reserve(marked0, size)) {
+  if (!pd_reserve(marked0, size)) {
     return false;
   }
 
-  if (!os_reserve(marked1, size)) {
-    os_unreserve(marked0, size);
+  if (!pd_reserve(marked1, size)) {
+    pd_unreserve(marked0, size);
     return false;
   }
 
-  if (!os_reserve(remapped, size)) {
-    os_unreserve(marked0, size);
-    os_unreserve(marked1, size);
+  if (!pd_reserve(remapped, size)) {
+    pd_unreserve(marked0, size);
+    pd_unreserve(marked1, size);
     return false;
   }
 

--- a/src/hotspot/share/gc/z/zVirtualMemory.cpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.cpp
@@ -49,7 +49,7 @@ ZVirtualMemoryManager::ZVirtualMemoryManager(size_t max_capacity) :
   }
 
   // Initialize OS specific parts
-  initialize_os();
+  os_initialize();
 
   // Successfully initialized
   _initialized = true;

--- a/src/hotspot/share/gc/z/zVirtualMemory.hpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.hpp
@@ -51,7 +51,7 @@ private:
   bool           _initialized;
 
   // OS specific implementation
-  void initialize_os();
+  void os_initialize();
   bool os_reserve(uintptr_t addr, size_t size);
   void os_unreserve(uintptr_t addr, size_t size);
 

--- a/src/hotspot/share/gc/z/zVirtualMemory.hpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.hpp
@@ -50,10 +50,10 @@ private:
   ZMemoryManager _manager;
   bool           _initialized;
 
-  // OS specific implementation
-  void os_initialize();
-  bool os_reserve(uintptr_t addr, size_t size);
-  void os_unreserve(uintptr_t addr, size_t size);
+  // Platform specific implementation
+  void pd_initialize();
+  bool pd_reserve(uintptr_t addr, size_t size);
+  void pd_unreserve(uintptr_t addr, size_t size);
 
   bool reserve_contiguous(uintptr_t start, size_t size);
   bool reserve_contiguous(size_t size);


### PR DESCRIPTION
ZGC uses the suffixes \_platform and \_os to denote platform dependent code. It's more common to name these functions with a pd_ prefix. I suggest that we do the same in ZGC.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253418](https://bugs.openjdk.java.net/browse/JDK-8253418): ZGC: Use pd_ prefix to denote platform dependent code


### Reviewers
 * [Per Lidén](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to b3745a3bacaf55f3ae2c1cd88e825a7acec12a69


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/283/head:pull/283`
`$ git checkout pull/283`
