### PR TITLE
8253539: Remove unused JavaThread functions for set_last_Java_fp/pc

### DIFF
--- a/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -80,8 +80,6 @@ public:
 
   void set_last_Java_sp(intptr_t* sp)            { _last_Java_sp = sp; OrderAccess::release(); }
 
-  intptr_t*   last_Java_fp(void)                     { return _last_Java_fp; }
-  // Assert (last_Java_sp == NULL || fp == NULL)
-  void set_last_Java_fp(intptr_t* fp)                { OrderAccess::release(); _last_Java_fp = fp; }
+  intptr_t*   last_Java_fp(void)                 { return _last_Java_fp; }
 
 #endif // CPU_AARCH64_JAVAFRAMEANCHOR_AARCH64_HPP

--- a/src/hotspot/cpu/arm/javaFrameAnchor_arm.hpp
+++ b/src/hotspot/cpu/arm/javaFrameAnchor_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,8 +79,6 @@ public:
 
   void set_last_Java_sp(intptr_t* sp)            { _last_Java_sp = sp; }
 
-  intptr_t*   last_Java_fp(void)                     { return _last_Java_fp; }
-  // Assert (last_Java_sp == NULL || fp == NULL)
-  void set_last_Java_fp(intptr_t* fp)                { _last_Java_fp = fp; }
+  intptr_t*   last_Java_fp(void)                 { return _last_Java_fp; }
 
 #endif // CPU_ARM_JAVAFRAMEANCHOR_ARM_HPP

--- a/src/hotspot/cpu/x86/javaFrameAnchor_x86.hpp
+++ b/src/hotspot/cpu/x86/javaFrameAnchor_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,8 +78,6 @@ public:
 
   void set_last_Java_sp(intptr_t* sp)            { _last_Java_sp = sp; }
 
-  intptr_t*   last_Java_fp(void)                     { return _last_Java_fp; }
-  // Assert (last_Java_sp == NULL || fp == NULL)
-  void set_last_Java_fp(intptr_t* fp)                { _last_Java_fp = fp; }
+  intptr_t*   last_Java_fp(void)                 { return _last_Java_fp; }
 
 #endif // CPU_X86_JAVAFRAMEANCHOR_X86_HPP

--- a/src/hotspot/os_cpu/bsd_x86/thread_bsd_x86.hpp
+++ b/src/hotspot/os_cpu/bsd_x86/thread_bsd_x86.hpp
@@ -33,10 +33,6 @@
   frame pd_last_frame();
 
  public:
-  // Mutators are highly dangerous....
-  intptr_t* last_Java_fp()                       { return _anchor.last_Java_fp(); }
-  void  set_last_Java_fp(intptr_t* fp)           { _anchor.set_last_Java_fp(fp);   }
-
   static ByteSize last_Java_fp_offset()          {
     return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::last_Java_fp_offset();
   }

--- a/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.hpp
@@ -44,10 +44,6 @@
   frame pd_last_frame();
 
  public:
-  // Mutators are highly dangerous....
-  intptr_t* last_Java_fp()                       { return _anchor.last_Java_fp(); }
-  void  set_last_Java_fp(intptr_t* fp)           { _anchor.set_last_Java_fp(fp);   }
-
   static ByteSize last_Java_fp_offset()          {
     return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::last_Java_fp_offset();
   }

--- a/src/hotspot/os_cpu/linux_arm/thread_linux_arm.hpp
+++ b/src/hotspot/os_cpu/linux_arm/thread_linux_arm.hpp
@@ -40,10 +40,6 @@
   frame pd_last_frame();
 
  public:
-  intptr_t* last_Java_fp()                       { return _anchor.last_Java_fp(); }
-  void  set_last_Java_fp(intptr_t* fp)           { _anchor.set_last_Java_fp(fp);  }
-  void  set_last_Java_pc(address pc)             { _anchor.set_last_Java_pc(pc);  }
-
   static ByteSize last_Java_fp_offset()          {
     return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::last_Java_fp_offset();
   }

--- a/src/hotspot/os_cpu/linux_x86/thread_linux_x86.hpp
+++ b/src/hotspot/os_cpu/linux_x86/thread_linux_x86.hpp
@@ -33,10 +33,6 @@
   frame pd_last_frame();
 
  public:
-  // Mutators are highly dangerous....
-  intptr_t* last_Java_fp()                       { return _anchor.last_Java_fp(); }
-  void  set_last_Java_fp(intptr_t* fp)           { _anchor.set_last_Java_fp(fp);   }
-
   static ByteSize last_Java_fp_offset()          {
     return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::last_Java_fp_offset();
   }

--- a/src/hotspot/os_cpu/windows_x86/thread_windows_x86.hpp
+++ b/src/hotspot/os_cpu/windows_x86/thread_windows_x86.hpp
@@ -40,10 +40,6 @@
   frame pd_last_frame();
 
  public:
-  // Mutators are highly dangerous....
-  intptr_t* last_Java_fp()                       { return _anchor.last_Java_fp(); }
-  void  set_last_Java_fp(intptr_t* fp)           { _anchor.set_last_Java_fp(fp);   }
-
   static ByteSize last_Java_fp_offset()          {
     return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::last_Java_fp_offset();
   }

--- a/src/hotspot/share/runtime/javaFrameAnchor.hpp
+++ b/src/hotspot/share/runtime/javaFrameAnchor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,8 +84,6 @@ friend class JavaCallWrapper;
 public:
   JavaFrameAnchor()                              { clear(); }
   JavaFrameAnchor(JavaFrameAnchor *src)          { copy(src); }
-
-  void set_last_Java_pc(address pc)              { _last_Java_pc = pc; }
 
   // Assembly stub generation helpers
 


### PR DESCRIPTION
These functions are also unused and in the thread_platform.hpp files.  _last_Java_sp and _last_Java_fp are set in the assembly code for platforms that use these (x86, arm32 and aarch64).  The shared runtime code never sets these, or should it. last_Java_fp() is always called through JavaFrameAnchor, so that function is not needed. last_Java_fp_offset() is used and needs to be in these platform dependent files because not all platforms save last_Java_fp.

Tested with build on arm32 and tier1 on Oracle platforms including aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253539](https://bugs.openjdk.java.net/browse/JDK-8253539): Remove unused JavaThread functions for set_last_Java_fp/pc


### Reviewers
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/324/head:pull/324`
`$ git checkout pull/324`
