### PR TITLE
7179006: [macosx] Print-to-file doesn't work: printing to the default printer instead.

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -30,6 +30,7 @@ import java.awt.*;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.awt.print.*;
+import java.net.URI;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
@@ -37,6 +38,7 @@ import javax.print.*;
 import javax.print.attribute.PrintRequestAttributeSet;
 import javax.print.attribute.HashPrintRequestAttributeSet;
 import javax.print.attribute.standard.Copies;
+import javax.print.attribute.standard.Destination;
 import javax.print.attribute.standard.Media;
 import javax.print.attribute.standard.MediaPrintableArea;
 import javax.print.attribute.standard.MediaSize;
@@ -249,6 +251,22 @@ public final class CPrinterJob extends RasterPrinterJob {
     boolean isPrintToFile = false;
     private void setPrintToFile(boolean printToFile) {
         isPrintToFile = printToFile;
+    }
+
+    private void setDestinationFile(String dest) {
+        System.out.println("dest="+dest+" attrs="+attributes);
+        if (attributes != null && dest != null) {
+            try {
+               URI destURI = new URI(dest);
+               attributes.add(new Destination(destURI));
+               destinationAttr = "" + destURI.getSchemeSpecificPart();
+            } catch (Exception e) {
+            }
+        }
+    }
+
+    private String getDestinationFile() {
+        return destinationAttr;
     }
 
     @Override

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -254,7 +254,6 @@ public final class CPrinterJob extends RasterPrinterJob {
     }
 
     private void setDestinationFile(String dest) {
-        System.out.println("dest="+dest+" attrs="+attributes);
         if (attributes != null && dest != null) {
             try {
                URI destURI = new URI(dest);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -318,6 +318,7 @@ static void nsPrintInfoToJavaPrinterJob(JNIEnv* env, NSPrintInfo* src, jobject d
     static JNF_MEMBER_CACHE(jm_setPrintToFile, sjc_CPrinterJob, "setPrintToFile", "(Z)V");
     static JNF_MEMBER_CACHE(jm_setDestinationFile, sjc_CPrinterJob, "setDestinationFile", "(Ljava/lang/String;)V");
 
+    // get the selected printer's name, and set the appropriate PrintService on the Java side
     NSString *name = [[src printer] name];
     jstring printerName = JNFNSToJavaString(env, name);
     JNFCallVoidMethod(env, dstPrinterJob, jm_setService, printerName);
@@ -334,7 +335,6 @@ static void nsPrintInfoToJavaPrinterJob(JNIEnv* env, NSPrintInfo* src, jobject d
         JNFCallVoidMethod(env, dstPrinterJob, jm_setPrintToFile, false);
     }
 
-    // get the selected printer's name, and set the appropriate PrintService on the Java side
     NSNumber* nsCopies = [printingDictionary objectForKey:NSPrintCopies];
     if ([nsCopies respondsToSelector:@selector(integerValue)])
     {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -316,21 +316,25 @@ static void nsPrintInfoToJavaPrinterJob(JNIEnv* env, NSPrintInfo* src, jobject d
     static JNF_MEMBER_CACHE(jm_setCollated, sjc_CPrinterJob, "setCollated", "(Z)V");
     static JNF_MEMBER_CACHE(jm_setPageRangeAttribute, sjc_CPrinterJob, "setPageRangeAttribute", "(IIZ)V");
     static JNF_MEMBER_CACHE(jm_setPrintToFile, sjc_CPrinterJob, "setPrintToFile", "(Z)V");
+    static JNF_MEMBER_CACHE(jm_setDestinationFile, sjc_CPrinterJob, "setDestinationFile", "(Ljava/lang/String;)V");
+
+    NSString *name = [[src printer] name];
+    jstring printerName = JNFNSToJavaString(env, name);
+    JNFCallVoidMethod(env, dstPrinterJob, jm_setService, printerName);
+
+    NSMutableDictionary* printingDictionary = [src dictionary];
 
     if (src.jobDisposition == NSPrintSaveJob) {
         JNFCallVoidMethod(env, dstPrinterJob, jm_setPrintToFile, true);
+        NSURL *url = [printingDictionary objectForKey:NSPrintJobSavingURL];
+        NSString *nsStr = [url absoluteString];
+        jstring str = JNFNSToJavaString(env, nsStr);
+        JNFCallVoidMethod(env, dstPrinterJob, jm_setDestinationFile, str);
     } else {
         JNFCallVoidMethod(env, dstPrinterJob, jm_setPrintToFile, false);
     }
 
     // get the selected printer's name, and set the appropriate PrintService on the Java side
-    NSString *name = [[src printer] name];
-    jstring printerName = JNFNSToJavaString(env, name);
-    JNFCallVoidMethod(env, dstPrinterJob, jm_setService, printerName);
-
-
-    NSMutableDictionary* printingDictionary = [src dictionary];
-
     NSNumber* nsCopies = [printingDictionary objectForKey:NSPrintCopies];
     if ([nsCopies respondsToSelector:@selector(integerValue)])
     {
@@ -384,6 +388,8 @@ static void javaPrinterJobToNSPrintInfo(JNIEnv* env, jobject srcPrinterJob, jobj
     static JNF_MEMBER_CACHE(jm_getSelectAttrib, sjc_CPrinterJob, "getSelectAttrib", "()I");
     static JNF_MEMBER_CACHE(jm_getNumberOfPages, jc_Pageable, "getNumberOfPages", "()I");
     static JNF_MEMBER_CACHE(jm_getPageFormat, sjc_CPrinterJob, "getPageFormatFromAttributes", "()Ljava/awt/print/PageFormat;");
+    static JNF_MEMBER_CACHE(jm_getDestinationFile, sjc_CPrinterJob,
+                            "getDestinationFile", "()Ljava/lang/String;");
 
     NSMutableDictionary* printingDictionary = [dst dictionary];
 
@@ -422,6 +428,19 @@ static void javaPrinterJobToNSPrintInfo(JNIEnv* env, jobject srcPrinterJob, jobj
     jobject page = JNFCallObjectMethod(env, srcPrinterJob, jm_getPageFormat);
     if (page != NULL) {
         javaPageFormatToNSPrintInfo(env, NULL, page, dst);
+    }
+
+    jstring dest = JNFCallObjectMethod(env, srcPrinterJob, jm_getDestinationFile);
+    if (dest != NULL) {
+       NSString *nsDestStr = JNFJavaToNSString(env, dest);
+       [dst setJobDisposition:NSPrintSaveJob];
+      // [printingDictionary setObject:nsDestStr forKey:NSPrintSavePath];
+       //NSURL *nsURL = [NSURL URLWithString:nsDestStr];
+       NSURL *nsURL = [NSURL fileURLWithPath:nsDestStr isDirectory:NO];
+       [printingDictionary setObject:nsURL forKey:NSPrintJobSavingURL];
+//        JNFCallVoidMethod(env, dstPrinterJob, jm_setPrintToFile, true);
+    } else {
+       [dst setJobDisposition:NSPrintSpoolJob];
     }
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -432,13 +432,10 @@ static void javaPrinterJobToNSPrintInfo(JNIEnv* env, jobject srcPrinterJob, jobj
 
     jstring dest = JNFCallObjectMethod(env, srcPrinterJob, jm_getDestinationFile);
     if (dest != NULL) {
-       NSString *nsDestStr = JNFJavaToNSString(env, dest);
        [dst setJobDisposition:NSPrintSaveJob];
-      // [printingDictionary setObject:nsDestStr forKey:NSPrintSavePath];
-       //NSURL *nsURL = [NSURL URLWithString:nsDestStr];
+       NSString *nsDestStr = JNFJavaToNSString(env, dest);
        NSURL *nsURL = [NSURL fileURLWithPath:nsDestStr isDirectory:NO];
        [printingDictionary setObject:nsURL forKey:NSPrintJobSavingURL];
-//        JNFCallVoidMethod(env, dstPrinterJob, jm_setPrintToFile, true);
     } else {
        [dst setJobDisposition:NSPrintSpoolJob];
     }

--- a/test/jdk/java/awt/print/Dialog/PrintDlgApp.java
+++ b/test/jdk/java/awt/print/Dialog/PrintDlgApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,76 +23,85 @@
 
 /*
   @test
-  @bug 4865976 7158366
-  @summary  Pass if it program exits.
+  @bug 4865976 7158366 7179006
+  @summary Pass if program exits.
   @run main/manual PrintDlgApp
 */
-import java.awt.*;
-import java.awt.print.*;
-import javax.print.attribute.*;
+
+import java.io.File;
+import java.net.URI;
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterJob;
+import java.awt.print.PrinterException;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
 import javax.print.attribute.standard.Copies;
 import javax.print.attribute.standard.Destination;
-import java.util.Locale;
 
-import javax.print.*;
+public class PrintDlgApp implements Printable {
 
-class PrintDlgApp implements Printable {
-        /**
-         * Constructor
-         */
-        public PrintDlgApp() {
-                super();
+    public PrintDlgApp() {}
+
+    public static void main(String[] args) {
+         PrinterJob pj = PrinterJob.getPrinterJob();
+         if (pj.getPrintService() == null) {
+             System.out.println("No printers installed. Skipping test");
+             return;
+         }
+
+         PrintDlgApp pd = new PrintDlgApp();
+         PageFormat pf = new PageFormat();
+         pj.setPrintable(pd, pf);
+
+         PrintRequestAttributeSet pSet = new HashPrintRequestAttributeSet();
+         pSet.add(new Copies(1));
+
+         Destination dest = null;
+         for (int i=0; i<2; i++) {
+             File file = new File("./out"+i+".prn");
+             dest = new Destination(file.toURI());
+             pSet.add(dest);
+             System.out.println("open PrintDialog.");
+             if (pj.printDialog(pSet)) {
+                 // In case tester changes the destination :
+                 dest = (Destination)pSet.get(Destination.class);
+                 System.out.println("DEST="+dest);
+                 if (dest != null) {
+                     URI uri = dest.getURI();
+                     file = new File(uri.getSchemeSpecificPart());
+                     System.out.println("will be checking for file " + file);
+                 }
+                 try {
+                     System.out.println("About to print the data ...");
+                     pj.print(pSet);
+                     System.out.println("Printed.");
+                 }
+                 catch (PrinterException pe) {
+                     pe.printStackTrace();
+                 }
+             }
+             if (dest != null && !file.exists()) {
+                 throw new RuntimeException("No file created");
+             }
+         }
+    }
+
+    public int print(Graphics g, PageFormat pf, int pi) throws PrinterException {
+
+        if (pi > 0) {
+            return Printable.NO_SUCH_PAGE;
         }
-        /**
-         * Starts the application.
-         */
-        public static void main(java.lang.String[] args) {
-                PrintDlgApp pd = new PrintDlgApp();
-                PrinterJob pj = PrinterJob.getPrinterJob();
-                System.out.println(pj);
-                PrintRequestAttributeSet pSet = new HashPrintRequestAttributeSet();
-                pSet.add(new Copies(1));
-                //PageFormat pf = pj.pageDialog(pSet);
-                PageFormat pf = new PageFormat();
-                System.out.println("Setting Printable...pf = "+pf);
-                if (pf == null) {
-                    return;
-                }
-                pj.setPrintable(pd,pf);
-
-                //try { pj.setPrintService(services[0]); } catch(Exception e) { e.printStackTrace(); }
-                pSet.add(new Destination(new java.io.File("./out.prn").toURI()));
-                System.out.println("open PrintDialog..");
-                for (int i=0; i<2; i++) {
-                if (pj.printDialog(pSet)) {
-                        try {
-                                System.out.println("About to print the data ...");
-                                pj.print(pSet);
-                                System.out.println("Printed");
-                        }
-                        catch (PrinterException pe) {
-                                pe.printStackTrace();
-                        }
-                }
-                }
-
-        }
-
-        //printable interface
-        public int print(Graphics g, PageFormat pf, int pi) throws
-PrinterException {
-
-                if (pi > 0) {
-                        System.out.println("pi is greater than 0");
-                        return Printable.NO_SUCH_PAGE;
-                }
-                // Simply draw two rectangles
-                Graphics2D g2 = (Graphics2D)g;
-                g2.setColor(Color.black);
-                g2.translate(pf.getImageableX(), pf.getImageableY());
-                g2.drawRect(1,1,200,300);
-                g2.drawRect(1,1,25,25);
-                System.out.println("print method called "+pi);
-                return Printable.PAGE_EXISTS;
-        }
+        // Simply draw two rectangles
+        Graphics2D g2 = (Graphics2D)g;
+        g2.setColor(Color.black);
+        g2.translate(pf.getImageableX(), pf.getImageableY());
+        g2.drawRect(1,1,200,300);
+        g2.drawRect(1,1,25,25);
+        System.out.println("print method called "+pi);
+        return Printable.PAGE_EXISTS;
+    }
 }

--- a/test/jdk/java/awt/print/Dialog/PrintDlgApp.java
+++ b/test/jdk/java/awt/print/Dialog/PrintDlgApp.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key printer
   @bug 4865976 7158366 7179006
   @summary Pass if program exits.
   @run main/manual PrintDlgApp

--- a/test/jdk/java/awt/print/PrinterJob/PrintToFileTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintToFileTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key printer
  * @bug 7179006
  * @summary Confirm printing to file works.
 */

--- a/test/jdk/java/awt/print/PrinterJob/PrintToFileTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintToFileTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 7179006
+ * @summary Confirm printing to file works.
+*/
+
+import java.io.File;
+import java.net.URI;
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterJob;
+import java.awt.print.PrinterException;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.print.attribute.standard.Destination;
+
+public class PrintToFileTest implements Printable {
+
+    public PrintToFileTest() {}
+
+    public static void main(String[] args) throws Exception {
+        PrinterJob pj = PrinterJob.getPrinterJob();
+        if (pj.getPrintService() == null) {
+            System.out.println("No printers installed. Skipping test.");
+            return;
+        }
+        pj.setPrintable(new PrintToFileTest(), new PageFormat());
+        PrintRequestAttributeSet pSet = new HashPrintRequestAttributeSet();
+        File file = new File("./out.prn");
+        pSet.add(new Destination(file.toURI()));
+        pj.print(pSet);
+        if (!file.exists()) {
+             throw new RuntimeException("No file created");
+        }
+    }
+
+    public int print(Graphics g, PageFormat pf, int pi) throws
+                                PrinterException {
+
+        if (pi > 0) {
+            return Printable.NO_SUCH_PAGE;
+        }
+        Graphics2D g2 = (Graphics2D)g;
+        g2.setColor(Color.black);
+        g2.translate(pf.getImageableX(), pf.getImageableY());
+        g2.drawRect(1,1,200,300);
+        g2.drawRect(1,1,25,25);
+        return Printable.PAGE_EXISTS;
+    }
+}


### PR DESCRIPTION
A long-standing bug on macOS: https://bugs.openjdk.java.net/browse/JDK-7179006

The fix is to propagate whatever is set as the Destination down to native and set it on the native printing object.

Also if using the native dialog, but with attributes, copy back the destination from native to the Java attribute set.

The new test can directly test printing to file in an automated way - so long as there is a printer.

The updated manual test can be used to verify the  cross-platform dialog case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-7179006](https://bugs.openjdk.java.net/browse/JDK-7179006): [macosx] Print-to-file doesn't work: printing to the default printer instead ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/339/head:pull/339`
`$ git checkout pull/339`
