### PR TITLE
8253457: Remove unimplemented register stack functions

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.hpp
+++ b/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2013 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,16 +35,6 @@
   frame pd_last_frame();
 
  public:
-  void set_base_of_stack_pointer(intptr_t* base_sp) {}
-  intptr_t* base_of_stack_pointer()   { return NULL; }
-  void record_base_of_stack_pointer() {}
-
-  // These routines are only used on cpu architectures that
-  // have separate register stacks (Itanium).
-  static bool register_stack_overflow() { return false; }
-  static void enable_register_stack_guard() {}
-  static void disable_register_stack_guard() {}
-
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
                                            bool isInJava);
 

--- a/src/hotspot/os_cpu/bsd_x86/thread_bsd_x86.hpp
+++ b/src/hotspot/os_cpu/bsd_x86/thread_bsd_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,17 +37,8 @@
   intptr_t* last_Java_fp()                       { return _anchor.last_Java_fp(); }
   void  set_last_Java_fp(intptr_t* fp)           { _anchor.set_last_Java_fp(fp);   }
 
-  void set_base_of_stack_pointer(intptr_t* base_sp) {
-  }
-
   static ByteSize last_Java_fp_offset()          {
     return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::last_Java_fp_offset();
-  }
-
-  intptr_t* base_of_stack_pointer() {
-    return NULL;
-  }
-  void record_base_of_stack_pointer() {
   }
 
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
@@ -58,12 +49,5 @@
 
 private:
   bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
-public:
-
-  // These routines are only used on cpu architectures that
-  // have separate register stacks (Itanium).
-  static bool register_stack_overflow() { return false; }
-  static void enable_register_stack_guard() {}
-  static void disable_register_stack_guard() {}
 
 #endif // OS_CPU_BSD_X86_THREAD_BSD_X86_HPP

--- a/src/hotspot/os_cpu/bsd_zero/thread_bsd_zero.hpp
+++ b/src/hotspot/os_cpu/bsd_zero/thread_bsd_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008, 2009, 2010 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -61,15 +61,6 @@
   }
 
  public:
-  void record_base_of_stack_pointer() {
-    assert(top_zero_frame() == NULL, "junk on stack prior to Java call");
-  }
-  void set_base_of_stack_pointer(intptr_t* base_sp) {
-    assert(base_sp == NULL, "should be");
-    assert(top_zero_frame() == NULL, "junk on stack after Java call");
-  }
-
- public:
   void set_last_Java_frame() {
     set_last_Java_frame(top_zero_frame(), zero_stack()->sp());
   }
@@ -109,11 +100,5 @@
     ShouldNotCallThis();
     return false;
   }
-
-  // These routines are only used on cpu architectures that
-  // have separate register stacks (Itanium).
-  static bool register_stack_overflow() { return false; }
-  static void enable_register_stack_guard() {}
-  static void disable_register_stack_guard() {}
 
 #endif // OS_CPU_BSD_ZERO_THREAD_BSD_ZERO_HPP

--- a/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -48,17 +48,8 @@
   intptr_t* last_Java_fp()                       { return _anchor.last_Java_fp(); }
   void  set_last_Java_fp(intptr_t* fp)           { _anchor.set_last_Java_fp(fp);   }
 
-  void set_base_of_stack_pointer(intptr_t* base_sp) {
-  }
-
   static ByteSize last_Java_fp_offset()          {
     return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::last_Java_fp_offset();
-  }
-
-  intptr_t* base_of_stack_pointer() {
-    return NULL;
-  }
-  void record_base_of_stack_pointer() {
   }
 
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
@@ -70,11 +61,5 @@ private:
 public:
 
   static Thread *aarch64_get_thread_helper();
-
-  // These routines are only used on cpu architectures that
-  // have separate register stacks (Itanium).
-  static bool register_stack_overflow() { return false; }
-  static void enable_register_stack_guard() {}
-  static void disable_register_stack_guard() {}
 
 #endif // OS_CPU_LINUX_AARCH64_THREAD_LINUX_AARCH64_HPP

--- a/src/hotspot/os_cpu/linux_arm/thread_linux_arm.hpp
+++ b/src/hotspot/os_cpu/linux_arm/thread_linux_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,24 +40,8 @@
   frame pd_last_frame();
 
  public:
-  intptr_t* last_Java_fp()                       { return _anchor.last_Java_fp(); }
-  void  set_last_Java_fp(intptr_t* fp)           { _anchor.set_last_Java_fp(fp);  }
-  void  set_last_Java_pc(address pc)             { _anchor.set_last_Java_pc(pc);  }
-
   static ByteSize last_Java_fp_offset()          {
     return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::last_Java_fp_offset();
-  }
-
-  void set_base_of_stack_pointer(intptr_t* base_sp) {
-    // Nothing to do
-  }
-
-  intptr_t* base_of_stack_pointer() {
-    return NULL;
-  }
-
-  void record_base_of_stack_pointer() {
-    // Nothing to do
   }
 
   static ByteSize heap_top_addr_offset()         { return byte_offset_of(JavaThread, _heap_top_addr); }
@@ -77,11 +61,5 @@ public:
 private:
   bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
 public:
-
-  // These routines are only used on cpu architectures that
-  // have separate register stacks (Itanium).
-  static bool register_stack_overflow() { return false; }
-  static void enable_register_stack_guard() {}
-  static void disable_register_stack_guard() {}
 
 #endif // OS_CPU_LINUX_ARM_THREAD_LINUX_ARM_HPP

--- a/src/hotspot/os_cpu/linux_arm/thread_linux_arm.hpp
+++ b/src/hotspot/os_cpu/linux_arm/thread_linux_arm.hpp
@@ -40,6 +40,10 @@
   frame pd_last_frame();
 
  public:
+  intptr_t* last_Java_fp()                       { return _anchor.last_Java_fp(); }
+  void  set_last_Java_fp(intptr_t* fp)           { _anchor.set_last_Java_fp(fp);  }
+  void  set_last_Java_pc(address pc)             { _anchor.set_last_Java_pc(pc);  }
+
   static ByteSize last_Java_fp_offset()          {
     return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::last_Java_fp_offset();
   }

--- a/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.hpp
+++ b/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2013 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -36,16 +36,6 @@
   frame pd_last_frame();
 
  public:
-
-  void set_base_of_stack_pointer(intptr_t* base_sp) {}
-  intptr_t* base_of_stack_pointer() { return NULL; }
-  void record_base_of_stack_pointer() {}
-
-  // These routines are only used on cpu architectures that
-  // have separate register stacks (Itanium).
-  static bool register_stack_overflow() { return false; }
-  static void enable_register_stack_guard() {}
-  static void disable_register_stack_guard() {}
 
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava);
 

--- a/src/hotspot/os_cpu/linux_s390/thread_linux_s390.hpp
+++ b/src/hotspot/os_cpu/linux_s390/thread_linux_s390.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -36,16 +36,6 @@
   frame pd_last_frame();
 
  public:
-  void set_base_of_stack_pointer(intptr_t* base_sp) {}
-  intptr_t* base_of_stack_pointer() { return NULL; }
-  void record_base_of_stack_pointer() {}
-
-  // These routines are only used on cpu architectures that
-  // have separate register stacks (Itanium).
-  static bool register_stack_overflow() { return false; }
-  static void enable_register_stack_guard() {}
-  static void disable_register_stack_guard() {}
-
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava);
 
   bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava);

--- a/src/hotspot/os_cpu/linux_x86/thread_linux_x86.hpp
+++ b/src/hotspot/os_cpu/linux_x86/thread_linux_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,17 +37,8 @@
   intptr_t* last_Java_fp()                       { return _anchor.last_Java_fp(); }
   void  set_last_Java_fp(intptr_t* fp)           { _anchor.set_last_Java_fp(fp);   }
 
-  void set_base_of_stack_pointer(intptr_t* base_sp) {
-  }
-
   static ByteSize last_Java_fp_offset()          {
     return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::last_Java_fp_offset();
-  }
-
-  intptr_t* base_of_stack_pointer() {
-    return NULL;
-  }
-  void record_base_of_stack_pointer() {
   }
 
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
@@ -57,11 +48,5 @@
 private:
   bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
 public:
-
-  // These routines are only used on cpu architectures that
-  // have separate register stacks (Itanium).
-  static bool register_stack_overflow() { return false; }
-  static void enable_register_stack_guard() {}
-  static void disable_register_stack_guard() {}
 
 #endif // OS_CPU_LINUX_X86_THREAD_LINUX_X86_HPP

--- a/src/hotspot/os_cpu/linux_zero/thread_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/thread_linux_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008, 2009, 2010 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -61,15 +61,6 @@
   }
 
  public:
-  void record_base_of_stack_pointer() {
-    assert(top_zero_frame() == NULL, "junk on stack prior to Java call");
-  }
-  void set_base_of_stack_pointer(intptr_t* base_sp) {
-    assert(base_sp == NULL, "should be");
-    assert(top_zero_frame() == NULL, "junk on stack after Java call");
-  }
-
- public:
   void set_last_Java_frame() {
     set_last_Java_frame(top_zero_frame(), zero_stack()->sp());
   }
@@ -116,12 +107,5 @@
     ShouldNotCallThis();
     return false; // silence compile warning
   }
-
-
-  // These routines are only used on cpu architectures that
-  // have separate register stacks (Itanium).
-  static bool register_stack_overflow() { return false; }
-  static void enable_register_stack_guard() {}
-  static void disable_register_stack_guard() {}
 
 #endif // OS_CPU_LINUX_ZERO_THREAD_LINUX_ZERO_HPP

--- a/src/hotspot/os_cpu/windows_x86/thread_windows_x86.hpp
+++ b/src/hotspot/os_cpu/windows_x86/thread_windows_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,15 +44,9 @@
   intptr_t* last_Java_fp()                       { return _anchor.last_Java_fp(); }
   void  set_last_Java_fp(intptr_t* fp)           { _anchor.set_last_Java_fp(fp);   }
 
-  void set_base_of_stack_pointer(intptr_t* base_sp)  {}
-
-
   static ByteSize last_Java_fp_offset()          {
     return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::last_Java_fp_offset();
   }
-
-  intptr_t* base_of_stack_pointer()              { return NULL; }
-  void record_base_of_stack_pointer()            {}
 
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
     bool isInJava);
@@ -63,12 +57,5 @@
   static ByteSize windows_saved_rdi_offset() { return byte_offset_of(JavaThread, _windows_saved_rdi); }
 private:
   bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
-
- public:
-  // These routines are only used on cpu architectures that
-  // have separate register stacks (Itanium).
-  static bool register_stack_overflow() { return false; }
-  static void enable_register_stack_guard() {}
-  static void disable_register_stack_guard() {}
 
 #endif // OS_CPU_WINDOWS_X86_THREAD_WINDOWS_X86_HPP

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -108,10 +108,6 @@ JavaCallWrapper::JavaCallWrapper(const methodHandle& callee_method, Handle recei
   if(clear_pending_exception) {
     _thread->clear_pending_exception();
   }
-
-  if (_anchor.last_Java_sp() == NULL) {
-    _thread->record_base_of_stack_pointer();
-  }
 }
 
 
@@ -125,11 +121,6 @@ JavaCallWrapper::~JavaCallWrapper() {
   _thread->frame_anchor()->zap();
 
   debug_only(_thread->dec_java_call_counter());
-
-  if (_anchor.last_Java_sp() == NULL) {
-    _thread->set_base_of_stack_pointer(NULL);
-  }
-
 
   // Old thread-local info. has been restored. We are not back in the VM.
   ThreadStateTransition::transition_from_java(_thread, _thread_in_vm);

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1807,13 +1807,6 @@ bool JavaThread::reguard_stack(address cur_sp) {
     return true; // Stack already guarded or guard pages not needed.
   }
 
-  if (register_stack_overflow()) {
-    // For those architectures which have separate register and
-    // memory stacks, we must check the register stack to see if
-    // it has overflowed.
-    return false;
-  }
-
   // Java code never executes within the yellow zone: the latter is only
   // there to provoke an exception during stack banging.  If java code
   // is executing there, either StackShadowPages should be larger, or
@@ -1941,13 +1934,6 @@ void JavaThread::pre_run() {
 void JavaThread::run() {
   // initialize thread-local alloc buffer related fields
   this->initialize_tlab();
-
-  // Used to test validity of stack trace backs.
-  // This can't be moved into pre_run() else we invalidate
-  // the requirement that thread_main_inner is lower on
-  // the stack. Consequently all the initialization logic
-  // stays here in run() rather than pre_run().
-  this->record_base_of_stack_pointer();
 
   this->create_stack_guard_pages();
 
@@ -2794,7 +2780,6 @@ void JavaThread::enable_stack_reserved_zone() {
   } else {
     warning("Attempt to guard stack reserved zone failed.");
   }
-  enable_register_stack_guard();
 }
 
 void JavaThread::disable_stack_reserved_zone() {
@@ -2812,7 +2797,6 @@ void JavaThread::disable_stack_reserved_zone() {
   } else {
     warning("Attempt to unguard stack reserved zone failed.");
   }
-  disable_register_stack_guard();
 }
 
 void JavaThread::enable_stack_yellow_reserved_zone() {
@@ -2831,7 +2815,6 @@ void JavaThread::enable_stack_yellow_reserved_zone() {
   } else {
     warning("Attempt to guard stack yellow zone failed.");
   }
-  enable_register_stack_guard();
 }
 
 void JavaThread::disable_stack_yellow_reserved_zone() {
@@ -2850,7 +2833,6 @@ void JavaThread::disable_stack_yellow_reserved_zone() {
   } else {
     warning("Attempt to unguard stack yellow zone failed.");
   }
-  disable_register_stack_guard();
 }
 
 void JavaThread::enable_stack_red_zone() {


### PR DESCRIPTION
Please review removed functions left over from Itanium.

Ran tier1 testing on Oracle platforms (linux-x64, macos-x64, windows-x64 and linux-aarch64) and built on linux-arm32,linux-ppc64le-debug,linux-s390x-debug,linux-x64-zero.

Thanks,
Coleen
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253457](https://bugs.openjdk.java.net/browse/JDK-8253457): Remove unimplemented register stack functions


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/300/head:pull/300`
`$ git checkout pull/300`
