### PR TITLE
8253464: ARM32 Zero: atomic_copy64 is incorrect, breaking volatile stores

### DIFF
--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.hpp
@@ -68,15 +68,23 @@
                   : "=&f"(tmp), "=Q"(*(volatile double*)dst)
                   : "Q"(*(volatile double*)src));
 #elif defined(__ARM_ARCH_7A__)
-    // Note that a ldrexd + clrex combination is only needed for
-    // correctness on the OS level (context-switches). In this
-    // case, clrex *may* be beneficial for performance. For now
-    // don't bother with clrex as this is Zero.
-    jlong tmp;
-    asm volatile ("ldrexd  %0, [%1]\n"
-                  : "=r"(tmp)
-                  : "r"(src), "m"(src));
-    *(jlong *) dst = tmp;
+    // The only way to perform the atomic 64-bit load store 
+    // is to use ldrexd/strexd for both reads and writes.
+    // For store, we need to have the matching (fake) load first.
+    // Put clrex between exclusive ops on src and dst for clarity.
+    uint64_t tmp_r, tmp_w;
+    uint32_t flag_w;
+    asm volatile ("ldrexd %[tmp_r], [%[src]]\n"
+                  "clrex\n"
+                  "1: \n"
+                  "ldrexd %[tmp_w], [%[dst]]\n"
+                  "strexd %[flag_w], %[tmp_r], [%[dst]]\n"
+                  "cmp    %[flag_w], 0\n"
+                  "bne    1b\n"
+                  : [tmp_r] "=&r" (tmp_r), [tmp_w] "=&r" (tmp_r),
+                    [flag_w] "=&r" (flag_w)
+                  : [src] "r" (src), [dst] "r" (dst)
+                  : "cc", "memory");
 #else
     *(jlong *) dst = *(const jlong *) src;
 #endif

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.hpp
@@ -81,7 +81,7 @@
                   "strexd %[flag_w], %[tmp_r], [%[dst]]\n"
                   "cmp    %[flag_w], 0\n"
                   "bne    1b\n"
-                  : [tmp_r] "=&r" (tmp_r), [tmp_w] "=&r" (tmp_r),
+                  : [tmp_r] "=&r" (tmp_r), [tmp_w] "=&r" (tmp_w),
                     [flag_w] "=&r" (flag_w)
                   : [src] "r" (src), [dst] "r" (dst)
                   : "cc", "memory");

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.hpp
@@ -68,7 +68,7 @@
                   : "=&f"(tmp), "=Q"(*(volatile double*)dst)
                   : "Q"(*(volatile double*)src));
 #elif defined(__ARM_ARCH_7A__)
-    // The only way to perform the atomic 64-bit load store 
+    // The only way to perform the atomic 64-bit load/store
     // is to use ldrexd/strexd for both reads and writes.
     // For store, we need to have the matching (fake) load first.
     // Put clrex between exclusive ops on src and dst for clarity.
@@ -76,7 +76,7 @@
     uint32_t flag_w;
     asm volatile ("ldrexd %[tmp_r], [%[src]]\n"
                   "clrex\n"
-                  "1: \n"
+                  "1:\n"
                   "ldrexd %[tmp_w], [%[dst]]\n"
                   "strexd %[flag_w], %[tmp_r], [%[dst]]\n"
                   "cmp    %[flag_w], 0\n"


### PR DESCRIPTION
There is a regression introduced by addition of ARMv7-specific block by JDK-8211387. It readily manifests as crash during jcstress initialization, and investigation points at broken volatile stores. Reverting JDK-8211387 from head JDK makes ARM32 start and run jcstress.

The underlying reason seems to be the half-done `atomic_copy64`: it does the load with exclusive load, but then defers to the C++ store. Somewhere during handing over the value from the asm load to C++ store and/or C++ store itself, we garble the value. The way out is to implement the whole thing in asm. 

Also see `StubGenerator::generate_atomic_load_long` and `StubGenerator::generate_atomic_store_long` in `stubGenerator_arm.cpp`, that do roughly the same thing and were the basis for this implementation.

Attention @theRealAph, @bulasevich.

Testing:
 - [x] ARM32 Linux zero release jcstress run

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253464](https://bugs.openjdk.java.net/browse/JDK-8253464): ARM32 Zero: atomic_copy64 is incorrect, breaking volatile stores


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/299/head:pull/299`
`$ git checkout pull/299`
