### PR TITLE
8253053: Javadoc clean up in Authenticator and BasicAuthenicator

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
@@ -51,8 +51,6 @@ public abstract class Authenticator {
         protected Result () {}
     }
 
-
-
     /**
      * Indicates an authentication failure. The authentication
      * attempt has completed.
@@ -64,7 +62,7 @@ public abstract class Authenticator {
         /**
          * Creates a {@code Failure} instance with given response code.
          *
-         * @param responseCode The response code to associate with this
+         * @param responseCode the response code to associate with this
          *                     {@code Failure} instance
          */
         public Failure (int responseCode) {
@@ -74,7 +72,7 @@ public abstract class Authenticator {
         /**
          * returns the response code to send to the client
          *
-         * @return The response code associated with this {@code Failure} instance
+         * @return the response code associated with this {@code Failure} instance
          */
         public int getResponseCode() {
             return responseCode;
@@ -92,7 +90,7 @@ public abstract class Authenticator {
         /**
          * Creates a {@code Success} instance with given {@code Principal}.
          *
-         * @param p The authenticated user you wish to set as Principal
+         * @param p the authenticated user you wish to set as {@code Principal}
          */
         public Success (HttpPrincipal p) {
             principal = p;
@@ -100,7 +98,7 @@ public abstract class Authenticator {
         /**
          * returns the authenticated user Principal
          *
-         * @return The {@code Principal} instance associated with the authenticated user
+         * @return the {@code Principal} instance associated with the authenticated user
          *
          */
         public HttpPrincipal getPrincipal() {
@@ -122,7 +120,7 @@ public abstract class Authenticator {
         /**
          * Creates a {@code Retry} instance with given response code.
          *
-         * @param responseCode The response code to associate with this
+         * @param responseCode the response code to associate with this
          *                     {@code Retry} instance
          */
         public Retry (int responseCode) {
@@ -132,7 +130,7 @@ public abstract class Authenticator {
         /**
          * returns the response code to send to the client
          *
-         * @return The response code associated with this {@code Retry} instance
+         * @return the response code associated with this {@code Retry} instance
          */
         public int getResponseCode() {
             return responseCode;

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
@@ -143,14 +143,14 @@ public abstract class Authenticator {
      * must return a {@link Failure}, {@link Success} or {@link Retry} object as appropriate:
      * <ul>
      *     <li> {@code Failure} means the authentication has completed, but has
-     *     failed due to invalid credentials.</li>
+     *     failed due to invalid credentials.
      *     <li> {@code Success} means that the authentication has succeeded,
      *     and a {@code Principal} object representing the user can be retrieved
-     *     by calling {@link Success#getPrincipal()}.</li>
+     *     by calling {@link Success#getPrincipal()}.
      *     <li> {@code Retry} means that another HTTP {@linkplain HttpExchange exchange}
      *     is required. Any response headers needing to be sent back to the client are set
      *     in the given {@code HttpExchange}. The response code to be returned must be
-     *     provided in the {@code Retry} object. {@code Retry} may occur multiple times.</li>
+     *     provided in the {@code Retry} object. {@code Retry} may occur multiple times.
      * <ul/>
      *
      * @param exch the {@code HttpExchange} upon which authenticate is called

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/Authenticator.java
@@ -41,7 +41,7 @@ public abstract class Authenticator {
     protected Authenticator () { }
 
     /**
-     * Base class for return type from authenticate() method
+     * Base class for return type from {@link #authenticate(HttpExchange)} method.
      */
     public abstract static class Result {
 
@@ -70,7 +70,7 @@ public abstract class Authenticator {
         }
 
         /**
-         * returns the response code to send to the client
+         * Returns the response code to send to the client.
          *
          * @return the response code associated with this {@code Failure} instance
          */
@@ -81,8 +81,8 @@ public abstract class Authenticator {
 
     /**
      * Indicates an authentication has succeeded and the
-     * authenticated user principal can be acquired by calling
-     * getPrincipal().
+     * authenticated user {@linkplain HttpPrincipal principal} can be acquired by calling
+     * {@link #getPrincipal()}.
      */
     public static class Success extends Result {
         private HttpPrincipal principal;
@@ -95,8 +95,9 @@ public abstract class Authenticator {
         public Success (HttpPrincipal p) {
             principal = p;
         }
+
         /**
-         * returns the authenticated user Principal
+         * Returns the authenticated user {@code Principal}.
          *
          * @return the {@code Principal} instance associated with the authenticated user
          *
@@ -109,9 +110,9 @@ public abstract class Authenticator {
     /**
      * Indicates an authentication must be retried. The
      * response code to be sent back is as returned from
-     * getResponseCode(). The Authenticator must also have
-     * set any necessary response headers in the given HttpExchange
-     * before returning this Retry object.
+     * {@link #getResponseCode()}. The {@code Authenticator} must also have
+     * set any necessary response headers in the given {@link HttpExchange}
+     * before returning this {@code Retry} object.
      */
     public static class Retry extends Result {
 
@@ -128,7 +129,7 @@ public abstract class Authenticator {
         }
 
         /**
-         * returns the response code to send to the client
+         * Returns the response code to send to the client.
          *
          * @return the response code associated with this {@code Retry} instance
          */
@@ -138,23 +139,22 @@ public abstract class Authenticator {
     }
 
     /**
-     * called to authenticate each incoming request. The implementation
-     * must return a Failure, Success or Retry object as appropriate :-
-     * <p>
-     * Failure means the authentication has completed, but has failed
-     * due to invalid credentials.
-     * <p>
-     * Sucess means that the authentication
-     * has succeeded, and a Principal object representing the user
-     * can be retrieved by calling Sucess.getPrincipal() .
-     * <p>
-     * Retry means that another HTTP exchange is required. Any response
-     * headers needing to be sent back to the client are set in the
-     * given HttpExchange. The response code to be returned must be provided
-     * in the Retry object. Retry may occur multiple times.
+     * Called to authenticate each incoming request. The implementation
+     * must return a {@link Failure}, {@link Success} or {@link Retry} object as appropriate:
+     * <ul>
+     *     <li> {@code Failure} means the authentication has completed, but has
+     *     failed due to invalid credentials.</li>
+     *     <li> {@code Success} means that the authentication has succeeded,
+     *     and a {@code Principal} object representing the user can be retrieved
+     *     by calling {@link Success#getPrincipal()}.</li>
+     *     <li> {@code Retry} means that another HTTP {@linkplain HttpExchange exchange}
+     *     is required. Any response headers needing to be sent back to the client are set
+     *     in the given {@code HttpExchange}. The response code to be returned must be
+     *     provided in the {@code Retry} object. {@code Retry} may occur multiple times.</li>
+     * <ul/>
      *
-     * @param exch The HttpExchange upon which authenticate is called
-     * @return The result
+     * @param exch the {@code HttpExchange} upon which authenticate is called
+     * @return the result
      */
     public abstract Result authenticate (HttpExchange exch);
 }

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
@@ -133,7 +133,7 @@ public abstract class BasicAuthenticator extends Authenticator {
     /**
      * Called for each incoming request to verify the
      * given name and password in the context of this
-     * Authenticator's realm. Any caching of credentials
+     * authenticator's realm. Any caching of credentials
      * must be done by the implementation of this method.
      *
      * @param username the username from the request

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
@@ -45,7 +45,7 @@ public abstract class BasicAuthenticator extends Authenticator {
     private final boolean isUTF8;
 
     /**
-     * Creates a BasicAuthenticator for the given HTTP realm.
+     * Creates a {@code BasicAuthenticator} for the given HTTP realm.
      * The Basic authentication credentials (username and password) are decoded
      * using the platform's {@link Charset#defaultCharset() default character set}.
      *
@@ -66,8 +66,8 @@ public abstract class BasicAuthenticator extends Authenticator {
      * communicated to the client, and therefore more likely to be used also
      * by the client.
      *
-     * @param realm The HTTP Basic authentication realm
-     * @param charset The Charset to decode incoming credentials from the client
+     * @param realm the HTTP Basic authentication realm
+     * @param charset the {@code Charset} to decode incoming credentials from the client
      * @throws NullPointerException if realm or charset are {@code null}
      * @throws IllegalArgumentException if realm is an empty string
      */

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
@@ -49,7 +49,7 @@ public abstract class BasicAuthenticator extends Authenticator {
      * The Basic authentication credentials (username and password) are decoded
      * using the platform's {@link Charset#defaultCharset() default character set}.
      *
-     * @param realm The HTTP Basic authentication realm
+     * @param realm the HTTP Basic authentication realm
      * @throws NullPointerException if realm is {@code null}
      * @throws IllegalArgumentException if realm is an empty string
      */
@@ -58,7 +58,7 @@ public abstract class BasicAuthenticator extends Authenticator {
     }
 
     /**
-     * Creates a BasicAuthenticator for the given HTTP realm and using the
+     * Creates a {@code BasicAuthenticator} for the given HTTP realm and using the
      * given {@link Charset} to decode the Basic authentication credentials
      * (username and password).
      *
@@ -81,8 +81,9 @@ public abstract class BasicAuthenticator extends Authenticator {
     }
 
     /**
-     * returns the realm this BasicAuthenticator was created with
-     * @return the authenticator's realm string.
+     * Returns the realm this {@code BasicAuthenticator} was created with.
+     *
+     * @return the authenticator's realm string
      */
     public String getRealm () {
         return realm;
@@ -130,14 +131,14 @@ public abstract class BasicAuthenticator extends Authenticator {
     }
 
     /**
-     * called for each incoming request to verify the
+     * Called for each incoming request to verify the
      * given name and password in the context of this
      * Authenticator's realm. Any caching of credentials
-     * must be done by the implementation of this method
+     * must be done by the implementation of this method.
+     *
      * @param username the username from the request
      * @param password the password from the request
-     * @return <code>true</code> if the credentials are valid,
-     *    <code>false</code> otherwise.
+     * @return {@code true} if the credentials are valid, {@code false} otherwise
      */
     public abstract boolean checkCredentials (String username, String password);
 }


### PR DESCRIPTION
Hi,

Could someone please review my doc-only fix for JDK-8253053 - 'Javadoc clean up in Authenticator and BasicAuthenicator' ?

This fix is set of formatting changes intended to clean up the javadoc of the following classes :

`com.sun.net.httpserver.Authenticator`
`com.sun.net.httpserver.Authenticator.Result`
`com.sun.net.httpserver.Authenticator.Failure`
`com.sun.net.httpserver.Authenticator.Success`
`com.sun.net.httpserver.Authenticator.Retry`

`com.sun.net.httpserver.BasicAuthenticator` 

This issue is a sub-task of [JDK-8252822](https://bugs.openjdk.java.net/browse/JDK-8252822)

Kind regards,
Patrick

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253053](https://bugs.openjdk.java.net/browse/JDK-8253053): Javadoc clean up in Authenticator and BasicAuthenicator


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to 5d9004612a60da62af3b30502ef2a1d8dfce2826
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/301/head:pull/301`
`$ git checkout pull/301`
