### PR TITLE
8253429: Error reporting should report correct state of terminated/aborted threads

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -938,11 +938,13 @@ void Thread::print_on_error(outputStream* st, char* buf, int buflen) const {
     st->print(" \"%s\"", name());
   }
 
-  st->print(" [stack: " PTR_FORMAT "," PTR_FORMAT "]",
-            p2i(stack_end()), p2i(stack_base()));
-
-  if (osthread()) {
+  OSThread* os_thr = osthread();
+  if (os_thr != NULL && os_thr->get_state() != ZOMBIE) {
+    st->print(" [stack: " PTR_FORMAT "," PTR_FORMAT "]",
+              p2i(stack_end()), p2i(stack_base()));
     st->print(" [id=%d]", osthread()->thread_id());
+  } else {
+    st->print(" exited");
   }
 
   ThreadsSMRSupport::print_info_on(this, st);
@@ -1334,6 +1336,7 @@ void NonJavaThread::post_run() {
   unregister_thread_stack_with_NMT();
   // Ensure thread-local-storage is cleared before termination.
   Thread::clear_thread_current();
+  osthread()->set_state(ZOMBIE);
 }
 
 // NamedThread --  non-JavaThread subclasses with multiple

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -915,11 +915,8 @@ void Thread::print_on(outputStream* st, bool print_extended_info) const {
 
     st->print("tid=" INTPTR_FORMAT " ", p2i(this));
     osthread()->print_on(st);
-
-    if (osthread()->get_state() != ZOMBIE) {
-      ThreadsSMRSupport::print_info_on(this, st);
-    }
   }
+  ThreadsSMRSupport::print_info_on(this, st);
   st->print(" ");
   debug_only(if (WizardMode) print_owned_locks_on(st);)
 }
@@ -947,13 +944,13 @@ void Thread::print_on_error(outputStream* st, char* buf, int buflen) const {
       st->print(" [stack: " PTR_FORMAT "," PTR_FORMAT "]",
                 p2i(stack_end()), p2i(stack_base()));
       st->print(" [id=%d]", osthread()->thread_id());
-      ThreadsSMRSupport::print_info_on(this, st);
     } else {
-      st->print(" Terminated");
+      st->print(" terminated");
     }
   } else {
-    st->print(" Aborted");
+    st->print(" unknown state (no osThread)");
   }
+  ThreadsSMRSupport::print_info_on(this, st);
 }
 
 void Thread::print_value_on(outputStream* st) const {


### PR DESCRIPTION
For some non-JavaThread, their object instances can outlast threads' lifespan. For example, we still can query/report thread's state after thread terminated.

But the query/report currently returns wrong state. E.g. a terminated thread appears to be alive and seemly has valid thread stack, etc.

This patch sets non-JavaThread's state to ZOMBIE just before it terminates, so that we can distinguish terminated thread from live thread.

Also, thread should not report its SMR info, if it has terminated or it never started (thread->osthread() == NULL).

Note: Java thread does not have such issue, its thread object is deleted before thread terminates.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253429](https://bugs.openjdk.java.net/browse/JDK-8253429): Error reporting should report correct state of terminated/aborted threads 


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/341/head:pull/341`
`$ git checkout pull/341`
