### PR TITLE
8253481: Shenandoah: ShenandoahConcurrentRootScanner::oops_do() should always use _claim_strong for CLDClosure

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
@@ -169,7 +169,7 @@ ShenandoahConcurrentRootScanner<CONCURRENT>::~ShenandoahConcurrentRootScanner() 
 template <bool CONCURRENT>
 void ShenandoahConcurrentRootScanner<CONCURRENT>::oops_do(OopClosure* oops, uint worker_id) {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  CLDToOopClosure clds_cl(oops, CONCURRENT ? ClassLoaderData::_claim_strong : ClassLoaderData::_claim_none);
+  CLDToOopClosure clds_cl(oops, ClassLoaderData::_claim_strong);
   _vm_roots.oops_do(oops, worker_id);
 
   if (!heap->unload_classes()) {


### PR DESCRIPTION
_claim_none should only be used for single thread scanning, regardless concurrent or not.

 ShenandoahConcurrentRootScanner declares ShenandoahClassLoaderDataRoots multi-thread capable, so should always use _claim_strong for scanning CLDG.

This is not a correctness bug. _claim_none results CLDG to be scanned by every worker.

Test:
  - [x] hotspot_gc_shenandoah
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8253481](https://bugs.openjdk.java.net/browse/JDK-8253481): Shenandoah: ShenandoahConcurrentRootScanner::oops_do() should always use _claim_strong for CLDClosure


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/304/head:pull/304`
`$ git checkout pull/304`
