### PR TITLE
8253379: [windows] Several jpackage tests failed with error code 1638

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -705,7 +705,7 @@ final public class TKit {
                     TKit.assertFalse(files.findFirst().isEmpty(), String.format
                             ("Check [%s] is not an empty directory", path));
                 }
-            }).run(); 
+            }).run();
          }
     }
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -698,7 +698,18 @@ final public class TKit {
         }
     }
 
-     public static void assertDirectoryExists(Path path) {
+    public static void assertPathNotEmptyDirectory(Path path) {
+        if (Files.isDirectory(path)) {
+            ThrowingRunnable.toRunnable(() -> {
+                try (var files = Files.list(path)) {
+                    TKit.assertFalse(files.findFirst().isEmpty(), String.format
+                            ("Check [%s] is not an empty directory", path));
+                }
+            }).run(); 
+         }
+    }
+
+    public static void assertDirectoryExists(Path path) {
         assertPathExists(path, true);
         assertTrue(path.toFile().isDirectory(), String.format(
                 "Check [%s] is a directory", path));

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -208,6 +208,9 @@ public class WindowsHelper {
         private void verifyStartMenuShortcut(Path shortcutsRoot, boolean exists) {
             Path shortcutPath = shortcutsRoot.resolve(startMenuShortcutPath());
             verifyShortcut(shortcutPath, exists);
+            if (!exists) {
+                TKit.assertPathNotEmptyDirectory(shortcutPath.getParent());
+            }
         }
 
         private void verifySystemStartMenuShortcut(boolean exists) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -110,10 +110,12 @@ public class WindowsHelper {
 
     static PackageHandlers createExePackageHandlers() {
         PackageHandlers exe = new PackageHandlers();
-        exe.installHandler = cmd -> {
-            cmd.verifyIsOfType(PackageType.WIN_EXE);
-            new Executor().setExecutable(cmd.outputBundle()).execute();
-        };
+        // can't have install handler without also having uninstall handler
+        // so following is commented out for now
+        // exe.installHandler = cmd -> {
+        //     cmd.verifyIsOfType(PackageType.WIN_EXE);
+        //     new Executor().setExecutable(cmd.outputBundle()).execute();
+        // };
 
         return exe;
     }
@@ -206,9 +208,6 @@ public class WindowsHelper {
         private void verifyStartMenuShortcut(Path shortcutsRoot, boolean exists) {
             Path shortcutPath = shortcutsRoot.resolve(startMenuShortcutPath());
             verifyShortcut(shortcutPath, exists);
-            if (!exists) {
-                TKit.assertPathExists(shortcutPath.getParent(), false);
-            }
         }
 
         private void verifySystemStartMenuShortcut(boolean exists) {


### PR DESCRIPTION
8253379: [windows] Several jpackage tests failed with error code 1638
two windows specific test fixes in WindowsHelper:
1.) do not test that the parent directory of a windows menu shortcut is empty after shortcut is uninstalled (there may be other shortcuts using that directory)
2.) do not programmatically install windows exe installers (since we have no way of programmatically uninstalling them)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253379](https://bugs.openjdk.java.net/browse/JDK-8253379): [windows] Several jpackage tests failed with error code 1638


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer) ⚠️ Review applies to 1e20f1c7b11f13542325b413334011617d6b41ce
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/337/head:pull/337`
`$ git checkout pull/337`
