### PR TITLE
8251999: remove usage of PropertyResolvingWrapper in vmTestbase/nsk/aod

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/AttachProvider/AttachProvider01/AttachProvider01.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/AttachProvider/AttachProvider01/AttachProvider01.java
@@ -35,22 +35,24 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.aod.AttachProvider.AttachProvider01.AttachProvider01
- *        nsk.share.aod.DummyTargetApplication
- * @run main/othervm -XX:+UsePerfData PropertyResolvingWrapper
+ * @build nsk.share.aod.DummyTargetApplication
+ * @run main/othervm
+ *      -XX:+UsePerfData
  *      nsk.aod.AttachProvider.AttachProvider01.AttachProvider01
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.DummyTargetApplication
  */
 
 package nsk.aod.AttachProvider.AttachProvider01;
 
-import java.util.List;
-import com.sun.tools.attach.*;
+import com.sun.tools.attach.VirtualMachine;
+import com.sun.tools.attach.VirtualMachineDescriptor;
 import com.sun.tools.attach.spi.AttachProvider;
-import nsk.share.aod.*;
+import nsk.share.aod.AODTestRunner;
 import nsk.share.test.TestUtils;
+
+import java.util.List;
 
 /*
  * Test checks method AttachProvider.listVirtualMachines()
@@ -63,7 +65,7 @@ public class AttachProvider01 extends AODTestRunner {
         super(args);
     }
 
-    public void doTestActions(String targetVMId) throws Throwable {
+    public void doTestActions(String targetVMId) {
         String currentVMId = getCurrentVMId();
 
         for (AttachProvider provider : AttachProvider.providers()) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/AttachProvider/AttachProvider02/AttachProvider02.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/AttachProvider/AttachProvider02/AttachProvider02.java
@@ -37,23 +37,25 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.aod.AttachProvider.AttachProvider02.AttachProvider02
- *        nsk.share.aod.DummyTargetApplication
- * @run main/othervm -Djdk.attach.allowAttachSelf -XX:+UsePerfData
- *      PropertyResolvingWrapper
+ * @build nsk.share.aod.DummyTargetApplication
+ * @run main/othervm
+ *      -Djdk.attach.allowAttachSelf
+ *      -XX:+UsePerfData
  *      nsk.aod.AttachProvider.AttachProvider02.AttachProvider02
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.DummyTargetApplication
  */
 
 package nsk.aod.AttachProvider.AttachProvider02;
 
-import java.util.Properties;
-import com.sun.tools.attach.*;
+import com.sun.tools.attach.VirtualMachine;
+import com.sun.tools.attach.VirtualMachineDescriptor;
 import com.sun.tools.attach.spi.AttachProvider;
-import nsk.share.aod.*;
+import nsk.share.aod.AODTestRunner;
 import nsk.share.test.TestUtils;
+
+import java.util.Properties;
 
 /*
  * Test checks following methods:
@@ -80,11 +82,9 @@ public class AttachProvider02 extends AODTestRunner {
             TestUtils.assertNotNull(provider.type(), "Provider.type() returns null");
 
             tryAttach(provider, currentVMId, false);
-
             tryAttach(provider, currentVMId, true);
 
             tryAttach(provider, targetVMId, false);
-
             tryAttach(provider, targetVMId, true);
         }
     }
@@ -95,17 +95,17 @@ public class AttachProvider02 extends AODTestRunner {
 
         VirtualMachine vm;
 
-        if (useVMDescriptor)
+        if (useVMDescriptor) {
             vm = provider.attachVirtualMachine(new VirtualMachineDescriptor(provider, vmId));
-        else
+        } else {
             vm = provider.attachVirtualMachine(vmId);
+        }
 
         try {
             log.display("Attached to vm: " + vm);
             TestUtils.assertEquals(vm.id(), vmId, "VirtualMachine.id() returns unexpected value for attached vm: " + vm.id());
 
             // try to use created VirtualMachine
-
             log.display("Trying to call VirtualMachine.getSystemProperties()");
             Properties properties = vm.getSystemProperties();
             TestUtils.assertNotNull(properties, "VirtualMachine.getSystemProperties() returns null");

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8251999 is fixed
-allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine01/VirtualMachine01.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine01/VirtualMachine01.java
@@ -39,21 +39,23 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.aod.VirtualMachine.VirtualMachine01.VirtualMachine01
- *        nsk.share.aod.DummyTargetApplication
- * @run main/othervm -XX:+UsePerfData PropertyResolvingWrapper
+ * @build nsk.share.aod.DummyTargetApplication
+ * @run main/othervm
+ *      -XX:+UsePerfData
  *      nsk.aod.VirtualMachine.VirtualMachine01.VirtualMachine01
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.DummyTargetApplication
  */
 
 package nsk.aod.VirtualMachine.VirtualMachine01;
 
-import nsk.share.aod.*;
-import nsk.share.test.TestUtils;
-import com.sun.tools.attach.*;
+import com.sun.tools.attach.AttachNotSupportedException;
+import com.sun.tools.attach.VirtualMachine;
+import com.sun.tools.attach.VirtualMachineDescriptor;
 import com.sun.tools.attach.spi.AttachProvider;
+import nsk.share.aod.AODTestRunner;
+import nsk.share.test.TestUtils;
 
 /*
  * Test provokes exception which should be thrown by VirtualMachine methods:

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine02/VirtualMachine02.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine02/VirtualMachine02.java
@@ -39,30 +39,30 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.aod.VirtualMachine.VirtualMachine02.VirtualMachine02
- *        nsk.share.aod.DummyTargetApplication
- * @run main/othervm -Djdk.attach.allowAttachSelf -XX:+UsePerfData
- *      PropertyResolvingWrapper
+ * @build nsk.share.aod.DummyTargetApplication
+ * @run main/othervm
+ *      -Djdk.attach.allowAttachSelf
+ *      -XX:+UsePerfData
  *      nsk.aod.VirtualMachine.VirtualMachine02.VirtualMachine02
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.DummyTargetApplication
  */
 
 package nsk.aod.VirtualMachine.VirtualMachine02;
 
-import java.io.IOException;
-import com.sun.tools.attach.*;
+import com.sun.tools.attach.VirtualMachine;
+import com.sun.tools.attach.VirtualMachineDescriptor;
 import com.sun.tools.attach.spi.AttachProvider;
-import nsk.share.aod.*;
+import nsk.share.aod.AODTestRunner;
 import nsk.share.test.TestUtils;
+
+import java.io.IOException;
 
 /*
  * Test checks following methods:
  *      -  VirtualMachine.attach(String) (test tries to attach to current and to another VM)
- *
  *      -  VirtualMachine.attach(VirtualMachineDescriptor) (test tries to attach to current and to another VM)
- *
  *      -  VirtualMachine.detach() (test checks that after detaching operations on VirtualMachine
  *      throw IOException)
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine03/VirtualMachine03.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine03/VirtualMachine03.java
@@ -34,20 +34,20 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.aod.VirtualMachine.VirtualMachine03.VirtualMachine03
- *        nsk.share.aod.DummyTargetApplication
- * @run main/othervm -Djdk.attach.allowAttachSelf -XX:+UsePerfData
- *      PropertyResolvingWrapper
+ * @build nsk.share.aod.DummyTargetApplication
+ * @run main/othervm
+ *      -Djdk.attach.allowAttachSelf
+ *      -XX:+UsePerfData
  *      nsk.aod.VirtualMachine.VirtualMachine03.VirtualMachine03
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.DummyTargetApplication
  */
 
 package nsk.aod.VirtualMachine.VirtualMachine03;
 
 import com.sun.tools.attach.VirtualMachine;
-import nsk.share.aod.*;
+import nsk.share.aod.AODTestRunner;
 import nsk.share.test.TestUtils;
 
 /*
@@ -63,23 +63,21 @@ public class VirtualMachine03 extends AODTestRunner {
         String currentVMId = getCurrentVMId();
 
         VirtualMachine vm1 = VirtualMachine.attach(currentVMId);
-
-        VirtualMachine vm2 = VirtualMachine.attach(targetVMId);
-
         try {
-            TestUtils.assertEquals(vm1.id(), currentVMId, "vm.id() returns unexpected value: " + vm1.id());
+            VirtualMachine vm2 = VirtualMachine.attach(targetVMId);
+            try {
+                TestUtils.assertEquals(vm1.id(), currentVMId, "vm.id() returns unexpected value: " + vm1.id());
+                TestUtils.assertEquals(vm2.id(), targetVMId, "vm.id() returns unexpected value: " + vm2.id());
 
-            TestUtils.assertEquals(vm2.id(), targetVMId, "vm.id() returns unexpected value: " + vm2.id());
+                TestUtils.assertTrue(!vm1.equals(vm2), vm1 + ".equals(" + vm2 + ") returns 'true'");
 
-            TestUtils.assertTrue(!vm1.equals(vm2), vm1 + ".equals(" + vm2 + ") returns 'true'");
-
-            checkVM(vm1);
-
-            checkVM(vm2);
+                checkVM(vm1);
+                checkVM(vm2);
+            } finally {
+                vm2.detach();
+            }
         } finally {
             vm1.detach();
-
-            vm2.detach();
         }
     }
 
@@ -90,15 +88,13 @@ public class VirtualMachine03 extends AODTestRunner {
         VirtualMachine vm2 = VirtualMachine.attach(vm1.id());
         try {
             TestUtils.assertEquals(vm1, vm2, vm1 + ".equals(" + vm2 + ") returns 'false'");
-
             TestUtils.assertTrue(vm1.hashCode() == vm2.hashCode(), "vm.hashCode() returns different values for " + vm1 + " and " + vm2);
-
             TestUtils.assertEquals(vm1.provider(), vm2.provider(), "vm.provider() returns non-equals objects for " + vm1 + " and " + vm2);
         } finally {
             vm2.detach();
         }
 
-        TestUtils.assertTrue(!vm1.equals(new String()), "vm.equals(String) returns 'true'");
+        TestUtils.assertTrue(!vm1.equals(""), "vm.equals(String) returns 'true'");
 
         TestUtils.assertTrue(!vm1.equals(null), "vm.equals(null) returns 'true'");
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine04/VM04Target.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine04/VM04Target.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package nsk.aod.VirtualMachine.VirtualMachine04;
 
 import nsk.share.TestBug;
@@ -30,28 +31,26 @@ import nsk.share.aod.DummyTargetApplication;
  * main test application tries to get this property using VirtualMachine.getSystemProperties()
  */
 public class VM04Target extends DummyTargetApplication {
-
-    static String testPropertyKey = "VirtualMachine04_testPropertyKey";
-
-    static String testPropertyValue = "VirtualMachine04_testPropertyValue";
-
-    static String changedTestPropertyValue = "VirtualMachine04_testPropertyValue_changed";
+    static final String TEST_PROPERTY_KEY = "VirtualMachine04_testPropertyKey";
+    static final String TEST_PROPERTY_VALUE = "VirtualMachine04_testPropertyValue";
+    static final String CHANGED_TEST_PROPERTY_VALUE = "VirtualMachine04_testPropertyValue_changed";
 
     VM04Target(String[] args) {
         super(args);
 
-        log.display("Setting property " + testPropertyKey + " = " + testPropertyValue);
-        System.setProperty(testPropertyKey, testPropertyValue);
+        log.display("Setting property " + TEST_PROPERTY_KEY + " = " + TEST_PROPERTY_VALUE);
+        System.setProperty(TEST_PROPERTY_KEY, TEST_PROPERTY_VALUE);
     }
 
     protected void targetApplicationActions() {
         String signal = pipe.readln();
-        log.display("Received signal: "  + signal);
-        if (!signal.equals(VirtualMachine04.SIGNAL_CHANGE_PROPERTY))
+        log.display("Received signal: " + signal);
+        if (!signal.equals(VirtualMachine04.SIGNAL_CHANGE_PROPERTY)) {
             throw new TestBug("Received unexpected signal: " + signal);
+        }
 
-        log.display("Setting property " + testPropertyKey + " = " + changedTestPropertyValue);
-        System.setProperty(testPropertyKey, changedTestPropertyValue);
+        log.display("Setting property " + TEST_PROPERTY_KEY + " = " + CHANGED_TEST_PROPERTY_VALUE);
+        System.setProperty(TEST_PROPERTY_KEY, CHANGED_TEST_PROPERTY_VALUE);
 
         log.display("Sending signal " + VirtualMachine04.SIGNAL_PROPERTY_CHANGED);
         pipe.println(VirtualMachine04.SIGNAL_PROPERTY_CHANGED);

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine04/VirtualMachine04.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine04/VirtualMachine04.java
@@ -38,33 +38,31 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.aod.VirtualMachine.VirtualMachine04.VirtualMachine04
- *        nsk.aod.VirtualMachine.VirtualMachine04.VM04Target
- * @run main/othervm -XX:+UsePerfData PropertyResolvingWrapper
+ * @build nsk.aod.VirtualMachine.VirtualMachine04.VM04Target
+ * @run main/othervm
+ *      -XX:+UsePerfData
  *      nsk.aod.VirtualMachine.VirtualMachine04.VirtualMachine04
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.aod.VirtualMachine.VirtualMachine04.VM04Target
  */
 
 package nsk.aod.VirtualMachine.VirtualMachine04;
 
-import java.util.Properties;
 import com.sun.tools.attach.VirtualMachine;
+import nsk.share.TestBug;
 import nsk.share.aod.AODTestRunner;
 import nsk.share.test.TestUtils;
-import nsk.share.*;
+
+import java.util.Properties;
 
 /*
  * Test checks following methods:
  *      - VirtualMachine.getSystemProperties()
- *
  *      - VirtualMachine.getAgentProperties()
  */
 public class VirtualMachine04 extends AODTestRunner {
-
     static final String SIGNAL_CHANGE_PROPERTY = "change_property";
-
     static final String SIGNAL_PROPERTY_CHANGED = "property_changed";
 
     public VirtualMachine04(String[] args) {
@@ -75,16 +73,16 @@ public class VirtualMachine04 extends AODTestRunner {
         VirtualMachine vm = VirtualMachine.attach(targetVMId);
 
         try {
-            checkSystemProperties(vm, VM04Target.testPropertyKey, VM04Target.testPropertyValue);
+            checkSystemProperties(vm, VM04Target.TEST_PROPERTY_KEY, VM04Target.TEST_PROPERTY_VALUE);
 
             log.display("Sending signal " + SIGNAL_CHANGE_PROPERTY);
             pipe.println(SIGNAL_CHANGE_PROPERTY);
             String signal = pipe.readln();
             log.display("Received signal " + signal);
-            if (!signal.equals(SIGNAL_PROPERTY_CHANGED))
+            if (!signal.equals(SIGNAL_PROPERTY_CHANGED)) {
                 throw new TestBug("Unexpected signal received: " + signal);
-
-            checkSystemProperties(vm, VM04Target.testPropertyKey, VM04Target.changedTestPropertyValue);
+            }
+            checkSystemProperties(vm, VM04Target.TEST_PROPERTY_KEY, VM04Target.CHANGED_TEST_PROPERTY_VALUE);
 
             Properties properties = vm.getAgentProperties();
             System.out.println("VirtualMachine.getAgentProperties(): " + properties);
@@ -95,14 +93,14 @@ public class VirtualMachine04 extends AODTestRunner {
     }
 
     void checkSystemProperties(VirtualMachine vm,
-            String propertyToCheck,
-            String expectedPropertyValue) throws Throwable {
+                               String propertyToCheck,
+                               String expectedPropertyValue) throws Throwable {
 
         Properties properties = vm.getSystemProperties();
         System.out.println("VirtualMachine.getSystemProperties(): " + properties);
         checkProperties(properties);
 
-        String checkedPropertyValue  = properties.getProperty(propertyToCheck);
+        String checkedPropertyValue = properties.getProperty(propertyToCheck);
         TestUtils.assertNotNull(checkedPropertyValue, "Properties doesn't contain property '" + propertyToCheck + "'");
         TestUtils.assertEquals(checkedPropertyValue, expectedPropertyValue,
                 "Unexpected value of the property '" + propertyToCheck + "': " + checkedPropertyValue + ", expected value is '" + expectedPropertyValue + "'");
@@ -120,7 +118,6 @@ public class VirtualMachine04 extends AODTestRunner {
             log.display("Value of '" + key + "' = " + value);
 
             TestUtils.assertTrue(key instanceof String, "Property key isn't String: " + key.getClass().getName());
-
             TestUtils.assertTrue(value instanceof String, "Property value isn't String: " + value.getClass().getName());
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine05/VirtualMachine05.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine05/VirtualMachine05.java
@@ -35,21 +35,23 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.aod.VirtualMachine.VirtualMachine05.VirtualMachine05
- *        nsk.share.aod.DummyTargetApplication
- * @run main/othervm -XX:+UsePerfData PropertyResolvingWrapper
+ * @build nsk.share.aod.DummyTargetApplication
+ * @run main/othervm
+ *      -XX:+UsePerfData
  *      nsk.aod.VirtualMachine.VirtualMachine05.VirtualMachine05
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.DummyTargetApplication
  */
 
 package nsk.aod.VirtualMachine.VirtualMachine05;
 
-import java.util.List;
-import com.sun.tools.attach.*;
-import nsk.share.aod.*;
+import com.sun.tools.attach.VirtualMachine;
+import com.sun.tools.attach.VirtualMachineDescriptor;
+import nsk.share.aod.AODTestRunner;
 import nsk.share.test.TestUtils;
+
+import java.util.List;
 
 /*
  * Test checks method VirtualMachine.list()
@@ -62,14 +64,14 @@ public class VirtualMachine05 extends AODTestRunner {
         super(args);
     }
 
-    public void doTestActions(String targetVMId) throws Throwable {
+    public void doTestActions(String targetVMId) {
         String currentVMId = getCurrentVMId();
 
         log.display("Checking VirtualMachine.list()");
-        checkList(VirtualMachine.list(), currentVMId, targetVMId);
+        checkList(currentVMId, targetVMId);
     }
 
-    private void checkList(List<VirtualMachineDescriptor> vmDescriptors, String currentVMId, String targetVMId) {
+    private void checkList(String currentVMId, String targetVMId) {
         VirtualMachineDescriptor currentVM = null;
         VirtualMachineDescriptor targetVM = null;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine06/VM06Agent00.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine06/VM06Agent00.java
@@ -20,11 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package nsk.aod.VirtualMachine.VirtualMachine06;
 
-import java.lang.instrument.Instrumentation;
-
 import nsk.share.aod.TargetApplicationWaitingAgents;
+
+import java.lang.instrument.Instrumentation;
 
 public class VM06Agent00 {
     public static void agentmain(String options, Instrumentation inst) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine06/VM06Agent01.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine06/VM06Agent01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,11 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package nsk.aod.VirtualMachine.VirtualMachine06;
 
-import java.lang.instrument.Instrumentation;
-
 import nsk.share.aod.TargetApplicationWaitingAgents;
+
+import java.lang.instrument.Instrumentation;
 
 public class VM06Agent01 {
     public static void agentmain(String options, Instrumentation inst) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine06/VM06Agent02.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine06/VM06Agent02.java
@@ -20,11 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package nsk.aod.VirtualMachine.VirtualMachine06;
 
-import java.lang.instrument.Instrumentation;
-
 import nsk.share.aod.TargetApplicationWaitingAgents;
+
+import java.lang.instrument.Instrumentation;
 
 public class VM06Agent02 {
     public static void agentmain(String options, Instrumentation inst) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine06/VM06Agent03.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine06/VM06Agent03.java
@@ -20,11 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package nsk.aod.VirtualMachine.VirtualMachine06;
 
-import java.lang.instrument.Instrumentation;
-
 import nsk.share.aod.TargetApplicationWaitingAgents;
+
+import java.lang.instrument.Instrumentation;
 
 public class VM06Agent03 {
     public static void agentmain(String options, Instrumentation inst) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine06/VirtualMachine06.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine06/VirtualMachine06.java
@@ -53,51 +53,52 @@
  *      nsk.aod.VirtualMachine.VirtualMachine06.VM06Agent03
  *
  * @comment create VM06Agent0[0-3].jar in current directory
- * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${test.jdk}/bin/jar
  *      -cmf ${test.src}/VM06Agent00.mf
  *      VM06Agent00.jar
  *      nsk/aod/VirtualMachine/VirtualMachine06/VM06Agent00.class
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${test.jdk}/bin/jar
  *      -cmf ${test.src}/VM06Agent01.mf
  *      VM06Agent01.jar
  *      nsk/aod/VirtualMachine/VirtualMachine06/VM06Agent01.class
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${test.jdk}/bin/jar
  *      -cmf ${test.src}/VM06Agent02.mf
  *      VM06Agent02.jar
  *      nsk/aod/VirtualMachine/VirtualMachine06/VM06Agent02.class
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${test.jdk}/bin/jar
  *      -cmf ${test.src}/VM06Agent03.mf
  *      VM06Agent03.jar
  *      nsk/aod/VirtualMachine/VirtualMachine06/VM06Agent03.class
  *
  *
- * @build nsk.aod.VirtualMachine.VirtualMachine06.VirtualMachine06
- *        nsk.share.aod.TargetApplicationWaitingAgents
- * @run main/othervm -XX:+UsePerfData PropertyResolvingWrapper
+ * @build nsk.share.aod.TargetApplicationWaitingAgents
+ * @run main/othervm
+ *      -XX:+UsePerfData
  *      nsk.aod.VirtualMachine.VirtualMachine06.VirtualMachine06
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
  *      -ja VM06Agent00.jar,VM06Agent01.jar,VM06Agent02.jar,VM06Agent03.jar
  */
 
 package nsk.aod.VirtualMachine.VirtualMachine06;
 
+import com.sun.tools.attach.AgentInitializationException;
+import com.sun.tools.attach.VirtualMachine;
 import nsk.share.TestBug;
-import nsk.share.aod.*;
+import nsk.share.aod.AODTestRunner;
+import nsk.share.aod.AgentInformation;
 import nsk.share.test.TestUtils;
-import java.util.*;
-import com.sun.tools.attach.*;
+
+import java.util.List;
 
 /*
  * Test checks following methods:
  *      - VirtualMachine.loadAgent(String)
- *
  *      - VirtualMachine.loadAgent(String, String)
  */
 public class VirtualMachine06 extends AODTestRunner {
@@ -109,12 +110,13 @@ public class VirtualMachine06 extends AODTestRunner {
     public void doTestActions(String targetVMId) throws Throwable {
         // check that all required parameters were passed to the test
         List<AgentInformation> agents = argParser.getAgents();
-        if (agents.size() != 4)
+        if (agents.size() != 4) {
             throw new TestBug("Test requires 4 agents, actually " + agents.size() + " were specified");
-
+        }
         for (AgentInformation agent : agents) {
-            if (!agent.jarAgent)
+            if (!agent.jarAgent) {
                 throw new TestBug("Non JAR agent was specified");
+            }
         }
 
         VirtualMachine vm = VirtualMachine.attach(targetVMId);

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine07/VirtualMachine07.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine07/VirtualMachine07.java
@@ -40,12 +40,12 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.aod.VirtualMachine.VirtualMachine07.VirtualMachine07
- *        nsk.share.aod.TargetApplicationWaitingAgents
- * @run main/othervm/native -XX:+UsePerfData PropertyResolvingWrapper
+ * @build nsk.share.aod.TargetApplicationWaitingAgents
+ * @run main/othervm/native
+ *      -XX:+UsePerfData
  *      nsk.aod.VirtualMachine.VirtualMachine07.VirtualMachine07
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
  *      -na VirtualMachine07agent00,VirtualMachine07agent01,VirtualMachine07agent02,VirtualMachine07agent03
  *      -testedMethod loadAgentLibrary
@@ -53,27 +53,26 @@
 
 package nsk.aod.VirtualMachine.VirtualMachine07;
 
-import nsk.share.*;
-import nsk.share.aod.*;
+import com.sun.tools.attach.AgentInitializationException;
+import com.sun.tools.attach.VirtualMachine;
+import nsk.share.TestBug;
+import nsk.share.aod.AODRunnerArgParser;
+import nsk.share.aod.AODTestRunner;
+import nsk.share.aod.AgentInformation;
 import nsk.share.test.TestUtils;
 
-import java.util.*;
-
-import com.sun.tools.attach.*;
+import java.util.List;
 
 /*
  * Test is written to test following methods:
  *      - VirtualMachine.loadAgentLibrary
- *
  *      - VirtualMachine.loadAgentPath
  *
  *(method to test is specified via command line parameter 'testedMethod')
  */
 public class VirtualMachine07 extends AODTestRunner {
-
-    static class ArgParser extends AODRunnerArgParser {
-
-        final String testedMethodOpt = "testedMethod";
+    private static class ArgParser extends AODRunnerArgParser {
+        private static final String TESTED_METHOD_OPT = "testedMethod";
 
         ArgParser(String[] args) {
             super(args);
@@ -83,11 +82,12 @@ public class VirtualMachine07 extends AODTestRunner {
             if (super.checkOption(option, value))
                 return true;
 
-            if (option.equals(testedMethodOpt)) {
-                if (value.equals("loadAgentLibrary") || value.equals("loadAgentPath"))
+            if (option.equals(TESTED_METHOD_OPT)) {
+                if ("loadAgentLibrary".equals(value) || "loadAgentPath".equals(value)) {
                     return true;
-                else
-                    throw new TestBug("Unexpected value of '" + testedMethodOpt + "': " + value);
+                } else {
+                    throw new TestBug("Unexpected value of '" + TESTED_METHOD_OPT + "': " + value);
+                }
             }
 
             return false;
@@ -98,13 +98,14 @@ public class VirtualMachine07 extends AODTestRunner {
 
             // if test loadAgentPath parameter arch is needed
             if (!testLoadAgentLibrary()) {
-                if (!options.containsKey("arch"))
+                if (!options.containsKey("arch")) {
                     throw new TestBug("Option 'arch' wasn't specified");
+                }
             }
         }
 
         boolean testLoadAgentLibrary() {
-            return options.getProperty(testedMethodOpt).equals("loadAgentLibrary");
+            return options.getProperty(TESTED_METHOD_OPT).equals("loadAgentLibrary");
         }
     }
 
@@ -141,10 +142,11 @@ public class VirtualMachine07 extends AODTestRunner {
     protected void loadAgent(VirtualMachine vm, String agent) throws Throwable {
         boolean testLoadAgentLibrary = ((ArgParser) argParser).testLoadAgentLibrary();
 
-        if (testLoadAgentLibrary)
+        if (testLoadAgentLibrary) {
             log.display("Test method VirtualMachine.loadAgentLibrary");
-        else
+        } else {
             log.display("Test method VirtualMachine.loadAgentPath");
+        }
 
         if (testLoadAgentLibrary) {
             log.display("Loading '" + agent + "'");
@@ -159,10 +161,11 @@ public class VirtualMachine07 extends AODTestRunner {
     protected void loadAgent(VirtualMachine vm, String agent, String options) throws Throwable {
         boolean testLoadAgentLibrary = ((ArgParser) argParser).testLoadAgentLibrary();
 
-        if (testLoadAgentLibrary)
+        if (testLoadAgentLibrary) {
             log.display("Test method VirtualMachine.loadAgentLibrary");
-        else
+        } else {
             log.display("Test method VirtualMachine.loadAgentPath");
+        }
 
         if (testLoadAgentLibrary) {
             log.display("Loading '" + agent + "'");
@@ -177,12 +180,13 @@ public class VirtualMachine07 extends AODTestRunner {
     public void doTestActions(String targetVMId) throws Throwable {
         // check that all required parameters were passed to the test
         List<AgentInformation> agents = argParser.getAgents();
-        if (agents.size() != 4)
+        if (agents.size() != 4) {
             throw new TestBug("Test requires 4 agents, actually " + agents.size() + " were specified");
-
+        }
         for (AgentInformation agent : agents) {
-            if (agent.jarAgent)
+            if (agent.jarAgent) {
                 throw new TestBug("Non native agent was specified");
+            }
         }
 
         VirtualMachine vm = VirtualMachine.attach(targetVMId);
@@ -209,7 +213,7 @@ public class VirtualMachine07 extends AODTestRunner {
                 log.display("Expected AgentInitializationException was caught");
                 log.display("AgentInitializationException.returnValue(): " + e.returnValue());
                 TestUtils.assertEquals(e.returnValue(), 10,
-                        "AgentInitializationException.returnValue() returns unexpected value: " + e.returnValue()+ ", expected value is 10");
+                        "AgentInitializationException.returnValue() returns unexpected value: " + e.returnValue() + ", expected value is 10");
             }
         } finally {
             vm.detach();

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine08/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine08/TestDescription.java
@@ -41,12 +41,12 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.aod.VirtualMachine.VirtualMachine07.VirtualMachine07
- *        nsk.share.aod.TargetApplicationWaitingAgents
- * @run main/othervm/native -XX:+UsePerfData PropertyResolvingWrapper
+ * @build nsk.share.aod.TargetApplicationWaitingAgents
+ * @run main/othervm/native
+ *      -XX:+UsePerfData
  *      nsk.aod.VirtualMachine.VirtualMachine07.VirtualMachine07
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
  *      -na ${test.nativepath}/VirtualMachine07agent00,${test.nativepath}/VirtualMachine07agent01,${test.nativepath}/VirtualMachine07agent02,${test.nativepath}/VirtualMachine07agent03
  *      -testedMethod loadAgentPath

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine09/VirtualMachine09.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine09/VirtualMachine09.java
@@ -37,12 +37,12 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.aod.VirtualMachine.VirtualMachine09.VirtualMachine09
- *        nsk.aod.VirtualMachine.VirtualMachine09.VM09Target
- * @run main/othervm/native -XX:+UsePerfData PropertyResolvingWrapper
+ * @build nsk.aod.VirtualMachine.VirtualMachine09.VM09Target
+ * @run main/othervm/native
+ *      -XX:+UsePerfData
  *      nsk.aod.VirtualMachine.VirtualMachine09.VirtualMachine09
  *      -jdk ${test.jdk}
- *      "-javaOpts=-agentlib:VirtualMachine09agent00 -XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-agentlib:VirtualMachine09agent00 -XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.aod.VirtualMachine.VirtualMachine09.VM09Target
  *      -na VirtualMachine09agent00
  *      -testedMethod loadAgentLibrary
@@ -50,13 +50,12 @@
 
 package nsk.aod.VirtualMachine.VirtualMachine09;
 
+import com.sun.tools.attach.VirtualMachine;
 import nsk.aod.VirtualMachine.VirtualMachine07.VirtualMachine07;
 import nsk.share.TestBug;
-import nsk.share.aod.*;
+import nsk.share.aod.AgentInformation;
 
-import java.util.*;
-
-import com.sun.tools.attach.*;
+import java.util.List;
 
 /*
  * Test checks methods VirtualMachine.loadAgentLib and VirtualMachineloadAgentPath.
@@ -73,12 +72,13 @@ public class VirtualMachine09 extends VirtualMachine07 {
     public void doTestActions(String targetVMId) throws Throwable {
         // check that all required parameters were passed to the test
         List<AgentInformation> agents = argParser.getAgents();
-        if (agents.size() != 1)
+        if (agents.size() != 1) {
             throw new TestBug("Test requires 1 agent, actually " + agents.size() + " were specified");
-
+        }
         for (AgentInformation agent : agents) {
-            if (agent.jarAgent)
+            if (agent.jarAgent) {
                 throw new TestBug("Non native agent was specified");
+            }
         }
 
         VirtualMachine vm = VirtualMachine.attach(targetVMId);

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine10/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachine/VirtualMachine10/TestDescription.java
@@ -38,12 +38,12 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.aod.VirtualMachine.VirtualMachine09.VirtualMachine09
- *        nsk.aod.VirtualMachine.VirtualMachine09.VM09Target
- * @run main/othervm/native -XX:+UsePerfData PropertyResolvingWrapper
+ * @build nsk.aod.VirtualMachine.VirtualMachine09.VM09Target
+ * @run main/othervm/native
+ *      -XX:+UsePerfData
  *      nsk.aod.VirtualMachine.VirtualMachine09.VirtualMachine09
  *      -jdk ${test.jdk}
- *      "-javaOpts=-agentlib:VirtualMachine09agent00 -XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-agentlib:VirtualMachine09agent00 -XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.aod.VirtualMachine.VirtualMachine09.VM09Target
  *      -na ${test.nativepath}/VirtualMachine09agent00
  *      -testedMethod loadAgentPath

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachineDescriptor/VirtualMachineDescriptor01/VirtualMachineDescriptor01.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/VirtualMachineDescriptor/VirtualMachineDescriptor01/VirtualMachineDescriptor01.java
@@ -37,20 +37,21 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.aod.VirtualMachineDescriptor.VirtualMachineDescriptor01.VirtualMachineDescriptor01
- *        nsk.share.aod.DummyTargetApplication
- * @run main/othervm -XX:+UsePerfData PropertyResolvingWrapper
+ * @build nsk.share.aod.DummyTargetApplication
+ * @run main/othervm
+ *      -XX:+UsePerfData
  *      nsk.aod.VirtualMachineDescriptor.VirtualMachineDescriptor01.VirtualMachineDescriptor01
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.DummyTargetApplication
  */
 
 package nsk.aod.VirtualMachineDescriptor.VirtualMachineDescriptor01;
 
-import com.sun.tools.attach.*;
+import com.sun.tools.attach.VirtualMachine;
+import com.sun.tools.attach.VirtualMachineDescriptor;
 import com.sun.tools.attach.spi.AttachProvider;
-import nsk.share.aod.*;
+import nsk.share.aod.AODTestRunner;
 import nsk.share.test.TestUtils;
 
 /*
@@ -108,8 +109,7 @@ public class VirtualMachineDescriptor01 extends AODTestRunner {
                     "VirtualMachineDescriptor.equals() returns 'false' for '" + targetVMDesc + "' and '" + targetVMDesc2 + "'");
 
             TestUtils.assertEquals(targetVMDesc.hashCode(), targetVMDesc2.hashCode(),
-                    "VirtualMachineDescriptor.hashCode() returns different values " + "(" + targetVMDesc.hashCode() + " and " + targetVMDesc2.hashCode() + ")" +
-                    " for '" + targetVMDesc + "' and '" + targetVMDesc2 + "'");
+                    "VirtualMachineDescriptor.hashCode() returns different values for '" + targetVMDesc + "' and '" + targetVMDesc2 + "'");
         } finally {
             targetVM.detach();
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AODRunnerArgParser.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AODRunnerArgParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,33 +20,28 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package nsk.share.aod;
 
-import nsk.share.*;
-import java.util.*;
+import nsk.share.ArgumentParser;
+import nsk.share.TestBug;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 public class AODRunnerArgParser extends ArgumentParser {
-
-    public static final String jarAgentParam = "ja";
-
-    public static final String nativeAgentParam = "na";
-
-    public static final String targetAppParam = "target";
-
-    public static final String javaOptsParam = "javaOpts";
-
-    public static final String testedJdkParam = "jdk";
-
-    private static List<String> supportedOptions;
-
-    static {
-        supportedOptions = new ArrayList<String>();
-        supportedOptions.add(jarAgentParam);
-        supportedOptions.add(nativeAgentParam);
-        supportedOptions.add(targetAppParam);
-        supportedOptions.add(javaOptsParam);
-        supportedOptions.add(testedJdkParam);
-    }
+    private static final String JAR_AGENT_PARAM = "ja";
+    private static final String NATIVE_AGENT_PARAM = "na";
+    private static final String TARGET_APP_PARAM = "target";
+    private static final String JAVA_OPTS_PARAM = "javaOpts";
+    private static final String TESTED_JDK_PARAM = "jdk";
+    private static final Set<String> SUPPORTED_OPTIONS = Set.of(
+            JAR_AGENT_PARAM,
+            NATIVE_AGENT_PARAM,
+            TARGET_APP_PARAM,
+            JAVA_OPTS_PARAM,
+            TESTED_JDK_PARAM);
 
     private List<AgentInformation> agents;
 
@@ -55,17 +50,19 @@ public class AODRunnerArgParser extends ArgumentParser {
     }
 
     protected boolean checkOption(String option, String value) {
-        if (super.checkOption(option, value))
+        if (super.checkOption(option, value)) {
             return true;
+        }
 
-        if (!supportedOptions.contains(option))
+        if (!SUPPORTED_OPTIONS.contains(option)) {
             return false;
+        }
 
-        if (option.equals(jarAgentParam)) {
+        if (option.equals(JAR_AGENT_PARAM)) {
             addAgentInfo(true, value);
         }
 
-        if (option.equals(nativeAgentParam)) {
+        if (option.equals(NATIVE_AGENT_PARAM)) {
             addAgentInfo(false, value);
         }
 
@@ -74,21 +71,22 @@ public class AODRunnerArgParser extends ArgumentParser {
 
     protected void checkOptions() {
         if (agents == null) {
-            agents = new ArrayList<AgentInformation>();
+            agents = new ArrayList<>();
         }
     }
 
     private void addAgentInfo(boolean jarAgent, String unsplittedAgentsString) {
         if (agents == null) {
-            agents = new ArrayList<AgentInformation>();
+            agents = new ArrayList<>();
         }
 
-        String agentStrings[];
+        String[] agentStrings;
 
-        if (unsplittedAgentsString.contains(","))
+        if (unsplittedAgentsString.contains(",")) {
             agentStrings = unsplittedAgentsString.split(",");
-        else
-            agentStrings = new String[]{unsplittedAgentsString};
+        } else {
+            agentStrings = new String[]{ unsplittedAgentsString };
+        }
 
         for (String agentString : agentStrings) {
             int index = agentString.indexOf('=');
@@ -104,21 +102,27 @@ public class AODRunnerArgParser extends ArgumentParser {
     }
 
     public String getTargetApp() {
-        if (!options.containsKey(targetAppParam))
+        if (!options.containsKey(TARGET_APP_PARAM)) {
             throw new TestBug("Target application isn't specified");
+        }
 
-        return options.getProperty(targetAppParam);
+        return options.getProperty(TARGET_APP_PARAM);
     }
 
     public String getTestedJDK() {
-        if (!options.containsKey(testedJdkParam))
+        if (!options.containsKey(TESTED_JDK_PARAM)) {
             throw new TestBug("Tested JDK isn't specified");
+        }
 
-        return options.getProperty(testedJdkParam);
+        return options.getProperty(TESTED_JDK_PARAM);
     }
 
     public String getJavaOpts() {
-        return options.getProperty(javaOptsParam, "");
+        var value = options.getProperty(JAVA_OPTS_PARAM, "");
+        if (value.length() > 1 && value.startsWith("\"") && value.endsWith("\"")) {
+            value = value.substring(1, value.length() - 1);
+        }
+        return value.trim();
     }
 
     public List<AgentInformation> getAgents() {


### PR DESCRIPTION
the patch 
- removes `PropertyResolvingWrapper` from `vmTestbase/nsk/aod` tests
- updates `AODRunnerArgParser` to remove surrounding `"` symbols from `javaOpts` option values
- updates vmTestbase/nsk/aod test descriptions to have `"` in `javaOpts` values (as opposed of around `-javaOpts=$value` as it's now)
- mechanically reformats/cleans up the tests (whitespaces, imports, etc) 

testing:
* [x] vmTestbase/nsk/aod on  {macosx,windows,linux}-x64 
* [x] vmTestbase/nsk/aod on macosx-x64 w/ `VM_OPTIONS`, `JAVA_OPTIONS` being empty and having value

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251999](https://bugs.openjdk.java.net/browse/JDK-8251999): remove usage of PropertyResolvingWrapper in vmTestbase/nsk/aod


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/311/head:pull/311`
`$ git checkout pull/311`
