### PR TITLE
8253447: Remove buggy code introduced by 8249451

### DIFF
--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -529,7 +529,7 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
 #endif
 
   if (thread->frames_to_pop_failed_realloc() > 0 && exec_mode != Unpack_uncommon_trap) {
-    assert(thread->has_pending_exception(), "should have thrown OOME/Async");
+    assert(thread->has_pending_exception(), "should have thrown OOME");
     thread->set_exception_oop(thread->pending_exception());
     thread->clear_pending_exception();
     exec_mode = Unpack_exception;

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -528,7 +528,7 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   }
 #endif
 
-  if ((thread->has_pending_exception() || thread->frames_to_pop_failed_realloc() > 0) && exec_mode != Unpack_uncommon_trap) {
+  if (thread->frames_to_pop_failed_realloc() > 0 && exec_mode != Unpack_uncommon_trap) {
     assert(thread->has_pending_exception(), "should have thrown OOME/Async");
     thread->set_exception_oop(thread->pending_exception());
     thread->clear_pending_exception();


### PR DESCRIPTION
if ((thread->has_pending_exception() || thread->frames_to_pop_failed_realloc() > 0) && exec_mode != Unpack_uncommon_trap) {
    assert(thread->has_pending_exception(), "should have thrown OOME/Async");

introduced a buggy code checking, clearing pending exception and taking Unpack_exception route.

This can have consequences as the deopt entries may have additional logic depending on bci's. and the change introduced in 8249451 doesn't honor deopt exception checking and forward logic.
Thank you @fisk  for pointing the bug in the code.
Request for review.

/cc hotspot-compiler
/cc hotspot-runtime
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253447](https://bugs.openjdk.java.net/browse/JDK-8253447): Remove buggy code introduced by 8249451


### Reviewers
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/292/head:pull/292`
`$ git checkout pull/292`
