### PR TITLE
8253424: Add support for running pre-submit testing using GitHub Actions

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,596 @@
+name: Submit tests
+
+on:
+  push:
+    branches-ignore: [master]
+
+env:
+  BOOT_JDK_VERSION: '14.0.2'
+  JTREG_VERSION: 'jtreg5.1-b01'
+  GTEST_VERSION: 'release-1.8.1'
+
+jobs:
+  prerequisites:
+    name: Prerequisites
+    runs-on: 'ubuntu-latest'
+    steps:
+    - name: Determine unique bundle identifier
+      run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+
+    - name: Check if a jtreg image is present in the cache
+      id: jtreg
+      uses: actions/cache@v2
+      with:
+        path: ~/jtreg/
+        key: jtreg-${{ env.JTREG_VERSION }}-v1
+
+    - name: Checkout the jtreg source
+      uses: actions/checkout@v2
+      with:
+        repository: 'openjdk/jtreg'
+        ref: ${{ env.JTREG_VERSION }}
+      if: steps.jtreg.outputs.cache-hit != 'true'
+
+    - name: Build jtreg
+      run: sh make/build-all.sh ${JAVA_HOME}
+      if: steps.jtreg.outputs.cache-hit != 'true'
+
+    - name: Move jtreg image to destination folder
+      run: mv build/images/jtreg ~/
+      if: steps.jtreg.outputs.cache-hit != 'true'
+
+    - name: Store jtreg for later steps
+      uses: actions/upload-artifact@v2
+      with:
+        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+        path: ~/jtreg/
+
+  linux_x64_build:
+    if: true
+    name: Linux x64 (build)
+    runs-on: 'ubuntu-latest'
+    needs: prerequisites
+    env:
+      BOOT_JDK_FILENAME: 'openjdk-14.0.2_linux-x64_bin.tar.gz'
+      BOOT_JDK_URL: 'https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz'
+      BOOT_JDK_SHA256: '91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d'
+
+    steps:
+    - name: Determine unique bundle identifier
+      run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        path: jdk
+
+    - name: Restore boot JDK from cache
+      id: bootjdk
+      uses: actions/cache@v2
+      with:
+        path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+        key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+
+    - name: Download boot JDK
+      run: |
+        mkdir -p "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+        wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
+        echo "${BOOT_JDK_SHA256} ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | sha256sum -c >/dev/null -
+        tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+      if: steps.bootjdk.outputs.cache-hit != 'true'
+
+    - name: Restore jtreg artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+        path: ~/jtreg/
+
+    - name: Checkout gtest sources
+      uses: actions/checkout@v2
+      with:
+        repository: 'google/googletest'
+        ref: ${{ env.GTEST_VERSION }}
+        path: gtest
+
+    - name: Install dependencies
+      run: sudo apt-get install libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
+
+    - name: Configure
+      run: >
+        bash configure
+        --with-conf-name=linux-x64-debug
+        --enable-debug
+        --with-target-bits=64
+        --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
+        --with-version-build=0
+        --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}
+        --with-jtreg=${HOME}/jtreg
+        --with-gtest=${GITHUB_WORKSPACE}/gtest
+        --with-default-make-target="product-bundles test-bundles"
+        --with-zlib=system
+        --enable-jtreg-failure-handler
+        --with-exclude-translations=de,es,fr,it,ko,pt_BR,sv,ca,tr,cs,sk,ja_JP_A,ja_JP_HA,ja_JP_HI,ja_JP_I,zh_TW,zh_HK
+        --disable-manpages
+      working-directory: jdk
+
+    - name: Build
+      run: make CONF_NAME=linux-x64-debug
+      working-directory: jdk
+
+    - name: Persist test bundles
+      uses: actions/upload-artifact@v2
+      with:
+        name: jdk-linux-x64-debug_${{ env.bundleid }}
+        path: |
+          jdk/build/linux-x64-debug/bundles/jdk-16-internal+0_linux-x64_bin-debug.tar.gz
+          jdk/build/linux-x64-debug/bundles/jdk-16-internal+0_linux-x64_bin-tests-debug.tar.gz
+
+  linux_x64_test:
+    if: true
+    name: Linux x64
+    runs-on: 'ubuntu-latest'
+    needs: linux_x64_build
+
+    strategy:
+      matrix:
+        test:
+          - test/jdk/:tier1_part1
+          - test/jdk/:tier1_part2
+          - test/jdk/:tier1_part3
+          - test/langtools/:tier1
+          - test/hotspot/jtreg/:tier1_common
+          - test/hotspot/jtreg/:tier1_compiler
+          - test/hotspot/jtreg/:tier1_gc
+          - test/hotspot/jtreg/:tier1_runtime
+          - test/hotspot/jtreg/:tier1_serviceability
+
+    steps:
+    - name: Determine unique bundle identifier
+      run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+
+    - name: Checkout the source
+      uses: actions/checkout@v2
+
+    - name: Restore boot JDK from cache
+      id: bootjdk
+      uses: actions/cache@v2
+      with:
+        path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+        key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+
+    - name: Download boot JDK
+      run: |
+        mkdir -p "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+        wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
+        echo "${BOOT_JDK_SHA256} ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | sha256sum -c >/dev/null -
+        tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+      if: steps.bootjdk.outputs.cache-hit != 'true'
+
+    - name: Restore jtreg artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+        path: ~/jtreg/
+
+    - name: Restore build artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: jdk-linux-x64-debug_${{ env.bundleid }}
+        path: ~/jdk-linux-x64-debug
+
+    - name: Unpack jdk
+      run: |
+        mkdir -p "${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-debug"
+        tar -xf "${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-debug.tar.gz" -C "${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-debug"
+
+    - name: Unpack tests
+      run: |
+        mkdir -p "${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-tests-debug"
+        tar -xf "${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-tests-debug.tar.gz" -C "${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-tests-debug"
+
+    - name: Run tests
+      run: >
+        JDK_IMAGE_DIR=${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-debug/jdk-16/fastdebug
+        TEST_IMAGE_DIR=${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-tests-debug
+        BOOT_JDK=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}
+        JT_HOME=${HOME}/jtreg
+        make test-prebuilt
+        CONF_NAME=run-test-prebuilt
+        LOG_CMDLINES=true
+        JTREG_VERBOSE=fail,error,time
+        TEST=${{ matrix.test }}
+        TEST_OPTS_JAVA_OPTIONS=
+        JTREG_KEYWORDS="!headful"
+
+    - name: Create suitable test log artifact name
+      run: echo "::set-env name=suite::`echo ${{ matrix.test }} | sed -e 's!test/!!' -e 's!/jtreg!!' -e 's!/:!_!' -e 's!/!_!g'`"
+      if: ${{ failure() }}
+
+    - name: Persist test logs
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: linux-x64-debug_testlogs_${{ env.suite }}
+        path: |
+          build/*/test-results/
+          build/*/test-resupport/
+
+  windows_x64_build:
+    if: true
+    name: Windows x64 (build)
+    runs-on: 'windows-latest'
+    needs: prerequisites
+    env:
+      BOOT_JDK_FILENAME: 'openjdk-14.0.2_windows-x64_bin.zip'
+      BOOT_JDK_URL: 'https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip'
+      BOOT_JDK_SHA256: '20600c0bda9d1db9d20dbe1ab656a5f9175ffb990ef3df6af5d994673e4d8ff9'
+
+    steps:
+    - name: Determine unique bundle identifier
+      run: echo ("::set-env name=bundleid::$env:GITHUB_ACTOR" + "_" + (-join "$env:GITHUB_SHA"[0..7]))
+
+    - name: Restore cygwin packages from cache
+      id: cygwin
+      uses: actions/cache@v2
+      with:
+        path: ~/cygwin/packages
+        key: cygwin-packages-${{ runner.os }}-v1
+
+    - name: Install cygwin
+      run: |
+        New-Item -Force -ItemType directory -Path "$HOME\cygwin"
+        & curl -L "https://www.cygwin.com/setup-x86_64.exe" -o "$HOME/cygwin/setup-x86_64.exe"
+        Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
+
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        path: jdk
+
+    - name: Restore boot JDK from cache
+      id: bootjdk
+      uses: actions/cache@v2
+      with:
+        path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+        key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+
+    - name: Download boot JDK
+      run: |
+        mkdir -p "$HOME\bootjdk\$env:BOOT_JDK_VERSION"
+        & curl -L "$env:BOOT_JDK_URL" -o "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
+        $FileHash = Get-FileHash -Algorithm SHA256 "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
+        $FileHash.Hash -eq $env:BOOT_JDK_SHA256
+        & tar -xf "$HOME/bootjdk/$env:BOOT_JDK_FILENAME" -C "$HOME/bootjdk/$env:BOOT_JDK_VERSION"
+      if: steps.bootjdk.outputs.cache-hit != 'true'
+
+    - name: Checkout gtest sources
+      uses: actions/checkout@v2
+      with:
+        repository: 'google/googletest'
+        ref: ${{ env.GTEST_VERSION }}
+        path: gtest
+
+    - name: Restore jtreg artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+        path: ~/jtreg/
+
+    - name: Configure
+      run: >
+        $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
+        $env:Path = $env:Path -split ";" -match "C:\\Windows|PowerShell|cygwin" -join ";" ;
+        & bash configure 
+        --with-conf-name=windows-x64-debug
+        --enable-debug
+        --with-target-bits=64
+        --with-version-opt="$env:GITHUB_ACTOR-$env:GITHUB_SHA" 
+        --with-version-build=0 
+        --with-boot-jdk="$HOME/bootjdk/$env:BOOT_JDK_VERSION/jdk-$env:BOOT_JDK_VERSION" 
+        --with-jtreg="$HOME/jtreg" 
+        --with-gtest="$env:GITHUB_WORKSPACE/gtest"
+        --with-default-make-target="product-bundles test-bundles"
+        --enable-jtreg-failure-handler
+        --with-exclude-translations=de,es,fr,it,ko,pt_BR,sv,ca,tr,cs,sk,ja_JP_A,ja_JP_HA,ja_JP_HI,ja_JP_I,zh_TW,zh_HK
+        --disable-manpages
+      working-directory: jdk
+
+    - name: Build
+      run: |
+        $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
+        $env:Path = $env:Path -split ";" -match "C:\\Windows|PowerShell|cygwin" -join ";" ;
+        & make CONF_NAME=windows-x64-debug
+      working-directory: jdk
+
+    - name: Persist test bundles
+      uses: actions/upload-artifact@v2
+      with:
+        name: jdk-windows-x64-debug_${{ env.bundleid }}
+        path: |
+          jdk/build/windows-x64-debug/bundles/jdk-16-internal+0_windows-x64_bin-debug.zip
+          jdk/build/windows-x64-debug/bundles/jdk-16-internal+0_windows-x64_bin-tests-debug.tar.gz
+          jdk/build/windows-x64-debug/bundles/jdk-16-internal+0_windows-x64_bin-debug-symbols.tar.gz
+
+  windows_x64_test:
+    if: true
+    name: Windows x64
+    runs-on: 'windows-latest'
+    needs: windows_x64_build
+
+    strategy:
+      matrix:
+        test:
+          - test/jdk/:tier1_part1
+          - test/jdk/:tier1_part2
+          - test/jdk/:tier1_part3
+          # - test/langtools/:tier1
+          - test/hotspot/jtreg/:tier1_common
+          - test/hotspot/jtreg/:tier1_compiler
+          - test/hotspot/jtreg/:tier1_gc
+          - test/hotspot/jtreg/:tier1_runtime
+          - test/hotspot/jtreg/:tier1_serviceability
+
+    steps:
+    - name: Determine unique bundle identifier
+      run: echo ("::set-env name=bundleid::$env:GITHUB_ACTOR" + "_" + (-join "$env:GITHUB_SHA"[0..7]))
+
+    - name: Checkout the source
+      uses: actions/checkout@v2
+
+    - name: Restore boot JDK from cache
+      id: bootjdk
+      uses: actions/cache@v2
+      with:
+        path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+        key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+
+    - name: Download boot JDK
+      run: |
+        mkdir -p "$HOME\bootjdk\$env:BOOT_JDK_VERSION"
+        & curl -L "$env:BOOT_JDK_URL" -o "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
+        $FileHash = Get-FileHash -Algorithm SHA256 "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
+        $FileHash.Hash -eq $env:BOOT_JDK_SHA256
+        & tar -xf "$HOME/bootjdk/$env:BOOT_JDK_FILENAME" -C "$HOME/bootjdk/$env:BOOT_JDK_VERSION"
+      if: steps.bootjdk.outputs.cache-hit != 'true'
+
+    - name: Restore cygwin packages from cache
+      id: cygwin
+      uses: actions/cache@v2
+      with:
+        path: ~/cygwin/packages
+        key: cygwin-packages-${{ runner.os }}-v1
+
+    - name: Install cygwin
+      run: |
+        New-Item -Force -ItemType directory -Path "$HOME\cygwin"
+        & curl -L "https://www.cygwin.com/setup-x86_64.exe" -o "$HOME/cygwin/setup-x86_64.exe"
+        Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
+
+    - name: Restore jtreg artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+        path: ~/jtreg/
+
+    - name: Restore build artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: jdk-windows-x64-debug_${{ env.bundleid }}
+        path: ~/jdk-windows-x64-debug
+
+    - name: Unpack jdk
+      run: |
+        mkdir -p "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug"
+        tar -xf "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug.zip" -C "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug"
+
+    - name: Unpack symbols
+      run: |
+        mkdir -p "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug-symbols"
+        tar -xf "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug-symbols.tar.gz" -C "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug-symbols"
+
+    - name: Unpack tests
+      run: |
+        mkdir -p "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-tests-debug"
+        tar -xf "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-tests-debug.tar.gz" -C "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-tests-debug"
+
+    - name: Run tests
+      run: >
+        $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
+        $env:Path = $env:Path -split ";" -match "C:\\Windows|PowerShell|cygwin" -join ";" ;
+        $env:JDK_IMAGE_DIR = cygpath "$HOME/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug/jdk-16/fastdebug" ;
+        $env:SYMBOLS_IMAGE_DIR = cygpath "$HOME/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug/jdk-16/fastdebug" ;
+        $env:TEST_IMAGE_DIR = cygpath "$HOME/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-tests-debug" ;
+        $env:BOOT_JDK = cygpath "$HOME/bootjdk/$env:BOOT_JDK_VERSION/jdk-$env:BOOT_JDK_VERSION" ;
+        $env:JT_HOME = cygpath "$HOME/jtreg" ;
+        & make test-prebuilt
+        CONF_NAME=run-test-prebuilt
+        LOG_CMDLINES=true
+        JTREG_VERBOSE=fail,error,time
+        TEST=${{ matrix.test }}
+        TEST_OPTS_JAVA_OPTIONS=
+        JTREG_KEYWORDS="!headful"
+
+    - name: Create suitable test log artifact name
+      run: echo ("::set-env name=suite::${{ matrix.test }}" -replace "test/", "" -replace "/jtreg", "" -replace "/:", "_" -replace "/", "_")
+      if: ${{ failure() }}
+
+    - name: Persist test logs
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: windows-x64-debug_testlogs_${{ env.suite }}
+        path: |
+          build/*/test-results/
+          build/*/test-resupport/
+
+  macos_x64_build:
+    if: true
+    name: macOS x64 (build)
+    runs-on: 'macos-latest'
+    needs: prerequisites
+    env:
+      BOOT_JDK_FILENAME: 'openjdk-14.0.2_osx-x64_bin.tar.gz'
+      BOOT_JDK_URL: 'https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_osx-x64_bin.tar.gz'
+      BOOT_JDK_SHA256: '386a96eeef63bf94b450809d69ceaa1c9e32a97230e0a120c1b41786b743ae84'
+
+    steps:
+    - name: Determine unique bundle identifier
+      run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        path: jdk
+
+    - name: Restore boot JDK from cache
+      id: bootjdk
+      uses: actions/cache@v2
+      with:
+        path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+        key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+
+    - name: Download boot JDK
+      run: |
+        mkdir -p ${HOME}/bootjdk/${BOOT_JDK_VERSION} || true
+        wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
+        echo "${BOOT_JDK_SHA256}  ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | shasum -a 256 -c >/dev/null -
+        tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+      if: steps.bootjdk.outputs.cache-hit != 'true'
+
+    - name: Restore jtreg artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+        path: ~/jtreg/
+
+    - name: Checkout gtest sources
+      uses: actions/checkout@v2
+      with:
+        repository: 'google/googletest'
+        ref: ${{ env.GTEST_VERSION }}
+        path: gtest
+
+    - name: Install dependencies
+      run: brew install make
+
+    - name: Configure
+      run: >
+        bash configure
+        --with-conf-name=macos-x64-debug
+        --enable-debug
+        --with-target-bits=64
+        --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
+        --with-version-build=0
+        --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}.jdk/Contents/Home
+        --with-jtreg=${HOME}/jtreg
+        --with-gtest=${GITHUB_WORKSPACE}/gtest
+        --with-default-make-target="product-bundles test-bundles"
+        --with-zlib=system
+        --enable-jtreg-failure-handler
+        --with-exclude-translations=de,es,fr,it,ko,pt_BR,sv,ca,tr,cs,sk,ja_JP_A,ja_JP_HA,ja_JP_HI,ja_JP_I,zh_TW,zh_HK
+        --disable-manpages
+      working-directory: jdk
+
+    - name: Build
+      run: make CONF_NAME=macos-x64-debug
+      working-directory: jdk
+
+    - name: Persist test bundles
+      uses: actions/upload-artifact@v2
+      with:
+        name: jdk-macos-x64-debug_${{ env.bundleid }}
+        path: |
+          jdk/build/macos-x64-debug/bundles/jdk-16-internal+0_osx-x64_bin-debug.tar.gz
+          jdk/build/macos-x64-debug/bundles/jdk-16-internal+0_osx-x64_bin-tests-debug.tar.gz
+
+  macos_x64_test:
+    name: macOS x64
+    runs-on: 'macos-latest'
+    needs: macos_x64_build
+
+    strategy:
+      matrix:
+        test:
+          - test/jdk/:tier1_part1
+          - test/jdk/:tier1_part2
+          - test/jdk/:tier1_part3
+          - test/langtools/:tier1
+          - test/hotspot/jtreg/:tier1_common
+          - test/hotspot/jtreg/:tier1_compiler
+          - test/hotspot/jtreg/:tier1_gc
+          - test/hotspot/jtreg/:tier1_runtime
+          - test/hotspot/jtreg/:tier1_serviceability
+
+    steps:
+    - name: Determine unique bundle identifier
+      run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+
+    - name: Checkout the source
+      uses: actions/checkout@v2
+
+    - name: Restore boot JDK from cache
+      id: bootjdk
+      uses: actions/cache@v2
+      with:
+        path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+        key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+
+    - name: Download boot JDK
+      run: |
+        mkdir -p ${HOME}/bootjdk/${BOOT_JDK_VERSION} || true
+        wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
+        echo "${BOOT_JDK_SHA256}  ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | shasum -a 256 -c >/dev/null -
+        tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+      if: steps.bootjdk.outputs.cache-hit != 'true'
+
+    - name: Restore jtreg artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+        path: ~/jtreg/
+
+    - name: Restore build artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: jdk-macos-x64-debug_${{ env.bundleid }}
+        path: ~/jdk-macos-x64-debug
+
+    - name: Unpack jdk
+      run: |
+        mkdir -p "${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-debug"
+        tar -xf "${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-debug.tar.gz" -C "${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-debug"
+
+    - name: Unpack tests
+      run: |
+        mkdir -p "${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-tests-debug"
+        tar -xf "${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-tests-debug.tar.gz" -C "${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-tests-debug"
+
+    - name: Install dependencies
+      run: brew install make
+
+    - name: Run tests
+      run: >
+        JDK_IMAGE_DIR=${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-debug/jdk-16/fastdebug
+        TEST_IMAGE_DIR=${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-tests-debug
+        BOOT_JDK=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}.jdk/Contents/Home
+        JT_HOME=${HOME}/jtreg
+        gmake test-prebuilt
+        CONF_NAME=run-test-prebuilt
+        LOG_CMDLINES=true
+        JTREG_VERBOSE=fail,error,time
+        TEST=${{ matrix.test }}
+        TEST_OPTS_JAVA_OPTIONS=
+        JTREG_KEYWORDS="!headful"
+
+    - name: Create suitable test log artifact name
+      run: echo "::set-env name=suite::`echo ${{ matrix.test }} | sed -e 's!test/!!' -e 's!/jtreg!!' -e 's!/:!_!' -e 's!/!_!g'`"
+      if: ${{ failure() }}
+
+    - name: Persist test logs
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: macos-x64-debug_testlogs_${{ env.suite }}
+        path: |
+          build/*/test-results/
+          build/*/test-resupport/

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,596 +1,739 @@
-name: Submit tests
+name: Pre-submit tests
 
 on:
   push:
-    branches-ignore: [master]
+    branches-ignore:
+      - master
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: "Platform(s) to execute on"
+        required: true
+        default: "Linux x64, Windows x64, macOS x64"
 
 env:
-  BOOT_JDK_VERSION: '14.0.2'
-  JTREG_VERSION: 'jtreg5.1-b01'
-  GTEST_VERSION: 'release-1.8.1'
+  BOOT_JDK_VERSION: "14.0.2"
+  JTREG_VERSION: "jtreg5.1-b01"
+  GTEST_VERSION: "release-1.8.1"
 
 jobs:
   prerequisites:
     name: Prerequisites
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
+    outputs:
+      should_run: ${{ steps.check_submit.outputs.should_run }}
+      platform_linux_x64: ${{ steps.check_platforms.outputs.platform_linux_x64 }}
+      platform_windows_x64: ${{ steps.check_platforms.outputs.platform_windows_x64 }}
+      platform_macos_x64: ${{ steps.check_platforms.outputs.platform_macos_x64 }}
+
     steps:
-    - name: Determine unique bundle identifier
-      run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+      - name: Check if submit tests should actually run depending on secrets and manual triggering
+        id: check_submit
+        run: echo "::set-output name=should_run::${{ github.event.inputs.platforms != '' || (!secrets.JDK_SUBMIT_FILTER || startsWith(github.ref, 'refs/heads/submit/')) }}"
 
-    - name: Check if a jtreg image is present in the cache
-      id: jtreg
-      uses: actions/cache@v2
-      with:
-        path: ~/jtreg/
-        key: jtreg-${{ env.JTREG_VERSION }}-v1
+      - name: Check which platforms should be included
+        id: check_platforms
+        run: |
+          echo "::set-output name=platform_linux_x64::${{ contains(github.event.inputs.platforms, 'linux x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux x64'))) }}"
+          echo "::set-output name=platform_windows_x64::${{ contains(github.event.inputs.platforms, 'windows x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'windows x64'))) }}"
+          echo "::set-output name=platform_macos_x64::${{ contains(github.event.inputs.platforms, 'macos x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'macos x64'))) }}"
+        if: steps.check_submit.outputs.should_run != 'false'
 
-    - name: Checkout the jtreg source
-      uses: actions/checkout@v2
-      with:
-        repository: 'openjdk/jtreg'
-        ref: ${{ env.JTREG_VERSION }}
-      if: steps.jtreg.outputs.cache-hit != 'true'
+      - name: Determine unique bundle identifier
+        run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+        if: steps.check_submit.outputs.should_run != 'false'
 
-    - name: Build jtreg
-      run: sh make/build-all.sh ${JAVA_HOME}
-      if: steps.jtreg.outputs.cache-hit != 'true'
+      - name: Check if a jtreg image is present in the cache
+        id: jtreg
+        uses: actions/cache@v2
+        with:
+          path: ~/jtreg/
+          key: jtreg-${{ env.JTREG_VERSION }}-v1
+        if: steps.check_submit.outputs.should_run != 'false'
 
-    - name: Move jtreg image to destination folder
-      run: mv build/images/jtreg ~/
-      if: steps.jtreg.outputs.cache-hit != 'true'
+      - name: Checkout the jtreg source
+        uses: actions/checkout@v2
+        with:
+          repository: "openjdk/jtreg"
+          ref: ${{ env.JTREG_VERSION }}
+        if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
 
-    - name: Store jtreg for later steps
-      uses: actions/upload-artifact@v2
-      with:
-        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
-        path: ~/jtreg/
+      - name: Build jtreg
+        run: sh make/build-all.sh ${JAVA_HOME}
+        if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
+
+      - name: Move jtreg image to destination folder
+        run: mv build/images/jtreg ~/
+        if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
+
+      - name: Store jtreg for later steps
+        uses: actions/upload-artifact@v2
+        with:
+          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          path: ~/jtreg/
+        if: steps.check_submit.outputs.should_run != 'false'
 
   linux_x64_build:
-    if: true
-    name: Linux x64 (build)
-    runs-on: 'ubuntu-latest'
+    name: Linux x64
+    runs-on: "ubuntu-latest"
     needs: prerequisites
+    if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_x64 != 'false'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor:
+          - build release
+          - build debug
+          - build hotspot no-pch
+        include:
+          - flavor: build debug
+            flags: --enable-debug
+            artifact: -debug
+          - flavor: build hotspot no-pch
+            flags: --disable-precompiled-headers
+            build-target: hotspot
+
     env:
-      BOOT_JDK_FILENAME: 'openjdk-14.0.2_linux-x64_bin.tar.gz'
-      BOOT_JDK_URL: 'https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz'
-      BOOT_JDK_SHA256: '91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d'
+      BOOT_JDK_FILENAME: "openjdk-14.0.2_linux-x64_bin.tar.gz"
+      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz"
+      BOOT_JDK_SHA256: "91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d"
 
     steps:
-    - name: Determine unique bundle identifier
-      run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+      - name: Determine unique bundle identifier
+        run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
 
-    - name: Checkout the source
-      uses: actions/checkout@v2
-      with:
-        path: jdk
+      - name: Checkout the source
+        uses: actions/checkout@v2
+        with:
+          path: jdk
 
-    - name: Restore boot JDK from cache
-      id: bootjdk
-      uses: actions/cache@v2
-      with:
-        path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-        key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+      - name: Restore boot JDK from cache
+        id: bootjdk
+        uses: actions/cache@v2
+        with:
+          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
 
-    - name: Download boot JDK
-      run: |
-        mkdir -p "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
-        wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
-        echo "${BOOT_JDK_SHA256} ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | sha256sum -c >/dev/null -
-        tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
-      if: steps.bootjdk.outputs.cache-hit != 'true'
+      - name: Download boot JDK
+        run: |
+          mkdir -p "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+          wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
+          echo "${BOOT_JDK_SHA256} ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | sha256sum -c >/dev/null -
+          tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+        if: steps.bootjdk.outputs.cache-hit != 'true'
 
-    - name: Restore jtreg artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
-        path: ~/jtreg/
+      - name: Restore jtreg artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          path: ~/jtreg/
 
-    - name: Checkout gtest sources
-      uses: actions/checkout@v2
-      with:
-        repository: 'google/googletest'
-        ref: ${{ env.GTEST_VERSION }}
-        path: gtest
+      - name: Checkout gtest sources
+        uses: actions/checkout@v2
+        with:
+          repository: "google/googletest"
+          ref: ${{ env.GTEST_VERSION }}
+          path: gtest
 
-    - name: Install dependencies
-      run: sudo apt-get install libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
+      - name: Install dependencies
+        run: sudo apt-get install libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
 
-    - name: Configure
-      run: >
-        bash configure
-        --with-conf-name=linux-x64-debug
-        --enable-debug
-        --with-target-bits=64
-        --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
-        --with-version-build=0
-        --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}
-        --with-jtreg=${HOME}/jtreg
-        --with-gtest=${GITHUB_WORKSPACE}/gtest
-        --with-default-make-target="product-bundles test-bundles"
-        --with-zlib=system
-        --enable-jtreg-failure-handler
-        --with-exclude-translations=de,es,fr,it,ko,pt_BR,sv,ca,tr,cs,sk,ja_JP_A,ja_JP_HA,ja_JP_HI,ja_JP_I,zh_TW,zh_HK
-        --disable-manpages
-      working-directory: jdk
+      - name: Configure
+        run: >
+          bash configure
+          --with-conf-name=linux-x64
+          ${{ matrix.flags }}
+          --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
+          --with-version-build=0
+          --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}
+          --with-jtreg=${HOME}/jtreg
+          --with-gtest=${GITHUB_WORKSPACE}/gtest
+          --with-default-make-target="product-bundles test-bundles"
+          --with-zlib=system
+          --enable-jtreg-failure-handler
+        working-directory: jdk
 
-    - name: Build
-      run: make CONF_NAME=linux-x64-debug
-      working-directory: jdk
+      - name: Build
+        run: make CONF_NAME=linux-x64 ${{ matrix.build-target }}
+        working-directory: jdk
 
-    - name: Persist test bundles
-      uses: actions/upload-artifact@v2
-      with:
-        name: jdk-linux-x64-debug_${{ env.bundleid }}
-        path: |
-          jdk/build/linux-x64-debug/bundles/jdk-16-internal+0_linux-x64_bin-debug.tar.gz
-          jdk/build/linux-x64-debug/bundles/jdk-16-internal+0_linux-x64_bin-tests-debug.tar.gz
+      - name: Persist test bundles
+        uses: actions/upload-artifact@v2
+        with:
+          name: jdk-linux-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          path: |
+            jdk/build/linux-x64/bundles/jdk-16-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz
+            jdk/build/linux-x64/bundles/jdk-16-internal+0_linux-x64_bin-tests${{ matrix.artifact }}.tar.gz
+        if: matrix.build-target == false
 
   linux_x64_test:
-    if: true
     name: Linux x64
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     needs: linux_x64_build
 
     strategy:
+      fail-fast: false
       matrix:
         test:
-          - test/jdk/:tier1_part1
-          - test/jdk/:tier1_part2
-          - test/jdk/:tier1_part3
-          - test/langtools/:tier1
-          - test/hotspot/jtreg/:tier1_common
-          - test/hotspot/jtreg/:tier1_compiler
-          - test/hotspot/jtreg/:tier1_gc
-          - test/hotspot/jtreg/:tier1_runtime
-          - test/hotspot/jtreg/:tier1_serviceability
+          - jdk/tier1 part 1
+          - jdk/tier1 part 2
+          - jdk/tier1 part 3
+          - langtools/tier1
+          - hs/tier1 common
+          - hs/tier1 compiler
+          - hs/tier1 gc
+          - hs/tier1 runtime
+          - hs/tier1 serviceability
+        include:
+          - test: jdk/tier1 part 1
+            suites: test/jdk/:tier1_part1
+          - test: jdk/tier1 part 2
+            suites: test/jdk/:tier1_part2
+          - test: jdk/tier1 part 3
+            suites: test/jdk/:tier1_part3
+          - test: langtools/tier1
+            suites: test/langtools/:tier1
+          - test: hs/tier1 common
+            suites: test/hotspot/jtreg/:tier1_common
+            artifact: -debug
+          - test: hs/tier1 compiler
+            suites: test/hotspot/jtreg/:tier1_compiler
+            artifact: -debug
+          - test: hs/tier1 gc
+            suites: test/hotspot/jtreg/:tier1_gc
+            artifact: -debug
+          - test: hs/tier1 runtime
+            suites: test/hotspot/jtreg/:tier1_runtime
+            artifact: -debug
+          - test: hs/tier1 serviceability
+            suites: test/hotspot/jtreg/:tier1_serviceability
+            artifact: -debug
 
     steps:
-    - name: Determine unique bundle identifier
-      run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+      - name: Determine unique bundle identifier
+        run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
 
-    - name: Checkout the source
-      uses: actions/checkout@v2
+      - name: Checkout the source
+        uses: actions/checkout@v2
 
-    - name: Restore boot JDK from cache
-      id: bootjdk
-      uses: actions/cache@v2
-      with:
-        path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-        key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+      - name: Restore boot JDK from cache
+        id: bootjdk
+        uses: actions/cache@v2
+        with:
+          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
 
-    - name: Download boot JDK
-      run: |
-        mkdir -p "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
-        wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
-        echo "${BOOT_JDK_SHA256} ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | sha256sum -c >/dev/null -
-        tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
-      if: steps.bootjdk.outputs.cache-hit != 'true'
+      - name: Download boot JDK
+        run: |
+          mkdir -p "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+          wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
+          echo "${BOOT_JDK_SHA256} ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | sha256sum -c >/dev/null -
+          tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+        if: steps.bootjdk.outputs.cache-hit != 'true'
 
-    - name: Restore jtreg artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
-        path: ~/jtreg/
+      - name: Restore jtreg artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          path: ~/jtreg/
 
-    - name: Restore build artifacts
-      uses: actions/download-artifact@v2
-      with:
-        name: jdk-linux-x64-debug_${{ env.bundleid }}
-        path: ~/jdk-linux-x64-debug
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: jdk-linux-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          path: ~/jdk-linux-x64${{ matrix.artifact }}
 
-    - name: Unpack jdk
-      run: |
-        mkdir -p "${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-debug"
-        tar -xf "${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-debug.tar.gz" -C "${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-debug"
+      - name: Unpack jdk
+        run: |
+          mkdir -p "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin${{ matrix.artifact }}"
+          tar -xf "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin${{ matrix.artifact }}"
 
-    - name: Unpack tests
-      run: |
-        mkdir -p "${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-tests-debug"
-        tar -xf "${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-tests-debug.tar.gz" -C "${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-tests-debug"
+      - name: Unpack tests
+        run: |
+          mkdir -p "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin-tests${{ matrix.artifact }}"
+          tar -xf "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin-tests${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin-tests${{ matrix.artifact }}"
 
-    - name: Run tests
-      run: >
-        JDK_IMAGE_DIR=${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-debug/jdk-16/fastdebug
-        TEST_IMAGE_DIR=${HOME}/jdk-linux-x64-debug/jdk-16-internal+0_linux-x64_bin-tests-debug
-        BOOT_JDK=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}
-        JT_HOME=${HOME}/jtreg
-        make test-prebuilt
-        CONF_NAME=run-test-prebuilt
-        LOG_CMDLINES=true
-        JTREG_VERBOSE=fail,error,time
-        TEST=${{ matrix.test }}
-        TEST_OPTS_JAVA_OPTIONS=
-        JTREG_KEYWORDS="!headful"
+      - name: Find root of jdk image dir
+        run: |
+          imageroot=`find ${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin${{ matrix.artifact }} -name release -type f`
+          echo "::set-env name=imageroot::`dirname ${imageroot}`"
 
-    - name: Create suitable test log artifact name
-      run: echo "::set-env name=suite::`echo ${{ matrix.test }} | sed -e 's!test/!!' -e 's!/jtreg!!' -e 's!/:!_!' -e 's!/!_!g'`"
-      if: ${{ failure() }}
+      - name: Run tests
+        run: >
+          JDK_IMAGE_DIR=${{ env.imageroot }}
+          TEST_IMAGE_DIR=${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin-tests${{ matrix.artifact }}
+          BOOT_JDK=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}
+          JT_HOME=${HOME}/jtreg
+          make test-prebuilt
+          CONF_NAME=run-test-prebuilt
+          LOG_CMDLINES=true
+          JTREG_VERBOSE=fail,error,time
+          TEST="${{ matrix.suites }}"
+          TEST_OPTS_JAVA_OPTIONS=
+          JTREG_KEYWORDS="!headful"
 
-    - name: Persist test logs
-      uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: linux-x64-debug_testlogs_${{ env.suite }}
-        path: |
-          build/*/test-results/
-          build/*/test-resupport/
+      - name: Create suitable test log artifact name
+        run: echo "::set-env name=logsuffix::`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`"
+        if: ${{ failure() }}
+
+      - name: Persist test logs if any test fails
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: linux-x64${{ matrix.artifact }}_testlogs_${{ env.logsuffix }}
+          path: build/*/test-results
 
   windows_x64_build:
-    if: true
-    name: Windows x64 (build)
-    runs-on: 'windows-latest'
+    name: Windows x64
+    runs-on: "windows-latest"
     needs: prerequisites
+    if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_windows_x64 != 'false'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor:
+          - build release
+          - build debug
+        include:
+          - flavor: build debug
+            flags: --enable-debug
+            artifact: -debug
+
     env:
-      BOOT_JDK_FILENAME: 'openjdk-14.0.2_windows-x64_bin.zip'
-      BOOT_JDK_URL: 'https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip'
-      BOOT_JDK_SHA256: '20600c0bda9d1db9d20dbe1ab656a5f9175ffb990ef3df6af5d994673e4d8ff9'
+      BOOT_JDK_FILENAME: "openjdk-14.0.2_windows-x64_bin.zip"
+      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip"
+      BOOT_JDK_SHA256: "20600c0bda9d1db9d20dbe1ab656a5f9175ffb990ef3df6af5d994673e4d8ff9"
 
     steps:
-    - name: Determine unique bundle identifier
-      run: echo ("::set-env name=bundleid::$env:GITHUB_ACTOR" + "_" + (-join "$env:GITHUB_SHA"[0..7]))
+      - name: Determine unique bundle identifier
+        run: echo ("::set-env name=bundleid::$env:GITHUB_ACTOR" + "_" + (-join "$env:GITHUB_SHA"[0..7]))
 
-    - name: Restore cygwin packages from cache
-      id: cygwin
-      uses: actions/cache@v2
-      with:
-        path: ~/cygwin/packages
-        key: cygwin-packages-${{ runner.os }}-v1
+      - name: Restore cygwin packages from cache
+        id: cygwin
+        uses: actions/cache@v2
+        with:
+          path: ~/cygwin/packages
+          key: cygwin-packages-${{ runner.os }}-v1
 
-    - name: Install cygwin
-      run: |
-        New-Item -Force -ItemType directory -Path "$HOME\cygwin"
-        & curl -L "https://www.cygwin.com/setup-x86_64.exe" -o "$HOME/cygwin/setup-x86_64.exe"
-        Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
+      - name: Install cygwin
+        run: |
+          New-Item -Force -ItemType directory -Path "$HOME\cygwin"
+          & curl -L "https://www.cygwin.com/setup-x86_64.exe" -o "$HOME/cygwin/setup-x86_64.exe"
+          Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
 
-    - name: Checkout the source
-      uses: actions/checkout@v2
-      with:
-        path: jdk
+      - name: Checkout the source
+        uses: actions/checkout@v2
+        with:
+          path: jdk
 
-    - name: Restore boot JDK from cache
-      id: bootjdk
-      uses: actions/cache@v2
-      with:
-        path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-        key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+      - name: Restore boot JDK from cache
+        id: bootjdk
+        uses: actions/cache@v2
+        with:
+          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
 
-    - name: Download boot JDK
-      run: |
-        mkdir -p "$HOME\bootjdk\$env:BOOT_JDK_VERSION"
-        & curl -L "$env:BOOT_JDK_URL" -o "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
-        $FileHash = Get-FileHash -Algorithm SHA256 "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
-        $FileHash.Hash -eq $env:BOOT_JDK_SHA256
-        & tar -xf "$HOME/bootjdk/$env:BOOT_JDK_FILENAME" -C "$HOME/bootjdk/$env:BOOT_JDK_VERSION"
-      if: steps.bootjdk.outputs.cache-hit != 'true'
+      - name: Download boot JDK
+        run: |
+          mkdir -p "$HOME\bootjdk\$env:BOOT_JDK_VERSION"
+          & curl -L "$env:BOOT_JDK_URL" -o "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
+          $FileHash = Get-FileHash -Algorithm SHA256 "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
+          $FileHash.Hash -eq $env:BOOT_JDK_SHA256
+          & tar -xf "$HOME/bootjdk/$env:BOOT_JDK_FILENAME" -C "$HOME/bootjdk/$env:BOOT_JDK_VERSION"
+        if: steps.bootjdk.outputs.cache-hit != 'true'
 
-    - name: Checkout gtest sources
-      uses: actions/checkout@v2
-      with:
-        repository: 'google/googletest'
-        ref: ${{ env.GTEST_VERSION }}
-        path: gtest
+      - name: Checkout gtest sources
+        uses: actions/checkout@v2
+        with:
+          repository: "google/googletest"
+          ref: ${{ env.GTEST_VERSION }}
+          path: gtest
 
-    - name: Restore jtreg artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
-        path: ~/jtreg/
+      - name: Restore jtreg artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          path: ~/jtreg/
 
-    - name: Configure
-      run: >
-        $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
-        $env:Path = $env:Path -split ";" -match "C:\\Windows|PowerShell|cygwin" -join ";" ;
-        & bash configure 
-        --with-conf-name=windows-x64-debug
-        --enable-debug
-        --with-target-bits=64
-        --with-version-opt="$env:GITHUB_ACTOR-$env:GITHUB_SHA" 
-        --with-version-build=0 
-        --with-boot-jdk="$HOME/bootjdk/$env:BOOT_JDK_VERSION/jdk-$env:BOOT_JDK_VERSION" 
-        --with-jtreg="$HOME/jtreg" 
-        --with-gtest="$env:GITHUB_WORKSPACE/gtest"
-        --with-default-make-target="product-bundles test-bundles"
-        --enable-jtreg-failure-handler
-        --with-exclude-translations=de,es,fr,it,ko,pt_BR,sv,ca,tr,cs,sk,ja_JP_A,ja_JP_HA,ja_JP_HI,ja_JP_I,zh_TW,zh_HK
-        --disable-manpages
-      working-directory: jdk
+      - name: Configure
+        run: >
+          $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
+          $env:Path = $env:Path -split ";" -match "C:\\Windows|PowerShell|cygwin" -join ";" ;
+          & bash configure 
+          --with-conf-name=windows-x64
+          ${{ matrix.flags }}
+          --with-version-opt="$env:GITHUB_ACTOR-$env:GITHUB_SHA" 
+          --with-version-build=0 
+          --with-boot-jdk="$HOME/bootjdk/$env:BOOT_JDK_VERSION/jdk-$env:BOOT_JDK_VERSION" 
+          --with-jtreg="$HOME/jtreg" 
+          --with-gtest="$env:GITHUB_WORKSPACE/gtest"
+          --with-default-make-target="product-bundles test-bundles"
+          --enable-jtreg-failure-handler
+        working-directory: jdk
 
-    - name: Build
-      run: |
-        $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
-        $env:Path = $env:Path -split ";" -match "C:\\Windows|PowerShell|cygwin" -join ";" ;
-        & make CONF_NAME=windows-x64-debug
-      working-directory: jdk
+      - name: Build
+        run: |
+          $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
+          $env:Path = $env:Path -split ";" -match "C:\\Windows|PowerShell|cygwin" -join ";" ;
+          & make CONF_NAME=windows-x64 ${{ matrix.build-target }}
+        working-directory: jdk
 
-    - name: Persist test bundles
-      uses: actions/upload-artifact@v2
-      with:
-        name: jdk-windows-x64-debug_${{ env.bundleid }}
-        path: |
-          jdk/build/windows-x64-debug/bundles/jdk-16-internal+0_windows-x64_bin-debug.zip
-          jdk/build/windows-x64-debug/bundles/jdk-16-internal+0_windows-x64_bin-tests-debug.tar.gz
-          jdk/build/windows-x64-debug/bundles/jdk-16-internal+0_windows-x64_bin-debug-symbols.tar.gz
+      - name: Persist test bundles
+        uses: actions/upload-artifact@v2
+        with:
+          name: jdk-windows-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          path: |
+            jdk/build/windows-x64/bundles/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}.zip
+            jdk/build/windows-x64/bundles/jdk-16-internal+0_windows-x64_bin-tests${{ matrix.artifact }}.tar.gz
+            jdk/build/windows-x64/bundles/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}-symbols.tar.gz
+        if: matrix.build-target == false
 
   windows_x64_test:
-    if: true
     name: Windows x64
-    runs-on: 'windows-latest'
+    runs-on: "windows-latest"
     needs: windows_x64_build
 
     strategy:
+      fail-fast: false
       matrix:
         test:
-          - test/jdk/:tier1_part1
-          - test/jdk/:tier1_part2
-          - test/jdk/:tier1_part3
-          # - test/langtools/:tier1
-          - test/hotspot/jtreg/:tier1_common
-          - test/hotspot/jtreg/:tier1_compiler
-          - test/hotspot/jtreg/:tier1_gc
-          - test/hotspot/jtreg/:tier1_runtime
-          - test/hotspot/jtreg/:tier1_serviceability
+          - jdk/tier1 part 1
+          - jdk/tier1 part 2
+          - jdk/tier1 part 3
+          - langtools/tier1
+          - hs/tier1 common
+          - hs/tier1 compiler
+          - hs/tier1 gc
+          - hs/tier1 runtime
+          - hs/tier1 serviceability
+        include:
+          - test: jdk/tier1 part 1
+            suites: test/jdk/:tier1_part1
+          - test: jdk/tier1 part 2
+            suites: test/jdk/:tier1_part2
+          - test: jdk/tier1 part 3
+            suites: test/jdk/:tier1_part3
+          - test: langtools/tier1
+            suites: test/langtools/:tier1
+          - test: hs/tier1 common
+            suites: test/hotspot/jtreg/:tier1_common
+            artifact: -debug
+          - test: hs/tier1 compiler
+            suites: test/hotspot/jtreg/:tier1_compiler
+            artifact: -debug
+          - test: hs/tier1 gc
+            suites: test/hotspot/jtreg/:tier1_gc
+            artifact: -debug
+          - test: hs/tier1 runtime
+            suites: test/hotspot/jtreg/:tier1_runtime
+            artifact: -debug
+          - test: hs/tier1 serviceability
+            suites: test/hotspot/jtreg/:tier1_serviceability
+            artifact: -debug
 
     steps:
-    - name: Determine unique bundle identifier
-      run: echo ("::set-env name=bundleid::$env:GITHUB_ACTOR" + "_" + (-join "$env:GITHUB_SHA"[0..7]))
+      - name: Determine unique bundle identifier
+        run: echo ("::set-env name=bundleid::$env:GITHUB_ACTOR" + "_" + (-join "$env:GITHUB_SHA"[0..7]))
 
-    - name: Checkout the source
-      uses: actions/checkout@v2
+      - name: Checkout the source
+        uses: actions/checkout@v2
 
-    - name: Restore boot JDK from cache
-      id: bootjdk
-      uses: actions/cache@v2
-      with:
-        path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-        key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+      - name: Restore boot JDK from cache
+        id: bootjdk
+        uses: actions/cache@v2
+        with:
+          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
 
-    - name: Download boot JDK
-      run: |
-        mkdir -p "$HOME\bootjdk\$env:BOOT_JDK_VERSION"
-        & curl -L "$env:BOOT_JDK_URL" -o "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
-        $FileHash = Get-FileHash -Algorithm SHA256 "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
-        $FileHash.Hash -eq $env:BOOT_JDK_SHA256
-        & tar -xf "$HOME/bootjdk/$env:BOOT_JDK_FILENAME" -C "$HOME/bootjdk/$env:BOOT_JDK_VERSION"
-      if: steps.bootjdk.outputs.cache-hit != 'true'
+      - name: Download boot JDK
+        run: |
+          mkdir -p "$HOME\bootjdk\$env:BOOT_JDK_VERSION"
+          & curl -L "$env:BOOT_JDK_URL" -o "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
+          $FileHash = Get-FileHash -Algorithm SHA256 "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
+          $FileHash.Hash -eq $env:BOOT_JDK_SHA256
+          & tar -xf "$HOME/bootjdk/$env:BOOT_JDK_FILENAME" -C "$HOME/bootjdk/$env:BOOT_JDK_VERSION"
+        if: steps.bootjdk.outputs.cache-hit != 'true'
 
-    - name: Restore cygwin packages from cache
-      id: cygwin
-      uses: actions/cache@v2
-      with:
-        path: ~/cygwin/packages
-        key: cygwin-packages-${{ runner.os }}-v1
+      - name: Restore cygwin packages from cache
+        id: cygwin
+        uses: actions/cache@v2
+        with:
+          path: ~/cygwin/packages
+          key: cygwin-packages-${{ runner.os }}-v1
 
-    - name: Install cygwin
-      run: |
-        New-Item -Force -ItemType directory -Path "$HOME\cygwin"
-        & curl -L "https://www.cygwin.com/setup-x86_64.exe" -o "$HOME/cygwin/setup-x86_64.exe"
-        Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
+      - name: Install cygwin
+        run: |
+          New-Item -Force -ItemType directory -Path "$HOME\cygwin"
+          & curl -L "https://www.cygwin.com/setup-x86_64.exe" -o "$HOME/cygwin/setup-x86_64.exe"
+          Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
 
-    - name: Restore jtreg artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
-        path: ~/jtreg/
+      - name: Restore jtreg artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          path: ~/jtreg/
 
-    - name: Restore build artifacts
-      uses: actions/download-artifact@v2
-      with:
-        name: jdk-windows-x64-debug_${{ env.bundleid }}
-        path: ~/jdk-windows-x64-debug
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: jdk-windows-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          path: ~/jdk-windows-x64${{ matrix.artifact }}
 
-    - name: Unpack jdk
-      run: |
-        mkdir -p "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug"
-        tar -xf "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug.zip" -C "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug"
+      - name: Unpack jdk
+        run: |
+          mkdir -p "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}"
+          tar -xf "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}.zip" -C "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}"
 
-    - name: Unpack symbols
-      run: |
-        mkdir -p "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug-symbols"
-        tar -xf "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug-symbols.tar.gz" -C "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug-symbols"
+      - name: Unpack symbols
+        run: |
+          mkdir -p "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}-symbols"
+          tar -xf "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}-symbols.tar.gz" -C "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}-symbols"
 
-    - name: Unpack tests
-      run: |
-        mkdir -p "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-tests-debug"
-        tar -xf "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-tests-debug.tar.gz" -C "${HOME}/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-tests-debug"
+      - name: Unpack tests
+        run: |
+          mkdir -p "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin-tests${{ matrix.artifact }}"
+          tar -xf "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin-tests${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin-tests${{ matrix.artifact }}"
 
-    - name: Run tests
-      run: >
-        $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
-        $env:Path = $env:Path -split ";" -match "C:\\Windows|PowerShell|cygwin" -join ";" ;
-        $env:JDK_IMAGE_DIR = cygpath "$HOME/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug/jdk-16/fastdebug" ;
-        $env:SYMBOLS_IMAGE_DIR = cygpath "$HOME/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-debug/jdk-16/fastdebug" ;
-        $env:TEST_IMAGE_DIR = cygpath "$HOME/jdk-windows-x64-debug/jdk-16-internal+0_windows-x64_bin-tests-debug" ;
-        $env:BOOT_JDK = cygpath "$HOME/bootjdk/$env:BOOT_JDK_VERSION/jdk-$env:BOOT_JDK_VERSION" ;
-        $env:JT_HOME = cygpath "$HOME/jtreg" ;
-        & make test-prebuilt
-        CONF_NAME=run-test-prebuilt
-        LOG_CMDLINES=true
-        JTREG_VERBOSE=fail,error,time
-        TEST=${{ matrix.test }}
-        TEST_OPTS_JAVA_OPTIONS=
-        JTREG_KEYWORDS="!headful"
+      - name: Find root of jdk image dir
+        run: echo ("::set-env name=imageroot::" + (Get-ChildItem -Path $HOME/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }} -Filter release -Recurse -ErrorAction SilentlyContinue -Force).DirectoryName)
 
-    - name: Create suitable test log artifact name
-      run: echo ("::set-env name=suite::${{ matrix.test }}" -replace "test/", "" -replace "/jtreg", "" -replace "/:", "_" -replace "/", "_")
-      if: ${{ failure() }}
+      - name: Run tests
+        run: >
+          $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
+          $env:Path = $env:Path -split ";" -match "C:\\Windows|PowerShell|cygwin" -join ";" ;
+          $env:JDK_IMAGE_DIR = cygpath "${{ env.imageroot }}" ;
+          $env:SYMBOLS_IMAGE_DIR = cygpath "${{ env.imageroot }}" ;
+          $env:TEST_IMAGE_DIR = cygpath "$HOME/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin-tests${{ matrix.artifact }}" ;
+          $env:BOOT_JDK = cygpath "$HOME/bootjdk/$env:BOOT_JDK_VERSION/jdk-$env:BOOT_JDK_VERSION" ;
+          $env:JT_HOME = cygpath "$HOME/jtreg" ;
+          & make test-prebuilt
+          CONF_NAME=run-test-prebuilt
+          LOG_CMDLINES=true
+          JTREG_VERBOSE=fail,error,time
+          TEST=${{ matrix.suites }}
+          TEST_OPTS_JAVA_OPTIONS=
+          JTREG_KEYWORDS="!headful"
 
-    - name: Persist test logs
-      uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: windows-x64-debug_testlogs_${{ env.suite }}
-        path: |
-          build/*/test-results/
-          build/*/test-resupport/
+      - name: Create suitable test log artifact name
+        run: echo ("::set-env name=logsuffix::" + ("${{ matrix.test }}" -replace "/", "_" -replace " ", "_"))
+        if: ${{ failure() }}
+
+      - name: Persist test logs if any test fails
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: windows-x64${{ matrix.artifact }}_testlogs_${{ env.logsuffix }}
+          path: build/*/test-results
 
   macos_x64_build:
-    if: true
-    name: macOS x64 (build)
-    runs-on: 'macos-latest'
+    name: macOS x64
+    runs-on: "macos-latest"
     needs: prerequisites
+    if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_macos_x64 != 'false'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor:
+          - build release
+          - build debug
+        include:
+          - flavor: build release
+          - flavor: build debug
+            flags: --enable-debug
+            artifact: -debug
+
     env:
-      BOOT_JDK_FILENAME: 'openjdk-14.0.2_osx-x64_bin.tar.gz'
-      BOOT_JDK_URL: 'https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_osx-x64_bin.tar.gz'
-      BOOT_JDK_SHA256: '386a96eeef63bf94b450809d69ceaa1c9e32a97230e0a120c1b41786b743ae84'
+      BOOT_JDK_FILENAME: "openjdk-14.0.2_osx-x64_bin.tar.gz"
+      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_osx-x64_bin.tar.gz"
+      BOOT_JDK_SHA256: "386a96eeef63bf94b450809d69ceaa1c9e32a97230e0a120c1b41786b743ae84"
 
     steps:
-    - name: Determine unique bundle identifier
-      run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+      - name: Determine unique bundle identifier
+        run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
 
-    - name: Checkout the source
-      uses: actions/checkout@v2
-      with:
-        path: jdk
+      - name: Checkout the source
+        uses: actions/checkout@v2
+        with:
+          path: jdk
 
-    - name: Restore boot JDK from cache
-      id: bootjdk
-      uses: actions/cache@v2
-      with:
-        path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-        key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+      - name: Restore boot JDK from cache
+        id: bootjdk
+        uses: actions/cache@v2
+        with:
+          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v2
 
-    - name: Download boot JDK
-      run: |
-        mkdir -p ${HOME}/bootjdk/${BOOT_JDK_VERSION} || true
-        wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
-        echo "${BOOT_JDK_SHA256}  ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | shasum -a 256 -c >/dev/null -
-        tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
-      if: steps.bootjdk.outputs.cache-hit != 'true'
+      - name: Download boot JDK
+        run: |
+          mkdir -p ${HOME}/bootjdk/${BOOT_JDK_VERSION} || true
+          wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
+          echo "${BOOT_JDK_SHA256}  ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | shasum -a 256 -c >/dev/null -
+          tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+        if: steps.bootjdk.outputs.cache-hit != 'true'
 
-    - name: Restore jtreg artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
-        path: ~/jtreg/
+      - name: Restore jtreg artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          path: ~/jtreg/
 
-    - name: Checkout gtest sources
-      uses: actions/checkout@v2
-      with:
-        repository: 'google/googletest'
-        ref: ${{ env.GTEST_VERSION }}
-        path: gtest
+      - name: Checkout gtest sources
+        uses: actions/checkout@v2
+        with:
+          repository: "google/googletest"
+          ref: ${{ env.GTEST_VERSION }}
+          path: gtest
 
-    - name: Install dependencies
-      run: brew install make
+      - name: Install dependencies
+        run: brew install make
 
-    - name: Configure
-      run: >
-        bash configure
-        --with-conf-name=macos-x64-debug
-        --enable-debug
-        --with-target-bits=64
-        --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
-        --with-version-build=0
-        --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}.jdk/Contents/Home
-        --with-jtreg=${HOME}/jtreg
-        --with-gtest=${GITHUB_WORKSPACE}/gtest
-        --with-default-make-target="product-bundles test-bundles"
-        --with-zlib=system
-        --enable-jtreg-failure-handler
-        --with-exclude-translations=de,es,fr,it,ko,pt_BR,sv,ca,tr,cs,sk,ja_JP_A,ja_JP_HA,ja_JP_HI,ja_JP_I,zh_TW,zh_HK
-        --disable-manpages
-      working-directory: jdk
+      - name: Configure
+        run: >
+          bash configure
+          --with-conf-name=macos-x64
+          ${{ matrix.flags }}
+          --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
+          --with-version-build=0
+          --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}.jdk/Contents/Home
+          --with-jtreg=${HOME}/jtreg
+          --with-gtest=${GITHUB_WORKSPACE}/gtest
+          --with-default-make-target="product-bundles test-bundles"
+          --with-zlib=system
+          --enable-jtreg-failure-handler
+        working-directory: jdk
 
-    - name: Build
-      run: make CONF_NAME=macos-x64-debug
-      working-directory: jdk
+      - name: Build
+        run: make CONF_NAME=macos-x64 ${{ matrix.build-target }}
+        working-directory: jdk
 
-    - name: Persist test bundles
-      uses: actions/upload-artifact@v2
-      with:
-        name: jdk-macos-x64-debug_${{ env.bundleid }}
-        path: |
-          jdk/build/macos-x64-debug/bundles/jdk-16-internal+0_osx-x64_bin-debug.tar.gz
-          jdk/build/macos-x64-debug/bundles/jdk-16-internal+0_osx-x64_bin-tests-debug.tar.gz
+      - name: Persist test bundles
+        uses: actions/upload-artifact@v2
+        with:
+          name: jdk-macos-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          path: |
+            jdk/build/macos-x64/bundles/jdk-16-internal+0_osx-x64_bin${{ matrix.artifact }}.tar.gz
+            jdk/build/macos-x64/bundles/jdk-16-internal+0_osx-x64_bin-tests${{ matrix.artifact }}.tar.gz
+        if: matrix.build-target == false
 
   macos_x64_test:
     name: macOS x64
-    runs-on: 'macos-latest'
+    runs-on: "macos-latest"
     needs: macos_x64_build
 
     strategy:
+      fail-fast: false
       matrix:
         test:
-          - test/jdk/:tier1_part1
-          - test/jdk/:tier1_part2
-          - test/jdk/:tier1_part3
-          - test/langtools/:tier1
-          - test/hotspot/jtreg/:tier1_common
-          - test/hotspot/jtreg/:tier1_compiler
-          - test/hotspot/jtreg/:tier1_gc
-          - test/hotspot/jtreg/:tier1_runtime
-          - test/hotspot/jtreg/:tier1_serviceability
+          - jdk/tier1 part 1
+          - jdk/tier1 part 2
+          - jdk/tier1 part 3
+          - langtools/tier1
+          - hs/tier1 common
+          - hs/tier1 compiler
+          - hs/tier1 gc
+          - hs/tier1 runtime
+          - hs/tier1 serviceability
+        include:
+          - test: jdk/tier1 part 1
+            suites: test/jdk/:tier1_part1
+          - test: jdk/tier1 part 2
+            suites: test/jdk/:tier1_part2
+          - test: jdk/tier1 part 3
+            suites: test/jdk/:tier1_part3
+          - test: langtools/tier1
+            suites: test/langtools/:tier1
+          - test: hs/tier1 common
+            suites: test/hotspot/jtreg/:tier1_common
+            artifact: -debug
+          - test: hs/tier1 compiler
+            suites: test/hotspot/jtreg/:tier1_compiler
+            artifact: -debug
+          - test: hs/tier1 gc
+            suites: test/hotspot/jtreg/:tier1_gc
+            artifact: -debug
+          - test: hs/tier1 runtime
+            suites: test/hotspot/jtreg/:tier1_runtime
+            artifact: -debug
+          - test: hs/tier1 serviceability
+            suites: test/hotspot/jtreg/:tier1_serviceability
+            artifact: -debug
 
     steps:
-    - name: Determine unique bundle identifier
-      run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+      - name: Determine unique bundle identifier
+        run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
 
-    - name: Checkout the source
-      uses: actions/checkout@v2
+      - name: Checkout the source
+        uses: actions/checkout@v2
 
-    - name: Restore boot JDK from cache
-      id: bootjdk
-      uses: actions/cache@v2
-      with:
-        path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-        key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+      - name: Restore boot JDK from cache
+        id: bootjdk
+        uses: actions/cache@v2
+        with:
+          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
 
-    - name: Download boot JDK
-      run: |
-        mkdir -p ${HOME}/bootjdk/${BOOT_JDK_VERSION} || true
-        wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
-        echo "${BOOT_JDK_SHA256}  ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | shasum -a 256 -c >/dev/null -
-        tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
-      if: steps.bootjdk.outputs.cache-hit != 'true'
+      - name: Download boot JDK
+        run: |
+          mkdir -p ${HOME}/bootjdk/${BOOT_JDK_VERSION} || true
+          wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
+          echo "${BOOT_JDK_SHA256}  ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | shasum -a 256 -c >/dev/null -
+          tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+        if: steps.bootjdk.outputs.cache-hit != 'true'
 
-    - name: Restore jtreg artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
-        path: ~/jtreg/
+      - name: Restore jtreg artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          path: ~/jtreg/
 
-    - name: Restore build artifacts
-      uses: actions/download-artifact@v2
-      with:
-        name: jdk-macos-x64-debug_${{ env.bundleid }}
-        path: ~/jdk-macos-x64-debug
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: jdk-macos-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          path: ~/jdk-macos-x64${{ matrix.artifact }}
 
-    - name: Unpack jdk
-      run: |
-        mkdir -p "${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-debug"
-        tar -xf "${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-debug.tar.gz" -C "${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-debug"
+      - name: Unpack jdk
+        run: |
+          mkdir -p "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin${{ matrix.artifact }}"
+          tar -xf "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin${{ matrix.artifact }}"
 
-    - name: Unpack tests
-      run: |
-        mkdir -p "${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-tests-debug"
-        tar -xf "${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-tests-debug.tar.gz" -C "${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-tests-debug"
+      - name: Unpack tests
+        run: |
+          mkdir -p "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin-tests${{ matrix.artifact }}"
+          tar -xf "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin-tests${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin-tests${{ matrix.artifact }}"
 
-    - name: Install dependencies
-      run: brew install make
+      - name: Install dependencies
+        run: brew install make
 
-    - name: Run tests
-      run: >
-        JDK_IMAGE_DIR=${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-debug/jdk-16/fastdebug
-        TEST_IMAGE_DIR=${HOME}/jdk-macos-x64-debug/jdk-16-internal+0_osx-x64_bin-tests-debug
-        BOOT_JDK=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}.jdk/Contents/Home
-        JT_HOME=${HOME}/jtreg
-        gmake test-prebuilt
-        CONF_NAME=run-test-prebuilt
-        LOG_CMDLINES=true
-        JTREG_VERBOSE=fail,error,time
-        TEST=${{ matrix.test }}
-        TEST_OPTS_JAVA_OPTIONS=
-        JTREG_KEYWORDS="!headful"
+      - name: Find root of jdk image dir
+        run: |
+          imageroot=`find ${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin${{ matrix.artifact }} -name release -type f`
+          echo "::set-env name=imageroot::`dirname ${imageroot}`"
 
-    - name: Create suitable test log artifact name
-      run: echo "::set-env name=suite::`echo ${{ matrix.test }} | sed -e 's!test/!!' -e 's!/jtreg!!' -e 's!/:!_!' -e 's!/!_!g'`"
-      if: ${{ failure() }}
+      - name: Run tests
+        run: >
+          JDK_IMAGE_DIR=${{ env.imageroot }}
+          TEST_IMAGE_DIR=${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin-tests${{ matrix.artifact }}
+          BOOT_JDK=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}.jdk/Contents/Home
+          JT_HOME=${HOME}/jtreg
+          gmake test-prebuilt
+          CONF_NAME=run-test-prebuilt
+          LOG_CMDLINES=true
+          JTREG_VERBOSE=fail,error,time
+          TEST=${{ matrix.suites }}
+          TEST_OPTS_JAVA_OPTIONS=
+          JTREG_KEYWORDS="!headful"
 
-    - name: Persist test logs
-      uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: macos-x64-debug_testlogs_${{ env.suite }}
-        path: |
-          build/*/test-results/
-          build/*/test-resupport/
+      - name: Create suitable test log artifact name
+        run: echo "::set-env name=logsuffix::`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`"
+        if: ${{ failure() }}
+
+      - name: Persist test logs if any test fails
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: macos-x64${{ matrix.artifact }}_testlogs_${{ env.logsuffix }}
+          path: build/*/test-results

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -305,6 +305,7 @@ jobs:
         run: echo "::set-env name=logsuffix::`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`"
 
       - name: Persist test logs
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: linux-x64${{ matrix.artifact }}_testlogs_${{ env.logsuffix }}
@@ -560,6 +561,7 @@ jobs:
         run: echo ("::set-env name=logsuffix::" + ("${{ matrix.test }}" -replace "/", "_" -replace " ", "_"))
 
       - name: Persist test logs
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: windows-x64${{ matrix.artifact }}_testlogs_${{ env.logsuffix }}
@@ -783,6 +785,7 @@ jobs:
         run: echo "::set-env name=logsuffix::`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`"
 
       - name: Persist test logs
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: macos-x64${{ matrix.artifact }}_testlogs_${{ env.logsuffix }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -81,10 +81,10 @@ jobs:
         working-directory: jtreg
         if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
 
-      - name: Store jtreg for later steps
+      - name: Store jtreg for use by later steps
         uses: actions/upload-artifact@v2
         with:
-          name: jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ env.bundleid }}
           path: ~/jtreg/
         if: steps.check_submit.outputs.should_run != 'false'
 
@@ -144,7 +144,7 @@ jobs:
       - name: Restore jtreg artifact
         uses: actions/download-artifact@v2
         with:
-          name: jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ env.bundleid }}
           path: ~/jtreg/
 
       - name: Checkout gtest sources
@@ -179,7 +179,7 @@ jobs:
       - name: Persist test bundles
         uses: actions/upload-artifact@v2
         with:
-          name: jdk-linux-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ env.bundleid }}
           path: |
             jdk/build/linux-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz
             jdk/build/linux-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin-tests${{ matrix.artifact }}.tar.gz
@@ -263,13 +263,13 @@ jobs:
       - name: Restore jtreg artifact
         uses: actions/download-artifact@v2
         with:
-          name: jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ env.bundleid }}
           path: ~/jtreg/
 
       - name: Restore build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: jdk-linux-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ env.bundleid }}
           path: ~/jdk-linux-x64${{ matrix.artifact }}
 
       - name: Unpack jdk
@@ -303,14 +303,13 @@ jobs:
 
       - name: Create suitable test log artifact name
         run: echo "::set-env name=logsuffix::`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`"
-        if: ${{ failure() }}
 
-      - name: Persist test logs if any test fails
+      - name: Persist test logs
         uses: actions/upload-artifact@v2
-        if: ${{ failure() }}
         with:
           name: linux-x64${{ matrix.artifact }}_testlogs_${{ env.logsuffix }}
           path: build/*/test-results
+        continue-on-error: true
 
   windows_x64_build:
     name: Windows x64
@@ -385,20 +384,20 @@ jobs:
       - name: Restore jtreg artifact
         uses: actions/download-artifact@v2
         with:
-          name: jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ env.bundleid }}
           path: ~/jtreg/
 
       - name: Configure
         run: >
           $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
           $env:Path = $env:Path -split ";" -match "C:\\Windows|PowerShell|cygwin" -join ";" ;
-          & bash configure 
+          & bash configure
           --with-conf-name=windows-x64
           ${{ matrix.flags }}
-          --with-version-opt="$env:GITHUB_ACTOR-$env:GITHUB_SHA" 
-          --with-version-build=0 
-          --with-boot-jdk="$HOME/bootjdk/$env:BOOT_JDK_VERSION" 
-          --with-jtreg="$HOME/jtreg" 
+          --with-version-opt="$env:GITHUB_ACTOR-$env:GITHUB_SHA"
+          --with-version-build=0
+          --with-boot-jdk="$HOME/bootjdk/$env:BOOT_JDK_VERSION"
+          --with-jtreg="$HOME/jtreg"
           --with-gtest="$env:GITHUB_WORKSPACE/gtest"
           --with-default-make-target="product-bundles test-bundles"
           --enable-jtreg-failure-handler
@@ -414,7 +413,7 @@ jobs:
       - name: Persist test bundles
         uses: actions/upload-artifact@v2
         with:
-          name: jdk-windows-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ env.bundleid }}
           path: |
             jdk/build/windows-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }}.zip
             jdk/build/windows-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin-tests${{ matrix.artifact }}.tar.gz
@@ -513,13 +512,13 @@ jobs:
       - name: Restore jtreg artifact
         uses: actions/download-artifact@v2
         with:
-          name: jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ env.bundleid }}
           path: ~/jtreg/
 
       - name: Restore build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: jdk-windows-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ env.bundleid }}
           path: ~/jdk-windows-x64${{ matrix.artifact }}
 
       - name: Unpack jdk
@@ -559,14 +558,13 @@ jobs:
 
       - name: Create suitable test log artifact name
         run: echo ("::set-env name=logsuffix::" + ("${{ matrix.test }}" -replace "/", "_" -replace " ", "_"))
-        if: ${{ failure() }}
 
-      - name: Persist test logs if any test fails
+      - name: Persist test logs
         uses: actions/upload-artifact@v2
-        if: ${{ failure() }}
         with:
           name: windows-x64${{ matrix.artifact }}_testlogs_${{ env.logsuffix }}
           path: build/*/test-results
+        continue-on-error: true
 
   macos_x64_build:
     name: macOS x64
@@ -621,7 +619,7 @@ jobs:
       - name: Restore jtreg artifact
         uses: actions/download-artifact@v2
         with:
-          name: jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ env.bundleid }}
           path: ~/jtreg/
 
       - name: Checkout gtest sources
@@ -656,7 +654,7 @@ jobs:
       - name: Persist test bundles
         uses: actions/upload-artifact@v2
         with:
-          name: jdk-macos-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ env.bundleid }}
           path: |
             jdk/build/macos-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin${{ matrix.artifact }}.tar.gz
             jdk/build/macos-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin-tests${{ matrix.artifact }}.tar.gz
@@ -740,13 +738,13 @@ jobs:
       - name: Restore jtreg artifact
         uses: actions/download-artifact@v2
         with:
-          name: jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ env.bundleid }}
           path: ~/jtreg/
 
       - name: Restore build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: jdk-macos-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ env.bundleid }}
           path: ~/jdk-macos-x64${{ matrix.artifact }}
 
       - name: Unpack jdk
@@ -783,11 +781,71 @@ jobs:
 
       - name: Create suitable test log artifact name
         run: echo "::set-env name=logsuffix::`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`"
-        if: ${{ failure() }}
 
-      - name: Persist test logs if any test fails
+      - name: Persist test logs
         uses: actions/upload-artifact@v2
-        if: ${{ failure() }}
         with:
           name: macos-x64${{ matrix.artifact }}_testlogs_${{ env.logsuffix }}
           path: build/*/test-results
+        continue-on-error: true
+
+  artifacts:
+    name: Post-process artifacts
+    runs-on: "ubuntu-latest"
+    if: always()
+    continue-on-error: true
+    needs:
+      - linux_x64_test
+      - windows_x64_test
+      - macos_x64_test
+
+    steps:
+      - name: Determine current artifacts endpoint
+        id: actions_runtime
+        uses: actions/github-script@v3
+        with:
+          script: "return { url: process.env['ACTIONS_RUNTIME_URL'], token: process.env['ACTIONS_RUNTIME_TOKEN'] }"
+
+      - name: Display current artifacts
+        run: >
+          curl -s -H 'Accept: application/json;api-version=6.0-preview'
+          -H 'Authorization: Bearer ${{ fromJson(steps.actions_runtime.outputs.result).token }}'
+          '${{ fromJson(steps.actions_runtime.outputs.result).url }}_apis/pipelines/workflows/${{ github.run_id }}/artifacts?api-version=6.0-preview'
+
+      - name: Delete transient artifacts
+        run: >
+          for url in `
+          curl -s -H 'Accept: application/json;api-version=6.0-preview'
+          -H 'Authorization: Bearer ${{ fromJson(steps.actions_runtime.outputs.result).token }}'
+          '${{ fromJson(steps.actions_runtime.outputs.result).url }}_apis/pipelines/workflows/${{ github.run_id }}/artifacts?api-version=6.0-preview' |
+          jq -r -c '.value | map(select(.name|startswith("transient_"))) | .[].url'`; do
+          curl -s -H 'Accept: application/json;api-version=6.0-preview'
+          -H 'Authorization: Bearer ${{ fromJson(steps.actions_runtime.outputs.result).token }}'
+          -X DELETE "${url}";
+          done
+
+      - name: Fetch remaining artifacts (test results)
+        uses: actions/download-artifact@v2
+        with:
+          path: test-results
+
+      - name: Delete remaining artifacts
+        run: >
+          for url in `
+          curl -s -H 'Accept: application/json;api-version=6.0-preview'
+          -H 'Authorization: Bearer ${{ fromJson(steps.actions_runtime.outputs.result).token }}'
+          '${{ fromJson(steps.actions_runtime.outputs.result).url }}_apis/pipelines/workflows/${{ github.run_id }}/artifacts?api-version=6.0-preview' |
+          jq -r -c '.value | .[].url'`; do
+          curl -s -H 'Accept: application/json;api-version=6.0-preview'
+          -H 'Authorization: Bearer ${{ fromJson(steps.actions_runtime.outputs.result).token }}'
+          -X DELETE "${url}";
+          done
+
+      - name: Determine unique bundle identifier
+        run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+
+      - name: Upload a combined test results artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results_${{ env.bundleid }}
+          path: test-results

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -43,17 +43,21 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: jdk
+        if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Determine versions and locations to be used for dependencies
         id: check_deps
         run: "echo ::set-output name=dependencies::`cat make/autoconf/version-numbers make/conf/test-dependencies | sed -e '1i {' -e 's/#.*//g' -e 's/\"//g' -e 's/\\(.*\\)=\\(.*\\)/\"\\1\": \"\\2\",/g' -e '$s/,\\s\\{0,\\}$/\\}/'`"
         working-directory: jdk
+        if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Print extracted dependencies to the log
         run: "echo '${{ steps.check_deps.outputs.dependencies }}'"
+        if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Determine the jtreg ref to checkout
         run: "echo ::set-env name=JTREG_REF::jtreg${{ fromJson(steps.check_deps.outputs.dependencies).JTREG_VERSION }}-${{ fromJson(steps.check_deps.outputs.dependencies).JTREG_BUILD }}"
+        if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Check if a jtreg image is present in the cache
         id: jtreg
@@ -302,6 +306,7 @@ jobs:
           JTREG_KEYWORDS="!headful"
 
       - name: Create suitable test log artifact name
+        if: always()
         run: echo "::set-env name=logsuffix::`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`"
 
       - name: Persist test logs
@@ -558,6 +563,7 @@ jobs:
           JTREG_KEYWORDS="!headful"
 
       - name: Create suitable test log artifact name
+        if: always()
         run: echo ("::set-env name=logsuffix::" + ("${{ matrix.test }}" -replace "/", "_" -replace " ", "_"))
 
       - name: Persist test logs
@@ -782,6 +788,7 @@ jobs:
           JTREG_KEYWORDS="!headful"
 
       - name: Create suitable test log artifact name
+        if: always()
         run: echo "::set-env name=logsuffix::`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`"
 
       - name: Persist test logs

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -11,11 +11,6 @@ on:
         required: true
         default: "Linux x64, Windows x64, macOS x64"
 
-env:
-  BOOT_JDK_VERSION: "14.0.2"
-  JTREG_VERSION: "jtreg5.1-b01"
-  GTEST_VERSION: "release-1.8.1"
-
 jobs:
   prerequisites:
     name: Prerequisites
@@ -25,6 +20,7 @@ jobs:
       platform_linux_x64: ${{ steps.check_platforms.outputs.platform_linux_x64 }}
       platform_windows_x64: ${{ steps.check_platforms.outputs.platform_windows_x64 }}
       platform_macos_x64: ${{ steps.check_platforms.outputs.platform_macos_x64 }}
+      dependencies: ${{ steps.check_deps.outputs.dependencies }}
 
     steps:
       - name: Check if submit tests should actually run depending on secrets and manual triggering
@@ -43,33 +39,52 @@ jobs:
         run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
         if: steps.check_submit.outputs.should_run != 'false'
 
+      - name: Checkout the source
+        uses: actions/checkout@v2
+        with:
+          path: jdk
+
+      - name: Determine versions and locations to be used for dependencies
+        id: check_deps
+        run: "echo ::set-output name=dependencies::`cat make/autoconf/version-numbers make/conf/test-dependencies | sed -e '1i {' -e 's/#.*//g' -e 's/\"//g' -e 's/\\(.*\\)=\\(.*\\)/\"\\1\": \"\\2\",/g' -e '$s/,\\s\\{0,\\}$/\\}/'`"
+        working-directory: jdk
+
+      - name: Print extracted dependencies to the log
+        run: "echo '${{ steps.check_deps.outputs.dependencies }}'"
+
+      - name: Determine the jtreg ref to checkout
+        run: "echo ::set-env name=JTREG_REF::jtreg${{ fromJson(steps.check_deps.outputs.dependencies).JTREG_VERSION }}-${{ fromJson(steps.check_deps.outputs.dependencies).JTREG_BUILD }}"
+
       - name: Check if a jtreg image is present in the cache
         id: jtreg
         uses: actions/cache@v2
         with:
           path: ~/jtreg/
-          key: jtreg-${{ env.JTREG_VERSION }}-v1
+          key: jtreg-${{ env.JTREG_REF }}-v1
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Checkout the jtreg source
         uses: actions/checkout@v2
         with:
           repository: "openjdk/jtreg"
-          ref: ${{ env.JTREG_VERSION }}
+          ref: ${{ env.JTREG_REF }}
+          path: jtreg
         if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
 
       - name: Build jtreg
         run: sh make/build-all.sh ${JAVA_HOME}
+        working-directory: jtreg
         if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
 
       - name: Move jtreg image to destination folder
         run: mv build/images/jtreg ~/
+        working-directory: jtreg
         if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
 
       - name: Store jtreg for later steps
         uses: actions/upload-artifact@v2
         with:
-          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          name: jtreg_${{ env.bundleid }}
           path: ~/jtreg/
         if: steps.check_submit.outputs.should_run != 'false'
 
@@ -95,9 +110,11 @@ jobs:
             build-target: hotspot
 
     env:
-      BOOT_JDK_FILENAME: "openjdk-14.0.2_linux-x64_bin.tar.gz"
-      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz"
-      BOOT_JDK_SHA256: "91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d"
+      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
+      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
+      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
+      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
+      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
 
     steps:
       - name: Determine unique bundle identifier
@@ -113,7 +130,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
 
       - name: Download boot JDK
         run: |
@@ -121,19 +138,20 @@ jobs:
           wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
           echo "${BOOT_JDK_SHA256} ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | sha256sum -c >/dev/null -
           tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+          mv "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"*/* "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"
         if: steps.bootjdk.outputs.cache-hit != 'true'
 
       - name: Restore jtreg artifact
         uses: actions/download-artifact@v2
         with:
-          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          name: jtreg_${{ env.bundleid }}
           path: ~/jtreg/
 
       - name: Checkout gtest sources
         uses: actions/checkout@v2
         with:
           repository: "google/googletest"
-          ref: ${{ env.GTEST_VERSION }}
+          ref: "release-${{ fromJson(needs.prerequisites.outputs.dependencies).GTEST_VERSION }}"
           path: gtest
 
       - name: Install dependencies
@@ -146,7 +164,7 @@ jobs:
           ${{ matrix.flags }}
           --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
           --with-version-build=0
-          --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}
+          --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}
           --with-jtreg=${HOME}/jtreg
           --with-gtest=${GITHUB_WORKSPACE}/gtest
           --with-default-make-target="product-bundles test-bundles"
@@ -163,14 +181,16 @@ jobs:
         with:
           name: jdk-linux-x64${{ matrix.artifact }}_${{ env.bundleid }}
           path: |
-            jdk/build/linux-x64/bundles/jdk-16-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz
-            jdk/build/linux-x64/bundles/jdk-16-internal+0_linux-x64_bin-tests${{ matrix.artifact }}.tar.gz
+            jdk/build/linux-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz
+            jdk/build/linux-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin-tests${{ matrix.artifact }}.tar.gz
         if: matrix.build-target == false
 
   linux_x64_test:
     name: Linux x64
     runs-on: "ubuntu-latest"
-    needs: linux_x64_build
+    needs:
+      - prerequisites
+      - linux_x64_build
 
     strategy:
       fail-fast: false
@@ -210,6 +230,13 @@ jobs:
             suites: test/hotspot/jtreg/:tier1_serviceability
             artifact: -debug
 
+    env:
+      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
+      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
+      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
+      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
+      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
+
     steps:
       - name: Determine unique bundle identifier
         run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
@@ -222,7 +249,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
 
       - name: Download boot JDK
         run: |
@@ -230,12 +257,13 @@ jobs:
           wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
           echo "${BOOT_JDK_SHA256} ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | sha256sum -c >/dev/null -
           tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+          mv "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"*/* "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"
         if: steps.bootjdk.outputs.cache-hit != 'true'
 
       - name: Restore jtreg artifact
         uses: actions/download-artifact@v2
         with:
-          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          name: jtreg_${{ env.bundleid }}
           path: ~/jtreg/
 
       - name: Restore build artifacts
@@ -246,24 +274,24 @@ jobs:
 
       - name: Unpack jdk
         run: |
-          mkdir -p "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin${{ matrix.artifact }}"
-          tar -xf "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin${{ matrix.artifact }}"
+          mkdir -p "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }}"
+          tar -xf "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }}"
 
       - name: Unpack tests
         run: |
-          mkdir -p "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin-tests${{ matrix.artifact }}"
-          tar -xf "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin-tests${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin-tests${{ matrix.artifact }}"
+          mkdir -p "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin-tests${{ matrix.artifact }}"
+          tar -xf "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin-tests${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin-tests${{ matrix.artifact }}"
 
       - name: Find root of jdk image dir
         run: |
-          imageroot=`find ${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin${{ matrix.artifact }} -name release -type f`
+          imageroot=`find ${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }} -name release -type f`
           echo "::set-env name=imageroot::`dirname ${imageroot}`"
 
       - name: Run tests
         run: >
           JDK_IMAGE_DIR=${{ env.imageroot }}
-          TEST_IMAGE_DIR=${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-16-internal+0_linux-x64_bin-tests${{ matrix.artifact }}
-          BOOT_JDK=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}
+          TEST_IMAGE_DIR=${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin-tests${{ matrix.artifact }}
+          BOOT_JDK=${HOME}/bootjdk/${BOOT_JDK_VERSION}
           JT_HOME=${HOME}/jtreg
           make test-prebuilt
           CONF_NAME=run-test-prebuilt
@@ -302,9 +330,11 @@ jobs:
             artifact: -debug
 
     env:
-      BOOT_JDK_FILENAME: "openjdk-14.0.2_windows-x64_bin.zip"
-      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip"
-      BOOT_JDK_SHA256: "20600c0bda9d1db9d20dbe1ab656a5f9175ffb990ef3df6af5d994673e4d8ff9"
+      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
+      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
+      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).WINDOWS_X64_BOOT_JDK_FILENAME }}"
+      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).WINDOWS_X64_BOOT_JDK_URL }}"
+      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).WINDOWS_X64_BOOT_JDK_SHA256 }}"
 
     steps:
       - name: Determine unique bundle identifier
@@ -333,7 +363,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
 
       - name: Download boot JDK
         run: |
@@ -342,19 +372,20 @@ jobs:
           $FileHash = Get-FileHash -Algorithm SHA256 "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
           $FileHash.Hash -eq $env:BOOT_JDK_SHA256
           & tar -xf "$HOME/bootjdk/$env:BOOT_JDK_FILENAME" -C "$HOME/bootjdk/$env:BOOT_JDK_VERSION"
+          Get-ChildItem "$HOME\bootjdk\$env:BOOT_JDK_VERSION\*\*" | Move-Item -Destination "$HOME\bootjdk\$env:BOOT_JDK_VERSION"
         if: steps.bootjdk.outputs.cache-hit != 'true'
 
       - name: Checkout gtest sources
         uses: actions/checkout@v2
         with:
           repository: "google/googletest"
-          ref: ${{ env.GTEST_VERSION }}
+          ref: "release-${{ fromJson(needs.prerequisites.outputs.dependencies).GTEST_VERSION }}"
           path: gtest
 
       - name: Restore jtreg artifact
         uses: actions/download-artifact@v2
         with:
-          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          name: jtreg_${{ env.bundleid }}
           path: ~/jtreg/
 
       - name: Configure
@@ -366,7 +397,7 @@ jobs:
           ${{ matrix.flags }}
           --with-version-opt="$env:GITHUB_ACTOR-$env:GITHUB_SHA" 
           --with-version-build=0 
-          --with-boot-jdk="$HOME/bootjdk/$env:BOOT_JDK_VERSION/jdk-$env:BOOT_JDK_VERSION" 
+          --with-boot-jdk="$HOME/bootjdk/$env:BOOT_JDK_VERSION" 
           --with-jtreg="$HOME/jtreg" 
           --with-gtest="$env:GITHUB_WORKSPACE/gtest"
           --with-default-make-target="product-bundles test-bundles"
@@ -385,15 +416,17 @@ jobs:
         with:
           name: jdk-windows-x64${{ matrix.artifact }}_${{ env.bundleid }}
           path: |
-            jdk/build/windows-x64/bundles/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}.zip
-            jdk/build/windows-x64/bundles/jdk-16-internal+0_windows-x64_bin-tests${{ matrix.artifact }}.tar.gz
-            jdk/build/windows-x64/bundles/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}-symbols.tar.gz
+            jdk/build/windows-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }}.zip
+            jdk/build/windows-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin-tests${{ matrix.artifact }}.tar.gz
+            jdk/build/windows-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }}-symbols.tar.gz
         if: matrix.build-target == false
 
   windows_x64_test:
     name: Windows x64
     runs-on: "windows-latest"
-    needs: windows_x64_build
+    needs:
+      - prerequisites
+      - windows_x64_build
 
     strategy:
       fail-fast: false
@@ -433,6 +466,13 @@ jobs:
             suites: test/hotspot/jtreg/:tier1_serviceability
             artifact: -debug
 
+    env:
+      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
+      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
+      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).WINDOWS_X64_BOOT_JDK_FILENAME }}"
+      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).WINDOWS_X64_BOOT_JDK_URL }}"
+      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).WINDOWS_X64_BOOT_JDK_SHA256 }}"
+
     steps:
       - name: Determine unique bundle identifier
         run: echo ("::set-env name=bundleid::$env:GITHUB_ACTOR" + "_" + (-join "$env:GITHUB_SHA"[0..7]))
@@ -445,7 +485,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
 
       - name: Download boot JDK
         run: |
@@ -454,6 +494,7 @@ jobs:
           $FileHash = Get-FileHash -Algorithm SHA256 "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
           $FileHash.Hash -eq $env:BOOT_JDK_SHA256
           & tar -xf "$HOME/bootjdk/$env:BOOT_JDK_FILENAME" -C "$HOME/bootjdk/$env:BOOT_JDK_VERSION"
+          Get-ChildItem "$HOME\bootjdk\$env:BOOT_JDK_VERSION\*\*" | Move-Item -Destination "$HOME\bootjdk\$env:BOOT_JDK_VERSION"
         if: steps.bootjdk.outputs.cache-hit != 'true'
 
       - name: Restore cygwin packages from cache
@@ -472,7 +513,7 @@ jobs:
       - name: Restore jtreg artifact
         uses: actions/download-artifact@v2
         with:
-          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          name: jtreg_${{ env.bundleid }}
           path: ~/jtreg/
 
       - name: Restore build artifacts
@@ -483,21 +524,21 @@ jobs:
 
       - name: Unpack jdk
         run: |
-          mkdir -p "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}"
-          tar -xf "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}.zip" -C "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}"
+          mkdir -p "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }}"
+          tar -xf "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }}.zip" -C "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }}"
 
       - name: Unpack symbols
         run: |
-          mkdir -p "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}-symbols"
-          tar -xf "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}-symbols.tar.gz" -C "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }}-symbols"
+          mkdir -p "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }}-symbols"
+          tar -xf "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }}-symbols.tar.gz" -C "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }}-symbols"
 
       - name: Unpack tests
         run: |
-          mkdir -p "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin-tests${{ matrix.artifact }}"
-          tar -xf "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin-tests${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin-tests${{ matrix.artifact }}"
+          mkdir -p "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin-tests${{ matrix.artifact }}"
+          tar -xf "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin-tests${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin-tests${{ matrix.artifact }}"
 
       - name: Find root of jdk image dir
-        run: echo ("::set-env name=imageroot::" + (Get-ChildItem -Path $HOME/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin${{ matrix.artifact }} -Filter release -Recurse -ErrorAction SilentlyContinue -Force).DirectoryName)
+        run: echo ("::set-env name=imageroot::" + (Get-ChildItem -Path $HOME/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }} -Filter release -Recurse -ErrorAction SilentlyContinue -Force).DirectoryName)
 
       - name: Run tests
         run: >
@@ -505,8 +546,8 @@ jobs:
           $env:Path = $env:Path -split ";" -match "C:\\Windows|PowerShell|cygwin" -join ";" ;
           $env:JDK_IMAGE_DIR = cygpath "${{ env.imageroot }}" ;
           $env:SYMBOLS_IMAGE_DIR = cygpath "${{ env.imageroot }}" ;
-          $env:TEST_IMAGE_DIR = cygpath "$HOME/jdk-windows-x64${{ matrix.artifact }}/jdk-16-internal+0_windows-x64_bin-tests${{ matrix.artifact }}" ;
-          $env:BOOT_JDK = cygpath "$HOME/bootjdk/$env:BOOT_JDK_VERSION/jdk-$env:BOOT_JDK_VERSION" ;
+          $env:TEST_IMAGE_DIR = cygpath "$HOME/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin-tests${{ matrix.artifact }}" ;
+          $env:BOOT_JDK = cygpath "$HOME/bootjdk/$env:BOOT_JDK_VERSION" ;
           $env:JT_HOME = cygpath "$HOME/jtreg" ;
           & make test-prebuilt
           CONF_NAME=run-test-prebuilt
@@ -546,9 +587,11 @@ jobs:
             artifact: -debug
 
     env:
-      BOOT_JDK_FILENAME: "openjdk-14.0.2_osx-x64_bin.tar.gz"
-      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_osx-x64_bin.tar.gz"
-      BOOT_JDK_SHA256: "386a96eeef63bf94b450809d69ceaa1c9e32a97230e0a120c1b41786b743ae84"
+      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
+      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
+      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).MACOS_X64_BOOT_JDK_FILENAME }}"
+      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).MACOS_X64_BOOT_JDK_URL }}"
+      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).MACOS_X64_BOOT_JDK_SHA256 }}"
 
     steps:
       - name: Determine unique bundle identifier
@@ -564,7 +607,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v2
+          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
 
       - name: Download boot JDK
         run: |
@@ -572,19 +615,20 @@ jobs:
           wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
           echo "${BOOT_JDK_SHA256}  ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | shasum -a 256 -c >/dev/null -
           tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+          mv "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"*/* "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"
         if: steps.bootjdk.outputs.cache-hit != 'true'
 
       - name: Restore jtreg artifact
         uses: actions/download-artifact@v2
         with:
-          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          name: jtreg_${{ env.bundleid }}
           path: ~/jtreg/
 
       - name: Checkout gtest sources
         uses: actions/checkout@v2
         with:
           repository: "google/googletest"
-          ref: ${{ env.GTEST_VERSION }}
+          ref: "release-${{ fromJson(needs.prerequisites.outputs.dependencies).GTEST_VERSION }}"
           path: gtest
 
       - name: Install dependencies
@@ -597,7 +641,7 @@ jobs:
           ${{ matrix.flags }}
           --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
           --with-version-build=0
-          --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}.jdk/Contents/Home
+          --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}/Contents/Home
           --with-jtreg=${HOME}/jtreg
           --with-gtest=${GITHUB_WORKSPACE}/gtest
           --with-default-make-target="product-bundles test-bundles"
@@ -614,14 +658,16 @@ jobs:
         with:
           name: jdk-macos-x64${{ matrix.artifact }}_${{ env.bundleid }}
           path: |
-            jdk/build/macos-x64/bundles/jdk-16-internal+0_osx-x64_bin${{ matrix.artifact }}.tar.gz
-            jdk/build/macos-x64/bundles/jdk-16-internal+0_osx-x64_bin-tests${{ matrix.artifact }}.tar.gz
+            jdk/build/macos-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin${{ matrix.artifact }}.tar.gz
+            jdk/build/macos-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin-tests${{ matrix.artifact }}.tar.gz
         if: matrix.build-target == false
 
   macos_x64_test:
     name: macOS x64
     runs-on: "macos-latest"
-    needs: macos_x64_build
+    needs:
+      - prerequisites
+      - macos_x64_build
 
     strategy:
       fail-fast: false
@@ -661,6 +707,13 @@ jobs:
             suites: test/hotspot/jtreg/:tier1_serviceability
             artifact: -debug
 
+    env:
+      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
+      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
+      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).MACOS_X64_BOOT_JDK_FILENAME }}"
+      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).MACOS_X64_BOOT_JDK_URL }}"
+      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).MACOS_X64_BOOT_JDK_SHA256 }}"
+
     steps:
       - name: Determine unique bundle identifier
         run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
@@ -673,7 +726,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-v1
+          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
 
       - name: Download boot JDK
         run: |
@@ -681,12 +734,13 @@ jobs:
           wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
           echo "${BOOT_JDK_SHA256}  ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | shasum -a 256 -c >/dev/null -
           tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
+          mv "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"*/* "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"
         if: steps.bootjdk.outputs.cache-hit != 'true'
 
       - name: Restore jtreg artifact
         uses: actions/download-artifact@v2
         with:
-          name: jtreg_${{ env.JTREG_VERSION }}_${{ env.bundleid }}
+          name: jtreg_${{ env.bundleid }}
           path: ~/jtreg/
 
       - name: Restore build artifacts
@@ -697,27 +751,27 @@ jobs:
 
       - name: Unpack jdk
         run: |
-          mkdir -p "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin${{ matrix.artifact }}"
-          tar -xf "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin${{ matrix.artifact }}"
+          mkdir -p "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin${{ matrix.artifact }}"
+          tar -xf "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin${{ matrix.artifact }}"
 
       - name: Unpack tests
         run: |
-          mkdir -p "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin-tests${{ matrix.artifact }}"
-          tar -xf "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin-tests${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin-tests${{ matrix.artifact }}"
+          mkdir -p "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin-tests${{ matrix.artifact }}"
+          tar -xf "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin-tests${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin-tests${{ matrix.artifact }}"
 
       - name: Install dependencies
         run: brew install make
 
       - name: Find root of jdk image dir
         run: |
-          imageroot=`find ${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin${{ matrix.artifact }} -name release -type f`
+          imageroot=`find ${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin${{ matrix.artifact }} -name release -type f`
           echo "::set-env name=imageroot::`dirname ${imageroot}`"
 
       - name: Run tests
         run: >
           JDK_IMAGE_DIR=${{ env.imageroot }}
-          TEST_IMAGE_DIR=${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-16-internal+0_osx-x64_bin-tests${{ matrix.artifact }}
-          BOOT_JDK=${HOME}/bootjdk/${BOOT_JDK_VERSION}/jdk-${BOOT_JDK_VERSION}.jdk/Contents/Home
+          TEST_IMAGE_DIR=${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin-tests${{ matrix.artifact }}
+          BOOT_JDK=${HOME}/bootjdk/${BOOT_JDK_VERSION}/Contents/Home
           JT_HOME=${HOME}/jtreg
           gmake test-prebuilt
           CONF_NAME=run-test-prebuilt

--- a/make/conf/test-dependencies
+++ b/make/conf/test-dependencies
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# Versions and download locations for dependencies used by pre-submit testing.
+
+BOOT_JDK_VERSION="14"
+JTREG_VERSION="5.1"
+JTREG_BUILD="b01"
+GTEST_VERSION="1.8.1"
+
+LINUX_X64_BOOT_JDK_FILENAME="openjdk-14.0.2_linux-x64_bin.tar.gz"
+LINUX_X64_BOOT_JDK_URL="https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz"
+LINUX_X64_BOOT_JDK_SHA256="91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d"
+
+WINDOWS_X64_BOOT_JDK_FILENAME="openjdk-14.0.2_windows-x64_bin.zip"
+WINDOWS_X64_BOOT_JDK_URL="https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip"
+WINDOWS_X64_BOOT_JDK_SHA256="20600c0bda9d1db9d20dbe1ab656a5f9175ffb990ef3df6af5d994673e4d8ff9"
+
+MACOS_X64_BOOT_JDK_FILENAME="openjdk-14.0.2_osx-x64_bin.tar.gz"
+MACOS_X64_BOOT_JDK_URL="https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_osx-x64_bin.tar.gz"
+MACOS_X64_BOOT_JDK_SHA256="386a96eeef63bf94b450809d69ceaa1c9e32a97230e0a120c1b41786b743ae84"

--- a/make/conf/test-dependencies
+++ b/make/conf/test-dependencies
@@ -25,19 +25,19 @@
 
 # Versions and download locations for dependencies used by pre-submit testing.
 
-BOOT_JDK_VERSION="14"
-JTREG_VERSION="5.1"
-JTREG_BUILD="b01"
-GTEST_VERSION="1.8.1"
+BOOT_JDK_VERSION=14
+JTREG_VERSION=5.1
+JTREG_BUILD=b01
+GTEST_VERSION=1.8.1
 
-LINUX_X64_BOOT_JDK_FILENAME="openjdk-14.0.2_linux-x64_bin.tar.gz"
-LINUX_X64_BOOT_JDK_URL="https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz"
-LINUX_X64_BOOT_JDK_SHA256="91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d"
+LINUX_X64_BOOT_JDK_FILENAME=openjdk-14.0.2_linux-x64_bin.tar.gz
+LINUX_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz
+LINUX_X64_BOOT_JDK_SHA256=91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d
 
-WINDOWS_X64_BOOT_JDK_FILENAME="openjdk-14.0.2_windows-x64_bin.zip"
-WINDOWS_X64_BOOT_JDK_URL="https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip"
-WINDOWS_X64_BOOT_JDK_SHA256="20600c0bda9d1db9d20dbe1ab656a5f9175ffb990ef3df6af5d994673e4d8ff9"
+WINDOWS_X64_BOOT_JDK_FILENAME=openjdk-14.0.2_windows-x64_bin.zip
+WINDOWS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip
+WINDOWS_X64_BOOT_JDK_SHA256=20600c0bda9d1db9d20dbe1ab656a5f9175ffb990ef3df6af5d994673e4d8ff9
 
-MACOS_X64_BOOT_JDK_FILENAME="openjdk-14.0.2_osx-x64_bin.tar.gz"
-MACOS_X64_BOOT_JDK_URL="https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_osx-x64_bin.tar.gz"
-MACOS_X64_BOOT_JDK_SHA256="386a96eeef63bf94b450809d69ceaa1c9e32a97230e0a120c1b41786b743ae84"
+MACOS_X64_BOOT_JDK_FILENAME=openjdk-14.0.2_osx-x64_bin.tar.gz
+MACOS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_osx-x64_bin.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=386a96eeef63bf94b450809d69ceaa1c9e32a97230e0a120c1b41786b743ae84

--- a/make/conf/test-dependencies
+++ b/make/conf/test-dependencies
@@ -25,19 +25,19 @@
 
 # Versions and download locations for dependencies used by pre-submit testing.
 
-BOOT_JDK_VERSION=14
+BOOT_JDK_VERSION=15
 JTREG_VERSION=5.1
 JTREG_BUILD=b01
 GTEST_VERSION=1.8.1
 
-LINUX_X64_BOOT_JDK_FILENAME=openjdk-14.0.2_linux-x64_bin.tar.gz
-LINUX_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz
-LINUX_X64_BOOT_JDK_SHA256=91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d
+LINUX_X64_BOOT_JDK_FILENAME=openjdk-15_linux-x64_bin.tar.gz
+LINUX_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-x64_bin.tar.gz
+LINUX_X64_BOOT_JDK_SHA256=bb67cadee687d7b486583d03c9850342afea4593be4f436044d785fba9508fb7
 
-WINDOWS_X64_BOOT_JDK_FILENAME=openjdk-14.0.2_windows-x64_bin.zip
-WINDOWS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip
-WINDOWS_X64_BOOT_JDK_SHA256=20600c0bda9d1db9d20dbe1ab656a5f9175ffb990ef3df6af5d994673e4d8ff9
+WINDOWS_X64_BOOT_JDK_FILENAME=openjdk-15_windows-x64_bin.zip
+WINDOWS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_windows-x64_bin.zip
+WINDOWS_X64_BOOT_JDK_SHA256=764e39a71252a9791118a31ae56a4247c049463bda5eb72497122ec50b1d07f8
 
-MACOS_X64_BOOT_JDK_FILENAME=openjdk-14.0.2_osx-x64_bin.tar.gz
-MACOS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_osx-x64_bin.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=386a96eeef63bf94b450809d69ceaa1c9e32a97230e0a120c1b41786b743ae84
+MACOS_X64_BOOT_JDK_FILENAME=openjdk-115_osx-x64_bin.tar.gz
+MACOS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_osx-x64_bin.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=ab842c8c0953b816be308c098c1a021177a4776bef24da85b6bafbbd657c7e1a


### PR DESCRIPTION
A few days ago I posted an initial version of the necessary configuration required to run pre-submit build and tests for JDK main-line contributions using GitHub Actions [2] and the free tier [3] available to everyone working with open source repositories. I've incorporated the feedback into an updated version that I believe is ready to be integrated.

If this is integrated into the `master` branch, future branches created and updated in personal forks will build and run the basic tier 1 tests as described in this configuration, on Linux, Windows and macOS (all on x64). It's of course possible for any contributor to opt out fully or partially of these automatic runs in a few different ways.

To opt out completely, a contributor can simply disable GitHub Actions on their personal fork, and no further jobs will be executed. Another option is to add a repository secret [4] with the name `JDK_SUBMIT_FILTER` set to any value. If this is set, only branches prefixed with `submit/` will be subject to automatic build and test. This can also be further refined by adding a repository secret named `JDK_SUBMIT_PLATFORMS` with a value such as `Linux x64, Windows x64` to limit automatic build and test to these two platforms. It will still be possible to run the tests on any branch and/or platform by manually triggering the workflow.

To see what this looks like in practice, an example run can be found here: https://github.com/rwestberg/jdk/actions/runs/265131985 (note that there is currently a failing test on Windows which is tracked by JDK-8249095, which should probably be resolved before this change is integrated).

Best regards,
Robin

[1] https://mail.openjdk.java.net/pipermail/jdk-dev/2020-September/004736.html
[2] https://github.com/features/actions
[3] https://docs.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits
[4] https://docs.github.com/en/actions/reference/encrypted-secrets

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253424](https://bugs.openjdk.java.net/browse/JDK-8253424): Add support for running pre-submit testing using GitHub Actions


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**) ⚠️ Review applies to 441a18b7fa75635d7b06ed203018ea9e89af74fe
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 441a18b7fa75635d7b06ed203018ea9e89af74fe


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/284/head:pull/284`
`$ git checkout pull/284`
