### PR TITLE
8242882: opening jar file with large manifest might throw NegativeArraySizeException

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -152,13 +152,8 @@ public class JarFile extends ZipFile {
     private static final boolean MULTI_RELEASE_ENABLED;
     private static final boolean MULTI_RELEASE_FORCED;
     private static final ThreadLocal<Boolean> isInitializing = new ThreadLocal<>();
-    /**
-     * The maximum size of array to allocate.
-     * Some VMs reserve some header words in an array.
-     * Attempts to allocate larger arrays may result in
-     * OutOfMemoryError: Required array size too large
-     */
-    private static final int MAX_BUFFER_SIZE = Integer.MAX_VALUE - 8;
+    // The maximum size of array to allocate. Some VMs reserve some header words in an array.
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
 
     private SoftReference<Manifest> manRef;
     private JarEntry manEntry;
@@ -795,16 +790,17 @@ public class JarFile extends ZipFile {
      */
     private byte[] getBytes(ZipEntry ze) throws IOException {
         try (InputStream is = super.getInputStream(ze)) {
-            long len = ze.getSize();
-            if (len > MAX_BUFFER_SIZE) {
+            long uncompressedSize = ze.getSize();
+            if (uncompressedSize > MAX_ARRAY_SIZE) {
                 throw new OutOfMemoryError("Required array size too large");
             }
+            int len = (int)uncompressedSize;
             int bytesRead;
             byte[] b;
             // trust specified entry sizes when reasonably small
-            if (len >= 0 && len <= 65535) {
-                b = new byte[(int) len];
-                bytesRead = is.readNBytes(b, 0, (int) len);
+            if (len != -1 && len <= 65535) {
+                b = new byte[len];
+                bytesRead = is.readNBytes(b, 0, len);
             } else {
                 b = is.readAllBytes();
                 bytesRead = b.length;

--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -791,8 +791,10 @@ public class JarFile extends ZipFile {
             int len = (int)ze.getSize();
             int bytesRead;
             byte[] b;
-            // trust specified entry sizes when reasonably small
-            if (len != -1 && len <= 65535) {
+            if (len == 0) {
+                b = new byte[0];
+                bytesRead = 0;
+            } else if (len > 0 && len <= 65535) { // trust specified entry sizes when reasonably small
                 b = new byte[len];
                 bytesRead = is.readNBytes(b, 0, len);
             } else {

--- a/test/jdk/java/util/jar/JarFile/LargeManifestOOMTest.java
+++ b/test/jdk/java/util/jar/JarFile/LargeManifestOOMTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.util.JarUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.jar.JarFile;
+
+/**
+ * @test
+ * @bug 8242882
+ * @summary Verify that opening a jar file with a large manifest throws an OutOfMemoryError
+ * and not a NegativeArraySizeException
+ * @library /test/lib
+ * @run testng LargeManifestOOMTest
+ */
+public class LargeManifestOOMTest {
+
+
+    /**
+     * Creates a jar which has a large manifest file and then uses the {@link JarFile} to
+     * {@link JarFile#getManifest() load the manifest}. The call to the {@link JarFile#getManifest()}
+     * is then expected to throw a {@link OutOfMemoryError}
+     */
+    @Test
+    public void testOutOfMemoryError() throws Exception {
+        final Path jarSourceRoot = Paths.get("jar-source");
+        createLargeManifest(jarSourceRoot.resolve("META-INF"));
+        final Path jarFilePath = Paths.get("oom-test.jar");
+        JarUtils.createJarFile(jarFilePath.toAbsolutePath(), jarSourceRoot);
+        final JarFile jar = new JarFile(jarFilePath.toFile());
+        final OutOfMemoryError oome = Assert.expectThrows(OutOfMemoryError.class, () -> jar.getManifest());
+        // additionally verify that the OOM was for the right/expected reason
+        if (!"Required array size too large".equals(oome.getMessage())) {
+            Assert.fail("Unexpected OutOfMemoryError", oome);
+        }
+    }
+
+    /**
+     * Creates a {@code MANIFEST.MF}, whose content is 2GB in size, in the {@code parentDir}
+     *
+     * @param parentDir The directory in which the MANIFEST.MF file will be created
+     */
+    private static void createLargeManifest(final Path parentDir) throws IOException {
+        Files.createDirectories(parentDir.toAbsolutePath());
+        final Path manifestFile = parentDir.resolve("MANIFEST.MF");
+        try (final BufferedWriter bw = Files.newBufferedWriter(manifestFile)) {
+            bw.write("Manifest-Version: 1.0");
+            bw.newLine();
+            bw.write("OOM-Test: ");
+            for (long i = 0; i < 2147483648L; i++) {
+                bw.write("a");
+            }
+            bw.newLine();
+        }
+    }
+
+}


### PR DESCRIPTION
Can I please get a review and a sponsor for a fix for https://bugs.openjdk.java.net/browse/JDK-8242882?

As noted in that JBS issue, if the size of the Manifest entry in the jar happens to be very large (such that it exceeds the `Integer.MAX_VALUE`), then the current code in `JarFile#getBytes` can lead to a `NegativeArraySizeException`.  This is due to the:
```
if (len != -1 && len <= 65535) 
```
block which evaluates to `true` when the size of the manifest entry is larger than `Integer.MAX_VALUE`. As a result, this then ends up calling the code which can lead to the `NegativeArraySizeException`.

The commit in this PR fixes that issue by changing those `if/else` blocks to prevent this issue and instead use a code path that leads to the `InputStream#readAllBytes()` which internally has the necessary checks to throw the expected `OutOfMemoryError`.

This commit also includes a jtreg test case which reproduces the issue and verifies the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242882](https://bugs.openjdk.java.net/browse/JDK-8242882): opening jar file with large manifest might throw NegativeArraySizeException


### Reviewers
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/323/head:pull/323`
`$ git checkout pull/323`
