### PR TITLE
8253583: java/util/StringJoiner tests failing on 32-bit VMs after JDK-8246697

### DIFF
--- a/test/jdk/java/util/StringJoiner/MergeTest.java
+++ b/test/jdk/java/util/StringJoiner/MergeTest.java
@@ -26,7 +26,7 @@
  * @bug 8017231 8020977 8054221
  * @summary test  StringJoiner::merge
  * @modules java.base/jdk.internal.util
- * @requires os.maxMemory > 4G
+ * @requires vm.bits == "64" & os.maxMemory > 4G
  * @run testng/othervm -Xmx4g -XX:+CompactStrings MergeTest
  */
 

--- a/test/jdk/java/util/StringJoiner/StringJoinerTest.java
+++ b/test/jdk/java/util/StringJoiner/StringJoinerTest.java
@@ -25,7 +25,7 @@
  * @bug 5015163 7172553 8249258
  * @summary tests StringJoinerTest
  * @modules java.base/jdk.internal.util
- * @requires os.maxMemory > 4G
+ * @requires vm.bits == "64" & os.maxMemory > 4G
  * @run testng/othervm -Xmx4g -XX:+CompactStrings StringJoinerTest
  * @author Jim Gish
  */


### PR DESCRIPTION
JDK-8246697 added -Xmx4g to test configurations. 32-bit VMs cannot do it. @requires tests the OS RAM size, but you can easily have the x86_32 host with more than 4G ram, yet JVM would fail to acquire that heap size. Need to check for bitness explicitly.

Testing:
  - [x] java/util/StringJoiner on x86_64 (still run)
  - [x] java/util/StringJoiner on x86_32 (skipped now)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253583](https://bugs.openjdk.java.net/browse/JDK-8253583): java/util/StringJoiner tests failing on 32-bit VMs after JDK-8246697


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/331/head:pull/331`
`$ git checkout pull/331`
