### PR TITLE
8253493: Shenandoah: Remove ShenandoahSerialRoot definition

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
@@ -34,21 +34,6 @@
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "memory/iterator.hpp"
 
-class ShenandoahSerialRoot {
-public:
-  typedef void (*OopsDo)(OopClosure*);
-private:
-  ShenandoahSharedFlag                   _claimed;
-  const OopsDo                           _oops_do;
-  const ShenandoahPhaseTimings::Phase    _phase;
-  const ShenandoahPhaseTimings::ParPhase _par_phase;
-
-public:
-  ShenandoahSerialRoot(OopsDo oops_do,
-          ShenandoahPhaseTimings::Phase phase, ShenandoahPhaseTimings::ParPhase par_phase);
-  void oops_do(OopClosure* cl, uint worker_id);
-};
-
 class ShenandoahWeakSerialRoot {
   typedef void (*WeakOopsDo)(BoolObjectClosure*, OopClosure*);
 private:


### PR DESCRIPTION
JDK-8247281 removed ShenandoahSerialRoot's implementation and uses, but not its definition.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253493](https://bugs.openjdk.java.net/browse/JDK-8253493): Shenandoah: Remove ShenandoahSerialRoot definition


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/307/head:pull/307`
`$ git checkout pull/307`
