### PR TITLE
8253492: Miss comma after second copyright year in FDBigInteger.java

### DIFF
--- a/src/java.base/share/classes/jdk/internal/math/FDBigInteger.java
+++ b/src/java.base/share/classes/jdk/internal/math/FDBigInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/misc/CDS.java
+++ b/src/java.base/share/classes/jdk/internal/misc/CDS.java
@@ -44,7 +44,7 @@ public class CDS {
     public static native void defineArchivedModules(ClassLoader platformLoader, ClassLoader systemLoader);
 
     /**
-     * @return a predictable "random" seed derived from the VM's build ID and version,
+     * Returns a predictable "random" seed derived from the VM's build ID and version,
      * to be used by java.util.ImmutableCollections to ensure that archived
      * ImmutableCollections are always sorted the same order for the same VM build.
      */


### PR DESCRIPTION
In patch for jdk-8253208, a comma missed after copyright year in src/java.base/share/classes/jdk/internal/math/FDBigInteger.java. Also changed "@return" to "Returns" in the comment for CDS.getRandomSeedForDumping to keep consistent with others.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253492](https://bugs.openjdk.java.net/browse/JDK-8253492): Miss comma after second copyright year in FDBigInteger.java


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/306/head:pull/306`
`$ git checkout pull/306`
