### PR TITLE
8252752: Clear card table for old regions during scan in G1

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardTable.hpp
+++ b/src/hotspot/share/gc/g1/g1CardTable.hpp
@@ -84,6 +84,7 @@ public:
   }
 
   static CardValue g1_young_card_val() { return g1_young_gen; }
+  static CardValue g1_scanned_card_val() { return g1_card_already_scanned; }
 
   void verify_g1_young_region(MemRegion mr) PRODUCT_RETURN;
   void g1_mark_as_young(const MemRegion& mr);
@@ -103,8 +104,8 @@ public:
   // be inaccurate as it does not perform the dirtying atomically.
   inline size_t mark_region_dirty(size_t start_card_index, size_t num_cards);
 
-  // Mark the given range of cards as Scanned. All of these cards must be Dirty.
-  inline void mark_as_scanned(size_t start_card_index, size_t num_cards);
+  // Mark the given range of cards to "which". All of these cards must be Dirty.
+  inline void mark_dirty_as(size_t start_card_index, size_t num_cards, CardValue which);
 
   inline uint region_idx_for(CardValue* p);
 

--- a/src/hotspot/share/gc/g1/g1CardTable.hpp
+++ b/src/hotspot/share/gc/g1/g1CardTable.hpp
@@ -104,8 +104,8 @@ public:
   // be inaccurate as it does not perform the dirtying atomically.
   inline size_t mark_region_dirty(size_t start_card_index, size_t num_cards);
 
-  // Mark the given range of cards to "which". All of these cards must be Dirty.
-  inline void mark_dirty_as(size_t start_card_index, size_t num_cards, CardValue which);
+  // Change the given range of dirty cards to "which". All of these cards must be Dirty.
+  inline void change_dirty_cards_to(size_t start_card_index, size_t num_cards, CardValue which);
 
   inline uint region_idx_for(CardValue* p);
 

--- a/src/hotspot/share/gc/g1/g1CardTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardTable.inline.hpp
@@ -77,7 +77,7 @@ inline size_t G1CardTable::mark_region_dirty(size_t start_card_index, size_t num
   return result;
 }
 
-inline void G1CardTable::mark_dirty_as(size_t start_card_index, size_t num_cards, CardValue which) {
+inline void G1CardTable::change_dirty_cards_to(size_t start_card_index, size_t num_cards, CardValue which) {
   CardValue* start = &_byte_map[start_card_index];
   CardValue* const end = start + num_cards;
   while (start < end) {

--- a/src/hotspot/share/gc/g1/g1CardTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardTable.inline.hpp
@@ -77,14 +77,14 @@ inline size_t G1CardTable::mark_region_dirty(size_t start_card_index, size_t num
   return result;
 }
 
-inline void G1CardTable::mark_as_scanned(size_t start_card_index, size_t num_cards) {
+inline void G1CardTable::mark_dirty_as(size_t start_card_index, size_t num_cards, CardValue which) {
   CardValue* start = &_byte_map[start_card_index];
   CardValue* const end = start + num_cards;
   while (start < end) {
     CardValue value = *start;
     assert(value == dirty_card_val(),
            "Must have been dirty %d start " PTR_FORMAT " " PTR_FORMAT, value, p2i(start), p2i(end));
-    *start++ = g1_card_already_scanned;
+    *start++ = which;
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3045,10 +3045,11 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
                                                   collection_set()->optional_region_length());
         pre_evacuate_collection_set(evacuation_info, &per_thread_states);
 
+        bool may_do_optional_evacuation = _collection_set.optional_region_length() != 0;
         // Actually do the work...
-        evacuate_initial_collection_set(&per_thread_states);
+        evacuate_initial_collection_set(&per_thread_states, may_do_optional_evacuation);
 
-        if (_collection_set.optional_region_length() != 0) {
+        if (may_do_optional_evacuation) {
           evacuate_optional_collection_set(&per_thread_states);
         }
         post_evacuate_collection_set(evacuation_info, &rdcqs, &per_thread_states);
@@ -3820,10 +3821,11 @@ public:
 
 class G1EvacuateRegionsTask : public G1EvacuateRegionsBaseTask {
   G1RootProcessor* _root_processor;
+  bool _may_do_optional_evacuation;
 
   void scan_roots(G1ParScanThreadState* pss, uint worker_id) {
     _root_processor->evacuate_roots(pss, worker_id);
-    _g1h->rem_set()->scan_heap_roots(pss, worker_id, G1GCPhaseTimes::ScanHR, G1GCPhaseTimes::ObjCopy);
+    _g1h->rem_set()->scan_heap_roots(pss, worker_id, G1GCPhaseTimes::ScanHR, G1GCPhaseTimes::ObjCopy, _may_do_optional_evacuation);
     _g1h->rem_set()->scan_collection_set_regions(pss, worker_id, G1GCPhaseTimes::ScanHR, G1GCPhaseTimes::CodeRoots, G1GCPhaseTimes::ObjCopy);
   }
 
@@ -3844,13 +3846,16 @@ public:
                         G1ParScanThreadStateSet* per_thread_states,
                         G1ScannerTasksQueueSet* task_queues,
                         G1RootProcessor* root_processor,
-                        uint num_workers) :
+                        uint num_workers,
+                        bool may_do_optional_evacuation) :
     G1EvacuateRegionsBaseTask("G1 Evacuate Regions", per_thread_states, task_queues, num_workers),
-    _root_processor(root_processor)
+    _root_processor(root_processor),
+    _may_do_optional_evacuation(may_do_optional_evacuation)
   { }
 };
 
-void G1CollectedHeap::evacuate_initial_collection_set(G1ParScanThreadStateSet* per_thread_states) {
+void G1CollectedHeap::evacuate_initial_collection_set(G1ParScanThreadStateSet* per_thread_states,
+                                                      bool may_do_optional_evacuation) {
   G1GCPhaseTimes* p = phase_times();
 
   {
@@ -3865,7 +3870,12 @@ void G1CollectedHeap::evacuate_initial_collection_set(G1ParScanThreadStateSet* p
   Ticks start_processing = Ticks::now();
   {
     G1RootProcessor root_processor(this, num_workers);
-    G1EvacuateRegionsTask g1_par_task(this, per_thread_states, _task_queues, &root_processor, num_workers);
+    G1EvacuateRegionsTask g1_par_task(this,
+                                      per_thread_states,
+                                      _task_queues,
+                                      &root_processor,
+                                      num_workers,
+                                      may_do_optional_evacuation);
     task_time = run_task_timed(&g1_par_task);
     // Closing the inner scope will execute the destructor for the G1RootProcessor object.
     // To extract its code root fixup time we measure total time of this scope and
@@ -3875,12 +3885,14 @@ void G1CollectedHeap::evacuate_initial_collection_set(G1ParScanThreadStateSet* p
 
   p->record_initial_evac_time(task_time.seconds() * 1000.0);
   p->record_or_add_code_root_fixup_time((total_processing - task_time).seconds() * 1000.0);
+
+  rem_set()->evacuation_phase_done(may_do_optional_evacuation);
 }
 
 class G1EvacuateOptionalRegionsTask : public G1EvacuateRegionsBaseTask {
 
   void scan_roots(G1ParScanThreadState* pss, uint worker_id) {
-    _g1h->rem_set()->scan_heap_roots(pss, worker_id, G1GCPhaseTimes::OptScanHR, G1GCPhaseTimes::OptObjCopy);
+    _g1h->rem_set()->scan_heap_roots(pss, worker_id, G1GCPhaseTimes::OptScanHR, G1GCPhaseTimes::OptObjCopy, true /* remember_already_scanned_cards */);
     _g1h->rem_set()->scan_collection_set_regions(pss, worker_id, G1GCPhaseTimes::OptScanHR, G1GCPhaseTimes::OptCodeRoots, G1GCPhaseTimes::OptObjCopy);
   }
 
@@ -3940,6 +3952,8 @@ void G1CollectedHeap::evacuate_optional_collection_set(G1ParScanThreadStateSet* 
       evacuate_next_optional_regions(per_thread_states);
       phase_times()->record_or_add_optional_evac_time((Ticks::now() - start).seconds() * 1000.0);
     }
+
+    rem_set()->evacuation_phase_done(true /* has_more_than_one_evacuation_phase */);
   }
 
   _collection_set.abandon_optional_collection_set(per_thread_states);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3886,7 +3886,7 @@ void G1CollectedHeap::evacuate_initial_collection_set(G1ParScanThreadStateSet* p
   p->record_initial_evac_time(task_time.seconds() * 1000.0);
   p->record_or_add_code_root_fixup_time((total_processing - task_time).seconds() * 1000.0);
 
-  rem_set()->evacuation_phase_done(may_do_optional_evacuation);
+  rem_set()->complete_evac_phase(may_do_optional_evacuation);
 }
 
 class G1EvacuateOptionalRegionsTask : public G1EvacuateRegionsBaseTask {
@@ -3953,7 +3953,7 @@ void G1CollectedHeap::evacuate_optional_collection_set(G1ParScanThreadStateSet* 
       phase_times()->record_or_add_optional_evac_time((Ticks::now() - start).seconds() * 1000.0);
     }
 
-    rem_set()->evacuation_phase_done(true /* has_more_than_one_evacuation_phase */);
+    rem_set()->complete_evac_phase(true /* has_more_than_one_evacuation_phase */);
   }
 
   _collection_set.abandon_optional_collection_set(per_thread_states);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -782,10 +782,23 @@ private:
   void calculate_collection_set(G1EvacuationInfo& evacuation_info, double target_pause_time_ms);
 
   // Actually do the work of evacuating the parts of the collection set.
-  // The may_do_optional_evacuation flag indicates whether some or more optional evacuation
-  // steps will follow.
+  // The has_optional_evacuation_work flag for the initial collection set
+  // evacuation indicates whether some or more optional evacuation steps may
+  // follow.
+  // If not set, G1 can avoid clearing the card tables of regions that we scan
+  // for roots from the heap: when scanning the card table for dirty cards after
+  // all remembered sets have been dumped onto it, for optional evacuation we
+  // mark these cards as "Scanned" to know that we do not need to re-scan them
+  // in the additional optional evacuation passes. This means that in the "Clear
+  // Card Table" phase we need to clear those marks. However, if there is no
+  // optional evacuation, g1 can immediately clean the dirty cards it encounters
+  // as nobody else will be looking at them again, saving the clear card table
+  // work later.
+  // This case is very common (young only collections and most mixed gcs), so
+  // depending on the ratio between scanned and evacuated regions (which g1 always
+  // needs to clear), this is a big win.
   void evacuate_initial_collection_set(G1ParScanThreadStateSet* per_thread_states,
-                                       bool may_do_optional_evacuation);
+                                       bool has_optional_evacuation_work);
   void evacuate_optional_collection_set(G1ParScanThreadStateSet* per_thread_states);
 private:
   // Evacuate the next set of optional regions.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -782,7 +782,10 @@ private:
   void calculate_collection_set(G1EvacuationInfo& evacuation_info, double target_pause_time_ms);
 
   // Actually do the work of evacuating the parts of the collection set.
-  void evacuate_initial_collection_set(G1ParScanThreadStateSet* per_thread_states);
+  // The may_do_optional_evacuation flag indicates whether some or more optional evacuation
+  // steps will follow.
+  void evacuate_initial_collection_set(G1ParScanThreadStateSet* per_thread_states,
+                                       bool may_do_optional_evacuation);
   void evacuate_optional_collection_set(G1ParScanThreadStateSet* per_thread_states);
 private:
   // Evacuate the next set of optional regions.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -783,7 +783,7 @@ private:
 
   // Actually do the work of evacuating the parts of the collection set.
   // The has_optional_evacuation_work flag for the initial collection set
-  // evacuation indicates whether some or more optional evacuation steps may
+  // evacuation indicates whether one or more optional evacuation steps may
   // follow.
   // If not set, G1 can avoid clearing the card tables of regions that we scan
   // for roots from the heap: when scanning the card table for dirty cards after

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -339,7 +339,7 @@ public:
     ::memset(_region_scan_chunks, false, _num_total_scan_chunks * sizeof(*_region_scan_chunks));
   }
 
-  void evacuation_phase_done(bool merge_dirty_regions) {
+  void complete_evac_phase(bool merge_dirty_regions) {
     if (merge_dirty_regions) {
       _all_dirty_regions->merge(_next_dirty_regions);
     }
@@ -1278,8 +1278,8 @@ void G1RemSet::merge_heap_roots(bool initial_evacuation) {
   }
 }
 
-void G1RemSet::evacuation_phase_done(bool has_more_than_one_evacuation_phase) {
-  _scan_state->evacuation_phase_done(has_more_than_one_evacuation_phase);
+void G1RemSet::complete_evac_phase(bool has_more_than_one_evacuation_phase) {
+  _scan_state->complete_evac_phase(has_more_than_one_evacuation_phase);
 }
 
 void G1RemSet::exclude_region_from_scan(uint region_idx) {

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -691,7 +691,7 @@ class G1ScanHRForRegionClosure : public HeapRegionClosure {
   }
 
   ALWAYSINLINE void do_card_block(uint const region_idx, size_t const first_card, size_t const num_cards) {
-    _ct->mark_dirty_as(first_card, num_cards, _scanned_card_value);
+    _ct->change_dirty_cards_to(first_card, num_cards, _scanned_card_value);
     do_claimed_block(region_idx, first_card, num_cards);
     _blocks_scanned++;
   }

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -131,8 +131,17 @@ public:
   }
 
 private:
-  // The complete set of regions which card table needs to be cleared at the end of GC because
-  // we scribbled all over them.
+  // The complete set of regions which card table needs to be cleared at the end
+  // of GC because we scribbled over these card tables.
+  //
+  // Regions may be added for two reasons:
+  // - they were part of the collection set: they may contain g1_young_card_val
+  // or regular card marks that we never scan so we must always clear their card
+  // table
+  // - or in case g1 does an optional evacuation pass, g1 marks the cards in there
+  // as g1_scanned_card_val. If G1 only did an initial evacuation pass, the
+  // scanning already cleared these cards. In that case they are not in this set
+  // at the end of the collection.
   G1DirtyRegions* _all_dirty_regions;
   // The set of regions which card table needs to be scanned for new dirty cards
   // in the current evacuation pass.
@@ -321,14 +330,20 @@ public:
   }
 
   void prepare_for_merge_heap_roots() {
-    _all_dirty_regions->merge(_next_dirty_regions);
+    assert(_next_dirty_regions->size() == 0, "next dirty regions must be empty");
 
-    _next_dirty_regions->reset();
     for (size_t i = 0; i < _max_reserved_regions; i++) {
       _card_table_scan_state[i] = 0;
     }
 
     ::memset(_region_scan_chunks, false, _num_total_scan_chunks * sizeof(*_region_scan_chunks));
+  }
+
+  void evacuation_phase_done(bool merge_dirty_regions) {
+    if (merge_dirty_regions) {
+      _all_dirty_regions->merge(_next_dirty_regions);
+    }
+    _next_dirty_regions->reset();
   }
 
   // Returns whether the given region contains cards we need to scan. The remembered
@@ -374,8 +389,6 @@ public:
   }
 
   void cleanup(WorkGang* workers) {
-    _all_dirty_regions->merge(_next_dirty_regions);
-
     clear_card_table(workers);
 
     delete _all_dirty_regions;
@@ -448,7 +461,7 @@ public:
 #ifdef ASSERT
     HeapRegion* hr = G1CollectedHeap::heap()->region_at(region);
     assert(hr->in_collection_set(),
-           "Only add young regions to all dirty regions directly but %u is %s",
+           "Only add collection set regions to all dirty regions directly but %u is %s",
            hr->hrm_index(), hr->get_short_type_str());
 #endif
     _all_dirty_regions->add_dirty_region(region);
@@ -641,6 +654,7 @@ class G1ScanHRForRegionClosure : public HeapRegionClosure {
   // The address to which this thread already scanned (walked the heap) up to during
   // card scanning (exclusive).
   HeapWord* _scanned_to;
+  G1CardTable::CardValue _scanned_card_value;
 
   HeapWord* scan_memregion(uint region_idx_for_card, MemRegion mr) {
     HeapRegion* const card_region = _g1h->region_at(region_idx_for_card);
@@ -677,7 +691,7 @@ class G1ScanHRForRegionClosure : public HeapRegionClosure {
   }
 
   ALWAYSINLINE void do_card_block(uint const region_idx, size_t const first_card, size_t const num_cards) {
-    _ct->mark_as_scanned(first_card, num_cards);
+    _ct->mark_dirty_as(first_card, num_cards, _scanned_card_value);
     do_claimed_block(region_idx, first_card, num_cards);
     _blocks_scanned++;
   }
@@ -727,7 +741,8 @@ public:
   G1ScanHRForRegionClosure(G1RemSetScanState* scan_state,
                            G1ParScanThreadState* pss,
                            uint worker_id,
-                           G1GCPhaseTimes::GCParPhases phase) :
+                           G1GCPhaseTimes::GCParPhases phase,
+                           bool remember_already_scanned_cards) :
     _g1h(G1CollectedHeap::heap()),
     _ct(_g1h->card_table()),
     _bot(_g1h->bot()),
@@ -740,7 +755,9 @@ public:
     _chunks_claimed(0),
     _rem_set_root_scan_time(),
     _rem_set_trim_partially_time(),
-    _scanned_to(NULL) {
+    _scanned_to(NULL),
+    _scanned_card_value(remember_already_scanned_cards ? G1CardTable::g1_scanned_card_val()
+                                                       : G1CardTable::clean_card_val()) {
   }
 
   bool do_heap_region(HeapRegion* r) {
@@ -765,10 +782,11 @@ public:
 };
 
 void G1RemSet::scan_heap_roots(G1ParScanThreadState* pss,
-                            uint worker_id,
-                            G1GCPhaseTimes::GCParPhases scan_phase,
-                            G1GCPhaseTimes::GCParPhases objcopy_phase) {
-  G1ScanHRForRegionClosure cl(_scan_state, pss, worker_id, scan_phase);
+                               uint worker_id,
+                               G1GCPhaseTimes::GCParPhases scan_phase,
+                               G1GCPhaseTimes::GCParPhases objcopy_phase,
+                               bool remember_already_scanned_cards) {
+  G1ScanHRForRegionClosure cl(_scan_state, pss, worker_id, scan_phase, remember_already_scanned_cards);
   _scan_state->iterate_dirty_regions_from(&cl, worker_id);
 
   G1GCPhaseTimes* p = _g1p->phase_times();
@@ -898,7 +916,6 @@ void G1RemSet::prepare_region_for_scan(HeapRegion* region) {
     // So directly add them to the "all_dirty_regions".
     // Same for regions in the (initial) collection set: they may contain cards from
     // the log buffers, make sure they are cleaned.
-    _scan_state->add_all_dirty_region(hrm_index);
   } else if (region->is_old_or_humongous_or_archive()) {
     _scan_state->set_scan_top(hrm_index, region->top());
   } else {
@@ -984,13 +1001,35 @@ class G1MergeHeapRootsTask : public AbstractGangTask {
       }
     }
 
-    virtual bool do_heap_region(HeapRegion* r) {
+    // Helper to put the remembered set cards for these regions onto the card
+    // table.
+    //
+    // Called directly for humongous starts regions because we should not add
+    // humongous eager reclaim candidates to the "all" list of regions to
+    // clear the card table by default as we do not know yet whether this region
+    // will be reclaimed (and reused).
+    // If the humongous region contains dirty cards, g1 will scan them
+    // because dumping the remembered set entries onto the card table will add
+    // the humongous region to the "dirty" region list to scan. Then scanning
+    // either clears the card during scan (if there is only an initial evacuation
+    // pass) or the "dirty" list will be merged with the "all" list later otherwise.
+    // (And there is no problem either way if the region does not contain dirty
+    // cards).
+    void dump_rem_set_for_region(HeapRegion* r) {
       assert(r->in_collection_set() || r->is_starts_humongous(), "must be");
 
       HeapRegionRemSet* rem_set = r->rem_set();
       if (!rem_set->is_empty()) {
         rem_set->iterate_prts(*this);
       }
+    }
+
+    virtual bool do_heap_region(HeapRegion* r) {
+      assert(r->in_collection_set(), "must be");
+
+      _scan_state->add_all_dirty_region(r->hrm_index());
+
+      dump_rem_set_for_region(r);
 
       return false;
     }
@@ -1022,7 +1061,7 @@ class G1MergeHeapRootsTask : public AbstractGangTask {
       guarantee(r->rem_set()->occupancy_less_or_equal_than(G1RSetSparseRegionEntries),
                 "Found a not-small remembered set here. This is inconsistent with previous assumptions.");
 
-      _cl.do_heap_region(r);
+      _cl.dump_rem_set_for_region(r);
 
       // We should only clear the card based remembered set here as we will not
       // implicitly rebuild anything else during eager reclaim. Note that at the moment
@@ -1237,6 +1276,10 @@ void G1RemSet::merge_heap_roots(bool initial_evacuation) {
   if (log_is_enabled(Debug, gc, remset)) {
     print_merge_heap_roots_stats();
   }
+}
+
+void G1RemSet::evacuation_phase_done(bool has_more_than_one_evacuation_phase) {
+  _scan_state->evacuation_phase_done(has_more_than_one_evacuation_phase);
 }
 
 void G1RemSet::exclude_region_from_scan(uint region_idx) {

--- a/src/hotspot/share/gc/g1/g1RemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.hpp
@@ -84,13 +84,15 @@ public:
   void scan_heap_roots(G1ParScanThreadState* pss,
                        uint worker_id,
                        G1GCPhaseTimes::GCParPhases scan_phase,
-                       G1GCPhaseTimes::GCParPhases objcopy_phase);
+                       G1GCPhaseTimes::GCParPhases objcopy_phase,
+                       bool remember_already_scanned_cards);
 
   // Merge cards from various sources (remembered sets, hot card cache, log buffers)
   // and calculate the cards that need to be scanned later (via scan_heap_roots()).
   // If initial_evacuation is set, this is called during the initial evacuation.
   void merge_heap_roots(bool initial_evacuation);
 
+  void evacuation_phase_done(bool has_more_than_one_evacuation_phase);
   // Prepare for and cleanup after scanning the heap roots. Must be called
   // once before and after in sequential code.
   void prepare_for_scan_heap_roots();

--- a/src/hotspot/share/gc/g1/g1RemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.hpp
@@ -92,7 +92,7 @@ public:
   // If initial_evacuation is set, this is called during the initial evacuation.
   void merge_heap_roots(bool initial_evacuation);
 
-  void evacuation_phase_done(bool has_more_than_one_evacuation_phase);
+  void complete_evac_phase(bool has_more_than_one_evacuation_phase);
   // Prepare for and cleanup after scanning the heap roots. Must be called
   // once before and after in sequential code.
   void prepare_for_scan_heap_roots();


### PR DESCRIPTION
Hi all,

  can I get reviews for this change that removes the need for explicit clearing of the card table for typically a large amount of regions in most cases?

Currently g1 unconditionally marks scanned dirty cards as "scanned" to remember that they had already been scanned in earlier evacuation passes. Then in the "clear card table phase" g1 clears all these marks including the card table of evacuated regions.

This change modifies g1 so that if possible, it clears dirty cards after scanning them instead of setting them to "scanned" if there is only one evacuation pass. This saves a lot of work later (e.g. the amount of regions to clear in the clear card table phase may be reduced by a magnitude or more, depending on the ration between evacuated and scanned regions).

The main change here is which type of regions (ones in the collection set, ones that are only scanned) are put into which list of regions g1 already manages: there is one "all" list containing all regions that need clearing, and a "next" list containing the regions to be scanned in the current evacuation pass. Previously g1 put regions into at least one list; now regions in the current collection set are always directly put into the "all" list (as they independently of other reasons require card table cleaning), while to-be-scanned regions are always only put into the "next" list.

Then, to achieve the desired effect that only regions that absolutely require clearing are in the "all" list, g1 does not merge the "next" list into the "all" list when it detects that there will only be one evacuation pass.

Performance impact:
Decreases clear card table time significantly if the number of regions in the collection set is much smaller than the number of scanned regions (as it decreases the number of regions to clear). Some cursory perf testing showed slight overall pause time improvements.

Testing:
hs-tier1-5 ("Initial import" change)
hs-tier1-2 (latest)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252752](https://bugs.openjdk.java.net/browse/JDK-8252752): Clear card table for old regions during scan in G1


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to fd0d2835abc5773141a6dfb176d2a6f50126add6
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Author) ⚠️ Review applies to 260e58901b4e5c586ab6950b637ff3a16b041a5a
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author) ⚠️ Review applies to 260e58901b4e5c586ab6950b637ff3a16b041a5a


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/343/head:pull/343`
`$ git checkout pull/343`
