### PR TITLE
8253516: ZGC: Remove card table functions

### DIFF
--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -225,22 +225,6 @@ size_t ZCollectedHeap::unsafe_max_tlab_alloc(Thread* ignored) const {
   return _heap.unsafe_max_tlab_alloc();
 }
 
-bool ZCollectedHeap::can_elide_tlab_store_barriers() const {
-  return false;
-}
-
-bool ZCollectedHeap::can_elide_initializing_store_barrier(oop new_obj) {
-  // Not supported
-  ShouldNotReachHere();
-  return true;
-}
-
-bool ZCollectedHeap::card_mark_must_follow_store() const {
-  // Not supported
-  ShouldNotReachHere();
-  return false;
-}
-
 GrowableArray<GCMemoryManager*> ZCollectedHeap::memory_managers() {
   return GrowableArray<GCMemoryManager*>(1, 1, _heap.serviceability_memory_manager());
 }

--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -89,10 +89,6 @@ public:
   virtual size_t max_tlab_size() const;
   virtual size_t unsafe_max_tlab_alloc(Thread* thr) const;
 
-  virtual bool can_elide_tlab_store_barriers() const;
-  virtual bool can_elide_initializing_store_barrier(oop new_obj);
-  virtual bool card_mark_must_follow_store() const;
-
   virtual GrowableArray<GCMemoryManager*> memory_managers();
   virtual GrowableArray<MemoryPool*> memory_pools();
 


### PR DESCRIPTION
A few functions were not removed from ZCollectedHeap when the card table functions were moved out of CollectedHeap (JDK-8195103). Remove them.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253516](https://bugs.openjdk.java.net/browse/JDK-8253516): ZGC: Remove card table functions


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/316/head:pull/316`
`$ git checkout pull/316`
