### PR TITLE
8253581: runtime/stringtable/StringTableCleaningTest.java fails on 32-bit platforms

### DIFF
--- a/test/hotspot/jtreg/runtime/stringtable/StringTableCleaningTest.java
+++ b/test/hotspot/jtreg/runtime/stringtable/StringTableCleaningTest.java
@@ -55,7 +55,7 @@ import sun.hotspot.gc.GC;
 public class StringTableCleaningTest {
     public static void main(String[] args) throws Exception {
         List<String> subargs = new ArrayList<String>();
-        subargs.addAll(List.of("-Xlog:gc,gc+start,stringtable*=trace", "-Xmx3G"));
+        subargs.addAll(List.of("-Xlog:gc,gc+start,stringtable*=trace", "-Xmx1g"));
         subargs.add(Tester.class.getName());
         subargs.addAll(Arrays.asList(args));
         OutputAnalyzer output = ProcessTools.executeTestJvm(subargs);


### PR DESCRIPTION
Test fails because it requests 3g heap. It seems to accept 1g as well. Test is the new addition in 16 since JDK-8248391.

Running affected test:
 - [x] Linux x86_32 -XX:+UseSerialGC
 - [x] Linux x86_32 -XX:+UseParallelGC
 - [x] Linux x86_32 -XX:+UseG1GC
 - [x] Linux x86_32 -XX:+UseShenandoahGC
 - [x] Linux x86_64 -XX:+UseSerialGC
 - [x] Linux x86_64 -XX:+UseParallelGC
 - [x] Linux x86_64 -XX:+UseG1GC
 - [x] Linux x86_64 -XX:+UseShenandoahGC
 - [x] Linux x86_64 -XX:+UseZGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253581](https://bugs.openjdk.java.net/browse/JDK-8253581): runtime/stringtable/StringTableCleaningTest.java fails on 32-bit platforms


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/330/head:pull/330`
`$ git checkout pull/330`
