### PR TITLE
8247691: [aarch64] Incorrect handling of VM exceptions in C1 deopt stub/traps

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -555,7 +555,7 @@ OopMapSet* Runtime1::generate_patching(StubAssembler* sasm, address target) {
 #endif
 
   __ reset_last_Java_frame(true);
-  __ maybe_isb();
+
 #ifdef ASSERT
   // check that fields in JavaThread for exception oop and issuing pc are empty
   Label oop_empty;
@@ -575,7 +575,7 @@ OopMapSet* Runtime1::generate_patching(StubAssembler* sasm, address target) {
   // expected scenario and anything else is  an error. Note that we maintain a
   // check on the result purely as a defensive measure.
   Label no_deopt;
-  __ cbz(r0, no_deopt);                                // have we deoptimized?
+  __ cbz(r0, no_deopt);                                // Have we deoptimized?
 
   // Perform a re-execute. The proper return  address is already on the stack,
   // we just need  to restore registers, pop  all of our frame  but the return

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -553,81 +553,37 @@ OopMapSet* Runtime1::generate_patching(StubAssembler* sasm, address target) {
     __ bind(L);
   }
 #endif
+
   __ reset_last_Java_frame(true);
   __ maybe_isb();
-
-  // check for pending exceptions
-  { Label L;
-    __ ldr(rscratch1, Address(rthread, Thread::pending_exception_offset()));
-    __ cbz(rscratch1, L);
-    // exception pending => remove activation and forward to exception handler
-
-    { Label L1;
-      __ cbnz(r0, L1);                                  // have we deoptimized?
-      __ far_jump(RuntimeAddress(Runtime1::entry_for(Runtime1::forward_exception_id)));
-      __ bind(L1);
-    }
-
-    // the deopt blob expects exceptions in the special fields of
-    // JavaThread, so copy and clear pending exception.
-
-    // load and clear pending exception
-    __ ldr(r0, Address(rthread, Thread::pending_exception_offset()));
-    __ str(zr, Address(rthread, Thread::pending_exception_offset()));
-
-    // check that there is really a valid exception
-    __ verify_not_null_oop(r0);
-
-    // load throwing pc: this is the return address of the stub
-    __ mov(r3, lr);
-
 #ifdef ASSERT
-    // check that fields in JavaThread for exception oop and issuing pc are empty
-    Label oop_empty;
-    __ ldr(rscratch1, Address(rthread, Thread::pending_exception_offset()));
-    __ cbz(rscratch1, oop_empty);
-    __ stop("exception oop must be empty");
-    __ bind(oop_empty);
+  // check that fields in JavaThread for exception oop and issuing pc are empty
+  Label oop_empty;
+  __ ldr(rscratch1, Address(rthread, Thread::pending_exception_offset()));
+  __ cbz(rscratch1, oop_empty);
+  __ stop("exception oop must be empty");
+  __ bind(oop_empty);
 
-    Label pc_empty;
-    __ ldr(rscratch1, Address(rthread, JavaThread::exception_pc_offset()));
-    __ cbz(rscratch1, pc_empty);
-    __ stop("exception pc must be empty");
-    __ bind(pc_empty);
+  Label pc_empty;
+  __ ldr(rscratch1, Address(rthread, JavaThread::exception_pc_offset()));
+  __ cbz(rscratch1, pc_empty);
+  __ stop("exception pc must be empty");
+  __ bind(pc_empty);
 #endif
 
-    // store exception oop and throwing pc to JavaThread
-    __ str(r0, Address(rthread, JavaThread::exception_oop_offset()));
-    __ str(r3, Address(rthread, JavaThread::exception_pc_offset()));
+  // Runtime will return true if the nmethod has been deoptimized (this is the
+  // expected scenario). We then proceed with a deopt re-execute.
+  Label no_deopt;
+  __ cbz(r0, no_deopt);                                // have we deoptimized?
 
-    restore_live_registers(sasm);
-
-    __ leave();
-
-    // Forward the exception directly to deopt blob. We can blow no
-    // registers and must leave throwing pc on the stack.  A patch may
-    // have values live in registers so the entry point with the
-    // exception in tls.
-    __ far_jump(RuntimeAddress(deopt_blob->unpack_with_exception_in_tls()));
-
-    __ bind(L);
-  }
-
-
-  // Runtime will return true if the nmethod has been deoptimized during
-  // the patching process. In that case we must do a deopt reexecute instead.
-
-  Label cont;
-
-  __ cbz(r0, cont);                                 // have we deoptimized?
-
-  // Will reexecute. Proper return address is already on the stack we just restore
-  // registers, pop all of our frame but the return address and jump to the deopt blob
+  // Will re-execute.  Proper return address is already  on the stack  we just
+  // restore registers, pop  all of our frame but the  return address and jump
+  // to the deopt blob
   restore_live_registers(sasm);
   __ leave();
   __ far_jump(RuntimeAddress(deopt_blob->unpack_with_reexecution()));
 
-  __ bind(cont);
+  __ bind(no_deopt);
   restore_live_registers(sasm);
   __ leave();
   __ ret(lr);

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -571,22 +571,21 @@ OopMapSet* Runtime1::generate_patching(StubAssembler* sasm, address target) {
   __ bind(pc_empty);
 #endif
 
-  // Runtime will return true if the nmethod has been deoptimized (this is the
-  // expected scenario). We then proceed with a deopt re-execute.
+  // Runtime will return true if the nmethod has been deoptimized, this is the
+  // expected scenario and anything else is  an error. Note that we maintain a
+  // check on the result purely as a defensive measure.
   Label no_deopt;
   __ cbz(r0, no_deopt);                                // have we deoptimized?
 
-  // Will re-execute.  Proper return address is already  on the stack  we just
-  // restore registers, pop  all of our frame but the  return address and jump
-  // to the deopt blob
+  // Perform a re-execute. The proper return  address is already on the stack,
+  // we just need  to restore registers, pop  all of our frame  but the return
+  // address and jump to the deopt blob.
   restore_live_registers(sasm);
   __ leave();
   __ far_jump(RuntimeAddress(deopt_blob->unpack_with_reexecution()));
 
   __ bind(no_deopt);
-  restore_live_registers(sasm);
-  __ leave();
-  __ ret(lr);
+  __ stop("deopt not performed");
 
   return oop_maps;
 }

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1275,13 +1275,12 @@ void Runtime1::patch_code(JavaThread* thread, Runtime1::StubID stub_id) {
   }
 
   Deoptimization::deoptimize_frame(thread, caller_frame.id());
-
   // Return to the now deoptimized frame.
+  postcond(caller_is_deopted());
 }
 
 #endif // DEOPTIMIZE_WHEN_PATCHING
 
-//
 // Entry point for compiled code. We want to patch a nmethod.
 // We don't do a normal VM transition here because we want to
 // know after the patching is complete and any safepoint(s) are taken
@@ -1346,7 +1345,7 @@ int Runtime1::move_appendix_patching(JavaThread* thread) {
 
   return caller_is_deopted();
 }
-//
+
 // Entry point for compiled code. We want to patch a nmethod.
 // We don't do a normal VM transition here because we want to
 // know after the patching is complete and any safepoint(s) are taken
@@ -1355,7 +1354,6 @@ int Runtime1::move_appendix_patching(JavaThread* thread) {
 // completes we can check for deoptimization. This simplifies the
 // assembly code in the cpu directories.
 //
-
 int Runtime1::access_field_patching(JavaThread* thread) {
 //
 // NOTE: we are still in Java
@@ -1373,7 +1371,7 @@ int Runtime1::access_field_patching(JavaThread* thread) {
   // Return true if calling code is deoptimized
 
   return caller_is_deopted();
-JRT_END
+}
 
 
 JRT_LEAF(void, Runtime1::trace_block_entry(jint block_id))

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1255,19 +1255,20 @@ JRT_END
 
 #else // DEOPTIMIZE_WHEN_PATCHING
 
-JRT_ENTRY(void, Runtime1::patch_code(JavaThread* thread, Runtime1::StubID stub_id ))
-  RegisterMap reg_map(thread, false);
+void Runtime1::patch_code(JavaThread* thread, Runtime1::StubID stub_id) {
+  NOT_PRODUCT(_patch_code_slowcase_cnt++);
 
-  NOT_PRODUCT(_patch_code_slowcase_cnt++;)
   if (TracePatching) {
     tty->print_cr("Deoptimizing because patch is needed");
   }
 
+  RegisterMap reg_map(thread, false);
+
   frame runtime_frame = thread->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
+  assert(caller_frame.is_compiled_frame(), "Wrong frame type");
 
-  // It's possible the nmethod was invalidated in the last
-  // safepoint, but if it's still alive then make it not_entrant.
+  // Make sure the nmethod is invalidated, i.e. made not entrant.
   nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
   if (nm != NULL) {
     nm->make_not_entrant();
@@ -1276,7 +1277,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* thread, Runtime1::StubID stub_i
   Deoptimization::deoptimize_frame(thread, caller_frame.id());
 
   // Return to the now deoptimized frame.
-JRT_END
+}
 
 #endif // DEOPTIMIZE_WHEN_PATCHING
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1623,6 +1623,7 @@ void Deoptimization::deoptimize_frame_internal(JavaThread* thread, intptr_t* id,
   while (fr.id() != id) {
     fr = fr.sender(&reg_map);
   }
+  assert(fr.is_compiled_frame(), "Wrong frame type");
   deoptimize(thread, fr, reason);
 }
 


### PR DESCRIPTION
The immediate issue that causes the error symptom is due to the procedure link register (LR) not being preserved across the actual call to the "patching" function (in code generated from '_generate_patching()_'), invoked as part of the C1 deoptimization traps.

However, this update addresses a larger issue with the current implementation.

Since the Aarch64 implementation does not adopt patching but deoptimization to support load-mirror et.al., the "patching" stub-code does not need to support the exception protocol otherwise necessary when a VM transition might be needed in the actual patching function. The deoptimization is compulsory and the transition to the interpreter will cater for proper interaction with the VM.

The proposed solution is thus:
1. The version of '_patch_code()_' used with **DEOPTIMIZE_WHEN_PATCHING** should not be modelled as a **JRT_ENTRY**. The "patching" functions will not transfer control to VM (for up-call or otherwise).
2. The patch-stub code does not need to handle the VM exception protocol (code can be removed).
3. The patch-stub code need only to support deoptimization and re-execute (it's a fatal error otherwise).
4. The patch-stub code does not need to utilise any instruction stream synchronisation barrier as no patching/modifying of the instruction stream is done (including indirectly through a VM transition).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247691](https://bugs.openjdk.java.net/browse/JDK-8247691): [aarch64] Incorrect handling of VM exceptions in C1 deopt stub/traps


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/344/head:pull/344`
`$ git checkout pull/344`
