### PR TITLE
8253565: PPC64: Fix duplicate if condition in vm_version_ppc.cpp

### DIFF
--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -373,9 +373,7 @@ void VM_Version::initialize() {
     if (!has_tm()) {
       vm_exit_during_initialization("RTM is not supported on this OS version.");
     }
-  }
 
-  if (UseRTMLocking) {
 #if INCLUDE_RTM_OPT
     if (!FLAG_IS_CMDLINE(UseRTMLocking)) {
       // RTM locking should be used only for applications with


### PR DESCRIPTION
This is a very small change. There're two `if (UseRTMLocking) {` conditions, one just after the other. This code simply merge them.

https://bugs.openjdk.java.net/browse/JDK-8253565

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253565](https://bugs.openjdk.java.net/browse/JDK-8253565): PPC64: Fix duplicate if condition in vm_version_ppc.cpp


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/338/head:pull/338`
`$ git checkout pull/338`
