### PR TITLE
8253476: TestUseContainerSupport.java fails on some Linux kernels w/o swap limit capabilities

### DIFF
--- a/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
+++ b/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
@@ -60,8 +60,7 @@ public class TestUseContainerSupport {
         DockerRunOptions opts =
                 new DockerRunOptions(imageName, "/jdk/bin/java", "CheckUseContainerSupport");
         opts.addClassOptions(Boolean.valueOf(useContainerSupport).toString());
-        opts.addDockerOpts("--memory", "200m")
-            .addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/");
+        opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/");
         if (useContainerSupport) {
             opts.addJavaOpts("-XX:+UseContainerSupport");
         } else {


### PR DESCRIPTION
Please review this small change to remove "--memory 200m" option from TestUseContainerSupport.java.  This can cause test failures on systems where swap accounting is disabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253476](https://bugs.openjdk.java.net/browse/JDK-8253476): TestUseContainerSupport.java fails on some Linux kernels w/o swap limit capabilities


### Reviewers
 * [Bob Vandette](https://openjdk.java.net/census#bobv) (@bobvandette - Committer)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/303/head:pull/303`
`$ git checkout pull/303`
