### PR TITLE
8253615: Change to Visual Studio 2019 16.7.2 for building on Windows at Oracle

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -273,7 +273,7 @@
 </tr>
 <tr class="odd">
 <td style="text-align: left;">Windows</td>
-<td style="text-align: left;">Microsoft Visual Studio 2019 update 16.5.3</td>
+<td style="text-align: left;">Microsoft Visual Studio 2019 update 16.7.2</td>
 </tr>
 </tbody>
 </table>

--- a/doc/building.md
+++ b/doc/building.md
@@ -304,7 +304,7 @@ issues.
  ------------------ -------------------------------------------------------
  Linux              gcc 9.2.0
  macOS              Apple Xcode 10.1 (using clang 10.0.0)
- Windows            Microsoft Visual Studio 2019 update 16.5.3
+ Windows            Microsoft Visual Studio 2019 update 16.7.2
 
 All compilers are expected to be able to compile to the C99 language standard,
 as some C99 features are used in the source code. Microsoft Visual Studio

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -961,7 +961,7 @@ var getJibProfilesDependencies = function (input, common) {
     var devkit_platform_revisions = {
         linux_x64: "gcc9.2.0-OL6.4+1.0",
         macosx_x64: "Xcode11.3.1-MacOSX10.15+1.0",
-        windows_x64: "VS2019-16.5.3+1.0",
+        windows_x64: "VS2019-16.7.2+1.0",
         linux_aarch64: "gcc9.2.0-OL7.6+1.0",
         linux_arm: "gcc8.2.0-Fedora27+1.0",
         linux_ppc64le: "gcc8.2.0-Fedora27+1.0",


### PR DESCRIPTION
Oracle is changing the minor version of Visual Studio used for building the JDK on Windows. This patch updates the jib profiles configuration to point to the new devkit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253615](https://bugs.openjdk.java.net/browse/JDK-8253615): Change to Visual Studio 2019 16.7.2 for building on Windows at Oracle


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/346/head:pull/346`
`$ git checkout pull/346`
