### PR TITLE
8253426: jpackage is unable to generate working EXE for add-launcher configurations

### DIFF
--- a/src/jdk.incubator.jpackage/share/classes/jdk/incubator/jpackage/internal/AddLauncherArguments.java
+++ b/src/jdk.incubator.jpackage/share/classes/jdk/incubator/jpackage/internal/AddLauncherArguments.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 import jdk.incubator.jpackage.internal.Arguments.CLIOptions;
+import static jdk.incubator.jpackage.internal.StandardBundlerParam.LAUNCHER_DATA;
 
 /*
  * AddLauncherArguments
@@ -156,6 +157,9 @@ class AddLauncherArguments {
             Map<String, ? super Object> additional, String... exclude) {
         Map<String, ? super Object> tmp = new HashMap<>(original);
         List.of(exclude).forEach(tmp::remove);
+
+        // remove LauncherData from map so it will re-run the defaultValueFunction
+        tmp.remove(LAUNCHER_DATA.getID());
 
         if (additional.containsKey(CLIOptions.MODULE.getId())) {
             tmp.remove(CLIOptions.MAIN_JAR.getId());

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -791,11 +791,11 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
         }
     }
 
-    public CfgFile readLaunherCfgFile() {
-        return readLaunherCfgFile(null);
+    public CfgFile readLauncherCfgFile() {
+        return readLauncherCfgFile(null);
     }
 
-    public CfgFile readLaunherCfgFile(String launcherName) {
+    public CfgFile readLauncherCfgFile(String launcherName) {
         verifyIsOfType(PackageType.IMAGE);
         if (isRuntime()) {
             return null;

--- a/test/jdk/tools/jpackage/share/AddLauncherTest.java
+++ b/test/jdk/tools/jpackage/share/AddLauncherTest.java
@@ -203,20 +203,19 @@ public class AddLauncherTest {
 
         cmd.executeAndAssertHelloAppImageCreated();
 
-        // verify using each additional launchers cfg file that it has the
-        // main-jar/class or module/class
-
+        // check value of app.mainmodule in ModularAppLauncher's cfg file
         CfgFile cfg = cmd.readLauncherCfgFile("ModularAppLauncher");
         String moduleValue = cfg.getValue("Application", "app.mainmodule");
         String mainClass = null;
         String classpath = null;
-        TKit.assertEquals(moduleValue, JavaAppDesc.parse(
+        TKit.assertEquals(JavaAppDesc.parse(
                 modularAppDesc.toString()).setBundleFileName(null).toString(),
-                "app.mainmodule value in cfg file not as expected");
+                moduleValue,"app.mainmodule value in cfg file not as expected");
 
         TKit.trace("moduleValue: " + moduleValue + " mainClass: " + mainClass
                     + " classpath: " + classpath);
 
+        // check values of app.mainclass and app.classpath in cfg file
         cfg = cmd.readLauncherCfgFile("NonModularAppLauncher");
         moduleValue = null;
         mainClass = cfg.getValue("Application", "app.mainclass");

--- a/test/jdk/tools/jpackage/share/AddLauncherTest.java
+++ b/test/jdk/tools/jpackage/share/AddLauncherTest.java
@@ -208,26 +208,24 @@ public class AddLauncherTest {
         String moduleValue = cfg.getValue("Application", "app.mainmodule");
         String mainClass = null;
         String classpath = null;
-        TKit.assertEquals(JavaAppDesc.parse(
-                modularAppDesc.toString()).setBundleFileName(null).toString(),
-                moduleValue,"app.mainmodule value in cfg file not as expected");
-
-        TKit.trace("moduleValue: " + moduleValue + " mainClass: " + mainClass
-                    + " classpath: " + classpath);
+        String expectedMod = JavaAppDesc.parse(
+                modularAppDesc.toString()).setBundleFileName(null).toString();
+        TKit.assertEquals(expectedMod, moduleValue,
+                String.format("Check value of app.mainmodule=[%s]" +
+                "in ModularAppLauncher cfg file is as expected", expectedMod));
 
         // check values of app.mainclass and app.classpath in cfg file
         cfg = cmd.readLauncherCfgFile("NonModularAppLauncher");
         moduleValue = null;
         mainClass = cfg.getValue("Application", "app.mainclass");
         classpath = cfg.getValue("Application", "app.classpath");
-        TKit.assertEquals(mainClass, nonModularAppDesc.className(),
-                "app.mainclass value in NonModularAppLauncher cfg file");
+        String ExpectedCN = nonModularAppDesc.className();
+        TKit.assertEquals(ExpectedCN, mainClass,
+                String.format("Check value of app.mainclass=[%s]" +
+                "in NonModularAppLauncher cfg file is as expected", ExpectedCN));
         TKit.assertTrue(classpath.startsWith("$APPDIR" + File.separator
                 + nonModularAppDesc.jarFileName()),
-                "app.classpath value in ModularAppLauncher cfg file");
-
-        TKit.trace("moduleValue: " + moduleValue + " mainClass: " + mainClass
-                    + " classpath: " + classpath);
+                "Check app.classpath value in ModularAppLauncher cfg file");
     }
 
     private final static Path GOLDEN_ICON = TKit.TEST_SRC_ROOT.resolve(Path.of(


### PR DESCRIPTION
8253426: jpackage is unable to generate working EXE for add-launcher configurations.
secondary launchers ignored module, main-jar, and main-class in launcher properties file because  the LAUNCHER_DATA param was not removed from the set of params for each new add-module.
testcase added in AddLauncherTest,java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253426](https://bugs.openjdk.java.net/browse/JDK-8253426): jpackage is unable to generate working EXE for add-launcher configurations


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/347/head:pull/347`
`$ git checkout pull/347`
