### PR TITLE
8253455: Record Classes javax.lang.model changes

### DIFF
--- a/src/java.base/share/classes/jdk/internal/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/PreviewFeature.java
@@ -62,7 +62,13 @@ public @interface PreviewFeature {
         // JDK 15. Since the JDK 14 codebase uses the enum constant, it is
         // necessary for PreviewFeature in JDK 15 to declare the enum constant.
         TEXT_BLOCKS,
-        // remove the RECORDS entry before pushing
+        /*
+         * The RECORDS enum constant is not used in the JDK 16 codebase, but
+         * exists to support the bootcycle build of JDK 16. The bootcycle build
+         * of JDK 16 is performed with JDK 15 and the PreviewFeature type from
+         * JDK 16. Since the JDK 15 codebase uses the enum constant, it is
+         * necessary for PreviewFeature in JDK 16 to declare the enum constant
+         */
         RECORDS,
         SEALED_CLASSES,
         ;

--- a/src/java.base/share/classes/jdk/internal/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/PreviewFeature.java
@@ -62,13 +62,11 @@ public @interface PreviewFeature {
         // JDK 15. Since the JDK 14 codebase uses the enum constant, it is
         // necessary for PreviewFeature in JDK 15 to declare the enum constant.
         TEXT_BLOCKS,
-        /*
-         * The RECORDS enum constant is not used in the JDK 16 codebase, but
-         * exists to support the bootcycle build of JDK 16. The bootcycle build
-         * of JDK 16 is performed with JDK 15 and the PreviewFeature type from
-         * JDK 16. Since the JDK 15 codebase uses the enum constant, it is
-         * necessary for PreviewFeature in JDK 16 to declare the enum constant
-         */
+        // The RECORDS enum constant is not used in the JDK 16 codebase, but
+        // exists to support the bootcycle build of JDK 16. The bootcycle build
+        // of JDK 16 is performed with JDK 15 and the PreviewFeature type from
+        // JDK 16. Since the JDK 15 codebase uses the enum constant, it is
+        // necessary for PreviewFeature in JDK 16 to declare the enum constant.
         RECORDS,
         SEALED_CLASSES,
         ;

--- a/src/java.base/share/classes/jdk/internal/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/PreviewFeature.java
@@ -62,6 +62,7 @@ public @interface PreviewFeature {
         // JDK 15. Since the JDK 14 codebase uses the enum constant, it is
         // necessary for PreviewFeature in JDK 15 to declare the enum constant.
         TEXT_BLOCKS,
+        // remove the RECORDS entry before pushing
         RECORDS,
         SEALED_CLASSES,
         ;

--- a/src/java.compiler/share/classes/javax/lang/model/element/ElementKind.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ElementKind.java
@@ -110,33 +110,15 @@ public enum ElementKind {
      MODULE,
 
     /**
-     * {@preview Associated with records, a preview feature of the Java language.
-     *
-     *           This enum constant is associated with <i>records</i>, a preview
-     *           feature of the Java language. Preview features
-     *           may be removed in a future release, or upgraded to permanent
-     *           features of the Java language.}
-     *
      * A record type.
      * @since 14
      */
-    @jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.RECORDS,
-                                 essentialAPI=false)
     RECORD,
 
     /**
-     * {@preview Associated with records, a preview feature of the Java language.
-     *
-     *           This enum constant is associated with <i>records</i>, a preview
-     *           feature of the Java language. Preview features
-     *           may be removed in a future release, or upgraded to permanent
-     *           features of the Java language.}
-     *
      * A record component of a {@code record}.
      * @since 14
      */
-    @jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.RECORDS,
-                                 essentialAPI=false)
     RECORD_COMPONENT,
 
     /**

--- a/src/java.compiler/share/classes/javax/lang/model/element/ElementKind.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ElementKind.java
@@ -111,13 +111,13 @@ public enum ElementKind {
 
     /**
      * A record type.
-     * @since 14
+     * @since 16
      */
     RECORD,
 
     /**
      * A record component of a {@code record}.
-     * @since 14
+     * @since 16
      */
     RECORD_COMPONENT,
 

--- a/src/java.compiler/share/classes/javax/lang/model/element/ElementVisitor.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ElementVisitor.java
@@ -212,13 +212,6 @@ public interface ElementVisitor<R, P> {
     }
 
     /**
-     * {@preview Associated with records, a preview feature of the Java language.
-     *
-     *           This method is associated with <i>records</i>, a preview
-     *           feature of the Java language. Preview features
-     *           may be removed in a future release, or upgraded to permanent
-     *           features of the Java language.}
-     *
      * Visits a record component element.
      *
      * @implSpec The default implementation visits a {@code
@@ -229,9 +222,6 @@ public interface ElementVisitor<R, P> {
      * @return a visitor-specified result
      * @since 14
      */
-    @jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.RECORDS,
-                                 essentialAPI=false)
-    @SuppressWarnings("preview")
     default R visitRecordComponent(RecordComponentElement e, P p) {
         return visitUnknown(e, p);
     }

--- a/src/java.compiler/share/classes/javax/lang/model/element/ElementVisitor.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ElementVisitor.java
@@ -220,7 +220,7 @@ public interface ElementVisitor<R, P> {
      * @param e  the element to visit
      * @param p  a visitor-specified parameter
      * @return a visitor-specified result
-     * @since 14
+     * @since 16
      */
     default R visitRecordComponent(RecordComponentElement e, P p) {
         return visitUnknown(e, p);

--- a/src/java.compiler/share/classes/javax/lang/model/element/RecordComponentElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/RecordComponentElement.java
@@ -26,19 +26,10 @@
 package javax.lang.model.element;
 
 /**
- * {@preview Associated with records, a preview feature of the Java language.
- *
- *           This class is associated with <i>records</i>, a preview
- *           feature of the Java language. Preview features
- *           may be removed in a future release, or upgraded to permanent
- *           features of the Java language.}
- *
  * Represents a record component.
  *
  * @since 14
  */
-@jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.RECORDS,
-                             essentialAPI=false)
 public interface RecordComponentElement extends Element {
     /**
      * Returns the enclosing element of this record component.

--- a/src/java.compiler/share/classes/javax/lang/model/element/RecordComponentElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/RecordComponentElement.java
@@ -28,7 +28,7 @@ package javax.lang.model.element;
 /**
  * Represents a record component.
  *
- * @since 14
+ * @since 16
  */
 public interface RecordComponentElement extends Element {
     /**

--- a/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
@@ -189,7 +189,7 @@ public interface TypeElement extends Element, Parameterizable, QualifiedNameable
      * @return the record components, or an empty list if there are
      * none
      *
-     * @since 14
+     * @since 16
      */
     default List<? extends RecordComponentElement> getRecordComponents() {
         return List.of();

--- a/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
@@ -180,13 +180,6 @@ public interface TypeElement extends Element, Parameterizable, QualifiedNameable
     List<? extends TypeParameterElement> getTypeParameters();
 
     /**
-     * {@preview Associated with records, a preview feature of the Java language.
-     *
-     *           This method is associated with <i>records</i>, a preview
-     *           feature of the Java language. Preview features
-     *           may be removed in a future release, or upgraded to permanent
-     *           features of the Java language.}
-     *
      * Returns the record components of this type element in
      * declaration order.
      *
@@ -198,9 +191,6 @@ public interface TypeElement extends Element, Parameterizable, QualifiedNameable
      *
      * @since 14
      */
-    @jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.RECORDS,
-                                 essentialAPI=false)
-    @SuppressWarnings("preview")
     default List<? extends RecordComponentElement> getRecordComponents() {
         return List.of();
     }

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
@@ -47,7 +47,7 @@ import static javax.lang.model.SourceVersion.*;
  * @see AbstractElementVisitor7
  * @see AbstractElementVisitor8
  * @see AbstractElementVisitor9
- * @since 14
+ * @since 16
  */
 @SupportedSourceVersion(RELEASE_16)
 public abstract class AbstractElementVisitor14<R, P> extends AbstractElementVisitor9<R, P> {

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
@@ -31,13 +31,6 @@ import javax.lang.model.element.RecordComponentElement;
 import static javax.lang.model.SourceVersion.*;
 
 /**
- * {@preview Associated with records, a preview feature of the Java language.
- *
- *           This class is associated with <i>records</i>, a preview
- *           feature of the Java language. Preview features
- *           may be removed in a future release, or upgraded to permanent
- *           features of the Java language.}
- *
  * A skeletal visitor of program elements with default behavior
  * appropriate for the {@link SourceVersion#RELEASE_14 RELEASE_14}
  * source version.
@@ -56,8 +49,6 @@ import static javax.lang.model.SourceVersion.*;
  * @see AbstractElementVisitor9
  * @since 14
  */
-@jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.RECORDS,
-                             essentialAPI=false)
 @SupportedSourceVersion(RELEASE_16)
 public abstract class AbstractElementVisitor14<R, P> extends AbstractElementVisitor9<R, P> {
     /**
@@ -77,7 +68,6 @@ public abstract class AbstractElementVisitor14<R, P> extends AbstractElementVisi
      * @param p  {@inheritDoc}
      * @return   {@inheritDoc}
      */
-    @SuppressWarnings("preview")
     @Override
     public abstract R visitRecordComponent(RecordComponentElement t, P p);
 }

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementFilter.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementFilter.java
@@ -115,7 +115,7 @@ public class ElementFilter {
      * Returns a list of record components in {@code elements}.
      * @return a list of record components in {@code elements}
      * @param elements the elements to filter
-     * @since 14
+     * @since 16
      */
     public static List<RecordComponentElement>
         recordComponentsIn(Iterable<? extends Element> elements) {
@@ -126,7 +126,7 @@ public class ElementFilter {
      * Returns a set of record components in {@code elements}.
      * @return a set of record components in {@code elements}
      * @param elements the elements to filter
-     * @since 14
+     * @since 16
      */
     public static Set<RecordComponentElement>
     recordComponentsIn(Set<? extends Element> elements) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementFilter.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementFilter.java
@@ -112,42 +112,22 @@ public class ElementFilter {
     }
 
     /**
-     * {@preview Associated with records, a preview feature of the Java language.
-     *
-     *           This method is associated with <i>records</i>, a preview
-     *           feature of the Java language. Preview features
-     *           may be removed in a future release, or upgraded to permanent
-     *           features of the Java language.}
-     *
      * Returns a list of record components in {@code elements}.
      * @return a list of record components in {@code elements}
      * @param elements the elements to filter
      * @since 14
      */
-    @jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.RECORDS,
-                                 essentialAPI=false)
-    @SuppressWarnings("preview")
     public static List<RecordComponentElement>
         recordComponentsIn(Iterable<? extends Element> elements) {
         return listFilter(elements, RECORD_COMPONENT_KIND, RecordComponentElement.class);
     }
 
     /**
-     * {@preview Associated with records, a preview feature of the Java language.
-     *
-     *           This method is associated with <i>records</i>, a preview
-     *           feature of the Java language. Preview features
-     *           may be removed in a future release, or upgraded to permanent
-     *           features of the Java language.}
-     *
      * Returns a set of record components in {@code elements}.
      * @return a set of record components in {@code elements}
      * @param elements the elements to filter
      * @since 14
      */
-    @jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.RECORDS,
-                                 essentialAPI=false)
-    @SuppressWarnings("preview")
     public static Set<RecordComponentElement>
     recordComponentsIn(Set<? extends Element> elements) {
         return setFilter(elements, RECORD_COMPONENT_KIND, RecordComponentElement.class);

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor14.java
@@ -31,13 +31,6 @@ import static javax.lang.model.SourceVersion.*;
 import javax.lang.model.SourceVersion;
 
 /**
- * {@preview Associated with records, a preview feature of the Java language.
- *
- *           This class is associated with <i>records</i>, a preview
- *           feature of the Java language. Preview features
- *           may be removed in a future release, or upgraded to permanent
- *           features of the Java language.}
- *
  * A visitor of program elements based on their {@linkplain
  * ElementKind kind} with default behavior appropriate for the {@link
  * SourceVersion#RELEASE_14 RELEASE_14} source version.
@@ -68,8 +61,6 @@ import javax.lang.model.SourceVersion;
  * @see ElementKindVisitor9
  * @since 14
  */
-@jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.RECORDS,
-                             essentialAPI=false)
 @SupportedSourceVersion(RELEASE_16)
 public class ElementKindVisitor14<R, P> extends ElementKindVisitor9<R, P> {
     /**
@@ -99,7 +90,6 @@ public class ElementKindVisitor14<R, P> extends ElementKindVisitor9<R, P> {
      * @param p a visitor-specified parameter
      * @return  the result of {@code defaultAction}
      */
-    @SuppressWarnings("preview")
     @Override
     public R visitRecordComponent(RecordComponentElement e, P p) {
         return defaultAction(e, p);

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor14.java
@@ -59,7 +59,7 @@ import javax.lang.model.SourceVersion;
  * @see ElementKindVisitor7
  * @see ElementKindVisitor8
  * @see ElementKindVisitor9
- * @since 14
+ * @since 16
  */
 @SupportedSourceVersion(RELEASE_16)
 public class ElementKindVisitor14<R, P> extends ElementKindVisitor9<R, P> {

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor6.java
@@ -217,13 +217,6 @@ public class ElementKindVisitor6<R, P>
     }
 
     /**
-     * {@preview Associated with records, a preview feature of the Java language.
-     *
-     *           This method is associated with <i>records</i>, a preview
-     *           feature of the Java language. Preview features
-     *           may be removed in a future release, or upgraded to permanent
-     *           features of the Java language.}
-     *
      * Visits a {@code RECORD} type element.
      *
      * @implSpec This implementation calls {@code visitUnknown}.
@@ -234,8 +227,6 @@ public class ElementKindVisitor6<R, P>
      *
      * @since 14
      */
-    @jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.RECORDS,
-                                 essentialAPI=false)
     public R visitTypeAsRecord(TypeElement e, P p) {
         return visitUnknown(e, p);
     }

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor6.java
@@ -225,7 +225,7 @@ public class ElementKindVisitor6<R, P>
      * @param p a visitor-specified parameter
      * @return  the result of {@code visitUnknown}
      *
-     * @since 14
+     * @since 16
      */
     public R visitTypeAsRecord(TypeElement e, P p) {
         return visitUnknown(e, p);

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
@@ -74,7 +74,7 @@ import static javax.lang.model.SourceVersion.*;
  * @see ElementScanner7
  * @see ElementScanner8
  * @see ElementScanner9
- * @since 14
+ * @since 16
  */
 @SupportedSourceVersion(RELEASE_16)
 public class ElementScanner14<R, P> extends ElementScanner9<R, P> {

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
@@ -33,13 +33,6 @@ import javax.lang.model.SourceVersion;
 import static javax.lang.model.SourceVersion.*;
 
 /**
- * {@preview Associated with records, a preview feature of the Java language.
- *
- *           This class is associated with <i>records</i>, a preview
- *           feature of the Java language. Preview features
- *           may be removed in a future release, or upgraded to permanent
- *           features of the Java language.}
- *
  * A scanning visitor of program elements with default behavior
  * appropriate for the {@link SourceVersion#RELEASE_14 RELEASE_14}
  * source version.
@@ -83,8 +76,6 @@ import static javax.lang.model.SourceVersion.*;
  * @see ElementScanner9
  * @since 14
  */
-@jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.RECORDS,
-                             essentialAPI=false)
 @SupportedSourceVersion(RELEASE_16)
 public class ElementScanner14<R, P> extends ElementScanner9<R, P> {
     /**
@@ -156,7 +147,6 @@ public class ElementScanner14<R, P> extends ElementScanner9<R, P> {
      * @param p a visitor-specified parameter
      * @return  the result of the scan
      */
-    @SuppressWarnings("preview")
     @Override
     public R visitRecordComponent(RecordComponentElement e, P p) {
         return scan(e.getEnclosedElements(), p);

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -648,7 +648,7 @@ public interface Elements {
      * @param accessor the method for which the record component should be found.
      * @return the record component, or null if the given method is not an record
      * component accessor
-     * @since 14
+     * @since 16
      */
     default RecordComponentElement recordComponentFor(ExecutableElement accessor) {
         if (accessor.getEnclosingElement().getKind() == ElementKind.RECORD) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -634,13 +634,6 @@ public interface Elements {
     boolean isFunctionalInterface(TypeElement type);
 
     /**
-     * {@preview Associated with records, a preview feature of the Java language.
-     *
-     *           This method is associated with <i>records</i>, a preview
-     *           feature of the Java language. Preview features
-     *           may be removed in a future release, or upgraded to permanent
-     *           features of the Java language.}
-     *
      * Returns the record component for the given accessor. Returns null if the
      * given method is not a record component accessor.
      *
@@ -657,9 +650,6 @@ public interface Elements {
      * component accessor
      * @since 14
      */
-    @jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.RECORDS,
-                                 essentialAPI=false)
-    @SuppressWarnings("preview")
     default RecordComponentElement recordComponentFor(ExecutableElement accessor) {
         if (accessor.getEnclosingElement().getKind() == ElementKind.RECORD) {
             for (RecordComponentElement rec : ElementFilter.recordComponentsIn(accessor.getEnclosingElement().getEnclosedElements())) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor14.java
@@ -55,7 +55,7 @@ import static javax.lang.model.SourceVersion.*;
  * @see SimpleElementVisitor7
  * @see SimpleElementVisitor8
  * @see SimpleElementVisitor9
- * @since 14
+ * @since 16
  */
 @SupportedSourceVersion(RELEASE_16)
 public class SimpleElementVisitor14<R, P> extends SimpleElementVisitor9<R, P> {

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor14.java
@@ -31,13 +31,6 @@ import javax.lang.model.element.RecordComponentElement;
 import static javax.lang.model.SourceVersion.*;
 
 /**
- * {@preview Associated with records, a preview feature of the Java language.
- *
- *           This class is associated with <i>records</i>, a preview
- *           feature of the Java language. Preview features
- *           may be removed in a future release, or upgraded to permanent
- *           features of the Java language.}
- *
  * A simple visitor of program elements with default behavior
  * appropriate for the {@link SourceVersion#RELEASE_14 RELEASE_14}
  * source version.
@@ -64,8 +57,6 @@ import static javax.lang.model.SourceVersion.*;
  * @see SimpleElementVisitor9
  * @since 14
  */
-@jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.RECORDS,
-                             essentialAPI=false)
 @SupportedSourceVersion(RELEASE_16)
 public class SimpleElementVisitor14<R, P> extends SimpleElementVisitor9<R, P> {
     /**
@@ -96,7 +87,6 @@ public class SimpleElementVisitor14<R, P> extends SimpleElementVisitor9<R, P> {
      * @param p a visitor-specified parameter
      * @return  {@inheritDoc}
      */
-    @SuppressWarnings("preview")
     @Override
     public R visitRecordComponent(RecordComponentElement e, P p) {
         return defaultAction(e, p);

--- a/test/langtools/tools/javac/processing/model/element/JavaxLangModelForRecords.java
+++ b/test/langtools/tools/javac/processing/model/element/JavaxLangModelForRecords.java
@@ -105,13 +105,17 @@ public class JavaxLangModelForRecords extends TestRunner {
         tb.writeJavaFiles(r,
                 "record R(int i) {}");
 
-        List<String> expected = List.of(
-                "Note: field: i",
-                "Note: record component: i");
+        List<String> expected = List.of("Note: field: i",
+                "Note: record component: i",
+                "Note: testQualifiedClassForProcessing" + File.separator + "src" + File.separator
+                     + "R" + File.separator + "R.java uses preview language features.",
+                "Note: Recompile with -Xlint:preview for details.");
 
         for (Mode mode : new Mode[] {Mode.API}) {
             List<String> log = new JavacTask(tb, mode)
-                    .options("-processor", QualifiedClassForProcessing.class.getName())
+                    .options("-processor", QualifiedClassForProcessing.class.getName(),
+                            "--enable-preview",
+                            "-source", Integer.toString(Runtime.version().feature()))
                     .files(findJavaFiles(src))
                     .outdir(classes)
                     .run()

--- a/test/langtools/tools/javac/processing/model/element/JavaxLangModelForRecords.java
+++ b/test/langtools/tools/javac/processing/model/element/JavaxLangModelForRecords.java
@@ -105,17 +105,13 @@ public class JavaxLangModelForRecords extends TestRunner {
         tb.writeJavaFiles(r,
                 "record R(int i) {}");
 
-        List<String> expected = List.of("Note: field: i",
-                "Note: record component: i",
-                "Note: testQualifiedClassForProcessing" + File.separator + "src" + File.separator
-                     + "R" + File.separator + "R.java uses preview language features.",
-                "Note: Recompile with -Xlint:preview for details.");
+        List<String> expected = List.of(
+                "Note: field: i",
+                "Note: record component: i");
 
         for (Mode mode : new Mode[] {Mode.API}) {
             List<String> log = new JavacTask(tb, mode)
-                    .options("-processor", QualifiedClassForProcessing.class.getName(),
-                            "--enable-preview",
-                            "-source", Integer.toString(Runtime.version().feature()))
+                    .options("-processor", QualifiedClassForProcessing.class.getName())
                     .files(findJavaFiles(src))
                     .outdir(classes)
                     .run()


### PR DESCRIPTION
Please review the fix for [JDK-8253455](https://bugs.openjdk.java.net/browse/JDK-8253455) which is part of the effort to make records a final feature of the Java Language. The rest of the code has been published in [PR#290](https://github.com/openjdk/jdk/pull/290)

Thanks,
Vicente

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 gc)](https://github.com/vicente-romero-oracle/jdk/runs/1236237249)

### Issue
 * [JDK-8253455](https://bugs.openjdk.java.net/browse/JDK-8253455): Record Classes javax.lang.model changes


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to cd27384dc3e44b65c4792e40e88c2dbb7f51fe37


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/291/head:pull/291`
`$ git checkout pull/291`
