### PR TITLE
8253469: ARM32 Zero: replace usages of __sync_synchronize() with OrderAccess::fence

### DIFF
--- a/src/hotspot/os_cpu/bsd_zero/atomic_bsd_zero.hpp
+++ b/src/hotspot/os_cpu/bsd_zero/atomic_bsd_zero.hpp
@@ -219,7 +219,8 @@ inline T Atomic::PlatformXchg<4>::operator()(T volatile* dest,
   // All atomic operations are expected to be full memory barriers
   // (see atomic.hpp). However, __sync_lock_test_and_set is not
   // a full memory barrier, but an acquire barrier. Hence, this added
-  // barrier.
+  // barrier. Some platforms (notably ARM) have peculiarities with
+  // their barrier implementations, delegate it to OrderAccess.
   OrderAccess::fence();
   return result;
 #endif // M68K

--- a/src/hotspot/os_cpu/bsd_zero/atomic_bsd_zero.hpp
+++ b/src/hotspot/os_cpu/bsd_zero/atomic_bsd_zero.hpp
@@ -26,6 +26,7 @@
 #ifndef OS_CPU_BSD_ZERO_ATOMIC_BSD_ZERO_HPP
 #define OS_CPU_BSD_ZERO_ATOMIC_BSD_ZERO_HPP
 
+#include "orderAccess_bsd_zero.hpp"
 #include "runtime/os.hpp"
 
 // Implementation of class atomic
@@ -219,7 +220,7 @@ inline T Atomic::PlatformXchg<4>::operator()(T volatile* dest,
   // (see atomic.hpp). However, __sync_lock_test_and_set is not
   // a full memory barrier, but an acquire barrier. Hence, this added
   // barrier.
-  __sync_synchronize();
+  OrderAccess::fence();
   return result;
 #endif // M68K
 #endif // ARM
@@ -232,7 +233,7 @@ inline T Atomic::PlatformXchg<8>::operator()(T volatile* dest,
                                              atomic_memory_order order) const {
   STATIC_ASSERT(8 == sizeof(T));
   T result = __sync_lock_test_and_set (dest, exchange_value);
-  __sync_synchronize();
+  OrderAccess::fence();
   return result;
 }
 

--- a/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
@@ -75,7 +75,8 @@ inline T Atomic::PlatformXchg<4>::operator()(T volatile* dest,
   // All atomic operations are expected to be full memory barriers
   // (see atomic.hpp). However, __sync_lock_test_and_set is not
   // a full memory barrier, but an acquire barrier. Hence, this added
-  // barrier.
+  // barrier. Some platforms (notably ARM) have peculiarities with
+  // their barrier implementations, delegate it to OrderAccess.
   OrderAccess::fence();
   return result;
 }

--- a/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
@@ -26,6 +26,7 @@
 #ifndef OS_CPU_LINUX_ZERO_ATOMIC_LINUX_ZERO_HPP
 #define OS_CPU_LINUX_ZERO_ATOMIC_LINUX_ZERO_HPP
 
+#include "orderAccess_linux_zero.hpp"
 #include "runtime/os.hpp"
 
 // Implementation of class atomic
@@ -75,7 +76,7 @@ inline T Atomic::PlatformXchg<4>::operator()(T volatile* dest,
   // (see atomic.hpp). However, __sync_lock_test_and_set is not
   // a full memory barrier, but an acquire barrier. Hence, this added
   // barrier.
-  __sync_synchronize();
+  OrderAccess::fence();
   return result;
 }
 
@@ -86,7 +87,7 @@ inline T Atomic::PlatformXchg<8>::operator()(T volatile* dest,
                                              atomic_memory_order order) const {
   STATIC_ASSERT(8 == sizeof(T));
   T result = __sync_lock_test_and_set (dest, exchange_value);
-  __sync_synchronize();
+  OrderAccess::fence();
   return result;
 }
 


### PR DESCRIPTION
In `atomic_bsd_zero.hpp` and `atomic_linux_zero.hpp` there are uses of __sync_synchronize(). However, `orderAccess_*_zero.hpp` calls the kernel helper, because:

```
/*
 * ARM Kernel helper for memory barrier.
 * Using __asm __volatile ("":::"memory") does not work reliable on ARM
 * and gcc __sync_synchronize(); implementation does not use the kernel
 * helper for all gcc versions so it is unreliable to use as well.
 */
```

We need to clean this up to use `OrderAccess::fence()` to gain access to the kernel helper.

This depends on JDK-8253464 being fixed first.

Attention @bulasevich.

Testing:
 - [x] ARM32 Zero jcstress
 - [x] Mac OS x86_64 Zero jcstress

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253469](https://bugs.openjdk.java.net/browse/JDK-8253469): ARM32 Zero: replace usages of __sync_synchronize() with OrderAccess::fence


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/298/head:pull/298`
`$ git checkout pull/298`
