### PR TITLE
8253500: [REDO] JDK-8253208 Move CDS related code to a separate class

### DIFF
--- a/make/hotspot/symbols/symbols-unix
+++ b/make/hotspot/symbols/symbols-unix
@@ -123,7 +123,7 @@ JVM_GetPermittedSubclasses
 JVM_GetPrimitiveArrayElement
 JVM_GetProperties
 JVM_GetProtectionDomain
-JVM_GetRandomSeedForCDSDump
+JVM_GetRandomSeedForDumping
 JVM_GetRecordComponents
 JVM_GetSimpleBinaryName
 JVM_GetStackAccessControlContext
@@ -143,8 +143,8 @@ JVM_InternString
 JVM_Interrupt
 JVM_InvokeMethod
 JVM_IsArrayClass
-JVM_IsCDSDumpingEnabled
-JVM_IsCDSSharingEnabled
+JVM_IsDynamicDumpingEnabled
+JVM_IsSharingEnabled
 JVM_IsConstructorIx
 JVM_IsHiddenClass
 JVM_IsInterface

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -198,13 +198,13 @@ JVM_LookupLambdaProxyClassFromArchive(JNIEnv* env, jclass caller,
                                       jboolean initialize);
 
 JNIEXPORT jboolean JNICALL
-JVM_IsCDSDumpingEnabled(JNIEnv* env);
+JVM_IsDynamicDumpingEnabled(JNIEnv* env);
 
 JNIEXPORT jboolean JNICALL
-JVM_IsCDSSharingEnabled(JNIEnv* env);
+JVM_IsSharingEnabled(JNIEnv* env);
 
 JNIEXPORT jlong JNICALL
-JVM_GetRandomSeedForCDSDump();
+JVM_GetRandomSeedForDumping();
 
 /*
  * java.lang.Throwable

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3833,18 +3833,18 @@ JVM_ENTRY(jclass, JVM_LookupLambdaProxyClassFromArchive(JNIEnv* env,
 #endif // INCLUDE_CDS
 JVM_END
 
-JVM_ENTRY(jboolean, JVM_IsCDSDumpingEnabled(JNIEnv* env))
-    JVMWrapper("JVM_IsCDSDumpingEnable");
+JVM_ENTRY(jboolean, JVM_IsDynamicDumpingEnabled(JNIEnv* env))
+    JVMWrapper("JVM_IsDynamicDumpingEnable");
     return DynamicDumpSharedSpaces;
 JVM_END
 
-JVM_ENTRY(jboolean, JVM_IsCDSSharingEnabled(JNIEnv* env))
-    JVMWrapper("JVM_IsCDSSharingEnable");
+JVM_ENTRY(jboolean, JVM_IsSharingEnabled(JNIEnv* env))
+    JVMWrapper("JVM_IsSharingEnable");
     return UseSharedSpaces;
 JVM_END
 
-JVM_ENTRY_NO_ENV(jlong, JVM_GetRandomSeedForCDSDump())
-  JVMWrapper("JVM_GetRandomSeedForCDSDump");
+JVM_ENTRY_NO_ENV(jlong, JVM_GetRandomSeedForDumping())
+  JVMWrapper("JVM_GetRandomSeedForDumping");
   if (DumpSharedSpaces) {
     const char* release = Abstract_VM_Version::vm_release();
     const char* dbg_level = Abstract_VM_Version::jdk_debug_level();
@@ -3859,7 +3859,7 @@ JVM_ENTRY_NO_ENV(jlong, JVM_GetRandomSeedForCDSDump())
     if (seed == 0) { // don't let this ever be zero.
       seed = 0x87654321;
     }
-    log_debug(cds)("JVM_GetRandomSeedForCDSDump() = " JLONG_FORMAT, seed);
+    log_debug(cds)("JVM_GetRandomSeedForDumping() = " JLONG_FORMAT, seed);
     return seed;
   } else {
     return 0;

--- a/src/java.base/share/classes/java/lang/Byte.java
+++ b/src/java.base/share/classes/java/lang/Byte.java
@@ -26,7 +26,7 @@
 package java.lang;
 
 import jdk.internal.HotSpotIntrinsicCandidate;
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 
 import java.lang.constant.Constable;
 import java.lang.constant.DynamicConstantDesc;
@@ -108,7 +108,7 @@ public final class Byte extends Number implements Comparable<Byte>, Constable {
             final int size = -(-128) + 127 + 1;
 
             // Load and use the archived cache if it exists
-            VM.initializeFromArchive(ByteCache.class);
+            CDS.initializeFromArchive(ByteCache.class);
             if (archivedCache == null || archivedCache.length != size) {
                 Byte[] c = new Byte[size];
                 byte value = (byte)-128;

--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -26,7 +26,7 @@
 package java.lang;
 
 import jdk.internal.HotSpotIntrinsicCandidate;
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 
 import java.lang.constant.Constable;
 import java.lang.constant.DynamicConstantDesc;
@@ -8516,7 +8516,7 @@ class Character implements java.io.Serializable, Comparable<Character>, Constabl
             int size = 127 + 1;
 
             // Load and use the archived cache if it exists
-            VM.initializeFromArchive(CharacterCache.class);
+            CDS.initializeFromArchive(CharacterCache.class);
             if (archivedCache == null || archivedCache.length != size) {
                 Character[] c = new Character[size];
                 for (int i = 0; i < size; i++) {

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import jdk.internal.HotSpotIntrinsicCandidate;
+import jdk.internal.misc.CDS;
 import jdk.internal.misc.VM;
 
 import static java.lang.String.COMPACT_STRINGS;
@@ -1023,7 +1024,7 @@ public final class Integer extends Number
             high = h;
 
             // Load IntegerCache.archivedCache from archive, if possible
-            VM.initializeFromArchive(IntegerCache.class);
+            CDS.initializeFromArchive(IntegerCache.class);
             int size = (high - low) + 1;
 
             // Use the archived cache if it exists and is large enough

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import jdk.internal.HotSpotIntrinsicCandidate;
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 
 import static java.lang.String.COMPACT_STRINGS;
 import static java.lang.String.LATIN1;
@@ -1169,7 +1169,7 @@ public final class Long extends Number
             int size = -(-128) + 127 + 1;
 
             // Load and use the archived cache if it exists
-            VM.initializeFromArchive(LongCache.class);
+            CDS.initializeFromArchive(LongCache.class);
             if (archivedCache == null || archivedCache.length != size) {
                 Long[] c = new Long[size];
                 long value = -128;

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -55,6 +55,7 @@ import java.util.stream.Stream;
 import jdk.internal.loader.BuiltinClassLoader;
 import jdk.internal.loader.BootLoader;
 import jdk.internal.loader.ClassLoaders;
+import jdk.internal.misc.CDS;
 import jdk.internal.misc.VM;
 import jdk.internal.module.IllegalAccessLogger;
 import jdk.internal.module.ModuleLoaderMap;
@@ -277,7 +278,7 @@ public final class Module implements AnnotatedElement {
         }
 
         static {
-            VM.initializeFromArchive(ArchivedData.class);
+            CDS.initializeFromArchive(ArchivedData.class);
         }
     }
 

--- a/src/java.base/share/classes/java/lang/Short.java
+++ b/src/java.base/share/classes/java/lang/Short.java
@@ -26,7 +26,7 @@
 package java.lang;
 
 import jdk.internal.HotSpotIntrinsicCandidate;
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 
 import java.lang.constant.Constable;
 import java.lang.constant.DynamicConstantDesc;
@@ -234,7 +234,7 @@ public final class Short extends Number implements Comparable<Short>, Constable 
             int size = -(-128) + 127 + 1;
 
             // Load and use the archived cache if it exists
-            VM.initializeFromArchive(ShortCache.class);
+            CDS.initializeFromArchive(ShortCache.class);
             if (archivedCache == null || archivedCache.length != size) {
                 Short[] c = new Short[size];
                 short value = -128;

--- a/src/java.base/share/classes/java/lang/invoke/LambdaProxyClassArchive.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaProxyClassArchive.java
@@ -26,15 +26,15 @@
 package java.lang.invoke;
 
 import jdk.internal.loader.BuiltinClassLoader;
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 
 final class LambdaProxyClassArchive {
     private static final boolean dumpArchive;
     private static final boolean sharingEnabled;
 
     static {
-        dumpArchive = VM.isCDSDumpingEnabled();
-        sharingEnabled = VM.isCDSSharingEnabled();
+        dumpArchive = CDS.isDynamicDumpingEnabled();
+        sharingEnabled = CDS.isSharingEnabled();
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/module/Configuration.java
+++ b/src/java.base/share/classes/java/lang/module/Configuration.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 import jdk.internal.module.ModuleReferenceImpl;
 import jdk.internal.module.ModuleTarget;
 import jdk.internal.vm.annotation.Stable;
@@ -110,7 +110,7 @@ public final class Configuration {
 
     static {
         // Initialize EMPTY_CONFIGURATION from the archive.
-        VM.initializeFromArchive(Configuration.class);
+        CDS.initializeFromArchive(Configuration.class);
         // Create a new empty Configuration if there is no archived version.
         if (EMPTY_CONFIGURATION == null) {
             EMPTY_CONFIGURATION = new Configuration();

--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -37,7 +37,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 import jdk.internal.vm.annotation.Stable;
 
 /**
@@ -76,7 +76,7 @@ class ImmutableCollections {
         // derived from the JVM build/version, so can we generate the exact same
         // CDS archive for the same JDK build. This makes it possible to verify the
         // consistency of the JDK build.
-        long seed = VM.getRandomSeedForCDSDump();
+        long seed = CDS.getRandomSeedForDumping();
         if (seed == 0) {
           seed = System.nanoTime();
         }
@@ -100,7 +100,7 @@ class ImmutableCollections {
     static final MapN<?,?> EMPTY_MAP;
 
     static {
-        VM.initializeFromArchive(ImmutableCollections.class);
+        CDS.initializeFromArchive(ImmutableCollections.class);
         if (archivedObjects == null) {
             EMPTY = new Object();
             EMPTY_LIST = new ListN<>();

--- a/src/java.base/share/classes/java/util/jar/Attributes.java
+++ b/src/java.base/share/classes/java/util/jar/Attributes.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 import jdk.internal.vm.annotation.Stable;
 
 import sun.nio.cs.UTF_8;
@@ -672,7 +672,7 @@ public class Attributes implements Map<Object,Object>, Cloneable {
 
         static {
 
-            VM.initializeFromArchive(Attributes.Name.class);
+            CDS.initializeFromArchive(Attributes.Name.class);
 
             if (KNOWN_NAMES == null) {
                 MANIFEST_VERSION = new Name("Manifest-Version");

--- a/src/java.base/share/classes/jdk/internal/loader/ArchivedClassLoaders.java
+++ b/src/java.base/share/classes/jdk/internal/loader/ArchivedClassLoaders.java
@@ -25,7 +25,7 @@
 package jdk.internal.loader;
 
 import java.util.Map;
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 import jdk.internal.module.ServicesCatalog;
 
 /**
@@ -91,6 +91,6 @@ class ArchivedClassLoaders {
     }
 
     static {
-        VM.initializeFromArchive(ArchivedClassLoaders.class);
+        CDS.initializeFromArchive(ArchivedClassLoaders.class);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/math/FDBigInteger.java
+++ b/src/java.base/share/classes/jdk/internal/math/FDBigInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
  */
 package jdk.internal.math;
 
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -84,7 +84,7 @@ public /*@ spec_bigint_math @*/ class FDBigInteger {
 
     // Initialize FDBigInteger cache of powers of 5.
     static {
-        VM.initializeFromArchive(FDBigInteger.class);
+        CDS.initializeFromArchive(FDBigInteger.class);
         Object[] caches = archivedCaches;
         if (caches == null) {
             long[] long5pow = {

--- a/src/java.base/share/classes/jdk/internal/misc/VM.java
+++ b/src/java.base/share/classes/jdk/internal/misc/VM.java
@@ -458,31 +458,6 @@ public class VM {
     private static native void initialize();
 
     /**
-     * Initialize archived static fields in the given Class using archived
-     * values from CDS dump time. Also initialize the classes of objects in
-     * the archived graph referenced by those fields.
-     *
-     * Those static fields remain as uninitialized if there is no mapped CDS
-     * java heap data or there is any error during initialization of the
-     * object class in the archived graph.
-     */
-    public static native void initializeFromArchive(Class<?> c);
-
-    public static native void defineArchivedModules(ClassLoader platformLoader, ClassLoader systemLoader);
-
-    public static native long getRandomSeedForCDSDump();
-
-    /**
-     * Check if CDS dynamic dumping is enabled via the DynamicDumpSharedSpaces flag.
-     */
-    public static native boolean isCDSDumpingEnabled();
-
-    /**
-     * Check if CDS sharing is enabled by via the UseSharedSpaces flag.
-     */
-    public static native boolean isCDSSharingEnabled();
-
-    /**
      * Provides access to information on buffer usage.
      */
     public interface BufferPool {

--- a/src/java.base/share/classes/jdk/internal/module/ArchivedBootLayer.java
+++ b/src/java.base/share/classes/jdk/internal/module/ArchivedBootLayer.java
@@ -24,7 +24,7 @@
  */
 package jdk.internal.module;
 
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 
 /**
  * Used by ModuleBootstrap for archiving the boot layer and the builder needed to
@@ -59,6 +59,6 @@ class ArchivedBootLayer {
     }
 
     static {
-        VM.initializeFromArchive(ArchivedBootLayer.class);
+        CDS.initializeFromArchive(ArchivedBootLayer.class);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/module/ArchivedModuleGraph.java
+++ b/src/java.base/share/classes/jdk/internal/module/ArchivedModuleGraph.java
@@ -29,7 +29,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.lang.module.Configuration;
 import java.lang.module.ModuleFinder;
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 
 /**
  * Used by ModuleBootstrap for archiving the configuration for the boot layer,
@@ -123,6 +123,6 @@ class ArchivedModuleGraph {
     }
 
     static {
-        VM.initializeFromArchive(ArchivedModuleGraph.class);
+        CDS.initializeFromArchive(ArchivedModuleGraph.class);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -54,7 +54,7 @@ import jdk.internal.access.SharedSecrets;
 import jdk.internal.loader.BootLoader;
 import jdk.internal.loader.BuiltinClassLoader;
 import jdk.internal.loader.ClassLoaders;
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 import jdk.internal.perf.PerfCounter;
 
 /**
@@ -167,7 +167,7 @@ public final class ModuleBootstrap {
             assert canUseArchivedBootLayer();
             bootLayer = archivedBootLayer.bootLayer();
             BootLoader.getUnnamedModule(); // trigger <clinit> of BootLoader.
-            VM.defineArchivedModules(ClassLoaders.platformClassLoader(), ClassLoaders.appClassLoader());
+            CDS.defineArchivedModules(ClassLoaders.platformClassLoader(), ClassLoaders.appClassLoader());
 
             // assume boot layer has at least one module providing a service
             // that is mapped to the application class loader.

--- a/src/java.base/share/classes/sun/util/locale/BaseLocale.java
+++ b/src/java.base/share/classes/sun/util/locale/BaseLocale.java
@@ -32,7 +32,7 @@
 
 package sun.util.locale;
 
-import jdk.internal.misc.VM;
+import jdk.internal.misc.CDS;
 import jdk.internal.vm.annotation.Stable;
 
 import java.lang.ref.SoftReference;
@@ -62,7 +62,7 @@ public final class BaseLocale {
             ROOT = 18,
             NUM_CONSTANTS = 19;
     static {
-        VM.initializeFromArchive(BaseLocale.class);
+        CDS.initializeFromArchive(BaseLocale.class);
         BaseLocale[] baseLocales = constantBaseLocales;
         if (baseLocales == null) {
             baseLocales = new BaseLocale[NUM_CONSTANTS];

--- a/src/java.base/share/native/libjava/CDS.c
+++ b/src/java.base/share/native/libjava/CDS.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,35 +23,33 @@
  * questions.
  */
 
-#include "jni.h"
-#include "jni_util.h"
 #include "jvm.h"
-#include "jdk_util.h"
+#include "jdk_internal_misc_CDS.h"
 
-#include "jdk_internal_misc_VM.h"
-
-/* Only register the performance-critical methods */
-static JNINativeMethod methods[] = {
-    {"getNanoTimeAdjustment", "(J)J", (void *)&JVM_GetNanoTimeAdjustment}
-};
-
-JNIEXPORT jobject JNICALL
-Java_jdk_internal_misc_VM_latestUserDefinedLoader0(JNIEnv *env, jclass cls) {
-    return JVM_LatestUserDefinedLoader(env);
+JNIEXPORT void JNICALL
+Java_jdk_internal_misc_CDS_initializeFromArchive(JNIEnv *env, jclass ignore,
+                                                jclass c) {
+    JVM_InitializeFromArchive(env, c);
 }
 
 JNIEXPORT void JNICALL
-Java_jdk_internal_misc_VM_initialize(JNIEnv *env, jclass cls) {
-    // Registers implementations of native methods described in methods[]
-    // above.
-    // In particular, registers JVM_GetNanoTimeAdjustment as the implementation
-    // of the native VM.getNanoTimeAdjustment - avoiding the cost of
-    // introducing a Java_jdk_internal_misc_VM_getNanoTimeAdjustment wrapper
-    (*env)->RegisterNatives(env, cls,
-                            methods, sizeof(methods)/sizeof(methods[0]));
+Java_jdk_internal_misc_CDS_defineArchivedModules(JNIEnv *env, jclass ignore,
+                                                jobject platform_loader,
+                                                jobject system_loader) {
+    JVM_DefineArchivedModules(env, platform_loader, system_loader);
 }
 
-JNIEXPORT jobjectArray JNICALL
-Java_jdk_internal_misc_VM_getRuntimeArguments(JNIEnv *env, jclass cls) {
-    return JVM_GetVmArguments(env);
+JNIEXPORT jlong JNICALL
+Java_jdk_internal_misc_CDS_getRandomSeedForDumping(JNIEnv *env, jclass ignore) {
+    return JVM_GetRandomSeedForDumping();
+}
+
+JNIEXPORT jboolean JNICALL
+Java_jdk_internal_misc_CDS_isDynamicDumpingEnabled(JNIEnv *env, jclass jcls) {
+    return JVM_IsDynamicDumpingEnabled(env);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_jdk_internal_misc_CDS_isSharingEnabled(JNIEnv *env, jclass jcls) {
+    return JVM_IsSharingEnabled(env);
 }


### PR DESCRIPTION
This patch is a REDO for JDK-8253208 which was backed out since it caused runtime/cds/DeterministicDump.java failed, see JDK-8253495. Since the failure is another issue and only triggered by this patch, the test case now is put on ProblemList.txt. The real root cause for the failure is detailed in JDK-8253495. 
When JDK-8253208 was backed out, CDS.java remained without removed from that patch (see JDK-8253495 subtask), so this patch does not include CDS.java (this is why you will see CDS.c without CDS.java in this patch).

Tests tier1-4 passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253500](https://bugs.openjdk.java.net/browse/JDK-8253500): [REDO] JDK-8253208 Move CDS related code to a separate class


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/327/head:pull/327`
`$ git checkout pull/327`
