### PR TITLE
8253372: [TESTBUG] update tests which require jvmti - hotspot

### DIFF
--- a/test/hotspot/jtreg/applications/ctw/modules/java_instrument.java
+++ b/test/hotspot/jtreg/applications/ctw/modules/java_instrument.java
@@ -31,6 +31,7 @@
  *          java.base/jdk.internal.misc
  *          java.base/jdk.internal.reflect
  * @modules java.instrument
+ * @requires vm.jvmti
  *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/jsr292/NonInlinedCall/RedefineTest.java
+++ b/test/hotspot/jtreg/compiler/jsr292/NonInlinedCall/RedefineTest.java
@@ -28,7 +28,7 @@
  *          java.base/jdk.internal.misc
  *          java.base/jdk.internal.vm.annotation
  * @library /test/lib / ../patches
- * @requires vm.flavor != "minimal"
+ * @requires vm.jvmti
  *
  * @build sun.hotspot.WhiteBox
  *        java.base/java.lang.invoke.MethodHandleHelper

--- a/test/hotspot/jtreg/compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
+++ b/test/hotspot/jtreg/compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
@@ -31,6 +31,7 @@
  *          java.instrument
  *          java.management
  *          jdk.attach
+ * @requires vm.jvmti
  *
  * @run main/othervm -Djdk.attach.allowAttachSelf compiler.jsr292.RedefineMethodUsedByMultipleMethodHandles
  */

--- a/test/hotspot/jtreg/compiler/jsr292/cr8026328/Test8026328.java
+++ b/test/hotspot/jtreg/compiler/jsr292/cr8026328/Test8026328.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8026328
+ * @requires vm.jvmti
  * @run main/othervm/native -agentlib:Test8026328 compiler.jsr292.cr8026328.Test8026328
  */
 

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/RedefineClassTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/RedefineClassTest.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @requires vm.jvmci
+ * @requires vm.jvmti
  * @library ../../../../../
  * @modules jdk.internal.vm.ci/jdk.vm.ci.meta
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
@@ -28,6 +28,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.instrument
  *          java.management
+ * @requires vm.jvmti
  * @build compiler.profiling.spectrapredefineclass.Agent
  * @run driver ClassFileInstaller compiler.profiling.spectrapredefineclass.Agent
  * @run driver compiler.profiling.spectrapredefineclass.Launcher

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
@@ -28,6 +28,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.instrument
  *          java.management
+ * @requires vm.jvmti
  * @build compiler.profiling.spectrapredefineclass_classloaders.Agent
  *        compiler.profiling.spectrapredefineclass_classloaders.Test
  *        compiler.profiling.spectrapredefineclass_classloaders.A

--- a/test/hotspot/jtreg/gc/shenandoah/jvmti/TestHeapDump.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jvmti/TestHeapDump.java
@@ -26,6 +26,7 @@
  * @test TestHeapDump
  * @summary Tests JVMTI heap dumps
  * @requires vm.gc.Shenandoah
+ * @requires vm.jvmti
  * @compile TestHeapDump.java
  * @run main/othervm/native/timeout=300 -agentlib:TestHeapDump -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -Xmx128m -XX:ShenandoahGCHeuristics=aggressive                        TestHeapDump
  *
@@ -35,6 +36,7 @@
  * @test TestHeapDump
  * @summary Tests JVMTI heap dumps
  * @requires vm.gc.Shenandoah
+ * @requires vm.jvmti
  * @requires vm.bits == "64"
  * @compile TestHeapDump.java
  * @run main/othervm/native/timeout=300 -agentlib:TestHeapDump -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -Xmx128m -XX:ShenandoahGCHeuristics=aggressive -XX:-UseCompressedOops TestHeapDump
@@ -44,6 +46,7 @@
  * @test TestHeapDump
  * @summary Tests JVMTI heap dumps
  * @requires vm.gc.Shenandoah
+ * @requires vm.jvmti
  * @compile TestHeapDump.java
  * @run main/othervm/native/timeout=300 -agentlib:TestHeapDump -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -Xmx128m -XX:ShenandoahGCHeuristics=aggressive                         -XX:+UseStringDeduplication TestHeapDump
  */

--- a/test/hotspot/jtreg/runtime/6294277/SourceDebugExtension.java
+++ b/test/hotspot/jtreg/runtime/6294277/SourceDebugExtension.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 6294277
+ * @requires vm.jvmti
  * @summary java -Xdebug crashes on SourceDebugExtension attribute larger than 64K
  * @run main/othervm -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n SourceDebugExtension
  */

--- a/test/hotspot/jtreg/runtime/7158988/FieldMonitor.java
+++ b/test/hotspot/jtreg/runtime/7158988/FieldMonitor.java
@@ -24,6 +24,7 @@
 /*
  * @test FieldMonitor.java
  * @bug 7158988
+ * @requires vm.jvmti
  * @summary verify jvm does not crash while debugging
  * @run compile TestPostFieldModification.java
  * @run main/othervm FieldMonitor

--- a/test/hotspot/jtreg/runtime/Metaspace/DefineClass.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/DefineClass.java
@@ -26,6 +26,7 @@
  * @test
  * @bug 8173743
  * @requires vm.compMode != "Xcomp"
+ * @requires vm.jvmti
  * @summary Failures during class definition can lead to memory leaks in metaspace
  * @requires vm.opt.final.ClassUnloading
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/RedefineClassTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/RedefineClassTest.java
@@ -27,6 +27,7 @@
  * @summary Redefine shared class. GC should not cause crash with cached resolved_references.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes /test/hotspot/jtreg/runtime/cds/appcds/jvmti
  * @requires vm.cds.archived.java.heap
+ * @requires vm.jvmti
  * @build sun.hotspot.WhiteBox
  *        RedefineClassApp
  *        InstrumentationClassFileTransformer

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/AnonVmClassesDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/AnonVmClassesDuringDump.java
@@ -31,7 +31,7 @@
  *          See https://blogs.oracle.com/jrose/anonymous-classes-in-the-vm.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @requires vm.cds
- * @requires vm.flavor != "minimal"
+ * @requires vm.jvmti
  * @run driver AnonVmClassesDuringDump
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCDuringDump.java
@@ -27,7 +27,7 @@
  * @summary When dumping the CDS archive, try to cause garbage collection while classes are being loaded.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @requires vm.cds
- * @requires vm.flavor != "minimal"
+ * @requires vm.jvmti
  * @run driver GCDuringDump
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCSharedStringsDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCSharedStringsDuringDump.java
@@ -28,6 +28,7 @@
  *          option for testing the interaction with GC and shared strings.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @requires vm.cds.archived.java.heap
+ * @requires vm.jvmti
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run driver/timeout=480 GCSharedStringsDuringDump

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/HumongousDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/HumongousDuringDump.java
@@ -27,7 +27,7 @@
  * @summary Test how CDS dumping handles the existence of humongous G1 regions.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @requires vm.cds.archived.java.heap
- * @requires vm.flavor != "minimal"
+ * @requires vm.jvmti
  * @run driver/timeout=240 HumongousDuringDump
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/LockDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/LockDuringDump.java
@@ -29,7 +29,7 @@
  *          without the locking bits in the markWord.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @requires vm.cds
- * @requires vm.flavor != "minimal"
+ * @requires vm.jvmti
  * @modules java.instrument
  * @run driver LockDuringDump
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/ClassFileLoadHookTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/ClassFileLoadHookTest.java
@@ -27,6 +27,7 @@
  * @summary Test jvmti class file loader hook interaction with AppCDS
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @requires vm.cds
+ * @requires vm.jvmti
  * @build ClassFileLoadHook
  * @run main/othervm/native ClassFileLoadHookTest
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/InstrumentationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/InstrumentationTest.java
@@ -28,7 +28,7 @@
  *          using CDS/AppCDSv1/AppCDSv2.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @requires vm.cds
- * @requires vm.flavor != "minimal"
+ * @requires vm.jvmti
  * @build sun.hotspot.WhiteBox
  *        InstrumentationApp
  *        InstrumentationClassFileTransformer

--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/dumpingWithAgent/DumpingWithJavaAgent.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/dumpingWithAgent/DumpingWithJavaAgent.java
@@ -27,7 +27,7 @@
  * @summary CDS dumping with java agent.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @requires vm.cds
- * @requires vm.flavor != "minimal"
+ * @requires vm.jvmti
  * @build SimpleAgent Hello
  * @run main/othervm DumpingWithJavaAgent
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/dumpingWithAgent/DumpingWithJvmtiAgent.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/dumpingWithAgent/DumpingWithJvmtiAgent.java
@@ -25,7 +25,7 @@
  * @test
  * @summary CDS dumping with JVMTI agent.
  * @requires vm.cds
- * @requires vm.flavor != "minimal"
+ * @requires vm.jvmti
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile ../../test-classes/Hello.java
  * @run main/othervm/native DumpingWithJvmtiAgent

--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/parallelLoad/ParallelLoadAndTransformTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/parallelLoad/ParallelLoadAndTransformTest.java
@@ -31,6 +31,7 @@
  *     /test/hotspot/jtreg/testlibrary/jvmti
  * @requires vm.cds
  * @requires !vm.graal.enabled
+ * @requires vm.jvmti
  * @build TransformUtil TransformerAgent ParallelLoad
  * @run driver ParallelLoadAndTransformTest
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/transformRelatedClasses/TransformInterfaceImplementorAppCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/transformRelatedClasses/TransformInterfaceImplementorAppCDS.java
@@ -33,7 +33,7 @@
  *     /test/hotspot/jtreg/runtime/cds/appcds/customLoader
  *     /test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes
  * @requires vm.cds
- * @requires vm.flavor != "minimal"
+ * @requires vm.jvmti
  * @requires !vm.graal.enabled
  * @build TransformUtil TransformerAgent Interface Implementor
  * @run main/othervm TransformRelatedClassesAppCDS Interface Implementor

--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/transformRelatedClasses/TransformSuperSubAppCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/transformRelatedClasses/TransformSuperSubAppCDS.java
@@ -33,7 +33,7 @@
  *     /test/hotspot/jtreg/runtime/cds/appcds/customLoader
  *     /test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes
  * @requires vm.cds
- * @requires vm.flavor != "minimal"
+ * @requires vm.jvmti
  * @requires !vm.graal.enabled
  * @build TransformUtil TransformerAgent SubClass SuperClazz
  * @run main/othervm TransformRelatedClassesAppCDS SuperClazz SubClass

--- a/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineBasicTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineBasicTest.java
@@ -27,6 +27,7 @@
  * @summary Run /serviceability/jvmti/RedefineClasses/RedefineRunningMethods in AppCDS mode to
  *          make sure class redefinition works with CDS.
  * @requires vm.cds
+ * @requires vm.jvmti
  * @library /test/lib /test/hotspot/jtreg/serviceability/jvmti/RedefineClasses /test/hotspot/jtreg/runtime/cds/appcds
  * @run driver RedefineClassHelper
  * @build sun.hotspot.WhiteBox RedefineBasic

--- a/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineRunningMethods_Shared.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineRunningMethods_Shared.java
@@ -27,6 +27,7 @@
  * @summary Run /serviceability/jvmti/RedefineClasses/RedefineRunningMethods in AppCDS mode to
  *          make sure class redefinition works with CDS.
  * @requires vm.cds
+ * @requires vm.jvmti
  * @library /test/lib /test/hotspot/jtreg/serviceability/jvmti/RedefineClasses /test/hotspot/jtreg/runtime/cds/appcds
  * @run driver RedefineClassHelper
  * @build sun.hotspot.WhiteBox RedefineRunningMethods_SharedHelper

--- a/test/hotspot/jtreg/runtime/cds/serviceability/transformRelatedClasses/TransformInterfaceAndImplementor.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/transformRelatedClasses/TransformInterfaceAndImplementor.java
@@ -27,7 +27,7 @@
  *  with CDS with Interface/Implementor pair
  * @library /test/lib /runtime/cds /testlibrary/jvmti
  * @requires vm.cds
- * @requires vm.flavor != "minimal"
+ * @requires vm.jvmti
  * @requires !vm.graal.enabled
  * @build TransformUtil TransformerAgent Interface Implementor
  * @run main/othervm TransformRelatedClasses Interface Implementor

--- a/test/hotspot/jtreg/runtime/cds/serviceability/transformRelatedClasses/TransformSuperAndSubClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/transformRelatedClasses/TransformSuperAndSubClasses.java
@@ -28,7 +28,7 @@
  *  with CDS with SubClass and SuperClass
  * @library /test/lib /runtime/cds /testlibrary/jvmti
  * @requires vm.cds
- * @requires vm.flavor != "minimal"
+ * @requires vm.jvmti
  * @requires !vm.graal.enabled
  * @build TransformUtil TransformerAgent SubClass SuperClazz
  * @run main/othervm TransformRelatedClasses SuperClazz SubClass

--- a/test/hotspot/jtreg/runtime/cds/serviceability/transformRelatedClasses/TransformSuperSubTwoPckgs.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/transformRelatedClasses/TransformSuperSubTwoPckgs.java
@@ -28,7 +28,7 @@
  *  with CDS with SubClass and SuperClass, each lives in own separate package
  * @library /test/lib /runtime/cds /testlibrary/jvmti
  * @requires vm.cds
- * @requires vm.flavor != "minimal"
+ * @requires vm.jvmti
  * @requires !vm.graal.enabled
  * @build TransformUtil TransformerAgent SubClass SuperClazz
  * @compile myPkg2/SubClass.java myPkg1/SuperClazz.java

--- a/test/hotspot/jtreg/runtime/jni/FastGetField/FastGetField.java
+++ b/test/hotspot/jtreg/runtime/jni/FastGetField/FastGetField.java
@@ -26,6 +26,7 @@
  * @bug 8227680
  * @summary Tests that all FieldAccess notifications for Get*Field
             with primitive type are generated.
+ * @requires vm.jvmti
  * @compile FastGetField.java
  * @run main/othervm/native -agentlib:FastGetField -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyJNIFields FastGetField
  * @run main/othervm/native -agentlib:FastGetField -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyJNIFields -XX:+UnlockDiagnosticVMOptions -XX:+ForceUnreachable -XX:+SafepointALot -XX:GuaranteedSafepointInterval=1 FastGetField

--- a/test/hotspot/jtreg/runtime/logging/RedefineClasses.java
+++ b/test/hotspot/jtreg/runtime/logging/RedefineClasses.java
@@ -29,6 +29,7 @@
  * @library /test/lib
  * @modules java.compiler
  *          java.instrument
+ * @requires vm.jvmti
  * @run main RedefineClassHelper
  * @run main/othervm -Xmx256m -XX:MaxMetaspaceSize=64m -javaagent:redefineagent.jar -Xlog:all=trace:file=all.log RedefineClasses
  */

--- a/test/hotspot/jtreg/runtime/records/RedefineRecord.java
+++ b/test/hotspot/jtreg/runtime/records/RedefineRecord.java
@@ -28,6 +28,7 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.instrument
  *          jdk.jartool/sun.tools.jar
+ * @requires vm.jvmti
  * @compile --enable-preview -source ${jdk.version} RedefineRecord.java
  * @run main/othervm --enable-preview RedefineRecord buildagent
  * @run main/othervm/timeout=6000 --enable-preview RedefineRecord runtest

--- a/test/hotspot/jtreg/runtime/sealedClasses/RedefineSealedClass.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/RedefineSealedClass.java
@@ -29,6 +29,7 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.instrument
  *          jdk.jartool/sun.tools.jar
+ * @requires vm.jvmti
  * @compile --enable-preview -source ${jdk.version} RedefineSealedClass.java
  * @run main/othervm --enable-preview RedefineSealedClass buildagent
  * @run main/othervm/timeout=6000 --enable-preview RedefineSealedClass runtest

--- a/test/hotspot/jtreg/serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java
+++ b/test/hotspot/jtreg/serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java
@@ -30,6 +30,7 @@ package MyPackage;
  * @compile ASGCTBaseTest.java
  * @requires os.family == "linux"
  * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="arm" | os.arch=="aarch64" | os.arch=="ppc64" | os.arch=="s390"
+ * @requires vm.jvmti
  * @run main/othervm/native -agentlib:AsyncGetCallTraceTest MyPackage.ASGCTBaseTest
  */
 

--- a/test/hotspot/jtreg/serviceability/jdwp/AllModulesCommandTest.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/AllModulesCommandTest.java
@@ -34,6 +34,7 @@ import static jdk.test.lib.Asserts.assertTrue;
  * @library /test/lib
  * @modules jdk.jdwp.agent
  * @modules java.base/jdk.internal.misc
+ * @requires vm.jvmti
  * @compile AllModulesCommandTestDebuggee.java
  * @run main/othervm AllModulesCommandTest
  */

--- a/test/hotspot/jtreg/serviceability/jvmti/CanGenerateAllClassHook/CanGenerateAllClassHook.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/CanGenerateAllClassHook/CanGenerateAllClassHook.java
@@ -27,6 +27,7 @@
  * @summary Tests that jvmtiEnv::GetPotentialCapabilities reports
  *          can_generate_all_class_hook_events capability with CDS (-Xshare:on)
  *          at ONLOAD and LIVE phases
+ * @requires vm.jvmti
  * @requires vm.cds
  * @library /test/lib
  * @compile CanGenerateAllClassHook.java


### PR DESCRIPTION
This is subtask which covers test in hotspot/jtreg except test/hotspot/jtreg/vmTestbase/nsk/jvmti (there is a separate issue for it: JDK-8253371)

In most tests just "@requires vm.jvmti" is added,
in several test '@requires vm.flavor != "minimal"' is removed (when this requirement is only to ensure test VM has JVMTI included)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253372](https://bugs.openjdk.java.net/browse/JDK-8253372): [TESTBUG] update tests which require jvmti - hotspot


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/314/head:pull/314`
`$ git checkout pull/314`
