### PR TITLE
8253322 : Update the specification in the newly added constructors

### DIFF
--- a/src/java.desktop/share/classes/java/applet/Applet.java
+++ b/src/java.desktop/share/classes/java/applet/Applet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -579,7 +579,7 @@ public class Applet extends Panel {
         private static final long serialVersionUID = 8127374778187708896L;
 
         /**
-         * Constructs an {@code AccessibleApplet}
+         * Constructs an {@code AccessibleApplet}.
          */
         protected AccessibleApplet() {}
 

--- a/src/java.desktop/share/classes/java/awt/Button.java
+++ b/src/java.desktop/share/classes/java/awt/Button.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -538,7 +538,7 @@ public class Button extends Component implements Accessible {
         private static final long serialVersionUID = -5932203980244017102L;
 
         /**
-         * Constructs an {@code AccessibleAWTButton}
+         * Constructs an {@code AccessibleAWTButton}.
          */
         protected AccessibleAWTButton() {}
 

--- a/src/java.desktop/share/classes/java/awt/Canvas.java
+++ b/src/java.desktop/share/classes/java/awt/Canvas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -241,7 +241,7 @@ public class Canvas extends Component implements Accessible {
         private static final long serialVersionUID = -6325592262103146699L;
 
         /**
-         * Constructs an {@code AccessibleAWTCanvas}
+         * Constructs an {@code AccessibleAWTCanvas}.
          */
         protected AccessibleAWTCanvas() {}
 

--- a/src/java.desktop/share/classes/java/awt/CheckboxMenuItem.java
+++ b/src/java.desktop/share/classes/java/awt/CheckboxMenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -537,7 +537,7 @@ public class CheckboxMenuItem extends MenuItem implements ItemSelectable, Access
         private static final long serialVersionUID = -1122642964303476L;
 
         /**
-         * Constructs an {@code AccessibleAWTCheckboxMenuItem}
+         * Constructs an {@code AccessibleAWTCheckboxMenuItem}.
          */
         protected AccessibleAWTCheckboxMenuItem() {}
 

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -9342,7 +9342,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
             private static final long serialVersionUID = -1009684107426231869L;
 
             /**
-             * Constructs an {@code AccessibleAWTComponentHandler}
+             * Constructs an {@code AccessibleAWTComponentHandler}.
              */
             protected AccessibleAWTComponentHandler() {}
 
@@ -9379,7 +9379,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
             private static final long serialVersionUID = 3150908257351582233L;
 
             /**
-             * Constructs an {@code AccessibleAWTFocusHandler}
+             * Constructs an {@code AccessibleAWTFocusHandler}.
              */
             protected AccessibleAWTFocusHandler() {}
 

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3807,7 +3807,7 @@ public class Container extends Component {
         private static final long serialVersionUID = 5081320404842566097L;
 
         /**
-         * Constructs an {@code AccessibleAWTContainer}
+         * Constructs an {@code AccessibleAWTContainer}.
          */
         protected AccessibleAWTContainer() {}
 
@@ -3869,7 +3869,7 @@ public class Container extends Component {
             private static final long serialVersionUID = -480855353991814677L;
 
             /**
-             * Constructs an {@code AccessibleContainerHandler}
+             * Constructs an {@code AccessibleContainerHandler}.
              */
             protected AccessibleContainerHandler() {}
 

--- a/src/java.desktop/share/classes/java/awt/Dialog.java
+++ b/src/java.desktop/share/classes/java/awt/Dialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1659,7 +1659,7 @@ public class Dialog extends Window {
         private static final long serialVersionUID = 4837230331833941201L;
 
         /**
-         * Constructs an {@code AccessibleAWTDialog}
+         * Constructs an {@code AccessibleAWTDialog}.
          */
         protected AccessibleAWTDialog() {}
 

--- a/src/java.desktop/share/classes/java/awt/Frame.java
+++ b/src/java.desktop/share/classes/java/awt/Frame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1298,7 +1298,7 @@ public class Frame extends Window implements MenuContainer {
         private static final long serialVersionUID = -6172960752956030250L;
 
         /**
-         * Constructs an {@code AccessibleAWTFrame}
+         * Constructs an {@code AccessibleAWTFrame}.
          */
         protected AccessibleAWTFrame() {}
 

--- a/src/java.desktop/share/classes/java/awt/Menu.java
+++ b/src/java.desktop/share/classes/java/awt/Menu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -625,7 +625,7 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
         private static final long serialVersionUID = 5228160894980069094L;
 
         /**
-         * Constructs an {@code AccessibleAWTMenu}
+         * Constructs an {@code AccessibleAWTMenu}.
          */
         protected AccessibleAWTMenu() {}
 

--- a/src/java.desktop/share/classes/java/awt/MenuBar.java
+++ b/src/java.desktop/share/classes/java/awt/MenuBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -512,7 +512,7 @@ public class MenuBar extends MenuComponent implements MenuContainer, Accessible 
         private static final long serialVersionUID = -8577604491830083815L;
 
         /**
-         * Constructs an {@code AccessibleAWTMenuBar}
+         * Constructs an {@code AccessibleAWTMenuBar}.
          */
         protected AccessibleAWTMenuBar() {}
 

--- a/src/java.desktop/share/classes/java/awt/MenuItem.java
+++ b/src/java.desktop/share/classes/java/awt/MenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -824,7 +824,7 @@ public class MenuItem extends MenuComponent implements Accessible {
         private static final long serialVersionUID = -217847831945965825L;
 
         /**
-         * Constructs an {@code AccessibleAWTMenuItem}
+         * Constructs an {@code AccessibleAWTMenuItem}.
          */
         protected AccessibleAWTMenuItem() {}
 

--- a/src/java.desktop/share/classes/java/awt/Panel.java
+++ b/src/java.desktop/share/classes/java/awt/Panel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,7 +120,7 @@ public class Panel extends Container implements Accessible {
         private static final long serialVersionUID = -6409552226660031050L;
 
         /**
-         * Constructs an {@code AccessibleAWTPanel}
+         * Constructs an {@code AccessibleAWTPanel}.
          */
         protected AccessibleAWTPanel() {}
 

--- a/src/java.desktop/share/classes/java/awt/PopupMenu.java
+++ b/src/java.desktop/share/classes/java/awt/PopupMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -229,7 +229,7 @@ public class PopupMenu extends Menu {
         private static final long serialVersionUID = -4282044795947239955L;
 
         /**
-         * Constructs an {@code AccessibleAWTPopupMenu}
+         * Constructs an {@code AccessibleAWTPopupMenu}.
          */
         protected AccessibleAWTPopupMenu() {}
 

--- a/src/java.desktop/share/classes/java/awt/ScrollPane.java
+++ b/src/java.desktop/share/classes/java/awt/ScrollPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -792,7 +792,7 @@ public class ScrollPane extends Container implements Accessible {
         private static final long serialVersionUID = 6100703663886637L;
 
         /**
-         * Constructs an {@code AccessibleAWTScrollPane}
+         * Constructs an {@code AccessibleAWTScrollPane}.
          */
         protected AccessibleAWTScrollPane() {}
 

--- a/src/java.desktop/share/classes/java/awt/Scrollbar.java
+++ b/src/java.desktop/share/classes/java/awt/Scrollbar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1263,7 +1263,7 @@ public class Scrollbar extends Component implements Adjustable, Accessible {
         private static final long serialVersionUID = -344337268523697807L;
 
         /**
-         * Constructs an {@code AccessibleAWTScrollBar}
+         * Constructs an {@code AccessibleAWTScrollBar}.
          */
         protected AccessibleAWTScrollBar() {}
 

--- a/src/java.desktop/share/classes/java/awt/TextArea.java
+++ b/src/java.desktop/share/classes/java/awt/TextArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -720,7 +720,7 @@ public class TextArea extends TextComponent {
         private static final long serialVersionUID = 3472827823632144419L;
 
         /**
-         * Constructs an {@code AccessibleAWTTextArea}
+         * Constructs an {@code AccessibleAWTTextArea}.
          */
         protected AccessibleAWTTextArea() {}
 

--- a/src/java.desktop/share/classes/java/awt/TextField.java
+++ b/src/java.desktop/share/classes/java/awt/TextField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -789,7 +789,7 @@ public class TextField extends TextComponent {
         private static final long serialVersionUID = 6219164359235943158L;
 
         /**
-         * Constructs an {@code AccessibleAWTTextField}
+         * Constructs an {@code AccessibleAWTTextField}.
          */
         protected AccessibleAWTTextField() {}
 

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -3164,7 +3164,7 @@ public class Window extends Container implements Accessible {
         private static final long serialVersionUID = 4215068635060671780L;
 
         /**
-         * Constructs an {@code AccessibleAWTWindow}
+         * Constructs an {@code AccessibleAWTWindow}.
          */
         protected AccessibleAWTWindow() {}
 

--- a/src/java.desktop/share/classes/javax/sound/midi/spi/MidiDeviceProvider.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/spi/MidiDeviceProvider.java
@@ -39,7 +39,7 @@ import javax.sound.midi.MidiDevice;
 public abstract class MidiDeviceProvider {
 
     /**
-     * Constructs a {@code MidiDeviceProvider}.
+     * Constructor for subclasses to call.
      */
     protected MidiDeviceProvider() {}
 

--- a/src/java.desktop/share/classes/javax/sound/midi/spi/MidiFileReader.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/spi/MidiFileReader.java
@@ -46,7 +46,7 @@ import javax.sound.midi.Sequence;
 public abstract class MidiFileReader {
 
     /**
-     * Constructs a {@code MidiFileReader}.
+     * Constructor for subclasses to call.
      */
     protected MidiFileReader() {}
 

--- a/src/java.desktop/share/classes/javax/sound/midi/spi/MidiFileWriter.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/spi/MidiFileWriter.java
@@ -43,7 +43,7 @@ import javax.sound.midi.Sequence;
 public abstract class MidiFileWriter {
 
     /**
-     * Constructs a {@code MidiFileWriter}.
+     * Constructor for subclasses to call.
      */
     protected MidiFileWriter() {}
 

--- a/src/java.desktop/share/classes/javax/sound/midi/spi/SoundbankReader.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/spi/SoundbankReader.java
@@ -45,7 +45,7 @@ import javax.sound.midi.Synthesizer;
 public abstract class SoundbankReader {
 
     /**
-     * Constructs a {@code SoundbankReader}.
+     * Constructor for subclasses to call.
      */
     protected SoundbankReader() {}
 

--- a/src/java.desktop/share/classes/javax/sound/sampled/spi/AudioFileReader.java
+++ b/src/java.desktop/share/classes/javax/sound/sampled/spi/AudioFileReader.java
@@ -45,7 +45,7 @@ import javax.sound.sampled.UnsupportedAudioFileException;
 public abstract class AudioFileReader {
 
     /**
-     * Constructs an {@code AudioFileReader}.
+     * Constructor for subclasses to call.
      */
     protected AudioFileReader() {}
 

--- a/src/java.desktop/share/classes/javax/sound/sampled/spi/AudioFileWriter.java
+++ b/src/java.desktop/share/classes/javax/sound/sampled/spi/AudioFileWriter.java
@@ -46,7 +46,7 @@ import static javax.sound.sampled.AudioFileFormat.Type;
 public abstract class AudioFileWriter {
 
     /**
-     * Constructs an {@code AudioFileWriter}.
+     * Constructor for subclasses to call.
      */
     protected AudioFileWriter() {}
 

--- a/src/java.desktop/share/classes/javax/sound/sampled/spi/FormatConversionProvider.java
+++ b/src/java.desktop/share/classes/javax/sound/sampled/spi/FormatConversionProvider.java
@@ -52,7 +52,7 @@ import static javax.sound.sampled.AudioFormat.Encoding;
 public abstract class FormatConversionProvider {
 
     /**
-     * Constructs a {@code FormatConversionProvider}.
+     * Constructor for subclasses to call.
      */
     protected FormatConversionProvider() {}
 

--- a/src/java.desktop/share/classes/javax/sound/sampled/spi/MixerProvider.java
+++ b/src/java.desktop/share/classes/javax/sound/sampled/spi/MixerProvider.java
@@ -40,7 +40,7 @@ import javax.sound.sampled.Mixer;
 public abstract class MixerProvider {
 
     /**
-     * Constructs a {@code MixerProvider}.
+     * Constructor for subclasses to call.
      */
     protected MixerProvider() {}
 

--- a/src/java.desktop/share/classes/javax/swing/Box.java
+++ b/src/java.desktop/share/classes/javax/swing/Box.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -384,8 +384,9 @@ public class Box extends JComponent implements Accessible {
          */
         @SuppressWarnings("serial")
         protected class AccessibleBoxFiller extends AccessibleAWTComponent {
+
             /**
-             * Constructor for subclasses to call.
+             * Constructs an {@code AccessibleBoxFiller}.
              */
             protected AccessibleBoxFiller() {}
 
@@ -431,8 +432,9 @@ public class Box extends JComponent implements Accessible {
      */
     @SuppressWarnings("serial")
     protected class AccessibleBox extends AccessibleAWTContainer {
+
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleBox}.
          */
         protected AccessibleBox() {}
 

--- a/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
+++ b/src/java.desktop/share/classes/javax/swing/CellRendererPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -244,8 +244,9 @@ public class CellRendererPane extends Container implements Accessible
      * <code>CellRendererPane</code> class.
      */
     protected class AccessibleCellRendererPane extends AccessibleAWTContainer {
+
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleCellRendererPane}.
          */
         protected AccessibleCellRendererPane() {}
 

--- a/src/java.desktop/share/classes/javax/swing/DefaultCellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultCellEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -304,7 +304,7 @@ public class DefaultCellEditor extends AbstractCellEditor
         protected Object value;
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code EditorDelegate}.
          */
         protected EditorDelegate() {}
 

--- a/src/java.desktop/share/classes/javax/swing/ImageIcon.java
+++ b/src/java.desktop/share/classes/javax/swing/ImageIcon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -597,7 +597,7 @@ public class ImageIcon implements Icon, Serializable, Accessible {
         implements AccessibleIcon, Serializable {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleImageIcon}.
          */
         protected AccessibleImageIcon() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JApplet.java
+++ b/src/java.desktop/share/classes/javax/swing/JApplet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -566,8 +566,9 @@ public class JApplet extends Applet implements Accessible,
      * <code>JApplet</code> class.
      */
     protected class AccessibleJApplet extends AccessibleApplet {
+
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJApplet}.
          */
         protected AccessibleJApplet() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JButton.java
+++ b/src/java.desktop/share/classes/javax/swing/JButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -302,7 +302,7 @@ public class JButton extends AbstractButton implements Accessible {
     protected class AccessibleJButton extends AccessibleAbstractButton {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJButton}.
          */
         protected AccessibleJButton() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JCheckBox.java
+++ b/src/java.desktop/share/classes/javax/swing/JCheckBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -333,7 +333,7 @@ public class JCheckBox extends JToggleButton implements Accessible {
     protected class AccessibleJCheckBox extends AccessibleJToggleButton {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJCheckBox}.
          */
         protected AccessibleJCheckBox() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JCheckBoxMenuItem.java
+++ b/src/java.desktop/share/classes/javax/swing/JCheckBoxMenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -304,8 +304,9 @@ public class JCheckBoxMenuItem extends JMenuItem implements SwingConstants,
      */
     @SuppressWarnings("serial") // Same-version serialization only
     protected class AccessibleJCheckBoxMenuItem extends AccessibleJMenuItem {
+
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJCheckBoxMenuItem}.
          */
         protected AccessibleJCheckBoxMenuItem() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JColorChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JColorChooser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -600,7 +600,7 @@ public class JColorChooser extends JComponent implements Accessible {
     protected class AccessibleJColorChooser extends AccessibleJComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJColorChooser}.
          */
         protected AccessibleJColorChooser() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3710,8 +3710,9 @@ public abstract class JComponent extends Container implements Serializable,
          */
         protected class AccessibleContainerHandler
             implements ContainerListener {
+
             /**
-             * Constructor for subclasses to call.
+             * Constructs an {@code AccessibleContainerHandler}.
              */
             protected AccessibleContainerHandler() {}
             public void componentAdded(ContainerEvent e) {
@@ -3743,7 +3744,7 @@ public abstract class JComponent extends Container implements Serializable,
         @Deprecated
         protected class AccessibleFocusHandler implements FocusListener {
            /**
-            * Constructor for subclasses to call.
+            * Constructs an {@code AccessibleFocusHandler}.
             */
            protected AccessibleFocusHandler() {}
            public void focusGained(FocusEvent event) {

--- a/src/java.desktop/share/classes/javax/swing/JDesktopPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JDesktopPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -628,7 +628,7 @@ public class JDesktopPane extends JLayeredPane implements Accessible
     protected class AccessibleJDesktopPane extends AccessibleJComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJDesktopPane}.
          */
         protected AccessibleJDesktopPane() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JDialog.java
+++ b/src/java.desktop/share/classes/javax/swing/JDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1239,7 +1239,7 @@ public class JDialog extends Dialog implements WindowConstants,
     protected class AccessibleJDialog extends AccessibleAWTDialog {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJDialog}.
          */
         protected AccessibleJDialog() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JEditorPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JEditorPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1660,7 +1660,7 @@ public class JEditorPane extends JTextComponent {
     protected class AccessibleJEditorPane extends AccessibleJTextComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJEditorPane}.
          */
         protected AccessibleJEditorPane() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -2042,7 +2042,7 @@ public class JFileChooser extends JComponent implements Accessible {
     protected class AccessibleJFileChooser extends AccessibleJComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJFileChooser}.
          */
         protected AccessibleJFileChooser() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JFrame.java
+++ b/src/java.desktop/share/classes/javax/swing/JFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -883,7 +883,7 @@ public class JFrame  extends Frame implements WindowConstants,
     protected class AccessibleJFrame extends AccessibleAWTFrame {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJFrame}.
          */
         protected AccessibleJFrame() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
+++ b/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2012,7 +2012,7 @@ public class JInternalFrame extends JComponent implements
         implements AccessibleValue {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJInternalFrame}.
          */
         protected AccessibleJInternalFrame() {}
 
@@ -2308,7 +2308,7 @@ public class JInternalFrame extends JComponent implements
             implements AccessibleValue {
 
             /**
-             * Constructor for subclasses to call.
+             * Constructs an {@code AccessibleJDesktopIcon}.
              */
             protected AccessibleJDesktopIcon() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JLabel.java
+++ b/src/java.desktop/share/classes/javax/swing/JLabel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1044,7 +1044,7 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
         implements AccessibleText, AccessibleExtendedComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJLabel}.
          */
         protected AccessibleJLabel() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JLayeredPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JLayeredPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -767,7 +767,7 @@ public class JLayeredPane extends JComponent implements Accessible {
     protected class AccessibleJLayeredPane extends AccessibleJComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJLayeredPane}.
          */
         protected AccessibleJLayeredPane() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1396,7 +1396,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
         implements AccessibleSelection {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJMenu}.
          */
         protected AccessibleJMenu() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JMenuBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenuBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -511,7 +511,7 @@ public class JMenuBar extends JComponent implements Accessible,MenuElement
         implements AccessibleSelection {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJMenuBar}.
          */
         protected AccessibleJMenuBar() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JOptionPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JOptionPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2548,7 +2548,7 @@ public class JOptionPane extends JComponent implements Accessible
     protected class AccessibleJOptionPane extends AccessibleJComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJOptionPane}.
          */
         protected AccessibleJOptionPane() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JPanel.java
+++ b/src/java.desktop/share/classes/javax/swing/JPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -232,8 +232,9 @@ public class JPanel extends JComponent implements Accessible
      */
     @SuppressWarnings("serial") // Same-version serialization only
     protected class AccessibleJPanel extends AccessibleJComponent {
+
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJPanel}.
          */
         protected AccessibleJPanel() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JPasswordField.java
+++ b/src/java.desktop/share/classes/javax/swing/JPasswordField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -407,7 +407,7 @@ public class JPasswordField extends JTextField {
     protected class AccessibleJPasswordField extends AccessibleJTextField {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJPasswordField}.
          */
         protected AccessibleJPasswordField() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JProgressBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JProgressBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1012,7 +1012,7 @@ public class JProgressBar extends JComponent implements SwingConstants, Accessib
         implements AccessibleValue {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJProgressBar}.
          */
         protected AccessibleJProgressBar() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JRadioButton.java
+++ b/src/java.desktop/share/classes/javax/swing/JRadioButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -286,7 +286,7 @@ public class JRadioButton extends JToggleButton implements Accessible {
     protected class AccessibleJRadioButton extends AccessibleJToggleButton {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJRadioButton}.
          */
         protected AccessibleJRadioButton() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JRadioButtonMenuItem.java
+++ b/src/java.desktop/share/classes/javax/swing/JRadioButtonMenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -278,8 +278,9 @@ public class JRadioButtonMenuItem extends JMenuItem implements Accessible {
      */
     @SuppressWarnings("serial") // Same-version serialization only
     protected class AccessibleJRadioButtonMenuItem extends AccessibleJMenuItem {
+
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJRadioButtonMenuItem}.
          */
         protected AccessibleJRadioButtonMenuItem() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JRootPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JRootPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -848,7 +848,7 @@ public class JRootPane extends JComponent implements Accessible {
     protected class RootLayout implements LayoutManager2, Serializable
     {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code RootLayout}.
          */
         protected RootLayout() {}
 
@@ -1017,8 +1017,9 @@ public class JRootPane extends JComponent implements Accessible {
      */
     @SuppressWarnings("serial")
     protected class AccessibleJRootPane extends AccessibleJComponent {
+
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJRootPane}.
          */
         protected AccessibleJRootPane() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JScrollBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JScrollBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -856,7 +856,7 @@ public class JScrollBar extends JComponent implements Adjustable, Accessible
         implements AccessibleValue {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJScrollBar}.
          */
         protected AccessibleJScrollBar() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JSeparator.java
+++ b/src/java.desktop/share/classes/javax/swing/JSeparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -278,7 +278,7 @@ public class JSeparator extends JComponent implements SwingConstants, Accessible
     protected class AccessibleJSeparator extends AccessibleJComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJSeparator}.
          */
         protected AccessibleJSeparator() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1135,8 +1135,9 @@ public class JSplitPane extends JComponent implements Accessible
     @SuppressWarnings("serial") // Same-version serialization only
     protected class AccessibleJSplitPane extends AccessibleJComponent
         implements AccessibleValue {
+
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJSplitPane}.
          */
         protected AccessibleJSplitPane() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -289,8 +289,9 @@ public class JTabbedPane extends JComponent
      * the tabbedpane (instead of the model itself) as the event source.
      */
     protected class ModelListener implements ChangeListener, Serializable {
+
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code ModelListener}.
          */
         protected ModelListener() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JTextArea.java
+++ b/src/java.desktop/share/classes/javax/swing/JTextArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -784,7 +784,7 @@ public class JTextArea extends JTextComponent {
     protected class AccessibleJTextArea extends AccessibleJTextComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJTextArea}.
          */
         protected AccessibleJTextArea() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JTextField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -951,7 +951,7 @@ public class JTextField extends JTextComponent implements SwingConstants {
     protected class AccessibleJTextField extends AccessibleJTextComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJTextField}.
          */
         protected AccessibleJTextField() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JToolBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JToolBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -832,7 +832,7 @@ public class JToolBar extends JComponent implements SwingConstants, Accessible
     protected class AccessibleJToolBar extends AccessibleJComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJToolBar}.
          */
         protected AccessibleJToolBar() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JToolTip.java
+++ b/src/java.desktop/share/classes/javax/swing/JToolTip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -262,7 +262,7 @@ public class JToolTip extends JComponent implements Accessible {
     protected class AccessibleJToolTip extends AccessibleJComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJToolTip}.
          */
         protected AccessibleJToolTip() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JTree.java
+++ b/src/java.desktop/share/classes/javax/swing/JTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3321,7 +3321,7 @@ public class JTree extends JComponent implements Scrollable, Accessible
               DefaultTreeSelectionModel
     {
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code EmptySelectionModel}.
          */
         protected EmptySelectionModel() {}
 
@@ -3448,7 +3448,7 @@ public class JTree extends JComponent implements Scrollable, Accessible
                     TreeSelectionListener
     {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code TreeSelectionRedirector}.
          */
         protected TreeSelectionRedirector() {}
 
@@ -3873,10 +3873,11 @@ public class JTree extends JComponent implements Scrollable, Accessible
       * accordingly when nodes are removed, or changed.
       */
     protected class TreeModelHandler implements TreeModelListener {
-         /**
-          * Constructor for subclasses to call.
-          */
-         protected TreeModelHandler() {}
+
+        /**
+         * Constructs a {@code TreeModelHandler}.
+         */
+        protected TreeModelHandler() {}
 
         public void treeNodesChanged(TreeModelEvent e) { }
 

--- a/src/java.desktop/share/classes/javax/swing/JViewport.java
+++ b/src/java.desktop/share/classes/javax/swing/JViewport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1406,7 +1406,7 @@ public class JViewport extends JComponent implements Accessible
     protected class ViewListener extends ComponentAdapter implements Serializable
     {
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code ViewListener}.
          */
         protected ViewListener() {}
 
@@ -1882,7 +1882,7 @@ public class JViewport extends JComponent implements Accessible
     protected class AccessibleJViewport extends AccessibleJComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJViewport}.
          */
         protected AccessibleJViewport() {}
 

--- a/src/java.desktop/share/classes/javax/swing/JWindow.java
+++ b/src/java.desktop/share/classes/javax/swing/JWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -655,7 +655,7 @@ public class JWindow extends Window implements Accessible,
     protected class AccessibleJWindow extends AccessibleAWTWindow {
         // everything is in the new parent, AccessibleAWTWindow
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJWindow}.
          */
         protected AccessibleJWindow() {}
     }

--- a/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
+++ b/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -677,8 +677,9 @@ public class ToolTipManager extends MouseAdapter implements MouseMotionListener 
      * Inside timer action.
      */
     protected class insideTimerAction implements ActionListener {
+
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code insideTimerAction}.
          */
         protected insideTimerAction() {}
 
@@ -712,8 +713,9 @@ public class ToolTipManager extends MouseAdapter implements MouseMotionListener 
      * Outside timer action.
      */
     protected class outsideTimerAction implements ActionListener {
+
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code outsideTimerAction}.
          */
         protected outsideTimerAction() {}
 
@@ -729,8 +731,9 @@ public class ToolTipManager extends MouseAdapter implements MouseMotionListener 
      * Still inside timer action.
      */
     protected class stillInsideTimerAction implements ActionListener {
+
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code stillInsideTimerAction}.
          */
         protected stillInsideTimerAction() {}
 

--- a/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
+++ b/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -809,7 +809,7 @@ public class JTableHeader extends JComponent implements TableColumnModelListener
     protected class AccessibleJTableHeader extends AccessibleJComponent {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs an {@code AccessibleJTableHeader}.
          */
         protected AccessibleJTableHeader() {}
 

--- a/src/java.desktop/share/classes/javax/swing/text/html/FormView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/FormView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -553,7 +553,7 @@ public class FormView extends ComponentView implements ActionListener {
     protected class MouseEventListener extends MouseAdapter {
 
         /**
-         * Constructor for subclasses to call.
+         * Constructs a {@code MouseEventListener}.
          */
         protected MouseEventListener() {}
 


### PR DESCRIPTION
Looks like different people use a different style for the new constructors, it will be good to unify them. 

The text "Constructor for subclasses to call." should be used in the protected constructors in the abstract classes
In all other cases the text "Constructs an {@code ClassName}." should be used
A period (full stop) to the end of all javadoc comments, should be added if it is missing

I have started from https://bugs.openjdk.java.net/browse/JDK-8252721
See
https://bugs.openjdk.java.net/browse/JDK-8252908?focusedCommentId=14370006&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14370006

But since I already touched a bunch of classes, I decided to update some other fixes as well.

This will update the changes for:
https://bugs.openjdk.java.net/browse/JDK-8252721
https://bugs.openjdk.java.net/browse/JDK-8252195
https://bugs.openjdk.java.net/browse/JDK-8250858

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253322](https://bugs.openjdk.java.net/browse/JDK-8253322): Update the specification in the newly added constructors


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/315/head:pull/315`
`$ git checkout pull/315`
