### PR TITLE
8252000: remove usage of PropertyResolvingWrapper in vmTestbase/nsk/jdb

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8252000 is fixed
-allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002.java
@@ -45,9 +45,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.caught_exception.caught_exception002.caught_exception002
- *        nsk.jdb.caught_exception.caught_exception002.caught_exception002a
- * @run main/othervm PropertyResolvingWrapper
+ * @build nsk.jdb.caught_exception.caught_exception002.caught_exception002a
+ * @run main/othervm
  *      nsk.jdb.caught_exception.caught_exception002.caught_exception002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002.java
@@ -91,8 +91,6 @@ public class caught_exception002 extends JdbTest {
     /* ------------------------------------- */
 
     protected void runCases() {
-        String[] reply;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
@@ -101,7 +99,7 @@ public class caught_exception002 extends JdbTest {
         }
 
         for (int i = 0; i < MAX; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
             checkCatch(reply, i);
         }
 
@@ -109,14 +107,11 @@ public class caught_exception002 extends JdbTest {
     }
 
     private void checkCatch(String[] reply, int i) {
-        Paragrep grep;
-        int count;
-        Vector<String> v = new Vector<>();
-
-        grep = new Paragrep(reply);
+        var grep = new Paragrep(reply);
+        var v = new Vector<String>();
         v.add("Exception occurred");
         v.add(PACKAGE_NAME + ".MyException" + i);
-        count = grep.find(v);
+        int count = grep.find(v);
         if (count != 1) {
             log.complain("Failed to report catch of MyException" + i + " : " + count);
             success = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002.java
@@ -60,30 +60,31 @@
 
 package nsk.jdb.caught_exception.caught_exception002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class caught_exception002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new caught_exception002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.caught_exception.caught_exception002";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".caught_exception002";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.caught_exception.caught_exception002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".caught_exception002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static final int MAX = 10;
 
@@ -91,16 +92,12 @@ public class caught_exception002 extends JdbTest {
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         for (int i = 0; i < MAX; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand._catch + " caught " + PACKAGE_NAME + ".MyException" + i);
+            jdb.receiveReplyFor(JdbCommand._catch + " caught " + PACKAGE_NAME + ".MyException" + i);
         }
 
         for (int i = 0; i < MAX; i++) {
@@ -111,11 +108,10 @@ public class caught_exception002 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private void checkCatch (String[] reply, int i) {
+    private void checkCatch(String[] reply, int i) {
         Paragrep grep;
         int count;
-        String found;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         grep = new Paragrep(reply);
         v.add("Exception occurred");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002.java
@@ -60,58 +60,67 @@
 
 package nsk.jdb.caught_exception.caught_exception002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class caught_exception002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new caught_exception002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.caught_exception.caught_exception002";
-    static final String TEST_CLASS = PACKAGE_NAME + ".caught_exception002";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME       = "nsk.jdb.caught_exception.caught_exception002";
+    static final String TEST_CLASS         = PACKAGE_NAME + ".caught_exception002";
+    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     static final int MAX = 10;
 
     /* ------------------------------------- */
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         for (int i = 0; i < MAX; i++) {
-            jdb.receiveReplyFor(JdbCommand._catch + " caught " + PACKAGE_NAME + ".MyException" + i);
+            reply = jdb.receiveReplyFor(JdbCommand._catch + " caught " + PACKAGE_NAME + ".MyException" + i);
         }
 
         for (int i = 0; i < MAX; i++) {
-            String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
+            reply = jdb.receiveReplyFor(JdbCommand.cont);
             checkCatch(reply, i);
         }
 
         jdb.contToExit(1);
     }
 
-    private void checkCatch(String[] reply, int i) {
-        var grep = new Paragrep(reply);
-        var v = new Vector<String>();
+    private void checkCatch (String[] reply, int i) {
+        Paragrep grep;
+        int count;
+        String found;
+        Vector v = new Vector();
+
+        grep = new Paragrep(reply);
         v.add("Exception occurred");
         v.add(PACKAGE_NAME + ".MyException" + i);
-        int count = grep.find(v);
+        count = grep.find(v);
         if (count != 1) {
             log.complain("Failed to report catch of MyException" + i + " : " + count);
             success = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001.java
@@ -36,9 +36,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.classes.classes001.classes001
- *        nsk.jdb.classes.classes001.classes001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.classes.classes001.classes001
+ * @build nsk.jdb.classes.classes001.classes001a
+ * @run main/othervm
+ *      nsk.jdb.classes.classes001.classes001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001.java
@@ -51,63 +51,70 @@
 
 package nsk.jdb.classes.classes001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class classes001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new classes001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.classes.classes001";
-    static final String TEST_CLASS = PACKAGE_NAME + ".classes001";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME       = "nsk.jdb.classes.classes001";
+    static final String TEST_CLASS         = PACKAGE_NAME + ".classes001";
+    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String NOT_VALID_SAMPLE   = "is not a valid";
 
     static String[] checkedClasses = {
-            DEBUGGEE_CLASS,
-            DEBUGGEE_CLASS + "$Inner1",
-            DEBUGGEE_CLASS + "$Inner2",
-            DEBUGGEE_CLASS + "$Inner3",
-            DEBUGGEE_CLASS + "$Inner4",
-            DEBUGGEE_CLASS + "$Inner5",
-            DEBUGGEE_CLASS + "$Inner6",
-            DEBUGGEE_CLASS + "$Inner7",
-            DEBUGGEE_CLASS + "$Inner8",
-            DEBUGGEE_CLASS + "$InnerInt1",
-            DEBUGGEE_CLASS + "$InnerInt2",
-            DEBUGGEE_CLASS + "$InnerInt3",
-            DEBUGGEE_CLASS + "$InnerInt4",
-            DEBUGGEE_CLASS + "$InnerInt5",
-            PACKAGE_NAME + ".Outer1",
-            PACKAGE_NAME + ".Outer2",
-            PACKAGE_NAME + ".Outer3",
-            PACKAGE_NAME + ".OuterInt1",
-            PACKAGE_NAME + ".OuterInt2"
-    };
+        DEBUGGEE_CLASS,
+        DEBUGGEE_CLASS + "$Inner1",
+        DEBUGGEE_CLASS + "$Inner2",
+        DEBUGGEE_CLASS + "$Inner3",
+        DEBUGGEE_CLASS + "$Inner4",
+        DEBUGGEE_CLASS + "$Inner5",
+        DEBUGGEE_CLASS + "$Inner6",
+        DEBUGGEE_CLASS + "$Inner7",
+        DEBUGGEE_CLASS + "$Inner8",
+        DEBUGGEE_CLASS + "$InnerInt1",
+        DEBUGGEE_CLASS + "$InnerInt2",
+        DEBUGGEE_CLASS + "$InnerInt3",
+        DEBUGGEE_CLASS + "$InnerInt4",
+        DEBUGGEE_CLASS + "$InnerInt5",
+        PACKAGE_NAME + ".Outer1",
+        PACKAGE_NAME + ".Outer2",
+        PACKAGE_NAME + ".Outer3",
+        PACKAGE_NAME + ".OuterInt1",
+        PACKAGE_NAME + ".OuterInt2"
+                                      };
 
     /* ------------------------------------- */
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.classes);
+        reply = jdb.receiveReplyFor(JdbCommand.classes);
 
-        for (String checkedClass : checkedClasses) {
-            if (!checkClass(checkedClass, reply)) {
+        for (int i = 0; i < checkedClasses.length; i++) {
+            if (!checkClass(checkedClasses[i], reply)) {
                 success = false;
             }
         }
@@ -115,11 +122,13 @@ public class classes001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkClass(String className, String[] reply) {
+    private boolean checkClass (String className, String[] reply) {
+        Paragrep grep;
+        String found;
         boolean result = true;
 
-        var grep = new Paragrep(reply);
-        String found = grep.findFirst(className);
+        grep = new Paragrep(reply);
+        found = grep.findFirst(className);
         if (found.length() == 0) {
             log.complain("Failed to report class " + className);
             result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001.java
@@ -51,70 +51,65 @@
 
 package nsk.jdb.classes.classes001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class classes001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new classes001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.classes.classes001";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".classes001";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final String NOT_VALID_SAMPLE   = "is not a valid";
+    static final String PACKAGE_NAME = "nsk.jdb.classes.classes001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".classes001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static String[] checkedClasses = {
-        DEBUGGEE_CLASS,
-        DEBUGGEE_CLASS + "$Inner1",
-        DEBUGGEE_CLASS + "$Inner2",
-        DEBUGGEE_CLASS + "$Inner3",
-        DEBUGGEE_CLASS + "$Inner4",
-        DEBUGGEE_CLASS + "$Inner5",
-        DEBUGGEE_CLASS + "$Inner6",
-        DEBUGGEE_CLASS + "$Inner7",
-        DEBUGGEE_CLASS + "$Inner8",
-        DEBUGGEE_CLASS + "$InnerInt1",
-        DEBUGGEE_CLASS + "$InnerInt2",
-        DEBUGGEE_CLASS + "$InnerInt3",
-        DEBUGGEE_CLASS + "$InnerInt4",
-        DEBUGGEE_CLASS + "$InnerInt5",
-        PACKAGE_NAME + ".Outer1",
-        PACKAGE_NAME + ".Outer2",
-        PACKAGE_NAME + ".Outer3",
-        PACKAGE_NAME + ".OuterInt1",
-        PACKAGE_NAME + ".OuterInt2"
-                                      };
+            DEBUGGEE_CLASS,
+            DEBUGGEE_CLASS + "$Inner1",
+            DEBUGGEE_CLASS + "$Inner2",
+            DEBUGGEE_CLASS + "$Inner3",
+            DEBUGGEE_CLASS + "$Inner4",
+            DEBUGGEE_CLASS + "$Inner5",
+            DEBUGGEE_CLASS + "$Inner6",
+            DEBUGGEE_CLASS + "$Inner7",
+            DEBUGGEE_CLASS + "$Inner8",
+            DEBUGGEE_CLASS + "$InnerInt1",
+            DEBUGGEE_CLASS + "$InnerInt2",
+            DEBUGGEE_CLASS + "$InnerInt3",
+            DEBUGGEE_CLASS + "$InnerInt4",
+            DEBUGGEE_CLASS + "$InnerInt5",
+            PACKAGE_NAME + ".Outer1",
+            PACKAGE_NAME + ".Outer2",
+            PACKAGE_NAME + ".Outer3",
+            PACKAGE_NAME + ".OuterInt1",
+            PACKAGE_NAME + ".OuterInt2"
+    };
 
     /* ------------------------------------- */
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         reply = jdb.receiveReplyFor(JdbCommand.classes);
 
-        for (int i = 0; i < checkedClasses.length; i++) {
-            if (!checkClass(checkedClasses[i], reply)) {
+        for (String checkedClass : checkedClasses) {
+            if (!checkClass(checkedClass, reply)) {
                 success = false;
             }
         }
@@ -122,7 +117,7 @@ public class classes001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkClass (String className, String[] reply) {
+    private boolean checkClass(String className, String[] reply) {
         Paragrep grep;
         String found;
         boolean result = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001.java
@@ -101,12 +101,10 @@ public class classes001 extends JdbTest {
     /* ------------------------------------- */
 
     protected void runCases() {
-        String[] reply;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        reply = jdb.receiveReplyFor(JdbCommand.classes);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.classes);
 
         for (String checkedClass : checkedClasses) {
             if (!checkClass(checkedClass, reply)) {
@@ -118,12 +116,10 @@ public class classes001 extends JdbTest {
     }
 
     private boolean checkClass(String className, String[] reply) {
-        Paragrep grep;
-        String found;
         boolean result = true;
 
-        grep = new Paragrep(reply);
-        found = grep.findFirst(className);
+        var grep = new Paragrep(reply);
+        String found = grep.findFirst(className);
         if (found.length() == 0) {
             log.complain("Failed to report class " + className);
             result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001.java
@@ -35,9 +35,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.classpath.classpath001.classpath001
- *        nsk.jdb.classpath.classpath001.classpath001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.classpath.classpath001.classpath001
+ * @build nsk.jdb.classpath.classpath001.classpath001a
+ * @run main/othervm
+ *      nsk.jdb.classpath.classpath001.classpath001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001.java
@@ -76,14 +76,10 @@ public class classpath001 extends JdbTest {
     static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        String found;
+        String[] reply = jdb.receiveReplyFor(JdbCommand.classpath);
 
-        reply = jdb.receiveReplyFor(JdbCommand.classpath);
-
-        grep = new Paragrep(reply);
-        found = grep.findFirst("lasspath");
+        var grep = new Paragrep(reply);
+        String found = grep.findFirst("lasspath");
         if (found.length() == 0) {
             log.complain("Failed to report classpath");
             success = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001.java
@@ -50,20 +50,20 @@
 
 package nsk.jdb.classpath.classpath001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class classpath001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new classpath001().runTest(argv, out);
@@ -72,14 +72,12 @@ public class classpath001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.classpath.classpath001";
     static final String TEST_CLASS = PACKAGE_NAME + ".classpath001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
         String found;
 
         reply = jdb.receiveReplyFor(JdbCommand.classpath);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001.java
@@ -50,20 +50,20 @@
 
 package nsk.jdb.classpath.classpath001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class classpath001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new classpath001().runTest(argv, out);
@@ -72,14 +72,20 @@ public class classpath001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.classpath.classpath001";
     static final String TEST_CLASS = PACKAGE_NAME + ".classpath001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
-        String[] reply = jdb.receiveReplyFor(JdbCommand.classpath);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
 
-        var grep = new Paragrep(reply);
-        String found = grep.findFirst("lasspath");
+        reply = jdb.receiveReplyFor(JdbCommand.classpath);
+
+        grep = new Paragrep(reply);
+        found = grep.findFirst("lasspath");
         if (found.length() == 0) {
             log.complain("Failed to report classpath");
             success = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002.java
@@ -37,9 +37,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.clear.clear002.clear002
- *        nsk.jdb.clear.clear002.clear002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.clear.clear002.clear002
+ * @build nsk.jdb.clear.clear002.clear002a
+ * @run main/othervm
+ *      nsk.jdb.clear.clear002.clear002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002.java
@@ -84,9 +84,6 @@ public class clear002 extends JdbTest {
     static final String REMOVED_SAMPLE = "Removed:";
 
     protected void runCases() {
-        Paragrep grep;
-        int count;
-
         log.display("Setting breakpoint in method: " + METHOD1_TO_CLEAR);
         jdb.setBreakpointInMethod(METHOD1_TO_CLEAR);
 
@@ -106,8 +103,8 @@ public class clear002 extends JdbTest {
 
         jdb.contToExit(2);
 
-        grep = new Paragrep(jdb.getTotalReply());
-        count = grep.find(Jdb.BREAKPOINT_HIT);
+        var grep = new Paragrep(jdb.getTotalReply());
+        int count = grep.find(Jdb.BREAKPOINT_HIT);
         if (count != 2) {
             log.complain("Should hit 2 breakpoints.");
             log.complain("Breakpoint hit count reported: " + count);
@@ -124,15 +121,13 @@ public class clear002 extends JdbTest {
     }
 
     private boolean checkBreakpoint(String methodName, Paragrep grep) {
-        String found;
         boolean result = true;
-        Vector<String> v;
 
-        v = new Vector<>();
+        var v = new Vector<String>();
         v.add(Jdb.BREAKPOINT_HIT);
         v.add(methodName);
 
-        found = grep.findFirst(v);
+        String found = grep.findFirst(v);
         if (found.length() > 0) {
             log.complain("Wrong hit at removed breakpoint in method:" + methodName);
             result = false;
@@ -141,21 +136,17 @@ public class clear002 extends JdbTest {
     }
 
     private boolean checkClear(String methodName) {
-        Paragrep grep;
-        String found;
-        String[] reply;
         boolean result = true;
-        Vector<String> v;
 
-        v = new Vector<>();
+        var v = new Vector<String>();
         v.add(REMOVED_SAMPLE);
         v.add(methodName);
 
         log.display("Clearing breakpoint in method:" + methodName);
-        reply = jdb.receiveReplyFor(JdbCommand.clear + methodName);
-        grep = new Paragrep(reply);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.clear + methodName);
+        var grep = new Paragrep(reply);
 
-        found = grep.findFirst(v);
+        String found = grep.findFirst(v);
         if (found.length() == 0) {
             log.complain("Failed to clear breakpoint in method: " + methodName);
             result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002.java
@@ -52,41 +52,40 @@
 
 package nsk.jdb.clear.clear002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.Jdb;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class clear002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new clear002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.clear.clear002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".clear002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
-    static final String METHOD_TO_STOP   = DEBUGGEE_CLASS + ".func5";
+    static final String PACKAGE_NAME = "nsk.jdb.clear.clear002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".clear002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String METHOD_TO_STOP = DEBUGGEE_CLASS + ".func5";
     static final String METHOD1_TO_CLEAR = DEBUGGEE_CLASS + ".func4";
     static final String METHOD2_TO_CLEAR = DEBUGGEE_CLASS + "$A.func7";
-    static final String REMOVED_SAMPLE   = "Removed:";
+    static final String REMOVED_SAMPLE = "Removed:";
 
     protected void runCases() {
-        String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
         log.display("Setting breakpoint in method: " + METHOD1_TO_CLEAR);
         jdb.setBreakpointInMethod(METHOD1_TO_CLEAR);
@@ -97,11 +96,11 @@ public class clear002 extends JdbTest {
         log.display("Setting breakpoint in method: " + METHOD_TO_STOP);
         jdb.setBreakpointInMethod(METHOD_TO_STOP);
 
-        if (!checkClear (METHOD1_TO_CLEAR)) {
+        if (!checkClear(METHOD1_TO_CLEAR)) {
             success = false;
         }
 
-        if (!checkClear (METHOD2_TO_CLEAR)) {
+        if (!checkClear(METHOD2_TO_CLEAR)) {
             success = false;
         }
 
@@ -115,22 +114,21 @@ public class clear002 extends JdbTest {
             success = false;
         }
 
-        if (!checkBreakpoint (METHOD1_TO_CLEAR, grep)) {
+        if (!checkBreakpoint(METHOD1_TO_CLEAR, grep)) {
             success = false;
         }
 
-        if (!checkBreakpoint (METHOD2_TO_CLEAR, grep)) {
+        if (!checkBreakpoint(METHOD2_TO_CLEAR, grep)) {
             success = false;
         }
     }
 
-    private boolean checkBreakpoint (String methodName, Paragrep grep) {
+    private boolean checkBreakpoint(String methodName, Paragrep grep) {
         String found;
         boolean result = true;
-        int count;
-        Vector v;
+        Vector<String> v;
 
-        v = new Vector();
+        v = new Vector<>();
         v.add(Jdb.BREAKPOINT_HIT);
         v.add(methodName);
 
@@ -142,15 +140,14 @@ public class clear002 extends JdbTest {
         return result;
     }
 
-    private boolean checkClear (String methodName) {
+    private boolean checkClear(String methodName) {
         Paragrep grep;
         String found;
         String[] reply;
         boolean result = true;
-        int count;
-        Vector v;
+        Vector<String> v;
 
-        v = new Vector();
+        v = new Vector<>();
         v.add(REMOVED_SAMPLE);
         v.add(methodName);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002.java
@@ -52,38 +52,42 @@
 
 package nsk.jdb.clear.clear002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.Jdb;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class clear002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new clear002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.clear.clear002";
-    static final String TEST_CLASS = PACKAGE_NAME + ".clear002";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
-    static final String METHOD_TO_STOP = DEBUGGEE_CLASS + ".func5";
+    static final String PACKAGE_NAME     = "nsk.jdb.clear.clear002";
+    static final String TEST_CLASS       = PACKAGE_NAME + ".clear002";
+    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String METHOD_TO_STOP   = DEBUGGEE_CLASS + ".func5";
     static final String METHOD1_TO_CLEAR = DEBUGGEE_CLASS + ".func4";
     static final String METHOD2_TO_CLEAR = DEBUGGEE_CLASS + "$A.func7";
-    static final String REMOVED_SAMPLE = "Removed:";
+    static final String REMOVED_SAMPLE   = "Removed:";
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         log.display("Setting breakpoint in method: " + METHOD1_TO_CLEAR);
         jdb.setBreakpointInMethod(METHOD1_TO_CLEAR);
 
@@ -93,41 +97,44 @@ public class clear002 extends JdbTest {
         log.display("Setting breakpoint in method: " + METHOD_TO_STOP);
         jdb.setBreakpointInMethod(METHOD_TO_STOP);
 
-        if (!checkClear(METHOD1_TO_CLEAR)) {
+        if (!checkClear (METHOD1_TO_CLEAR)) {
             success = false;
         }
 
-        if (!checkClear(METHOD2_TO_CLEAR)) {
+        if (!checkClear (METHOD2_TO_CLEAR)) {
             success = false;
         }
 
         jdb.contToExit(2);
 
-        var grep = new Paragrep(jdb.getTotalReply());
-        int count = grep.find(Jdb.BREAKPOINT_HIT);
+        grep = new Paragrep(jdb.getTotalReply());
+        count = grep.find(Jdb.BREAKPOINT_HIT);
         if (count != 2) {
             log.complain("Should hit 2 breakpoints.");
             log.complain("Breakpoint hit count reported: " + count);
             success = false;
         }
 
-        if (!checkBreakpoint(METHOD1_TO_CLEAR, grep)) {
+        if (!checkBreakpoint (METHOD1_TO_CLEAR, grep)) {
             success = false;
         }
 
-        if (!checkBreakpoint(METHOD2_TO_CLEAR, grep)) {
+        if (!checkBreakpoint (METHOD2_TO_CLEAR, grep)) {
             success = false;
         }
     }
 
-    private boolean checkBreakpoint(String methodName, Paragrep grep) {
+    private boolean checkBreakpoint (String methodName, Paragrep grep) {
+        String found;
         boolean result = true;
+        int count;
+        Vector v;
 
-        var v = new Vector<String>();
+        v = new Vector();
         v.add(Jdb.BREAKPOINT_HIT);
         v.add(methodName);
 
-        String found = grep.findFirst(v);
+        found = grep.findFirst(v);
         if (found.length() > 0) {
             log.complain("Wrong hit at removed breakpoint in method:" + methodName);
             result = false;
@@ -135,18 +142,23 @@ public class clear002 extends JdbTest {
         return result;
     }
 
-    private boolean checkClear(String methodName) {
+    private boolean checkClear (String methodName) {
+        Paragrep grep;
+        String found;
+        String[] reply;
         boolean result = true;
+        int count;
+        Vector v;
 
-        var v = new Vector<String>();
+        v = new Vector();
         v.add(REMOVED_SAMPLE);
         v.add(methodName);
 
         log.display("Clearing breakpoint in method:" + methodName);
-        String[] reply = jdb.receiveReplyFor(JdbCommand.clear + methodName);
-        var grep = new Paragrep(reply);
+        reply = jdb.receiveReplyFor(JdbCommand.clear + methodName);
+        grep = new Paragrep(reply);
 
-        String found = grep.findFirst(v);
+        found = grep.findFirst(v);
         if (found.length() == 0) {
             log.complain("Failed to clear breakpoint in method: " + methodName);
             result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003.java
@@ -38,9 +38,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.clear.clear003.clear003
- *        nsk.jdb.clear.clear003.clear003a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.clear.clear003.clear003
+ * @build nsk.jdb.clear.clear003.clear003a
+ * @run main/othervm
+ *      nsk.jdb.clear.clear003.clear003
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003.java
@@ -53,21 +53,20 @@
 
 package nsk.jdb.clear.clear003;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.Jdb;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class clear003 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new clear003().runTest(argv, out);
@@ -76,20 +75,26 @@ public class clear003 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.clear.clear003";
     static final String TEST_CLASS = PACKAGE_NAME + ".clear003";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
     static final String METHOD4 = "func4";
     static final String METHOD5 = "func5";
     static final String METHOD_TO_CLEAR = DEBUGGEE_CLASS + "." + METHOD4;
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         log.display("Setting breakpoint in method: " + METHOD5);
         jdb.setBreakpointInMethod(DEBUGGEE_CLASS + "." + METHOD5);
 
         log.display("Clearing breakpoint.");
-        String[] reply = jdb.receiveReplyFor(JdbCommand.clear + METHOD_TO_CLEAR);
-        var grep = new Paragrep(reply);
-        int count = grep.find("Removed:");
+        reply = jdb.receiveReplyFor(JdbCommand.clear + METHOD_TO_CLEAR);
+        grep = new Paragrep(reply);
+        count = grep.find("Removed:");
         if (count > 0) {
             log.complain("Cleared non-existent breakpoint in method: " + METHOD_TO_CLEAR);
             success = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003.java
@@ -83,17 +83,13 @@ public class clear003 extends JdbTest {
     static final String METHOD_TO_CLEAR = DEBUGGEE_CLASS + "." + METHOD4;
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-
         log.display("Setting breakpoint in method: " + METHOD5);
         jdb.setBreakpointInMethod(DEBUGGEE_CLASS + "." + METHOD5);
 
         log.display("Clearing breakpoint.");
-        reply = jdb.receiveReplyFor(JdbCommand.clear + METHOD_TO_CLEAR);
-        grep = new Paragrep(reply);
-        count = grep.find("Removed:");
+        String[] reply = jdb.receiveReplyFor(JdbCommand.clear + METHOD_TO_CLEAR);
+        var grep = new Paragrep(reply);
+        int count = grep.find("Removed:");
         if (count > 0) {
             log.complain("Cleared non-existent breakpoint in method: " + METHOD_TO_CLEAR);
             success = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003.java
@@ -53,20 +53,21 @@
 
 package nsk.jdb.clear.clear003;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.Jdb;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class clear003 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new clear003().runTest(argv, out);
@@ -75,8 +76,8 @@ public class clear003 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.clear.clear003";
     static final String TEST_CLASS = PACKAGE_NAME + ".clear003";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
     static final String METHOD4 = "func4";
     static final String METHOD5 = "func5";
     static final String METHOD_TO_CLEAR = DEBUGGEE_CLASS + "." + METHOD4;
@@ -85,8 +86,6 @@ public class clear003 extends JdbTest {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
         log.display("Setting breakpoint in method: " + METHOD5);
         jdb.setBreakpointInMethod(DEBUGGEE_CLASS + "." + METHOD5);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004.java
@@ -39,9 +39,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.clear.clear004.clear004
- *        nsk.jdb.clear.clear004.clear004a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.clear.clear004.clear004
+ * @build nsk.jdb.clear.clear004.clear004a
+ * @run main/othervm
+ *      nsk.jdb.clear.clear004.clear004
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004.java
@@ -87,9 +87,6 @@ public class clear004 extends JdbTest {
     static final String REMOVED_SAMPLE = "Removed:";
 
     protected void runCases() {
-        Paragrep grep;
-        int count;
-
         for (String breakpoint : BREAKPOINTS) {
             log.display("Setting breakpoint at " + breakpoint);
             jdb.receiveReplyFor(JdbCommand.stop_at + breakpoint);
@@ -101,8 +98,8 @@ public class clear004 extends JdbTest {
 
         jdb.contToExit(3);
 
-        grep = new Paragrep(jdb.getTotalReply());
-        count = grep.find(Jdb.BREAKPOINT_HIT);
+        var grep = new Paragrep(jdb.getTotalReply());
+        int count = grep.find(Jdb.BREAKPOINT_HIT);
         if (count != 3) {
             log.complain("Should hit 3 breakpoints.");
             log.complain("Breakpoint hit count reported: " + count);
@@ -116,15 +113,12 @@ public class clear004 extends JdbTest {
     }
 
     private boolean checkBreakpoint(String breakpoint, Paragrep grep) {
-        String found;
         boolean result = true;
-        Vector<String> v;
-
-        v = new Vector<>();
+        var v = new Vector<String>();
         v.add(Jdb.BREAKPOINT_HIT);
         v.add(breakpoint);
 
-        found = grep.findFirst(v);
+        String found = grep.findFirst(v);
         if (found.length() > 0) {
             log.complain("Wrong hit at removed breakpoint at:" + breakpoint);
             result = false;
@@ -133,21 +127,17 @@ public class clear004 extends JdbTest {
     }
 
     private boolean checkClear(String breakpoint) {
-        Paragrep grep;
-        String found;
-        String[] reply;
         boolean result = true;
-        Vector<String> v;
 
-        v = new Vector<>();
+        var v = new Vector<String>();
         v.add(REMOVED_SAMPLE);
         v.add(breakpoint);
 
         log.display("Clearing breakpoint at: " + breakpoint);
-        reply = jdb.receiveReplyFor(JdbCommand.clear + breakpoint);
-        grep = new Paragrep(reply);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.clear + breakpoint);
+        var grep = new Paragrep(reply);
 
-        found = grep.findFirst(v);
+        String found = grep.findFirst(v);
         if (found.length() == 0) {
             log.complain("Failed to clear breakpoint at: " + breakpoint);
             result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004.java
@@ -54,49 +54,48 @@
 
 package nsk.jdb.clear.clear004;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.Jdb;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class clear004 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new clear004().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.clear.clear004";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".clear004";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
-    static final String[] BREAKPOINTS = new String[]
-        { DEBUGGEE_CLASS + ":63",
-          DEBUGGEE_CLASS + ":67",
-          DEBUGGEE_CLASS + ":71" };
-    static final String REMOVED_SAMPLE   = "Removed:";
+    static final String PACKAGE_NAME = "nsk.jdb.clear.clear004";
+    static final String TEST_CLASS = PACKAGE_NAME + ".clear004";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String[] BREAKPOINTS = new String[]{
+            DEBUGGEE_CLASS + ":63",
+            DEBUGGEE_CLASS + ":67",
+            DEBUGGEE_CLASS + ":71"};
+    static final String REMOVED_SAMPLE = "Removed:";
 
     protected void runCases() {
-        String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
-        for (int i = 0; i < BREAKPOINTS.length; i++) {
-           log.display("Setting breakpoint at " + BREAKPOINTS[i]);
-           reply = jdb.receiveReplyFor(JdbCommand.stop_at + BREAKPOINTS[i]);
+        for (String breakpoint : BREAKPOINTS) {
+            log.display("Setting breakpoint at " + breakpoint);
+            jdb.receiveReplyFor(JdbCommand.stop_at + breakpoint);
         }
 
-        if (!checkClear (BREAKPOINTS[1])) {
+        if (!checkClear(BREAKPOINTS[1])) {
             success = false;
         }
 
@@ -110,19 +109,18 @@ public class clear004 extends JdbTest {
             success = false;
         }
 
-        if (!checkBreakpoint (BREAKPOINTS[1], grep)) {
+        if (!checkBreakpoint(BREAKPOINTS[1], grep)) {
             success = false;
         }
 
     }
 
-    private boolean checkBreakpoint (String breakpoint, Paragrep grep) {
+    private boolean checkBreakpoint(String breakpoint, Paragrep grep) {
         String found;
         boolean result = true;
-        int count;
-        Vector v;
+        Vector<String> v;
 
-        v = new Vector();
+        v = new Vector<>();
         v.add(Jdb.BREAKPOINT_HIT);
         v.add(breakpoint);
 
@@ -134,15 +132,14 @@ public class clear004 extends JdbTest {
         return result;
     }
 
-    private boolean checkClear (String breakpoint) {
+    private boolean checkClear(String breakpoint) {
         Paragrep grep;
         String found;
         String[] reply;
         boolean result = true;
-        int count;
-        Vector v;
+        Vector<String> v;
 
-        v = new Vector();
+        v = new Vector<>();
         v.add(REMOVED_SAMPLE);
         v.add(breakpoint);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004.java
@@ -54,71 +54,79 @@
 
 package nsk.jdb.clear.clear004;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.Jdb;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class clear004 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new clear004().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.clear.clear004";
-    static final String TEST_CLASS = PACKAGE_NAME + ".clear004";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
-    static final String[] BREAKPOINTS = new String[]{
-            DEBUGGEE_CLASS + ":63",
-            DEBUGGEE_CLASS + ":67",
-            DEBUGGEE_CLASS + ":71"};
-    static final String REMOVED_SAMPLE = "Removed:";
+    static final String PACKAGE_NAME     = "nsk.jdb.clear.clear004";
+    static final String TEST_CLASS       = PACKAGE_NAME + ".clear004";
+    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String[] BREAKPOINTS = new String[]
+        { DEBUGGEE_CLASS + ":63",
+          DEBUGGEE_CLASS + ":67",
+          DEBUGGEE_CLASS + ":71" };
+    static final String REMOVED_SAMPLE   = "Removed:";
 
     protected void runCases() {
-        for (String breakpoint : BREAKPOINTS) {
-            log.display("Setting breakpoint at " + breakpoint);
-            jdb.receiveReplyFor(JdbCommand.stop_at + breakpoint);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
+        for (int i = 0; i < BREAKPOINTS.length; i++) {
+           log.display("Setting breakpoint at " + BREAKPOINTS[i]);
+           reply = jdb.receiveReplyFor(JdbCommand.stop_at + BREAKPOINTS[i]);
         }
 
-        if (!checkClear(BREAKPOINTS[1])) {
+        if (!checkClear (BREAKPOINTS[1])) {
             success = false;
         }
 
         jdb.contToExit(3);
 
-        var grep = new Paragrep(jdb.getTotalReply());
-        int count = grep.find(Jdb.BREAKPOINT_HIT);
+        grep = new Paragrep(jdb.getTotalReply());
+        count = grep.find(Jdb.BREAKPOINT_HIT);
         if (count != 3) {
             log.complain("Should hit 3 breakpoints.");
             log.complain("Breakpoint hit count reported: " + count);
             success = false;
         }
 
-        if (!checkBreakpoint(BREAKPOINTS[1], grep)) {
+        if (!checkBreakpoint (BREAKPOINTS[1], grep)) {
             success = false;
         }
 
     }
 
-    private boolean checkBreakpoint(String breakpoint, Paragrep grep) {
+    private boolean checkBreakpoint (String breakpoint, Paragrep grep) {
+        String found;
         boolean result = true;
-        var v = new Vector<String>();
+        int count;
+        Vector v;
+
+        v = new Vector();
         v.add(Jdb.BREAKPOINT_HIT);
         v.add(breakpoint);
 
-        String found = grep.findFirst(v);
+        found = grep.findFirst(v);
         if (found.length() > 0) {
             log.complain("Wrong hit at removed breakpoint at:" + breakpoint);
             result = false;
@@ -126,18 +134,23 @@ public class clear004 extends JdbTest {
         return result;
     }
 
-    private boolean checkClear(String breakpoint) {
+    private boolean checkClear (String breakpoint) {
+        Paragrep grep;
+        String found;
+        String[] reply;
         boolean result = true;
+        int count;
+        Vector v;
 
-        var v = new Vector<String>();
+        v = new Vector();
         v.add(REMOVED_SAMPLE);
         v.add(breakpoint);
 
         log.display("Clearing breakpoint at: " + breakpoint);
-        String[] reply = jdb.receiveReplyFor(JdbCommand.clear + breakpoint);
-        var grep = new Paragrep(reply);
+        reply = jdb.receiveReplyFor(JdbCommand.clear + breakpoint);
+        grep = new Paragrep(reply);
 
-        String found = grep.findFirst(v);
+        found = grep.findFirst(v);
         if (found.length() == 0) {
             log.complain("Failed to clear breakpoint at: " + breakpoint);
             result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002.java
@@ -42,9 +42,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.down.down002.down002
- *        nsk.jdb.down.down002.down002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.down.down002.down002
+ * @build nsk.jdb.down.down002.down002a
+ * @run main/othervm
+ *      nsk.jdb.down.down002.down002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002.java
@@ -57,68 +57,73 @@
 
 package nsk.jdb.down.down002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class down002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new down002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.down.down002";
-    static final String TEST_CLASS = PACKAGE_NAME + ".down002";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME     = "nsk.jdb.down.down002";
+    static final String TEST_CLASS       = PACKAGE_NAME + ".down002";
+    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][]{
-            {"[1]", DEBUGGEE_CLASS + ".func5"},
-            {"[2]", DEBUGGEE_CLASS + ".func4"},
-            {"[3]", DEBUGGEE_CLASS + ".func3"},
-            {"[4]", DEBUGGEE_CLASS + ".func2"},
-            {"[5]", DEBUGGEE_CLASS + ".func1"},
-            {"[6]", DEBUGGEE_CLASS + ".runIt"},
-            {"[7]", DEBUGGEE_CLASS + ".main"}
-    };
+    static final String[][] FRAMES = new String[][] {
+        {"[1]", DEBUGGEE_CLASS + ".func5"},
+        {"[2]", DEBUGGEE_CLASS + ".func4"},
+        {"[3]", DEBUGGEE_CLASS + ".func3"},
+        {"[4]", DEBUGGEE_CLASS + ".func2"},
+        {"[5]", DEBUGGEE_CLASS + ".func1"},
+        {"[6]", DEBUGGEE_CLASS + ".runIt"},
+        {"[7]", DEBUGGEE_CLASS + ".main"}
+                                                };
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.receiveReplyFor(JdbCommand.stop_in + DEBUGGEE_CLASS + ".func5");
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        for (int i = 0; i < (FRAMES.length - 1); i++) {
+        for (int i = 0; i < (FRAMES.length-1); i++) {
             jdb.receiveReplyFor(JdbCommand.up);
         }
 
-        for (int i = 0; i < (FRAMES.length - 1); i++) {
+        for (int i = 0; i < (FRAMES.length-1); i++) {
             jdb.receiveReplyFor(JdbCommand.down);
             jdb.receiveReplyFor(JdbCommand.where);
         }
 
         jdb.contToExit(1);
 
-        String[] reply = jdb.getTotalReply();
-        var grep = new Paragrep(reply);
+        reply = jdb.getTotalReply();
+        grep = new Paragrep(reply);
 
-        for (int i = 1; i < (FRAMES.length - 1); i++) {
-            var v = new Vector<String>();
+        for (int i = 1; i < (FRAMES.length-1); i++) {
+            v = new Vector();
             v.add(FRAMES[i][0]);
             v.add(FRAMES[i][1]);
-            int count = grep.find(v);
-            if (count != (i + 1)) {
+            count = grep.find(v);
+            if (count != (i+1)) {
                 failure("Unexpected number of the stack frame: " + FRAMES[i][1] +
-                        "\n\texpected value : " + (i + 1) + ", got : " + count);
+                    "\n\texpected value : " + (i+1) + ", got : " + count);
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002.java
@@ -57,56 +57,56 @@
 
 package nsk.jdb.down.down002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class down002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new down002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.down.down002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".down002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.down.down002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".down002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][] {
-        {"[1]", DEBUGGEE_CLASS + ".func5"},
-        {"[2]", DEBUGGEE_CLASS + ".func4"},
-        {"[3]", DEBUGGEE_CLASS + ".func3"},
-        {"[4]", DEBUGGEE_CLASS + ".func2"},
-        {"[5]", DEBUGGEE_CLASS + ".func1"},
-        {"[6]", DEBUGGEE_CLASS + ".runIt"},
-        {"[7]", DEBUGGEE_CLASS + ".main"}
-                                                };
+    static final String[][] FRAMES = new String[][]{
+            {"[1]", DEBUGGEE_CLASS + ".func5"},
+            {"[2]", DEBUGGEE_CLASS + ".func4"},
+            {"[3]", DEBUGGEE_CLASS + ".func3"},
+            {"[4]", DEBUGGEE_CLASS + ".func2"},
+            {"[5]", DEBUGGEE_CLASS + ".func1"},
+            {"[6]", DEBUGGEE_CLASS + ".runIt"},
+            {"[7]", DEBUGGEE_CLASS + ".main"}
+    };
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.receiveReplyFor(JdbCommand.stop_in + DEBUGGEE_CLASS + ".func5");
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        for (int i = 0; i < (FRAMES.length-1); i++) {
+        for (int i = 0; i < (FRAMES.length - 1); i++) {
             jdb.receiveReplyFor(JdbCommand.up);
         }
 
-        for (int i = 0; i < (FRAMES.length-1); i++) {
+        for (int i = 0; i < (FRAMES.length - 1); i++) {
             jdb.receiveReplyFor(JdbCommand.down);
             jdb.receiveReplyFor(JdbCommand.where);
         }
@@ -116,14 +116,14 @@ public class down002 extends JdbTest {
         reply = jdb.getTotalReply();
         grep = new Paragrep(reply);
 
-        for (int i = 1; i < (FRAMES.length-1); i++) {
-            v = new Vector();
+        for (int i = 1; i < (FRAMES.length - 1); i++) {
+            v = new Vector<>();
             v.add(FRAMES[i][0]);
             v.add(FRAMES[i][1]);
             count = grep.find(v);
-            if (count != (i+1)) {
+            if (count != (i + 1)) {
                 failure("Unexpected number of the stack frame: " + FRAMES[i][1] +
-                    "\n\texpected value : " + (i+1) + ", got : " + count);
+                        "\n\texpected value : " + (i + 1) + ", got : " + count);
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002.java
@@ -94,11 +94,6 @@ public class down002 extends JdbTest {
     };
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector<String> v;
-
         jdb.receiveReplyFor(JdbCommand.stop_in + DEBUGGEE_CLASS + ".func5");
         jdb.receiveReplyFor(JdbCommand.cont);
 
@@ -113,14 +108,14 @@ public class down002 extends JdbTest {
 
         jdb.contToExit(1);
 
-        reply = jdb.getTotalReply();
-        grep = new Paragrep(reply);
+        String[] reply = jdb.getTotalReply();
+        var grep = new Paragrep(reply);
 
         for (int i = 1; i < (FRAMES.length - 1); i++) {
-            v = new Vector<>();
+            var v = new Vector<String>();
             v.add(FRAMES[i][0]);
             v.add(FRAMES[i][1]);
-            count = grep.find(v);
+            int count = grep.find(v);
             if (count != (i + 1)) {
                 failure("Unexpected number of the stack frame: " + FRAMES[i][1] +
                         "\n\texpected value : " + (i + 1) + ", got : " + count);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002.java
@@ -46,9 +46,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.dump.dump002.dump002
- *        nsk.jdb.dump.dump002.dump002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.dump.dump002.dump002
+ * @build nsk.jdb.dump.dump002.dump002a
+ * @run main/othervm
+ *      nsk.jdb.dump.dump002.dump002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002.java
@@ -61,20 +61,21 @@
 
 package nsk.jdb.dump.dump002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class dump002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
@@ -84,56 +85,54 @@ public class dump002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.dump.dump002";
     static final String TEST_CLASS = PACKAGE_NAME + ".dump002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
     static final String COMPOUND_PROMPT_IDENT = "main";
 
     static final String[] CHECKED_FIELDS = {
-        "_dump002a",
-        "iStatic",
-        "iPrivate",
-        "iProtect",
-        "iPublic",
-        "iFinal",
-        "iTransient",
-        "iVolatile",
-        "iArray",
-        "sStatic",
-        "sPrivate",
-        "sProtected",
-        "sPublic",
-        "sFinal",
-        "sTransient",
-        "sVolatile",
-        "sArray",
-        "fBoolean",
-        "fByte",
-        "fChar",
-        "fDouble",
-        "fFloat",
-        "fInt",
-        "fLong",
-        "fShort"
-                                         };
+            "_dump002a",
+            "iStatic",
+            "iPrivate",
+            "iProtect",
+            "iPublic",
+            "iFinal",
+            "iTransient",
+            "iVolatile",
+            "iArray",
+            "sStatic",
+            "sPrivate",
+            "sProtected",
+            "sPublic",
+            "sFinal",
+            "sTransient",
+            "sVolatile",
+            "sArray",
+            "fBoolean",
+            "fByte",
+            "fChar",
+            "fDouble",
+            "fFloat",
+            "fInt",
+            "fLong",
+            "fShort"
+    };
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v = new Vector();
-        String found;
+        Vector<String> v = new Vector<>();
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         reply = jdb.receiveReplyFor(JdbCommand.dump + DEBUGGEE_CLASS + "._dump002a");
         grep = new Paragrep(reply);
-        for (int i = 0; i < CHECKED_FIELDS.length; i++) {
+        for (String field : CHECKED_FIELDS) {
             v.setSize(0);
-            v.add(CHECKED_FIELDS[i]);
+            v.add(field);
             v.add("null");
             if (grep.find(v) > 0) {
-                failure("The field is not dumped : " + CHECKED_FIELDS[i]);
+                failure("The field is not dumped : " + field);
             }
         }
 
@@ -148,9 +147,9 @@ public class dump002 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    void checkField (String[] reply, String fieldName) {
+    void checkField(String[] reply, String fieldName) {
         Paragrep grep;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         grep = new Paragrep(reply);
         v.setSize(0);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002.java
@@ -61,21 +61,20 @@
 
 package nsk.jdb.dump.dump002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class dump002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
@@ -85,51 +84,56 @@ public class dump002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.dump.dump002";
     static final String TEST_CLASS = PACKAGE_NAME + ".dump002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
     static final String COMPOUND_PROMPT_IDENT = "main";
 
     static final String[] CHECKED_FIELDS = {
-            "_dump002a",
-            "iStatic",
-            "iPrivate",
-            "iProtect",
-            "iPublic",
-            "iFinal",
-            "iTransient",
-            "iVolatile",
-            "iArray",
-            "sStatic",
-            "sPrivate",
-            "sProtected",
-            "sPublic",
-            "sFinal",
-            "sTransient",
-            "sVolatile",
-            "sArray",
-            "fBoolean",
-            "fByte",
-            "fChar",
-            "fDouble",
-            "fFloat",
-            "fInt",
-            "fLong",
-            "fShort"
-    };
+        "_dump002a",
+        "iStatic",
+        "iPrivate",
+        "iProtect",
+        "iPublic",
+        "iFinal",
+        "iTransient",
+        "iVolatile",
+        "iArray",
+        "sStatic",
+        "sPrivate",
+        "sProtected",
+        "sPublic",
+        "sFinal",
+        "sTransient",
+        "sVolatile",
+        "sArray",
+        "fBoolean",
+        "fByte",
+        "fChar",
+        "fDouble",
+        "fFloat",
+        "fInt",
+        "fLong",
+        "fShort"
+                                         };
 
     protected void runCases() {
-        jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v = new Vector();
+        String found;
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.dump + DEBUGGEE_CLASS + "._dump002a");
-        var grep = new Paragrep(reply);
-        var v = new Vector<String>();
-        for (String field : CHECKED_FIELDS) {
+        jdb.setBreakpointInMethod(LAST_BREAK);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
+
+        reply = jdb.receiveReplyFor(JdbCommand.dump + DEBUGGEE_CLASS + "._dump002a");
+        grep = new Paragrep(reply);
+        for (int i = 0; i < CHECKED_FIELDS.length; i++) {
             v.setSize(0);
-            v.add(field);
+            v.add(CHECKED_FIELDS[i]);
             v.add("null");
             if (grep.find(v) > 0) {
-                failure("The field is not dumped : " + field);
+                failure("The field is not dumped : " + CHECKED_FIELDS[i]);
             }
         }
 
@@ -144,9 +148,9 @@ public class dump002 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    void checkField(String[] reply, String fieldName) {
+    void checkField (String[] reply, String fieldName) {
         Paragrep grep;
-        var v = new Vector<String>();
+        Vector v = new Vector();
 
         grep = new Paragrep(reply);
         v.setSize(0);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002.java
@@ -118,15 +118,12 @@ public class dump002 extends JdbTest {
     };
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        Vector<String> v = new Vector<>();
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        reply = jdb.receiveReplyFor(JdbCommand.dump + DEBUGGEE_CLASS + "._dump002a");
-        grep = new Paragrep(reply);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.dump + DEBUGGEE_CLASS + "._dump002a");
+        var grep = new Paragrep(reply);
+        var v = new Vector<String>();
         for (String field : CHECKED_FIELDS) {
             v.setSize(0);
             v.add(field);
@@ -149,7 +146,7 @@ public class dump002 extends JdbTest {
 
     void checkField(String[] reply, String fieldName) {
         Paragrep grep;
-        Vector<String> v = new Vector<>();
+        var v = new Vector<String>();
 
         grep = new Paragrep(reply);
         v.setSize(0);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001.java
@@ -52,7 +52,8 @@
  * @clean nsk.jdb.eval.eval001.eval001a
  * @compile -g:lines,source,vars eval001a.java
  *
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.eval.eval001.eval001
+ * @run main/othervm
+ *      nsk.jdb.eval.eval001.eval001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001.java
@@ -120,14 +120,11 @@ public class eval001 extends JdbTest {
     }
 
     private boolean checkValue(String expr, String value) {
-        Paragrep grep;
-        String[] reply;
-        String found;
         boolean result = true;
 
-        reply = jdb.receiveReplyFor(JdbCommand.eval + expr);
-        grep = new Paragrep(reply);
-        found = grep.findFirst(value);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + expr);
+        var grep = new Paragrep(reply);
+        String found = grep.findFirst(value);
         if (found.length() <= 0) {
             log.complain("jdb failed to report value of expression: " + expr);
             log.complain("expected : " + value + " ;\nreported: " + (reply.length > 0 ? reply[0] : ""));

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001.java
@@ -66,20 +66,21 @@
 
 package nsk.jdb.eval.eval001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class eval001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new eval001().runTest(argv, out);
@@ -88,35 +89,29 @@ public class eval001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.eval.eval001";
     static final String TEST_CLASS = PACKAGE_NAME + ".eval001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String[][] checkedExpr = {
-        { DEBUGGEE_CLASS + ".myStaticField", "-2147483648" },
-        { DEBUGGEE_CLASS + "._eval001a.myInstanceField", "9223372036854775807" },
-        { DEBUGGEE_CLASS + "._eval001a.myArrayField[0][0].toString()", "ABCDE" },
-        { DEBUGGEE_CLASS + "._eval001a.myMethod()", "2147483647" },
-        { "myClass.toString().equals(\"abcde\")", "true"},
-        { "i + j + k", "777"},
-        { "new java.lang.String(\"Hello, World\").length()", "12"},
-        { DEBUGGEE_CLASS + "._eval001a.testPrimitiveArray(test)", "1.0" }
-                                          };
+            {DEBUGGEE_CLASS + ".myStaticField", "-2147483648"},
+            {DEBUGGEE_CLASS + "._eval001a.myInstanceField", "9223372036854775807"},
+            {DEBUGGEE_CLASS + "._eval001a.myArrayField[0][0].toString()", "ABCDE"},
+            {DEBUGGEE_CLASS + "._eval001a.myMethod()", "2147483647"},
+            {"myClass.toString().equals(\"abcde\")", "true"},
+            {"i + j + k", "777"},
+            {"new java.lang.String(\"Hello, World\").length()", "12"},
+            {DEBUGGEE_CLASS + "._eval001a.testPrimitiveArray(test)", "1.0"}
+    };
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // to get out of lastBreak()
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
 
-        for (int i = 0; i < checkedExpr.length; i++) {
-            if (!checkValue(checkedExpr[i][0], checkedExpr[i][1])) {
+        for (String[] strings : checkedExpr) {
+            if (!checkValue(strings[0], strings[1])) {
                 success = false;
             }
         }
@@ -124,11 +119,10 @@ public class eval001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkValue (String expr, String value) {
+    private boolean checkValue(String expr, String value) {
         Paragrep grep;
         String[] reply;
         String found;
-        Vector v;
         boolean result = true;
 
         reply = jdb.receiveReplyFor(JdbCommand.eval + expr);
@@ -136,7 +130,7 @@ public class eval001 extends JdbTest {
         found = grep.findFirst(value);
         if (found.length() <= 0) {
             log.complain("jdb failed to report value of expression: " + expr);
-            log.complain("expected : " + value + " ;\nreported: " + (reply.length > 0? reply[0]: ""));
+            log.complain("expected : " + value + " ;\nreported: " + (reply.length > 0 ? reply[0] : ""));
             result = false;
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001.java
@@ -66,21 +66,20 @@
 
 package nsk.jdb.eval.eval001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class eval001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new eval001().runTest(argv, out);
@@ -89,29 +88,35 @@ public class eval001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.eval.eval001";
     static final String TEST_CLASS = PACKAGE_NAME + ".eval001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String[][] checkedExpr = {
-            {DEBUGGEE_CLASS + ".myStaticField", "-2147483648"},
-            {DEBUGGEE_CLASS + "._eval001a.myInstanceField", "9223372036854775807"},
-            {DEBUGGEE_CLASS + "._eval001a.myArrayField[0][0].toString()", "ABCDE"},
-            {DEBUGGEE_CLASS + "._eval001a.myMethod()", "2147483647"},
-            {"myClass.toString().equals(\"abcde\")", "true"},
-            {"i + j + k", "777"},
-            {"new java.lang.String(\"Hello, World\").length()", "12"},
-            {DEBUGGEE_CLASS + "._eval001a.testPrimitiveArray(test)", "1.0"}
-    };
+        { DEBUGGEE_CLASS + ".myStaticField", "-2147483648" },
+        { DEBUGGEE_CLASS + "._eval001a.myInstanceField", "9223372036854775807" },
+        { DEBUGGEE_CLASS + "._eval001a.myArrayField[0][0].toString()", "ABCDE" },
+        { DEBUGGEE_CLASS + "._eval001a.myMethod()", "2147483647" },
+        { "myClass.toString().equals(\"abcde\")", "true"},
+        { "i + j + k", "777"},
+        { "new java.lang.String(\"Hello, World\").length()", "12"},
+        { DEBUGGEE_CLASS + "._eval001a.testPrimitiveArray(test)", "1.0" }
+                                          };
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         // to get out of lastBreak()
-        jdb.receiveReplyFor(JdbCommand.step);
+        reply = jdb.receiveReplyFor(JdbCommand.step);
 
-        for (String[] strings : checkedExpr) {
-            if (!checkValue(strings[0], strings[1])) {
+        for (int i = 0; i < checkedExpr.length; i++) {
+            if (!checkValue(checkedExpr[i][0], checkedExpr[i][1])) {
                 success = false;
             }
         }
@@ -119,15 +124,19 @@ public class eval001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkValue(String expr, String value) {
+    private boolean checkValue (String expr, String value) {
+        Paragrep grep;
+        String[] reply;
+        String found;
+        Vector v;
         boolean result = true;
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + expr);
-        var grep = new Paragrep(reply);
-        String found = grep.findFirst(value);
+        reply = jdb.receiveReplyFor(JdbCommand.eval + expr);
+        grep = new Paragrep(reply);
+        found = grep.findFirst(value);
         if (found.length() <= 0) {
             log.complain("jdb failed to report value of expression: " + expr);
-            log.complain("expected : " + value + " ;\nreported: " + (reply.length > 0 ? reply[0] : ""));
+            log.complain("expected : " + value + " ;\nreported: " + (reply.length > 0? reply[0]: ""));
             result = false;
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
@@ -58,9 +58,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.exclude.exclude001.exclude001
- *        nsk.jdb.exclude.exclude001.exclude001a
- * @run main/othervm/timeout=600 PropertyResolvingWrapper nsk.jdb.exclude.exclude001.exclude001
+ * @build nsk.jdb.exclude.exclude001.exclude001a
+ * @run main/othervm/timeout=600
+ *      nsk.jdb.exclude.exclude001.exclude001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=10
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
@@ -73,42 +73,40 @@
 
 package nsk.jdb.exclude.exclude001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class exclude001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new exclude001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.exclude.exclude001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".exclude001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.exclude.exclude001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".exclude001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String JAVA_CORE_METHOD = "java.lang.System.currentTimeMillis";
-    static final String SUN_METHOD   = "sun.util.calendar.Gregorian";
+    static final String SUN_METHOD = "sun.util.calendar.Gregorian";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
         String[] threads;
 
         String oldExclude = "";
@@ -141,22 +139,21 @@ public class exclude001 extends JdbTest {
                         success = false;
                     } else {
 
-                        reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
+                        jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
 
                         switch (testCase) {
-                        case 0: // block all
-                                reply = jdb.receiveReplyFor(JdbCommand.exclude + "java.*,javax.*,sun.*,com.sun.*,jdk.*");
-
+                            case 0: // block all
+                                jdb.receiveReplyFor(JdbCommand.exclude + "java.*,javax.*,sun.*,com.sun.*,jdk.*");
                                 break;
-                        case 1: // allow java.*
-                                reply = jdb.receiveReplyFor(JdbCommand.exclude + "javax.*,sun.*,com.sun.*,jdk.*");
+                            case 1: // allow java.*
+                                jdb.receiveReplyFor(JdbCommand.exclude + "javax.*,sun.*,com.sun.*,jdk.*");
                                 break;
-                        case 2: // allow sun.*
-                                reply = jdb.receiveReplyFor(JdbCommand.exclude + "java.*,javax.*,com.sun.*,jdk.*");
+                            case 2: // allow sun.*
+                                jdb.receiveReplyFor(JdbCommand.exclude + "java.*,javax.*,com.sun.*,jdk.*");
                                 break;
                         }
 
-                        reply = jdb.receiveReplyFor(JdbCommand.trace + "methods " + threads[0]);
+                        jdb.receiveReplyFor(JdbCommand.trace + "methods " + threads[0]);
 
                         while (true) {
                             reply = jdb.receiveReplyForWithMessageWait(JdbCommand.cont, expectedPrompt);
@@ -184,8 +181,8 @@ public class exclude001 extends JdbTest {
                             if (count > 0) {
                                 nskTraced = true;
 
-                                reply = jdb.receiveReplyFor(JdbCommand.exclude + oldExclude);
-                                reply = jdb.receiveReplyFor(JdbCommand.untrace + "methods "+ threads[0]);
+                                jdb.receiveReplyFor(JdbCommand.exclude + oldExclude);
+                                jdb.receiveReplyFor(JdbCommand.untrace + "methods " + threads[0]);
                                 break;
                             }
                         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
@@ -104,11 +104,6 @@ public class exclude001 extends JdbTest {
     static final String SUN_METHOD = "sun.util.calendar.Gregorian";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        String[] threads;
-
         String oldExclude = "";
         boolean javaTraced = false;
         boolean comTraced = false;
@@ -117,12 +112,11 @@ public class exclude001 extends JdbTest {
         jdb.setBreakpointInMethod(LAST_BREAK);
 
         // getting predefined 'exclude' value
-        reply = jdb.receiveReplyFor(JdbCommand.exclude);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.exclude);
         if (reply.length == 0) {
             log.complain("Predefined excluded lists of classes is empty");
             success = false;
         } else {
-
             oldExclude = reply[0];
 
             for (int testCase = 0; testCase < exclude001a.numThreads; testCase++) {
@@ -130,8 +124,7 @@ public class exclude001 extends JdbTest {
                 reply = jdb.receiveReplyFor(JdbCommand.cont);
 
                 if (jdb.isAtBreakpoint(reply, LAST_BREAK)) {
-
-                    threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+                    String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
                     if (threads.length != 1) {
                         log.complain("jdb should report 1 instance of " + DEBUGGEE_THREAD);
@@ -158,8 +151,8 @@ public class exclude001 extends JdbTest {
                         while (true) {
                             reply = jdb.receiveReplyForWithMessageWait(JdbCommand.cont, expectedPrompt);
 
-                            grep = new Paragrep(reply);
-                            count = grep.find(JAVA_CORE_METHOD);
+                            var grep = new Paragrep(reply);
+                            int count = grep.find(JAVA_CORE_METHOD);
                             if (count > 0) {
                                 if (testCase != 0) {
                                     javaTraced = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
@@ -73,37 +73,44 @@
 
 package nsk.jdb.exclude.exclude001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class exclude001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new exclude001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.exclude.exclude001";
-    static final String TEST_CLASS = PACKAGE_NAME + ".exclude001";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
-    static final String MYTHREAD = "MyThread";
+    static final String PACKAGE_NAME    = "nsk.jdb.exclude.exclude001";
+    static final String TEST_CLASS      = PACKAGE_NAME + ".exclude001";
+    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
+    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final String MYTHREAD        = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String JAVA_CORE_METHOD = "java.lang.System.currentTimeMillis";
-    static final String SUN_METHOD = "sun.util.calendar.Gregorian";
+    static final String SUN_METHOD   = "sun.util.calendar.Gregorian";
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+        String[] threads;
+
         String oldExclude = "";
         boolean javaTraced = false;
         boolean comTraced = false;
@@ -112,11 +119,12 @@ public class exclude001 extends JdbTest {
         jdb.setBreakpointInMethod(LAST_BREAK);
 
         // getting predefined 'exclude' value
-        String[] reply = jdb.receiveReplyFor(JdbCommand.exclude);
+        reply = jdb.receiveReplyFor(JdbCommand.exclude);
         if (reply.length == 0) {
             log.complain("Predefined excluded lists of classes is empty");
             success = false;
         } else {
+
             oldExclude = reply[0];
 
             for (int testCase = 0; testCase < exclude001a.numThreads; testCase++) {
@@ -124,7 +132,8 @@ public class exclude001 extends JdbTest {
                 reply = jdb.receiveReplyFor(JdbCommand.cont);
 
                 if (jdb.isAtBreakpoint(reply, LAST_BREAK)) {
-                    String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+
+                    threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
                     if (threads.length != 1) {
                         log.complain("jdb should report 1 instance of " + DEBUGGEE_THREAD);
@@ -132,27 +141,28 @@ public class exclude001 extends JdbTest {
                         success = false;
                     } else {
 
-                        jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
+                        reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
 
                         switch (testCase) {
-                            case 0: // block all
-                                jdb.receiveReplyFor(JdbCommand.exclude + "java.*,javax.*,sun.*,com.sun.*,jdk.*");
+                        case 0: // block all
+                                reply = jdb.receiveReplyFor(JdbCommand.exclude + "java.*,javax.*,sun.*,com.sun.*,jdk.*");
+
                                 break;
-                            case 1: // allow java.*
-                                jdb.receiveReplyFor(JdbCommand.exclude + "javax.*,sun.*,com.sun.*,jdk.*");
+                        case 1: // allow java.*
+                                reply = jdb.receiveReplyFor(JdbCommand.exclude + "javax.*,sun.*,com.sun.*,jdk.*");
                                 break;
-                            case 2: // allow sun.*
-                                jdb.receiveReplyFor(JdbCommand.exclude + "java.*,javax.*,com.sun.*,jdk.*");
+                        case 2: // allow sun.*
+                                reply = jdb.receiveReplyFor(JdbCommand.exclude + "java.*,javax.*,com.sun.*,jdk.*");
                                 break;
                         }
 
-                        jdb.receiveReplyFor(JdbCommand.trace + "methods " + threads[0]);
+                        reply = jdb.receiveReplyFor(JdbCommand.trace + "methods " + threads[0]);
 
                         while (true) {
                             reply = jdb.receiveReplyForWithMessageWait(JdbCommand.cont, expectedPrompt);
 
-                            var grep = new Paragrep(reply);
-                            int count = grep.find(JAVA_CORE_METHOD);
+                            grep = new Paragrep(reply);
+                            count = grep.find(JAVA_CORE_METHOD);
                             if (count > 0) {
                                 if (testCase != 0) {
                                     javaTraced = true;
@@ -174,8 +184,8 @@ public class exclude001 extends JdbTest {
                             if (count > 0) {
                                 nskTraced = true;
 
-                                jdb.receiveReplyFor(JdbCommand.exclude + oldExclude);
-                                jdb.receiveReplyFor(JdbCommand.untrace + "methods " + threads[0]);
+                                reply = jdb.receiveReplyFor(JdbCommand.exclude + oldExclude);
+                                reply = jdb.receiveReplyFor(JdbCommand.untrace + "methods "+ threads[0]);
                                 break;
                             }
                         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001.java
@@ -40,9 +40,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.fields.fields001.fields001
- *        nsk.jdb.fields.fields001.fields001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.fields.fields001.fields001
+ * @build nsk.jdb.fields.fields001.fields001a
+ * @run main/othervm
+ *      nsk.jdb.fields.fields001.fields001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001.java
@@ -55,64 +55,70 @@
 
 package nsk.jdb.fields.fields001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class fields001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new fields001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.fields.fields001";
-    static final String TEST_CLASS = PACKAGE_NAME + ".fields001";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String DEBUGGEE_CLASS1 = DEBUGGEE_CLASS + "$Inner";
-    static final String DEBUGGEE_CLASS2 = DEBUGGEE_CLASS + "$Extender";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME       = "nsk.jdb.fields.fields001";
+    static final String TEST_CLASS         = PACKAGE_NAME + ".fields001";
+    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
+    static final String DEBUGGEE_CLASS1    = DEBUGGEE_CLASS + "$Inner";
+    static final String DEBUGGEE_CLASS2    = DEBUGGEE_CLASS + "$Extender";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String NOT_VALID_SAMPLE   = "is not a valid";
 
     static String[] checkedFields1 = {
-            "i_st", "o_st",
-            "i_pv", "o_pv",
-            "i_pt", "o_pt",
-            "i_pb", "o_pb",
-            "i_fn", "o_fn",
-            "i_tr", "o_tr",
-            "i_vl", "o_vl",
-            "i_a", "o_a",
-            "i_aa", "o_aa",
-            "i_aaa", "o_aaa"
-    };
+        "i_st",    "o_st",
+        "i_pv",    "o_pv",
+        "i_pt",    "o_pt",
+        "i_pb",    "o_pb",
+        "i_fn",    "o_fn",
+        "i_tr",    "o_tr",
+        "i_vl",    "o_vl",
+        "i_a",     "o_a",
+        "i_aa",    "o_aa",
+        "i_aaa",   "o_aaa"
+                                      };
 
     static String[] checkedFields2 = {
-            "ii_pv", "oi_pv",
-            "ii_pt", "oi_pt",
-            "ii_pb", "oi_pb",
-            "ii_fn", "oi_fn",
-            "ii_tr", "oi_tr",
-            "ii_vl", "oi_vl",
-            "ii_a", "oi_a",
-            "ii_aa", "oi_aa",
-            "ii_aaa", "oi_aaa"
-    };
+        "ii_pv",    "oi_pv",
+        "ii_pt",    "oi_pt",
+        "ii_pb",    "oi_pb",
+        "ii_fn",    "oi_fn",
+        "ii_tr",    "oi_tr",
+        "ii_vl",    "oi_vl",
+        "ii_a",     "oi_a",
+        "ii_aa",    "oi_aa",
+        "ii_aaa",   "oi_aaa"
+                                      };
 
     protected void runCases() {
-        jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
+        jdb.setBreakpointInMethod(LAST_BREAK);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
+
+        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
         if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields1)) {
             success = false;
         }
@@ -130,13 +136,17 @@ public class fields001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkFields(String className, String[] reply, String[] checkedFields) {
+    private boolean checkFields (String className, String[] reply, String[] checkedFields) {
+        Paragrep grep;
+        String found;
         boolean result = true;
-        var grep = new Paragrep(reply);
-        for (String checkedField : checkedFields) {
-            int count = grep.find(checkedField);
+        int count;
+
+        grep = new Paragrep(reply);
+        for (int i = 0; i < checkedFields.length; i++) {
+            count = grep.find(checkedFields[i]);
             if (count == 0) {
-                log.complain("Failed to report field " + checkedField + " for class " + className);
+                log.complain("Failed to report field " + checkedFields[i] + " for class " + className);
                 result = false;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001.java
@@ -55,68 +55,64 @@
 
 package nsk.jdb.fields.fields001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class fields001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new fields001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.fields.fields001";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".fields001";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String DEBUGGEE_CLASS1    = DEBUGGEE_CLASS + "$Inner";
-    static final String DEBUGGEE_CLASS2    = DEBUGGEE_CLASS + "$Extender";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final String NOT_VALID_SAMPLE   = "is not a valid";
+    static final String PACKAGE_NAME = "nsk.jdb.fields.fields001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".fields001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String DEBUGGEE_CLASS1 = DEBUGGEE_CLASS + "$Inner";
+    static final String DEBUGGEE_CLASS2 = DEBUGGEE_CLASS + "$Extender";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static String[] checkedFields1 = {
-        "i_st",    "o_st",
-        "i_pv",    "o_pv",
-        "i_pt",    "o_pt",
-        "i_pb",    "o_pb",
-        "i_fn",    "o_fn",
-        "i_tr",    "o_tr",
-        "i_vl",    "o_vl",
-        "i_a",     "o_a",
-        "i_aa",    "o_aa",
-        "i_aaa",   "o_aaa"
-                                      };
+            "i_st", "o_st",
+            "i_pv", "o_pv",
+            "i_pt", "o_pt",
+            "i_pb", "o_pb",
+            "i_fn", "o_fn",
+            "i_tr", "o_tr",
+            "i_vl", "o_vl",
+            "i_a", "o_a",
+            "i_aa", "o_aa",
+            "i_aaa", "o_aaa"
+    };
 
     static String[] checkedFields2 = {
-        "ii_pv",    "oi_pv",
-        "ii_pt",    "oi_pt",
-        "ii_pb",    "oi_pb",
-        "ii_fn",    "oi_fn",
-        "ii_tr",    "oi_tr",
-        "ii_vl",    "oi_vl",
-        "ii_a",     "oi_a",
-        "ii_aa",    "oi_aa",
-        "ii_aaa",   "oi_aaa"
-                                      };
+            "ii_pv", "oi_pv",
+            "ii_pt", "oi_pt",
+            "ii_pb", "oi_pb",
+            "ii_fn", "oi_fn",
+            "ii_tr", "oi_tr",
+            "ii_vl", "oi_vl",
+            "ii_a", "oi_a",
+            "ii_aa", "oi_aa",
+            "ii_aaa", "oi_aaa"
+    };
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
         if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields1)) {
@@ -136,17 +132,16 @@ public class fields001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkFields (String className, String[] reply, String[] checkedFields) {
+    private boolean checkFields(String className, String[] reply, String[] checkedFields) {
         Paragrep grep;
-        String found;
         boolean result = true;
         int count;
 
         grep = new Paragrep(reply);
-        for (int i = 0; i < checkedFields.length; i++) {
-            count = grep.find(checkedFields[i]);
+        for (String checkedField : checkedFields) {
+            count = grep.find(checkedField);
             if (count == 0) {
-                log.complain("Failed to report field " + checkedFields[i] + " for class " + className);
+                log.complain("Failed to report field " + checkedField + " for class " + className);
                 result = false;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001.java
@@ -109,12 +109,10 @@ public class fields001 extends JdbTest {
     };
 
     protected void runCases() {
-        String[] reply;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
         if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields1)) {
             success = false;
         }
@@ -133,13 +131,10 @@ public class fields001 extends JdbTest {
     }
 
     private boolean checkFields(String className, String[] reply, String[] checkedFields) {
-        Paragrep grep;
         boolean result = true;
-        int count;
-
-        grep = new Paragrep(reply);
+        var grep = new Paragrep(reply);
         for (String checkedField : checkedFields) {
-            count = grep.find(checkedField);
+            int count = grep.find(checkedField);
             if (count == 0) {
                 log.complain("Failed to report field " + checkedField + " for class " + className);
                 result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001.java
@@ -29,10 +29,10 @@
  *          /test/lib
  * @modules jdk.jdi
  *          jdk.jdwp.agent
- * @build nsk.jdb.hidden_class.hc001.hc001
- *        nsk.jdb.hidden_class.hc001.hc001a
+ * @build nsk.jdb.hidden_class.hc001.hc001a
  *
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.hidden_class.hc001.hc001
+ * @run main/othervm
+ *      nsk.jdb.hidden_class.hc001.hc001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001.java
@@ -89,8 +89,6 @@ public class hc001 extends JdbTest {
      *  Return the hidden class name.
      */
     private String runPrologue() {
-        String[] reply;
-
         log.println("\n### Debugger: runPrologue");
 
         // uncomment this line to enable verbose output from jdb
@@ -101,7 +99,7 @@ public class hc001 extends JdbTest {
         log.println("\nDebugger: breakpoint is set at:\n\t" + EMPTY_METHOD_NAME);
 
         // run jdb command "cont"
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
         if (!jdb.isAtBreakpoint(reply, EMPTY_METHOD_NAME)) {
             throwFailure("Debugger: Missed breakpoint at:\n\t" + EMPTY_METHOD_NAME);
         }
@@ -124,12 +122,10 @@ public class hc001 extends JdbTest {
 
     /* Test jdb commands "classes" and "class" for hidden class. */
     private void testClassCommands(String hcName) {
-        String[] reply = null;
-
         log.println("\n### Debugger: testClassCommands");
 
         // run jdb command "classes"
-        reply = jdb.receiveReplyFor(JdbCommand.classes);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.classes);
         if (!checkPattern(reply, hcName)) {
             throwFailure("Debugger: expected jdb command classes to list hidden class:\n\t" + hcName);
         }
@@ -146,7 +142,6 @@ public class hc001 extends JdbTest {
     /* Transition the debuggee's execution to the hidden class method start. */
     private void stopInHiddenClassMethod(String hcName) {
         String hcMethodName = hcName + "." + HC_METHOD_NAME;
-        String[] reply = null;
 
         log.println("\n### Debugger: stopInHiddenClassMethod");
 
@@ -155,7 +150,7 @@ public class hc001 extends JdbTest {
         log.println("\nDebugger: breakpoint is set at:\n\t" + hcMethodName);
 
         // run jdb command "clear": should list breakpoint in hcMethodName
-        reply = jdb.receiveReplyFor(JdbCommand.clear);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.clear);
         if (!checkPattern(reply, hcMethodName)) {
             throwFailure("Debugger: expected jdb clear command to list breakpoint: " + hcMethodName);
         }
@@ -169,12 +164,11 @@ public class hc001 extends JdbTest {
     /* Test the jdb commands "up" and "where" for hidden class. */
     private void testUpWhereCommands(String hcName) {
         String hcMethodName = hcName + "." + HC_METHOD_NAME;
-        String[] reply = null;
 
         log.println("\n### Debugger: testUpWhereCommands");
 
         // run jdb command "where": should list hcMethodName frame
-        reply = jdb.receiveReplyFor(JdbCommand.where);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.where);
         if (!checkPattern(reply, hcMethodName)) {
             throwFailure("Debugger: jdb command where does not show expected frame: " + hcMethodName);
         }
@@ -195,7 +189,6 @@ public class hc001 extends JdbTest {
     /* Test the jdb commands "down" and "where" for hidden class. */
     private void testDownWhereCommands(String hcName) {
         String hcMethodName = hcName + "." + HC_METHOD_NAME;
-        String[] reply = null;
 
         log.println("\n### Debugger: testDownWhereCommands");
 
@@ -204,7 +197,7 @@ public class hc001 extends JdbTest {
         log.println("\nDebugger: executed jdb command down");
 
         // run jdb command "where": should list hcMethodName frame again
-        reply = jdb.receiveReplyFor(JdbCommand.where);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.where);
         if (!checkPattern(reply, hcMethodName)) {
             throwFailure("Debugger: jdb command where does not show expected frame: " + hcMethodName);
         }
@@ -213,12 +206,10 @@ public class hc001 extends JdbTest {
 
     /* Test the jdb commands "fields" and "methods" for hidden class. */
     private void testFieldsMethods(String hcName) {
-        String[] reply = null;
-
         log.println("\n### Debugger: testFieldsMethods");
 
         // run jdb command "methods" for hidden class
-        reply = jdb.receiveReplyFor(JdbCommand.methods + hcName);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.methods + hcName);
         if (!checkPattern(reply, hcName)) {
             throwFailure("Debugger: no expected hidden class name in its methods: " + hcName);
         }
@@ -235,12 +226,11 @@ public class hc001 extends JdbTest {
     /* Test the jdb commands "watch" and "unwatch" for hidden class. */
     private void testWatchCommands(String hcName) {
         String hcFieldName = hcName + "." + HC_FIELD_NAME;
-        String[] reply = null;
 
         log.println("\n### Debugger: testWatchCommands");
 
         // run jdb command "watch" for hidden class field HC_FIELD_NAME
-        reply = jdb.receiveReplyFor(JdbCommand.watch + hcFieldName);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.watch + hcFieldName);
         if (!checkPattern(reply, HC_FIELD_NAME)) {
             throwFailure("Debugger: was not able to set watch point: " + hcFieldName);
         }
@@ -261,12 +251,11 @@ public class hc001 extends JdbTest {
     /* Test the jdb commands "eval", "print" and "dump" for hidden class. */
     private void testEvalCommands(String hcName) {
         String hcFieldName = hcName + "." + HC_FIELD_NAME;
-        String[] reply = null;
 
         log.println("\n### Debugger: testEvalCommands");
 
         // run jdb command "eval" for hidden class field HC_FIELD_NAME
-        reply = jdb.receiveReplyFor(JdbCommand.eval + hcFieldName);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + hcFieldName);
         if (!checkPattern(reply, hcFieldName)) {
             throwFailure("Debugger: expected field name in jdb command eval field reply: " + hcFieldName);
         }
@@ -291,10 +280,9 @@ public class hc001 extends JdbTest {
     private void testInvWatchCommand(String hcName) {
         String hcFieldName = hcName + "." + HC_FIELD_NAME;
         String MsgBase = "\nDebugger: jdb command \"watch\" with invalid field " + hcFieldName;
-        String[] reply = null;
 
         // run jdb command "watch" with an invalid class name
-        reply = jdb.receiveReplyFor(JdbCommand.watch + hcFieldName);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.watch + hcFieldName);
         if (checkPattern(reply, "Deferring watch modification")) {
             throwFailure(MsgBase + " must not set deferred watch point");
         }
@@ -305,10 +293,9 @@ public class hc001 extends JdbTest {
     private void testInvEvalCommand(String hcName) {
         String hcFieldName = hcName + "." + HC_FIELD_NAME;
         String MsgBase = "\nDebugger: jdb command \"eval\" with invalid field " + hcFieldName;
-        String[] reply = null;
 
         // run jdb command "eval" with an invalid class name
-        reply = jdb.receiveReplyFor(JdbCommand.eval + hcFieldName);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + hcFieldName);
         if (!checkPattern(reply, "ParseException")) {
             throwFailure(MsgBase + " must be rejected with ParseException");
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001.java
@@ -45,33 +45,34 @@
 
 package nsk.jdb.hidden_class.hc001;
 
-import nsk.share.Failure;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
-
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
 public class hc001 extends JdbTest {
-    static final String DEBUGGEE_CLASS = hc001a.class.getTypeName();
-    static final String HC_NAME_FIELD = DEBUGGEE_CLASS + ".hcName";
-    static final String MAIN_METHOD_NAME = DEBUGGEE_CLASS + ".main";
+    static final String DEBUGGEE_CLASS    = hc001a.class.getTypeName();
+    static final String HC_NAME_FIELD     = DEBUGGEE_CLASS + ".hcName";
+    static final String MAIN_METHOD_NAME  = DEBUGGEE_CLASS + ".main";
     static final String EMPTY_METHOD_NAME = DEBUGGEE_CLASS + ".emptyMethod";
-    static final String HC_METHOD_NAME = "hcMethod";
-    static final String HC_FIELD_NAME = "hcField";
+    static final String HC_METHOD_NAME    = "hcMethod";
+    static final String HC_FIELD_NAME     = "hcField";
+    static final int    MAX_SLEEP_CNT     = 3;
 
-    public static void main(String[] argv) {
+    public static void main(String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
+    public static int run(String argv[], PrintStream out) {
         debuggeeClass = DEBUGGEE_CLASS; // needed for JdbTest.runTest
         firstBreak = MAIN_METHOD_NAME;  // needed for JdbTest.runTest
         return new hc001().runTest(argv, out);
     }
 
     static boolean checkPattern(String[] arr, String pattern) {
-        for (String str : arr) {
-            if (str.contains(pattern)) {
+        for (int idx = 0; idx < arr.length; idx++) {
+            String str = arr[idx];
+            if (str.indexOf(pattern) != -1) {
                 return true;
             }
         }
@@ -89,6 +90,8 @@ public class hc001 extends JdbTest {
      *  Return the hidden class name.
      */
     private String runPrologue() {
+        String[] reply = null;
+
         log.println("\n### Debugger: runPrologue");
 
         // uncomment this line to enable verbose output from jdb
@@ -99,7 +102,7 @@ public class hc001 extends JdbTest {
         log.println("\nDebugger: breakpoint is set at:\n\t" + EMPTY_METHOD_NAME);
 
         // run jdb command "cont"
-        String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
         if (!jdb.isAtBreakpoint(reply, EMPTY_METHOD_NAME)) {
             throwFailure("Debugger: Missed breakpoint at:\n\t" + EMPTY_METHOD_NAME);
         }
@@ -122,10 +125,12 @@ public class hc001 extends JdbTest {
 
     /* Test jdb commands "classes" and "class" for hidden class. */
     private void testClassCommands(String hcName) {
+        String[] reply = null;
+
         log.println("\n### Debugger: testClassCommands");
 
         // run jdb command "classes"
-        String[] reply = jdb.receiveReplyFor(JdbCommand.classes);
+        reply = jdb.receiveReplyFor(JdbCommand.classes);
         if (!checkPattern(reply, hcName)) {
             throwFailure("Debugger: expected jdb command classes to list hidden class:\n\t" + hcName);
         }
@@ -142,6 +147,7 @@ public class hc001 extends JdbTest {
     /* Transition the debuggee's execution to the hidden class method start. */
     private void stopInHiddenClassMethod(String hcName) {
         String hcMethodName = hcName + "." + HC_METHOD_NAME;
+        String[] reply = null;
 
         log.println("\n### Debugger: stopInHiddenClassMethod");
 
@@ -150,7 +156,7 @@ public class hc001 extends JdbTest {
         log.println("\nDebugger: breakpoint is set at:\n\t" + hcMethodName);
 
         // run jdb command "clear": should list breakpoint in hcMethodName
-        String[] reply = jdb.receiveReplyFor(JdbCommand.clear);
+        reply = jdb.receiveReplyFor(JdbCommand.clear);
         if (!checkPattern(reply, hcMethodName)) {
             throwFailure("Debugger: expected jdb clear command to list breakpoint: " + hcMethodName);
         }
@@ -164,11 +170,12 @@ public class hc001 extends JdbTest {
     /* Test the jdb commands "up" and "where" for hidden class. */
     private void testUpWhereCommands(String hcName) {
         String hcMethodName = hcName + "." + HC_METHOD_NAME;
+        String[] reply = null;
 
         log.println("\n### Debugger: testUpWhereCommands");
 
         // run jdb command "where": should list hcMethodName frame
-        String[] reply = jdb.receiveReplyFor(JdbCommand.where);
+        reply = jdb.receiveReplyFor(JdbCommand.where);
         if (!checkPattern(reply, hcMethodName)) {
             throwFailure("Debugger: jdb command where does not show expected frame: " + hcMethodName);
         }
@@ -189,6 +196,7 @@ public class hc001 extends JdbTest {
     /* Test the jdb commands "down" and "where" for hidden class. */
     private void testDownWhereCommands(String hcName) {
         String hcMethodName = hcName + "." + HC_METHOD_NAME;
+        String[] reply = null;
 
         log.println("\n### Debugger: testDownWhereCommands");
 
@@ -197,7 +205,7 @@ public class hc001 extends JdbTest {
         log.println("\nDebugger: executed jdb command down");
 
         // run jdb command "where": should list hcMethodName frame again
-        String[] reply = jdb.receiveReplyFor(JdbCommand.where);
+        reply = jdb.receiveReplyFor(JdbCommand.where);
         if (!checkPattern(reply, hcMethodName)) {
             throwFailure("Debugger: jdb command where does not show expected frame: " + hcMethodName);
         }
@@ -206,10 +214,12 @@ public class hc001 extends JdbTest {
 
     /* Test the jdb commands "fields" and "methods" for hidden class. */
     private void testFieldsMethods(String hcName) {
+        String[] reply = null;
+
         log.println("\n### Debugger: testFieldsMethods");
 
         // run jdb command "methods" for hidden class
-        String[] reply = jdb.receiveReplyFor(JdbCommand.methods + hcName);
+        reply = jdb.receiveReplyFor(JdbCommand.methods + hcName);
         if (!checkPattern(reply, hcName)) {
             throwFailure("Debugger: no expected hidden class name in its methods: " + hcName);
         }
@@ -226,11 +236,12 @@ public class hc001 extends JdbTest {
     /* Test the jdb commands "watch" and "unwatch" for hidden class. */
     private void testWatchCommands(String hcName) {
         String hcFieldName = hcName + "." + HC_FIELD_NAME;
+        String[] reply = null;
 
         log.println("\n### Debugger: testWatchCommands");
 
         // run jdb command "watch" for hidden class field HC_FIELD_NAME
-        String[] reply = jdb.receiveReplyFor(JdbCommand.watch + hcFieldName);
+        reply = jdb.receiveReplyFor(JdbCommand.watch + hcFieldName);
         if (!checkPattern(reply, HC_FIELD_NAME)) {
             throwFailure("Debugger: was not able to set watch point: " + hcFieldName);
         }
@@ -251,11 +262,12 @@ public class hc001 extends JdbTest {
     /* Test the jdb commands "eval", "print" and "dump" for hidden class. */
     private void testEvalCommands(String hcName) {
         String hcFieldName = hcName + "." + HC_FIELD_NAME;
+        String[] reply = null;
 
         log.println("\n### Debugger: testEvalCommands");
 
         // run jdb command "eval" for hidden class field HC_FIELD_NAME
-        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + hcFieldName);
+        reply = jdb.receiveReplyFor(JdbCommand.eval + hcFieldName);
         if (!checkPattern(reply, hcFieldName)) {
             throwFailure("Debugger: expected field name in jdb command eval field reply: " + hcFieldName);
         }
@@ -280,9 +292,10 @@ public class hc001 extends JdbTest {
     private void testInvWatchCommand(String hcName) {
         String hcFieldName = hcName + "." + HC_FIELD_NAME;
         String MsgBase = "\nDebugger: jdb command \"watch\" with invalid field " + hcFieldName;
+        String[] reply = null;
 
         // run jdb command "watch" with an invalid class name
-        String[] reply = jdb.receiveReplyFor(JdbCommand.watch + hcFieldName);
+        reply = jdb.receiveReplyFor(JdbCommand.watch + hcFieldName);
         if (checkPattern(reply, "Deferring watch modification")) {
             throwFailure(MsgBase + " must not set deferred watch point");
         }
@@ -293,9 +306,10 @@ public class hc001 extends JdbTest {
     private void testInvEvalCommand(String hcName) {
         String hcFieldName = hcName + "." + HC_FIELD_NAME;
         String MsgBase = "\nDebugger: jdb command \"eval\" with invalid field " + hcFieldName;
+        String[] reply = null;
 
         // run jdb command "eval" with an invalid class name
-        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + hcFieldName);
+        reply = jdb.receiveReplyFor(JdbCommand.eval + hcFieldName);
         if (!checkPattern(reply, "ParseException")) {
             throwFailure(MsgBase + " must be rejected with ParseException");
         }
@@ -304,16 +318,18 @@ public class hc001 extends JdbTest {
 
     /* Test the jdb commands "watch" and "eval" with various invalid class names. */
     private void testInvalidCommands() {
+        String className = null;
         String[] invClassNames = {
-                "xx.yyy/0x111/0x222",
-                "xx./0x111.0x222",
-                "xx.yyy.zzz/"
+            "xx.yyy/0x111/0x222",
+            "xx./0x111.0x222",
+            "xx.yyy.zzz/"
         };
 
         log.println("\n### Debugger: testInvalidCommands");
 
         // run jdb commands "watch" and "eval" with invalid class names
-        for (String className : invClassNames) {
+        for (int idx = 0; idx < invClassNames.length; idx++) {
+            className = invClassNames[idx];
             testInvWatchCommand(className + "." + HC_FIELD_NAME);
             testInvEvalCommand(className + "." + HC_FIELD_NAME);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001.java
@@ -45,34 +45,33 @@
 
 package nsk.jdb.hidden_class.hc001;
 
-import java.io.*;
-import java.util.*;
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Failure;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
+
+import java.io.PrintStream;
 
 public class hc001 extends JdbTest {
-    static final String DEBUGGEE_CLASS    = hc001a.class.getTypeName();
-    static final String HC_NAME_FIELD     = DEBUGGEE_CLASS + ".hcName";
-    static final String MAIN_METHOD_NAME  = DEBUGGEE_CLASS + ".main";
+    static final String DEBUGGEE_CLASS = hc001a.class.getTypeName();
+    static final String HC_NAME_FIELD = DEBUGGEE_CLASS + ".hcName";
+    static final String MAIN_METHOD_NAME = DEBUGGEE_CLASS + ".main";
     static final String EMPTY_METHOD_NAME = DEBUGGEE_CLASS + ".emptyMethod";
-    static final String HC_METHOD_NAME    = "hcMethod";
-    static final String HC_FIELD_NAME     = "hcField";
-    static final int    MAX_SLEEP_CNT     = 3;
+    static final String HC_METHOD_NAME = "hcMethod";
+    static final String HC_FIELD_NAME = "hcField";
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
+    public static int run(String[] argv, PrintStream out) {
         debuggeeClass = DEBUGGEE_CLASS; // needed for JdbTest.runTest
         firstBreak = MAIN_METHOD_NAME;  // needed for JdbTest.runTest
         return new hc001().runTest(argv, out);
     }
 
     static boolean checkPattern(String[] arr, String pattern) {
-        for (int idx = 0; idx < arr.length; idx++) {
-            String str = arr[idx];
-            if (str.indexOf(pattern) != -1) {
+        for (String str : arr) {
+            if (str.contains(pattern)) {
                 return true;
             }
         }
@@ -90,7 +89,7 @@ public class hc001 extends JdbTest {
      *  Return the hidden class name.
      */
     private String runPrologue() {
-        String[] reply = null;
+        String[] reply;
 
         log.println("\n### Debugger: runPrologue");
 
@@ -318,18 +317,16 @@ public class hc001 extends JdbTest {
 
     /* Test the jdb commands "watch" and "eval" with various invalid class names. */
     private void testInvalidCommands() {
-        String className = null;
         String[] invClassNames = {
-            "xx.yyy/0x111/0x222",
-            "xx./0x111.0x222",
-            "xx.yyy.zzz/"
+                "xx.yyy/0x111/0x222",
+                "xx./0x111.0x222",
+                "xx.yyy.zzz/"
         };
 
         log.println("\n### Debugger: testInvalidCommands");
 
         // run jdb commands "watch" and "eval" with invalid class names
-        for (int idx = 0; idx < invClassNames.length; idx++) {
-            className = invClassNames[idx];
+        for (String className : invClassNames) {
             testInvWatchCommand(className + "." + HC_FIELD_NAME);
             testInvEvalCommand(className + "." + HC_FIELD_NAME);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001.java
@@ -39,9 +39,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.ignore.ignore001.ignore001
- *        nsk.jdb.ignore.ignore001.ignore001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.ignore.ignore001.ignore001
+ * @build nsk.jdb.ignore.ignore001.ignore001a
+ * @run main/othervm
+ *      nsk.jdb.ignore.ignore001.ignore001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001.java
@@ -54,70 +54,69 @@
 
 package nsk.jdb.ignore.ignore001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class ignore001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new ignore001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.ignore.ignore001";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".ignore001";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String EXCEPTION_SAMPLE   = "Exception occurred:";
-    static final String REMOVED_SAMPLE     = "Removed:";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.ignore.ignore001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".ignore001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String EXCEPTION_SAMPLE = "Exception occurred:";
+    static final String REMOVED_SAMPLE = "Removed:";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
 //        jdb.setBreakpointInMethod(LAST_BREAK);
 
         log.display("Setting catch for: " + nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION);
-        reply = jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION);
+        jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION);
 
         log.display("Setting catch for: " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1);
-        reply = jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1);
+        jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1);
 
         log.display("Setting catch for: " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2);
-        reply = jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2);
+        jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2);
 
-        for (;;) {
-            if (!checkCatch(nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION)) {
-               success = false;
+        while (true) {
+            if (!checkCatch(ignore001a.JAVA_EXCEPTION)) {
+                success = false;
             }
-            if (!checkCatch(nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1)) {
-               success = false;
+            if (!checkCatch(ignore001a.USER_EXCEPTION1)) {
+                success = false;
             }
-            if (!checkCatch(nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2)) {
-               success = false;
+            if (!checkCatch(ignore001a.USER_EXCEPTION2)) {
+                success = false;
             }
 
-            if (!checkIgnore(nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION)) {
-               success = false;
+            if (!checkIgnore(ignore001a.JAVA_EXCEPTION)) {
+                success = false;
             }
-            if (!checkIgnore(nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1)) {
-               success = false;
+            if (!checkIgnore(ignore001a.USER_EXCEPTION1)) {
+                success = false;
             }
-            if (!checkIgnore(nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2)) {
-               success = false;
+            if (!checkIgnore(ignore001a.USER_EXCEPTION2)) {
+                success = false;
             }
 
             jdb.contToExit(6);
@@ -134,18 +133,17 @@ public class ignore001 extends JdbTest {
         }
     }
 
-    private boolean checkCatch (String exceptionName) {
+    private boolean checkCatch(String exceptionName) {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
+        Vector<String> v;
         String found;
         boolean result = true;
 
 //        log.display("Resuming debuggee.");
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        v = new Vector();
+        v = new Vector<>();
         v.add(EXCEPTION_SAMPLE);
         v.add(exceptionName);
 
@@ -158,18 +156,17 @@ public class ignore001 extends JdbTest {
         return result;
     }
 
-    private boolean checkIgnore (String exceptionName) {
+    private boolean checkIgnore(String exceptionName) {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
+        Vector<String> v;
         String found;
         boolean result = true;
 
         log.display("Unsetting catch for: " + exceptionName);
         reply = jdb.receiveReplyFor(JdbCommand.ignore + " caught " + exceptionName);
 
-        v = new Vector();
+        v = new Vector<>();
         v.add(REMOVED_SAMPLE);
         v.add(exceptionName);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001.java
@@ -83,10 +83,6 @@ public class ignore001 extends JdbTest {
     static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-
 //        jdb.setBreakpointInMethod(LAST_BREAK);
 
         log.display("Setting catch for: " + nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION);
@@ -121,9 +117,9 @@ public class ignore001 extends JdbTest {
 
             jdb.contToExit(6);
 
-            reply = jdb.getTotalReply();
-            grep = new Paragrep(reply);
-            count = grep.find(EXCEPTION_SAMPLE);
+            String[] reply = jdb.getTotalReply();
+            var grep = new Paragrep(reply);
+            int count = grep.find(EXCEPTION_SAMPLE);
             if (count != 3) {
                 success = false;
                 log.complain("Should report 3 catched exceptions.");
@@ -134,21 +130,17 @@ public class ignore001 extends JdbTest {
     }
 
     private boolean checkCatch(String exceptionName) {
-        String[] reply;
-        Paragrep grep;
-        Vector<String> v;
-        String found;
         boolean result = true;
 
 //        log.display("Resuming debuggee.");
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        v = new Vector<>();
+        var v = new Vector<String>();
         v.add(EXCEPTION_SAMPLE);
         v.add(exceptionName);
 
-        grep = new Paragrep(reply);
-        found = grep.findFirst(v);
+        var grep = new Paragrep(reply);
+        String found = grep.findFirst(v);
         if (found.length() == 0) {
             log.complain("Failed to catch " + exceptionName);
             result = false;
@@ -157,21 +149,17 @@ public class ignore001 extends JdbTest {
     }
 
     private boolean checkIgnore(String exceptionName) {
-        String[] reply;
-        Paragrep grep;
-        Vector<String> v;
-        String found;
         boolean result = true;
 
         log.display("Unsetting catch for: " + exceptionName);
-        reply = jdb.receiveReplyFor(JdbCommand.ignore + " caught " + exceptionName);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.ignore + " caught " + exceptionName);
 
-        v = new Vector<>();
+        var v = new Vector<String>();
         v.add(REMOVED_SAMPLE);
         v.add(exceptionName);
 
-        grep = new Paragrep(reply);
-        found = grep.findFirst(v);
+        var grep = new Paragrep(reply);
+        String found = grep.findFirst(v);
         if (found.length() == 0) {
             log.complain("Failed to remove catch for " + exceptionName);
             result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001.java
@@ -54,72 +54,77 @@
 
 package nsk.jdb.ignore.ignore001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class ignore001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new ignore001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.ignore.ignore001";
-    static final String TEST_CLASS = PACKAGE_NAME + ".ignore001";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String EXCEPTION_SAMPLE = "Exception occurred:";
-    static final String REMOVED_SAMPLE = "Removed:";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME       = "nsk.jdb.ignore.ignore001";
+    static final String TEST_CLASS         = PACKAGE_NAME + ".ignore001";
+    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
+    static final String EXCEPTION_SAMPLE   = "Exception occurred:";
+    static final String REMOVED_SAMPLE     = "Removed:";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
 //        jdb.setBreakpointInMethod(LAST_BREAK);
 
         log.display("Setting catch for: " + nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION);
-        jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION);
+        reply = jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION);
 
         log.display("Setting catch for: " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1);
-        jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1);
+        reply = jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1);
 
         log.display("Setting catch for: " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2);
-        jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2);
+        reply = jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2);
 
-        while (true) {
-            if (!checkCatch(ignore001a.JAVA_EXCEPTION)) {
-                success = false;
+        for (;;) {
+            if (!checkCatch(nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION)) {
+               success = false;
             }
-            if (!checkCatch(ignore001a.USER_EXCEPTION1)) {
-                success = false;
+            if (!checkCatch(nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1)) {
+               success = false;
             }
-            if (!checkCatch(ignore001a.USER_EXCEPTION2)) {
-                success = false;
+            if (!checkCatch(nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2)) {
+               success = false;
             }
 
-            if (!checkIgnore(ignore001a.JAVA_EXCEPTION)) {
-                success = false;
+            if (!checkIgnore(nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION)) {
+               success = false;
             }
-            if (!checkIgnore(ignore001a.USER_EXCEPTION1)) {
-                success = false;
+            if (!checkIgnore(nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1)) {
+               success = false;
             }
-            if (!checkIgnore(ignore001a.USER_EXCEPTION2)) {
-                success = false;
+            if (!checkIgnore(nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2)) {
+               success = false;
             }
 
             jdb.contToExit(6);
 
-            String[] reply = jdb.getTotalReply();
-            var grep = new Paragrep(reply);
-            int count = grep.find(EXCEPTION_SAMPLE);
+            reply = jdb.getTotalReply();
+            grep = new Paragrep(reply);
+            count = grep.find(EXCEPTION_SAMPLE);
             if (count != 3) {
                 success = false;
                 log.complain("Should report 3 catched exceptions.");
@@ -129,18 +134,23 @@ public class ignore001 extends JdbTest {
         }
     }
 
-    private boolean checkCatch(String exceptionName) {
+    private boolean checkCatch (String exceptionName) {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
         boolean result = true;
 
 //        log.display("Resuming debuggee.");
-        String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        var v = new Vector<String>();
+        v = new Vector();
         v.add(EXCEPTION_SAMPLE);
         v.add(exceptionName);
 
-        var grep = new Paragrep(reply);
-        String found = grep.findFirst(v);
+        grep = new Paragrep(reply);
+        found = grep.findFirst(v);
         if (found.length() == 0) {
             log.complain("Failed to catch " + exceptionName);
             result = false;
@@ -148,18 +158,23 @@ public class ignore001 extends JdbTest {
         return result;
     }
 
-    private boolean checkIgnore(String exceptionName) {
+    private boolean checkIgnore (String exceptionName) {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
         boolean result = true;
 
         log.display("Unsetting catch for: " + exceptionName);
-        String[] reply = jdb.receiveReplyFor(JdbCommand.ignore + " caught " + exceptionName);
+        reply = jdb.receiveReplyFor(JdbCommand.ignore + " caught " + exceptionName);
 
-        var v = new Vector<String>();
+        v = new Vector();
         v.add(REMOVED_SAMPLE);
         v.add(exceptionName);
 
-        var grep = new Paragrep(reply);
-        String found = grep.findFirst(v);
+        grep = new Paragrep(reply);
+        found = grep.findFirst(v);
         if (found.length() == 0) {
             log.complain("Failed to remove catch for " + exceptionName);
             result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
@@ -46,9 +46,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.interrupt.interrupt001.interrupt001
- *        nsk.jdb.interrupt.interrupt001.interrupt001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.interrupt.interrupt001.interrupt001
+ * @build nsk.jdb.interrupt.interrupt001.interrupt001a
+ * @run main/othervm
+ *      nsk.jdb.interrupt.interrupt001.interrupt001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
@@ -106,16 +106,10 @@ public class interrupt001 extends JdbTest {
     private static Pattern tidPattern = Pattern.compile("\\(.+" + MYTHREAD + "\\)(\\S+)");
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        String found;
-        String[] threads;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
-
+        String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
         if (threads.length != numThreads) {
             log.complain("jdb should report " + numThreads + " instance of " + DEBUGGEE_THREAD);
             log.complain("Found: " + threads.length);
@@ -131,9 +125,9 @@ public class interrupt001 extends JdbTest {
         jdb.receiveReplyFor(JdbCommand.threads);
         jdb.receiveReplyFor(JdbCommand.cont, true);
 
-        reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_RESULT);
-        grep = new Paragrep(reply);
-        found = grep.findFirst(DEBUGGEE_RESULT + " =");
+        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_RESULT);
+        var grep = new Paragrep(reply);
+        String found = grep.findFirst(DEBUGGEE_RESULT + " =");
         if (found.length() > 0) {
             if (!found.contains(DEBUGGEE_RESULT + " = 0")) {
                 log.complain("Not all " + MYTHREAD + "s were interrupted.");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
@@ -61,33 +61,37 @@
 
 package nsk.jdb.interrupt.interrupt001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class interrupt001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         return new interrupt001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.interrupt.interrupt001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".interrupt001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.interrupt.interrupt001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".interrupt001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = DEBUGGEE_CLASS + "$" + MYTHREAD;
     static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notInterrupted.get()";
 
@@ -108,7 +112,7 @@ public class interrupt001 extends JdbTest {
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
@@ -120,21 +124,21 @@ public class interrupt001 extends JdbTest {
 
         pauseTillAllThreadsWaiting(threads);
 
-        for (int i = 0; i < threads.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.interrupt + threads[i]);
+        for (String thread : threads) {
+            jdb.receiveReplyFor(JdbCommand.interrupt + thread);
         }
 
-        reply = jdb.receiveReplyFor(JdbCommand.threads);
-        reply = jdb.receiveReplyFor(JdbCommand.cont, true);
+        jdb.receiveReplyFor(JdbCommand.threads);
+        jdb.receiveReplyFor(JdbCommand.cont, true);
 
         reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_RESULT);
         grep = new Paragrep(reply);
-        found = grep.findFirst(DEBUGGEE_RESULT + " =" );
+        found = grep.findFirst(DEBUGGEE_RESULT + " =");
         if (found.length() > 0) {
-            if (found.indexOf(DEBUGGEE_RESULT + " = 0") < 0) {
-               log.complain("Not all " + MYTHREAD + "s were interrupted.");
-               log.complain(found);
-               success = false;
+            if (!found.contains(DEBUGGEE_RESULT + " = 0")) {
+                log.complain("Not all " + MYTHREAD + "s were interrupted.");
+                log.complain(found);
+                success = false;
             }
         } else {
             log.complain("TEST BUG: not found value for " + DEBUGGEE_RESULT);
@@ -144,34 +148,33 @@ public class interrupt001 extends JdbTest {
     }
 
     private void pauseTillAllThreadsWaiting(String[] threads) {
-        String[] reply;
         boolean tidswaiting = false;
 
         Set<String> tids = new HashSet<>(Arrays.asList(threads));
         Set<String> waitingTids = null;
 
         do {
-            String[] thrdsRply = (String[])jdb.receiveReplyFor(JdbCommand.threads);
-            waitingTids = Arrays.asList(thrdsRply).stream()
-                .filter((r)-> r.endsWith("waiting"))
-                .map((r)->{
-                    Matcher m = tidPattern.matcher(r);
-                    if (m.find()) {
-                        return m.group(1);
-                    }
-                    return null;
-                })
-                .filter((r)-> r != null)
-                .collect(Collectors.toSet());
+            String[] thrdsRply = jdb.receiveReplyFor(JdbCommand.threads);
+            waitingTids = Arrays.stream(thrdsRply)
+                    .filter((r) -> r.endsWith("waiting"))
+                    .map((r) -> {
+                        Matcher m = tidPattern.matcher(r);
+                        if (m.find()) {
+                            return m.group(1);
+                        }
+                        return null;
+                    })
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
 
             // If all Tids are waiting set allWorkersAreWaiting to true so
             // the main test thread will get out of its breakpoint loop
             // and continue with the test.
             if (waitingTids.containsAll(tids)) {
-                reply = jdb.receiveReplyFor(JdbCommand.set + DEBUGGEE_CLASS + ".allWorkersAreWaiting=true");
+                jdb.receiveReplyFor(JdbCommand.set + DEBUGGEE_CLASS + ".allWorkersAreWaiting=true");
                 tidswaiting = true;
             } else {
-                reply = jdb.receiveReplyFor(JdbCommand.cont);
+                jdb.receiveReplyFor(JdbCommand.cont);
             }
         } while (!tidswaiting);
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -46,9 +46,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.kill.kill001.kill001
- *        nsk.jdb.kill.kill001.kill001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.kill.kill001.kill001
+ * @build nsk.jdb.kill.kill001.kill001a
+ * @run main/othervm
+ *      nsk.jdb.kill.kill001.kill001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -61,31 +61,30 @@
 
 package nsk.jdb.kill.kill001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class kill001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         return new kill001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.kill.kill001";
-    static final String TEST_CLASS = PACKAGE_NAME + ".kill001";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
-    static final String MYTHREAD = "MyThread";
+    static final String PACKAGE_NAME    = "nsk.jdb.kill.kill001";
+    static final String TEST_CLASS      = PACKAGE_NAME + ".kill001";
+    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
+    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
+    static final String MYTHREAD        = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
     static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notKilled";
     static final String DEBUGGEE_EXCEPTIONS = DEBUGGEE_CLASS + ".exceptions";
@@ -93,10 +92,17 @@ public class kill001 extends JdbTest {
     static int numThreads = nsk.jdb.kill.kill001.kill001a.numThreads;
 
     protected void runCases() {
-        jdb.setBreakpointInMethod(LAST_BREAK);
-        String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+        String[] threads;
 
-        String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        jdb.setBreakpointInMethod(LAST_BREAK);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
+
+        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
         if (threads.length != numThreads) {
             log.complain("jdb should report " + numThreads + " instance of " + DEBUGGEE_THREAD);
@@ -106,8 +112,8 @@ public class kill001 extends JdbTest {
 
         for (int i = 0; i < threads.length; i++) {
             reply = jdb.receiveReplyForWithMessageWait(JdbCommand.kill + threads[i] + " " +
-                            DEBUGGEE_EXCEPTIONS + "[" + i + "]",
-                    "killed");
+                                                       DEBUGGEE_EXCEPTIONS + "[" + i + "]",
+                                                       "killed");
         }
 
         for (int i = 0; i <= numThreads; i++) {
@@ -122,20 +128,20 @@ public class kill001 extends JdbTest {
         log.display("Breakpoint has been hit");
 
         reply = jdb.receiveReplyForWithMessageWait(JdbCommand.eval + DEBUGGEE_RESULT,
-                DEBUGGEE_RESULT + " =");
-        var grep = new Paragrep(reply);
-        String found = grep.findFirst(DEBUGGEE_RESULT + " =");
+                                                   DEBUGGEE_RESULT + " =");
+        grep = new Paragrep(reply);
+        found = grep.findFirst(DEBUGGEE_RESULT + " =" );
         if (found.length() > 0) {
-            if (!found.contains(DEBUGGEE_RESULT + " = 0")) {
-                log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
-                success = false;
+            if (found.indexOf(DEBUGGEE_RESULT + " = 0") < 0) {
+               log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
+               success = false;
             }
         } else {
             log.complain("Value for " + DEBUGGEE_RESULT + " is not found.");
             success = false;
         }
 
-        jdb.receiveReplyFor(JdbCommand.threads);
+        reply = jdb.receiveReplyFor(JdbCommand.threads);
         jdb.contToExit(1);
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -93,15 +93,10 @@ public class kill001 extends JdbTest {
     static int numThreads = nsk.jdb.kill.kill001.kill001a.numThreads;
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        String found;
-        String[] threads;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
         if (threads.length != numThreads) {
             log.complain("jdb should report " + numThreads + " instance of " + DEBUGGEE_THREAD);
@@ -128,8 +123,8 @@ public class kill001 extends JdbTest {
 
         reply = jdb.receiveReplyForWithMessageWait(JdbCommand.eval + DEBUGGEE_RESULT,
                 DEBUGGEE_RESULT + " =");
-        grep = new Paragrep(reply);
-        found = grep.findFirst(DEBUGGEE_RESULT + " =");
+        var grep = new Paragrep(reply);
+        String found = grep.findFirst(DEBUGGEE_RESULT + " =");
         if (found.length() > 0) {
             if (!found.contains(DEBUGGEE_RESULT + " = 0")) {
                 log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -61,30 +61,31 @@
 
 package nsk.jdb.kill.kill001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class kill001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         return new kill001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.kill.kill001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".kill001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.kill.kill001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".kill001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
     static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notKilled";
     static final String DEBUGGEE_EXCEPTIONS = DEBUGGEE_CLASS + ".exceptions";
@@ -94,8 +95,6 @@ public class kill001 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
         String found;
         String[] threads;
 
@@ -112,8 +111,8 @@ public class kill001 extends JdbTest {
 
         for (int i = 0; i < threads.length; i++) {
             reply = jdb.receiveReplyForWithMessageWait(JdbCommand.kill + threads[i] + " " +
-                                                       DEBUGGEE_EXCEPTIONS + "[" + i + "]",
-                                                       "killed");
+                            DEBUGGEE_EXCEPTIONS + "[" + i + "]",
+                    "killed");
         }
 
         for (int i = 0; i <= numThreads; i++) {
@@ -128,20 +127,20 @@ public class kill001 extends JdbTest {
         log.display("Breakpoint has been hit");
 
         reply = jdb.receiveReplyForWithMessageWait(JdbCommand.eval + DEBUGGEE_RESULT,
-                                                   DEBUGGEE_RESULT + " =");
+                DEBUGGEE_RESULT + " =");
         grep = new Paragrep(reply);
-        found = grep.findFirst(DEBUGGEE_RESULT + " =" );
+        found = grep.findFirst(DEBUGGEE_RESULT + " =");
         if (found.length() > 0) {
-            if (found.indexOf(DEBUGGEE_RESULT + " = 0") < 0) {
-               log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
-               success = false;
+            if (!found.contains(DEBUGGEE_RESULT + " = 0")) {
+                log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
+                success = false;
             }
         } else {
             log.complain("Value for " + DEBUGGEE_RESULT + " is not found.");
             success = false;
         }
 
-        reply = jdb.receiveReplyFor(JdbCommand.threads);
+        jdb.receiveReplyFor(JdbCommand.threads);
         jdb.contToExit(1);
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002.java
@@ -42,9 +42,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.kill.kill002.kill002
- *        nsk.jdb.kill.kill002.kill002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.kill.kill002.kill002
+ * @build nsk.jdb.kill.kill002.kill002a
+ * @run main/othervm
+ *      nsk.jdb.kill.kill002.kill002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002.java
@@ -57,30 +57,30 @@
 
 package nsk.jdb.kill.kill002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class kill002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         return new kill002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.kill.kill002";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".kill002";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.kill.kill002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".kill002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
     static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notKilled";
     static final String DEBUGGEE_EXCEPTIONS = DEBUGGEE_CLASS + ".exceptions";
@@ -90,13 +90,11 @@ public class kill002 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
         String found;
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
@@ -107,11 +105,11 @@ public class kill002 extends JdbTest {
         }
 
         for (int i = 0; i < threads.length; i++) {
-            reply = jdb.receiveReplyForWithMessageWait(JdbCommand.kill + threads[i] + " " +
-                                                       DEBUGGEE_EXCEPTIONS + "[" + i + "]",
-                                                       "killed");
+            jdb.receiveReplyForWithMessageWait(JdbCommand.kill + threads[i] + " " +
+                            DEBUGGEE_EXCEPTIONS + "[" + i + "]",
+                    "killed");
         }
-        reply = jdb.receiveReplyFor(JdbCommand.threads);
+        jdb.receiveReplyFor(JdbCommand.threads);
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         // make sure the debugger is at a breakpoint
@@ -122,13 +120,13 @@ public class kill002 extends JdbTest {
         log.display("Breakpoint has been hit");
 
         reply = jdb.receiveReplyForWithMessageWait(JdbCommand.eval + DEBUGGEE_RESULT,
-                                            DEBUGGEE_RESULT + " =");
+                DEBUGGEE_RESULT + " =");
         grep = new Paragrep(reply);
-        found = grep.findFirst(DEBUGGEE_RESULT + " =" );
+        found = grep.findFirst(DEBUGGEE_RESULT + " =");
         if (found.length() > 0) {
-            if (found.indexOf(DEBUGGEE_RESULT + " = 0") < 0) {
-               log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
-               success = false;
+            if (!found.contains(DEBUGGEE_RESULT + " = 0")) {
+                log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
+                success = false;
             }
         } else {
             log.complain("Value for " + DEBUGGEE_RESULT + " is not found.");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002.java
@@ -57,30 +57,30 @@
 
 package nsk.jdb.kill.kill002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class kill002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         return new kill002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.kill.kill002";
-    static final String TEST_CLASS = PACKAGE_NAME + ".kill002";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
-    static final String MYTHREAD = "MyThread";
+    static final String PACKAGE_NAME    = "nsk.jdb.kill.kill002";
+    static final String TEST_CLASS      = PACKAGE_NAME + ".kill002";
+    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
+    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
+    static final String MYTHREAD        = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
     static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notKilled";
     static final String DEBUGGEE_EXCEPTIONS = DEBUGGEE_CLASS + ".exceptions";
@@ -88,10 +88,17 @@ public class kill002 extends JdbTest {
     static int numThreads = nsk.jdb.kill.kill002.kill002a.numThreads;
 
     protected void runCases() {
-        jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+        String[] threads;
 
-        String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        jdb.setBreakpointInMethod(LAST_BREAK);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
+
+        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
         if (threads.length != numThreads) {
             log.complain("jdb should report " + numThreads + " instance of " + DEBUGGEE_THREAD);
@@ -100,12 +107,12 @@ public class kill002 extends JdbTest {
         }
 
         for (int i = 0; i < threads.length; i++) {
-            jdb.receiveReplyForWithMessageWait(JdbCommand.kill + threads[i] + " " +
-                            DEBUGGEE_EXCEPTIONS + "[" + i + "]",
-                    "killed");
+            reply = jdb.receiveReplyForWithMessageWait(JdbCommand.kill + threads[i] + " " +
+                                                       DEBUGGEE_EXCEPTIONS + "[" + i + "]",
+                                                       "killed");
         }
-        jdb.receiveReplyFor(JdbCommand.threads);
-        String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.threads);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         // make sure the debugger is at a breakpoint
         if (!jdb.isAtBreakpoint(reply, LAST_BREAK)) {
@@ -115,13 +122,13 @@ public class kill002 extends JdbTest {
         log.display("Breakpoint has been hit");
 
         reply = jdb.receiveReplyForWithMessageWait(JdbCommand.eval + DEBUGGEE_RESULT,
-                DEBUGGEE_RESULT + " =");
-        var grep = new Paragrep(reply);
-        String found = grep.findFirst(DEBUGGEE_RESULT + " =");
+                                            DEBUGGEE_RESULT + " =");
+        grep = new Paragrep(reply);
+        found = grep.findFirst(DEBUGGEE_RESULT + " =" );
         if (found.length() > 0) {
-            if (!found.contains(DEBUGGEE_RESULT + " = 0")) {
-                log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
-                success = false;
+            if (found.indexOf(DEBUGGEE_RESULT + " = 0") < 0) {
+               log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
+               success = false;
             }
         } else {
             log.complain("Value for " + DEBUGGEE_RESULT + " is not found.");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002.java
@@ -88,15 +88,10 @@ public class kill002 extends JdbTest {
     static int numThreads = nsk.jdb.kill.kill002.kill002a.numThreads;
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        String found;
-        String[] threads;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
         if (threads.length != numThreads) {
             log.complain("jdb should report " + numThreads + " instance of " + DEBUGGEE_THREAD);
@@ -110,7 +105,7 @@ public class kill002 extends JdbTest {
                     "killed");
         }
         jdb.receiveReplyFor(JdbCommand.threads);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         // make sure the debugger is at a breakpoint
         if (!jdb.isAtBreakpoint(reply, LAST_BREAK)) {
@@ -121,8 +116,8 @@ public class kill002 extends JdbTest {
 
         reply = jdb.receiveReplyForWithMessageWait(JdbCommand.eval + DEBUGGEE_RESULT,
                 DEBUGGEE_RESULT + " =");
-        grep = new Paragrep(reply);
-        found = grep.findFirst(DEBUGGEE_RESULT + " =");
+        var grep = new Paragrep(reply);
+        String found = grep.findFirst(DEBUGGEE_RESULT + " =");
         if (found.length() > 0) {
             if (!found.contains(DEBUGGEE_RESULT + " = 0")) {
                 log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001.java
@@ -39,9 +39,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.klass.class001.class001
- *        nsk.jdb.klass.class001.class001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.klass.class001.class001
+ * @build nsk.jdb.klass.class001.class001a
+ * @run main/othervm
+ *      nsk.jdb.klass.class001.class001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001.java
@@ -107,15 +107,11 @@ public class class001 extends JdbTest {
     }
 
     private boolean checkClass(String className) {
-        String[] reply;
-        Paragrep grep;
-        String found;
         boolean result = true;
 
-        reply = jdb.receiveReplyFor(JdbCommand._class + className);
-
-        grep = new Paragrep(reply);
-        found = grep.findFirst(NOT_VALID_SAMPLE);
+        String[] reply = jdb.receiveReplyFor(JdbCommand._class + className);
+        var grep = new Paragrep(reply);
+        String found = grep.findFirst(NOT_VALID_SAMPLE);
         if (found.length() > 0) {
             log.complain("Failed to report class " + className);
             result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001.java
@@ -54,57 +54,51 @@
 
 package nsk.jdb.klass.class001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class class001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new class001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.klass.class001";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".class001";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final String NOT_VALID_SAMPLE   = "is not a valid";
+    static final String PACKAGE_NAME = "nsk.jdb.klass.class001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".class001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String NOT_VALID_SAMPLE = "is not a valid";
 
     static String[] checkedClasses = {
-        DEBUGGEE_CLASS,
-        DEBUGGEE_CLASS + "$InnerInt1",
-        DEBUGGEE_CLASS + "$Inner2",
-        DEBUGGEE_CLASS + "$Inner3",
-        DEBUGGEE_CLASS + "$Inner4",
-        DEBUGGEE_CLASS + "$Inner5",
-        DEBUGGEE_CLASS + "$Inner6",
-        PACKAGE_NAME + ".Outer1"
-                                      };
+            DEBUGGEE_CLASS,
+            DEBUGGEE_CLASS + "$InnerInt1",
+            DEBUGGEE_CLASS + "$Inner2",
+            DEBUGGEE_CLASS + "$Inner3",
+            DEBUGGEE_CLASS + "$Inner4",
+            DEBUGGEE_CLASS + "$Inner5",
+            DEBUGGEE_CLASS + "$Inner6",
+            PACKAGE_NAME + ".Outer1"
+    };
 
     /* ------------------------------------- */
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
-        for (int i = 0; i < checkedClasses.length; i++) {
-            if (!checkClass(checkedClasses[i])) {
+        for (String checkedClass : checkedClasses) {
+            if (!checkClass(checkedClass)) {
                 success = false;
             }
         }
@@ -112,10 +106,9 @@ public class class001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkClass (String className) {
+    private boolean checkClass(String className) {
         String[] reply;
         Paragrep grep;
-        int count;
         String found;
         boolean result = true;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001.java
@@ -54,51 +54,57 @@
 
 package nsk.jdb.klass.class001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class class001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new class001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.klass.class001";
-    static final String TEST_CLASS = PACKAGE_NAME + ".class001";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
-    static final String NOT_VALID_SAMPLE = "is not a valid";
+    static final String PACKAGE_NAME       = "nsk.jdb.klass.class001";
+    static final String TEST_CLASS         = PACKAGE_NAME + ".class001";
+    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String NOT_VALID_SAMPLE   = "is not a valid";
 
     static String[] checkedClasses = {
-            DEBUGGEE_CLASS,
-            DEBUGGEE_CLASS + "$InnerInt1",
-            DEBUGGEE_CLASS + "$Inner2",
-            DEBUGGEE_CLASS + "$Inner3",
-            DEBUGGEE_CLASS + "$Inner4",
-            DEBUGGEE_CLASS + "$Inner5",
-            DEBUGGEE_CLASS + "$Inner6",
-            PACKAGE_NAME + ".Outer1"
-    };
+        DEBUGGEE_CLASS,
+        DEBUGGEE_CLASS + "$InnerInt1",
+        DEBUGGEE_CLASS + "$Inner2",
+        DEBUGGEE_CLASS + "$Inner3",
+        DEBUGGEE_CLASS + "$Inner4",
+        DEBUGGEE_CLASS + "$Inner5",
+        DEBUGGEE_CLASS + "$Inner6",
+        PACKAGE_NAME + ".Outer1"
+                                      };
 
     /* ------------------------------------- */
 
     protected void runCases() {
-        jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
 
-        for (String checkedClass : checkedClasses) {
-            if (!checkClass(checkedClass)) {
+        jdb.setBreakpointInMethod(LAST_BREAK);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
+
+        for (int i = 0; i < checkedClasses.length; i++) {
+            if (!checkClass(checkedClasses[i])) {
                 success = false;
             }
         }
@@ -106,12 +112,17 @@ public class class001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkClass(String className) {
+    private boolean checkClass (String className) {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        String found;
         boolean result = true;
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand._class + className);
-        var grep = new Paragrep(reply);
-        String found = grep.findFirst(NOT_VALID_SAMPLE);
+        reply = jdb.receiveReplyFor(JdbCommand._class + className);
+
+        grep = new Paragrep(reply);
+        found = grep.findFirst(NOT_VALID_SAMPLE);
         if (found.length() > 0) {
             log.complain("Failed to report class " + className);
             result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
@@ -99,14 +99,11 @@ public class list002 extends JdbTest {
     final static String SOURCE_NOT_FOUND = "Source file not found";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        reply = jdb.receiveReplyFor(JdbCommand.list + "runIt");
-        grep = new Paragrep(reply);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.list + "runIt");
+        var grep = new Paragrep(reply);
         if (grep.find(SOURCE_NOT_FOUND) > 0) {
             failure(reply[0]);
         } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
@@ -59,64 +59,60 @@
 
 package nsk.jdb.list.list002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class list002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new list002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.list.list002";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".list002";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".runIt";
-    static final int    LINE_NUMBER     = 38;
+    static final String PACKAGE_NAME = "nsk.jdb.list.list002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".list002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".runIt";
+    static final int LINE_NUMBER = 38;
 
-    final static String METHOD_SOURCE[] = new String[] {
-        "public int runIt(String args[], PrintStream out) {",
-        "JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);",
-        "Log log = new Log(out, argumentHandler);",
-        "log.display(\"Debuggee PASSED\");",
-        "return list002.PASSED;"
-                                                    };
+    final static String[] METHOD_SOURCE = new String[]{
+            "public int runIt(String args[], PrintStream out) {",
+            "JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);",
+            "Log log = new Log(out, argumentHandler);",
+            "log.display(\"Debuggee PASSED\");",
+            "return list002.PASSED;"
+    };
 
     final static String LINE_SOURCE =
-        "System.exit(list002.JCK_STATUS_BASE + _list002a.runIt(args, System.out));";
+            "System.exit(list002.JCK_STATUS_BASE + _list002a.runIt(args, System.out));";
 
     final static String SOURCE_NOT_FOUND = "Source file not found";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         reply = jdb.receiveReplyFor(JdbCommand.list + "runIt");
         grep = new Paragrep(reply);
         if (grep.find(SOURCE_NOT_FOUND) > 0) {
             failure(reply[0]);
         } else {
-            for (int i = 0; i < METHOD_SOURCE.length; i++) {
-                if (grep.find(METHOD_SOURCE[i]) == 0) {
-                    failure("Line is not found in method sources:\n\t"+
-                        METHOD_SOURCE[i]);
+            for (String s : METHOD_SOURCE) {
+                if (grep.find(s) == 0) {
+                    failure("Line is not found in method sources:\n\t" + s);
                 }
             }
         }
@@ -127,8 +123,7 @@ public class list002 extends JdbTest {
             failure(reply[0]);
         } else {
             if (grep.find(LINE_SOURCE) == 0) {
-                failure("Line " + LINE_NUMBER + " is not found:\n\t"+
-                    LINE_SOURCE);
+                failure("Line " + LINE_NUMBER + " is not found:\n\t" + LINE_SOURCE);
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
@@ -42,10 +42,10 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.list.list002.list002
- *        nsk.jdb.list.list002.list002a
+ * @build nsk.jdb.list.list002.list002a
  * @run driver jdk.test.lib.FileInstaller list002a.java src/nsk/jdb/list/list002/list002a.java
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.list.list002.list002
+ * @run main/othervm
+ *      nsk.jdb.list.list002.list002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java
@@ -53,7 +53,7 @@
  *      -jdb=${test.jdk}/bin/jdb
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
- *      "-jdb.option=-sourcepath src/"
+ *      -jdb.option="-sourcepath src/"
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,57 +59,64 @@
 
 package nsk.jdb.list.list002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class list002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new list002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.list.list002";
-    static final String TEST_CLASS = PACKAGE_NAME + ".list002";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".runIt";
-    static final int LINE_NUMBER = 38;
+    static final String PACKAGE_NAME    = "nsk.jdb.list.list002";
+    static final String TEST_CLASS      = PACKAGE_NAME + ".list002";
+    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
+    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".runIt";
+    static final int    LINE_NUMBER     = 38;
 
-    final static String[] METHOD_SOURCE = new String[]{
-            "public int runIt(String args[], PrintStream out) {",
-            "JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);",
-            "Log log = new Log(out, argumentHandler);",
-            "log.display(\"Debuggee PASSED\");",
-            "return list002.PASSED;"
-    };
+    final static String METHOD_SOURCE[] = new String[] {
+        "public int runIt(String args[], PrintStream out) {",
+        "JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);",
+        "Log log = new Log(out, argumentHandler);",
+        "log.display(\"Debuggee PASSED\");",
+        "return list002.PASSED;"
+                                                    };
 
     final static String LINE_SOURCE =
-            "System.exit(list002.JCK_STATUS_BASE + _list002a.runIt(args, System.out));";
+        "System.exit(list002.JCK_STATUS_BASE + _list002a.runIt(args, System.out));";
 
     final static String SOURCE_NOT_FOUND = "Source file not found";
 
     protected void runCases() {
-        jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.list + "runIt");
-        var grep = new Paragrep(reply);
+        jdb.setBreakpointInMethod(LAST_BREAK);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
+
+        reply = jdb.receiveReplyFor(JdbCommand.list + "runIt");
+        grep = new Paragrep(reply);
         if (grep.find(SOURCE_NOT_FOUND) > 0) {
             failure(reply[0]);
         } else {
-            for (String s : METHOD_SOURCE) {
-                if (grep.find(s) == 0) {
-                    failure("Line is not found in method sources:\n\t" + s);
+            for (int i = 0; i < METHOD_SOURCE.length; i++) {
+                if (grep.find(METHOD_SOURCE[i]) == 0) {
+                    failure("Line is not found in method sources:\n\t"+
+                        METHOD_SOURCE[i]);
                 }
             }
         }
@@ -120,7 +127,8 @@ public class list002 extends JdbTest {
             failure(reply[0]);
         } else {
             if (grep.find(LINE_SOURCE) == 0) {
-                failure("Line " + LINE_NUMBER + " is not found:\n\t" + LINE_SOURCE);
+                failure("Line " + LINE_NUMBER + " is not found:\n\t"+
+                    LINE_SOURCE);
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
@@ -52,7 +52,8 @@
  * @clean nsk.jdb.locals.locals002.locals002a
  * @compile -g:lines,source,vars locals002a.java
  *
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.locals.locals002.locals002
+ * @run main/othervm
+ *      nsk.jdb.locals.locals002.locals002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
@@ -66,21 +66,20 @@
 
 package nsk.jdb.locals.locals002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class locals002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
@@ -90,53 +89,72 @@ public class locals002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.locals.locals002";
     static final String TEST_CLASS = PACKAGE_NAME + ".locals002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
     static final String COMPOUND_PROMPT_IDENT = "main";
-    static final int BREAKPOINT_LINE1 = 84;
-    static final int BREAKPOINT_LINE2 = 100;
+    static final int    BREAKPOINT_LINE1 = 84;
+    static final int    BREAKPOINT_LINE2 = 100;
 
-    static final String[][] LOCALS = new String[][]{
-            {"boolVar",     "true",         "false"},
-            {"byteVar",     "27",           "12"},
-            {"charVar",     "V",            "A"},
-            {"shortVar",    "767",          "327"},
-            {"intVar",      "1474",         "3647"},
-            {"longVar",     "21345",        "65789"},
-            {"floatVar",    "3.141",        "4.852"},
-            {"doubleVar",   "2.578",        "3.8976"},
-            {"objVar",      "objVarString", "objArgString"},
-            {"arrVar",      "int[5]",       "int[3]"}
-    };
+    static final String LOCALS[][] = new String[][] {
+       { "boolVar"  , "true"         , "false"         },
+       { "byteVar"  , "27"           , "12"            },
+       { "charVar"  , "V"            , "A"             },
+       { "shortVar" , "767"          , "327"           },
+       { "intVar"   , "1474"         , "3647"          },
+       { "longVar"  , "21345"        , "65789"         },
+       { "floatVar" , "3.141"        , "4.852"         },
+       { "doubleVar", "2.578"        , "3.8976"        },
+       { "objVar"   , "objVarString" , "objArgString"  },
+       { "arrVar"   , "int[5]"       , "int[3]"        }
+
+                                                    };
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE1);
         jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE2);
 
         jdb.receiveReplyFor(JdbCommand.cont);
-        String[] reply = jdb.receiveReplyFor(JdbCommand.locals);
-        var grep = new Paragrep(reply);
-        for (String[] local : LOCALS) {
-            var v = new Vector<String>();
-            v.add(local[0]);
-            v.add(local[2]);
+        reply = jdb.receiveReplyFor(JdbCommand.locals);
+        grep = new Paragrep(reply);
+        for (int i = 0; i < LOCALS.length; i++) {
+            v = new Vector();
+            v.add(LOCALS[i][0]);
+            v.add(LOCALS[i][2]);
             if (grep.find(v) == 0) {
-                failure("Cannot find " + LOCALS[0][0] + " with expected value: " + local[2]);
+                failure("Cannot find " + LOCALS[0][0] +
+                    " with expected value: " + LOCALS[i][2]);
             }
         }
 
         jdb.receiveReplyFor(JdbCommand.cont);
         reply = jdb.receiveReplyFor(JdbCommand.locals);
         grep = new Paragrep(reply);
-        for (String[] local : LOCALS) {
-            var v = new Vector<String>();
-            v.add(local[0]);
-            v.add(local[1]);
+        for (int i = 0; i < LOCALS.length; i++) {
+            v = new Vector();
+            v.add(LOCALS[i][0]);
+            v.add(LOCALS[i][1]);
             if (grep.find(v) == 0) {
-                failure("Cannot find " + LOCALS[0][0] + " with expected value: " + local[1]);
+                failure("Cannot find " + LOCALS[0][0] +
+                    " with expected value: " + LOCALS[i][1]);
             }
         }
 
         jdb.contToExit(1);
+    }
+
+    private boolean checkStop () {
+        Paragrep grep;
+        String[] reply;
+        String found;
+        Vector v;
+        boolean result = true;
+
+        return result;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
@@ -111,18 +111,14 @@ public class locals002 extends JdbTest {
     };
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        Vector<String> v;
-
         jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE1);
         jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE2);
 
         jdb.receiveReplyFor(JdbCommand.cont);
-        reply = jdb.receiveReplyFor(JdbCommand.locals);
-        grep = new Paragrep(reply);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.locals);
+        var grep = new Paragrep(reply);
         for (String[] local : LOCALS) {
-            v = new Vector<>();
+            var v = new Vector<String>();
             v.add(local[0]);
             v.add(local[2]);
             if (grep.find(v) == 0) {
@@ -134,7 +130,7 @@ public class locals002 extends JdbTest {
         reply = jdb.receiveReplyFor(JdbCommand.locals);
         grep = new Paragrep(reply);
         for (String[] local : LOCALS) {
-            v = new Vector<>();
+            var v = new Vector<String>();
             v.add(local[0]);
             v.add(local[1]);
             if (grep.find(v) == 0) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
@@ -97,17 +97,16 @@ public class locals002 extends JdbTest {
     static final int BREAKPOINT_LINE2 = 100;
 
     static final String[][] LOCALS = new String[][]{
-            {"boolVar", "true", "false"},
-            {"byteVar", "27", "12"},
-            {"charVar", "V", "A"},
-            {"shortVar", "767", "327"},
-            {"intVar", "1474", "3647"},
-            {"longVar", "21345", "65789"},
-            {"floatVar", "3.141", "4.852"},
-            {"doubleVar", "2.578", "3.8976"},
-            {"objVar", "objVarString", "objArgString"},
-            {"arrVar", "int[5]", "int[3]"}
-
+            {"boolVar",     "true",         "false"},
+            {"byteVar",     "27",           "12"},
+            {"charVar",     "V",            "A"},
+            {"shortVar",    "767",          "327"},
+            {"intVar",      "1474",         "3647"},
+            {"longVar",     "21345",        "65789"},
+            {"floatVar",    "3.141",        "4.852"},
+            {"doubleVar",   "2.578",        "3.8976"},
+            {"objVar",      "objVarString", "objArgString"},
+            {"arrVar",      "int[5]",       "int[3]"}
     };
 
     protected void runCases() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
@@ -66,20 +66,21 @@
 
 package nsk.jdb.locals.locals002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class locals002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
@@ -89,32 +90,30 @@ public class locals002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.locals.locals002";
     static final String TEST_CLASS = PACKAGE_NAME + ".locals002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
     static final String COMPOUND_PROMPT_IDENT = "main";
-    static final int    BREAKPOINT_LINE1 = 84;
-    static final int    BREAKPOINT_LINE2 = 100;
+    static final int BREAKPOINT_LINE1 = 84;
+    static final int BREAKPOINT_LINE2 = 100;
 
-    static final String LOCALS[][] = new String[][] {
-       { "boolVar"  , "true"         , "false"         },
-       { "byteVar"  , "27"           , "12"            },
-       { "charVar"  , "V"            , "A"             },
-       { "shortVar" , "767"          , "327"           },
-       { "intVar"   , "1474"         , "3647"          },
-       { "longVar"  , "21345"        , "65789"         },
-       { "floatVar" , "3.141"        , "4.852"         },
-       { "doubleVar", "2.578"        , "3.8976"        },
-       { "objVar"   , "objVarString" , "objArgString"  },
-       { "arrVar"   , "int[5]"       , "int[3]"        }
+    static final String[][] LOCALS = new String[][]{
+            {"boolVar", "true", "false"},
+            {"byteVar", "27", "12"},
+            {"charVar", "V", "A"},
+            {"shortVar", "767", "327"},
+            {"intVar", "1474", "3647"},
+            {"longVar", "21345", "65789"},
+            {"floatVar", "3.141", "4.852"},
+            {"doubleVar", "2.578", "3.8976"},
+            {"objVar", "objVarString", "objArgString"},
+            {"arrVar", "int[5]", "int[3]"}
 
-                                                    };
+    };
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE1);
         jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE2);
@@ -122,39 +121,27 @@ public class locals002 extends JdbTest {
         jdb.receiveReplyFor(JdbCommand.cont);
         reply = jdb.receiveReplyFor(JdbCommand.locals);
         grep = new Paragrep(reply);
-        for (int i = 0; i < LOCALS.length; i++) {
-            v = new Vector();
-            v.add(LOCALS[i][0]);
-            v.add(LOCALS[i][2]);
+        for (String[] local : LOCALS) {
+            v = new Vector<>();
+            v.add(local[0]);
+            v.add(local[2]);
             if (grep.find(v) == 0) {
-                failure("Cannot find " + LOCALS[0][0] +
-                    " with expected value: " + LOCALS[i][2]);
+                failure("Cannot find " + LOCALS[0][0] + " with expected value: " + local[2]);
             }
         }
 
         jdb.receiveReplyFor(JdbCommand.cont);
         reply = jdb.receiveReplyFor(JdbCommand.locals);
         grep = new Paragrep(reply);
-        for (int i = 0; i < LOCALS.length; i++) {
-            v = new Vector();
-            v.add(LOCALS[i][0]);
-            v.add(LOCALS[i][1]);
+        for (String[] local : LOCALS) {
+            v = new Vector<>();
+            v.add(local[0]);
+            v.add(local[1]);
             if (grep.find(v) == 0) {
-                failure("Cannot find " + LOCALS[0][0] +
-                    " with expected value: " + LOCALS[i][1]);
+                failure("Cannot find " + LOCALS[0][0] + " with expected value: " + local[1]);
             }
         }
 
         jdb.contToExit(1);
-    }
-
-    private boolean checkStop () {
-        Paragrep grep;
-        String[] reply;
-        String found;
-        Vector v;
-        boolean result = true;
-
-        return result;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002.java
@@ -49,9 +49,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.methods.methods002.methods002
- *        nsk.jdb.methods.methods002.methods002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.methods.methods002.methods002
+ * @build nsk.jdb.methods.methods002.methods002a
+ * @run main/othervm
+ *      nsk.jdb.methods.methods002.methods002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002.java
@@ -64,20 +64,22 @@
 
 package nsk.jdb.methods.methods002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.StringTokenizer;
+import java.util.Vector;
 
 public class methods002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new methods002().runTest(argv, out);
@@ -86,110 +88,106 @@ public class methods002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.methods.methods002";
     static final String TEST_CLASS = PACKAGE_NAME + ".methods002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // Case for class with method modifiers
         String testedClass1 = TEST_CLASS + "a";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass1);
         for (int i = 1; i <= 33; i++) {
-            checkMethod( reply, "m" + intToString(i), 1, testedClass1, testedClass1 );
+            checkMethod(reply, "m" + intToString(i), 1, testedClass1, testedClass1);
         }
         for (int i = 1; i <= 3; i++) {
-            checkMethod( reply, "f" + intToString(i), 1, testedClass1, testedClass1 );
+            checkMethod(reply, "f" + intToString(i), 1, testedClass1, testedClass1);
         }
 
         // Case for class with many constructors
         String testedClass2 = TEST_CLASS + "b";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass2);
         String[] reply1 = toStringArray(reply);  // on Windows reply is single string with embedded \r\n symbols
-        checkMethod( reply1, "<init>", 4, testedClass2, testedClass2 );
+        checkMethod(reply1, "<init>", 4, testedClass2, testedClass2);
 
         // Case for class with overloaded methods
         String testedClass3 = TEST_CLASS + "c";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass3);
         reply1 = toStringArray(reply);   // // on Windows reply is single string with embedded \r\n symbols
-        checkMethod( reply1, "m01", 3, testedClass3, testedClass3 );
+        checkMethod(reply1, "m01", 3, testedClass3, testedClass3);
 
         // Case for abstract class
         String testedClass4 = TEST_CLASS + "d";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass4);
-        checkMethod( reply, "m01", 1, testedClass4, testedClass4 );
+        checkMethod(reply, "m01", 1, testedClass4, testedClass4);
 
         // Case for interface
         String testedClass5 = TEST_CLASS + "i";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass5);
-        checkMethod( reply, "i01", 1, testedClass5, testedClass5 );
+        checkMethod(reply, "i01", 1, testedClass5, testedClass5);
 
         // Case for class with implemented method
         String testedClass6 = TEST_CLASS + "e";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass6);
-        checkMethod( reply, "m01", 1, testedClass4, testedClass6 );
-        checkMethod( reply, "i01", 1, testedClass5, testedClass6 );
-        checkMethod( reply, "m01", 1, testedClass6, testedClass6 );
+        checkMethod(reply, "m01", 1, testedClass4, testedClass6);
+        checkMethod(reply, "i01", 1, testedClass5, testedClass6);
+        checkMethod(reply, "m01", 1, testedClass6, testedClass6);
 
         // Case for class with inherited methods
         String testedClass7 = TEST_CLASS + "f";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass7);
         for (int i = 1; i <= 33; i++) {
-            checkMethod( reply, "m" + intToString(i), 1, testedClass1, testedClass7 );
+            checkMethod(reply, "m" + intToString(i), 1, testedClass1, testedClass7);
         }
         for (int i = 1; i <= 3; i++) {
-            checkMethod( reply, "f" + intToString(i), 1, testedClass1, testedClass7 );
+            checkMethod(reply, "f" + intToString(i), 1, testedClass1, testedClass7);
         }
 
         // Case for class with inherited and overrided methods
         String testedClass8 = TEST_CLASS + "g";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass8);
         for (int i = 1; i <= 33; i++) {
-            checkMethod( reply, "m" + intToString(i), 1, testedClass8, testedClass8 );
+            checkMethod(reply, "m" + intToString(i), 1, testedClass8, testedClass8);
         }
         for (int i = 1; i <= 33; i++) {
-            checkMethod( reply, "m" + intToString(i), 1, testedClass1, testedClass8 );
+            checkMethod(reply, "m" + intToString(i), 1, testedClass1, testedClass8);
         }
         for (int i = 1; i <= 3; i++) {
-            checkMethod( reply, "f" + intToString(i), 1, testedClass1, testedClass8 );
+            checkMethod(reply, "f" + intToString(i), 1, testedClass1, testedClass8);
         }
 
         jdb.contToExit(1);
     }
 
-    private void checkMethod (
-        String[] reply,       /* reply on 'methods' command */
-        String methodName,    /* method name */
-        int expOccur,         /* expected number of occurences of the method */
-        String ownerClass,    /* name of class defining method */
-        String testedClass    /* name of tested class */
-                             ) {
+    private void checkMethod(
+            String[] reply,       /* reply on 'methods' command */
+            String methodName,    /* method name */
+            int expOccur,         /* expected number of occurences of the method */
+            String ownerClass,    /* name of class defining method */
+            String testedClass    /* name of tested class */
+    ) {
 
         Paragrep grep = new Paragrep(reply);
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         v.add(ownerClass);
         v.add(methodName);
         int j = grep.find(v);
         if (j != expOccur) {
             failure("Wrong number of occurences of method " + methodName +
-                "\n\t of class " + ownerClass +
-                "\n\t in class " + testedClass +
-                "\n\t expected number: " + expOccur + " got: " + j);
+                    "\n\t of class " + ownerClass +
+                    "\n\t in class " + testedClass +
+                    "\n\t expected number: " + expOccur + " got: " + j);
         }
     }
 
-    private String[] toStringArray (String[] arr) {
-        Vector v = new Vector();
-        for (int i = 0; i < arr.length; i++) {
-            StringTokenizer st = new StringTokenizer(arr[i], "\r\n");
+    private String[] toStringArray(String[] arr) {
+        Vector<String> v = new Vector<>();
+        for (String s : arr) {
+            StringTokenizer st = new StringTokenizer(s, "\r\n");
             while (st.hasMoreTokens()) {
                 v.add(st.nextToken());
             }
@@ -197,15 +195,16 @@ public class methods002 extends JdbTest {
         Object[] objects = v.toArray();
         String[] results = new String[objects.length];
         for (int i = 0; i < objects.length; i++) {
-            results[i] = (String)objects[i];
+            results[i] = (String) objects[i];
         }
         return results;
     }
 
-    private String intToString (int i) {
+    private String intToString(int i) {
         String s = String.valueOf(i);
-        if (s.length()==1)
+        if (s.length() == 1) {
             s = "0" + s;
+        }
         return s;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002.java
@@ -92,14 +92,12 @@ public class methods002 extends JdbTest {
     static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
-        String[] reply;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
         // Case for class with method modifiers
         String testedClass1 = TEST_CLASS + "a";
-        reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass1);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass1);
         for (int i = 1; i <= 33; i++) {
             checkMethod(reply, "m" + intToString(i), 1, testedClass1, testedClass1);
         }
@@ -169,9 +167,8 @@ public class methods002 extends JdbTest {
             String ownerClass,    /* name of class defining method */
             String testedClass    /* name of tested class */
     ) {
-
-        Paragrep grep = new Paragrep(reply);
-        Vector<String> v = new Vector<>();
+        var grep = new Paragrep(reply);
+        var v = new Vector<String>();
 
         v.add(ownerClass);
         v.add(methodName);
@@ -185,7 +182,7 @@ public class methods002 extends JdbTest {
     }
 
     private String[] toStringArray(String[] arr) {
-        Vector<String> v = new Vector<>();
+        var v = new Vector<String>();
         for (String s : arr) {
             StringTokenizer st = new StringTokenizer(s, "\r\n");
             while (st.hasMoreTokens()) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002.java
@@ -64,22 +64,20 @@
 
 package nsk.jdb.methods.methods002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.StringTokenizer;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class methods002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new methods002().runTest(argv, out);
@@ -88,103 +86,110 @@ public class methods002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.methods.methods002";
     static final String TEST_CLASS = PACKAGE_NAME + ".methods002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         // Case for class with method modifiers
         String testedClass1 = TEST_CLASS + "a";
-        String[] reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass1);
+        reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass1);
         for (int i = 1; i <= 33; i++) {
-            checkMethod(reply, "m" + intToString(i), 1, testedClass1, testedClass1);
+            checkMethod( reply, "m" + intToString(i), 1, testedClass1, testedClass1 );
         }
         for (int i = 1; i <= 3; i++) {
-            checkMethod(reply, "f" + intToString(i), 1, testedClass1, testedClass1);
+            checkMethod( reply, "f" + intToString(i), 1, testedClass1, testedClass1 );
         }
 
         // Case for class with many constructors
         String testedClass2 = TEST_CLASS + "b";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass2);
         String[] reply1 = toStringArray(reply);  // on Windows reply is single string with embedded \r\n symbols
-        checkMethod(reply1, "<init>", 4, testedClass2, testedClass2);
+        checkMethod( reply1, "<init>", 4, testedClass2, testedClass2 );
 
         // Case for class with overloaded methods
         String testedClass3 = TEST_CLASS + "c";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass3);
         reply1 = toStringArray(reply);   // // on Windows reply is single string with embedded \r\n symbols
-        checkMethod(reply1, "m01", 3, testedClass3, testedClass3);
+        checkMethod( reply1, "m01", 3, testedClass3, testedClass3 );
 
         // Case for abstract class
         String testedClass4 = TEST_CLASS + "d";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass4);
-        checkMethod(reply, "m01", 1, testedClass4, testedClass4);
+        checkMethod( reply, "m01", 1, testedClass4, testedClass4 );
 
         // Case for interface
         String testedClass5 = TEST_CLASS + "i";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass5);
-        checkMethod(reply, "i01", 1, testedClass5, testedClass5);
+        checkMethod( reply, "i01", 1, testedClass5, testedClass5 );
 
         // Case for class with implemented method
         String testedClass6 = TEST_CLASS + "e";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass6);
-        checkMethod(reply, "m01", 1, testedClass4, testedClass6);
-        checkMethod(reply, "i01", 1, testedClass5, testedClass6);
-        checkMethod(reply, "m01", 1, testedClass6, testedClass6);
+        checkMethod( reply, "m01", 1, testedClass4, testedClass6 );
+        checkMethod( reply, "i01", 1, testedClass5, testedClass6 );
+        checkMethod( reply, "m01", 1, testedClass6, testedClass6 );
 
         // Case for class with inherited methods
         String testedClass7 = TEST_CLASS + "f";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass7);
         for (int i = 1; i <= 33; i++) {
-            checkMethod(reply, "m" + intToString(i), 1, testedClass1, testedClass7);
+            checkMethod( reply, "m" + intToString(i), 1, testedClass1, testedClass7 );
         }
         for (int i = 1; i <= 3; i++) {
-            checkMethod(reply, "f" + intToString(i), 1, testedClass1, testedClass7);
+            checkMethod( reply, "f" + intToString(i), 1, testedClass1, testedClass7 );
         }
 
         // Case for class with inherited and overrided methods
         String testedClass8 = TEST_CLASS + "g";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass8);
         for (int i = 1; i <= 33; i++) {
-            checkMethod(reply, "m" + intToString(i), 1, testedClass8, testedClass8);
+            checkMethod( reply, "m" + intToString(i), 1, testedClass8, testedClass8 );
         }
         for (int i = 1; i <= 33; i++) {
-            checkMethod(reply, "m" + intToString(i), 1, testedClass1, testedClass8);
+            checkMethod( reply, "m" + intToString(i), 1, testedClass1, testedClass8 );
         }
         for (int i = 1; i <= 3; i++) {
-            checkMethod(reply, "f" + intToString(i), 1, testedClass1, testedClass8);
+            checkMethod( reply, "f" + intToString(i), 1, testedClass1, testedClass8 );
         }
 
         jdb.contToExit(1);
     }
 
-    private void checkMethod(
-            String[] reply,       /* reply on 'methods' command */
-            String methodName,    /* method name */
-            int expOccur,         /* expected number of occurences of the method */
-            String ownerClass,    /* name of class defining method */
-            String testedClass    /* name of tested class */
-    ) {
-        var grep = new Paragrep(reply);
-        var v = new Vector<String>();
+    private void checkMethod (
+        String[] reply,       /* reply on 'methods' command */
+        String methodName,    /* method name */
+        int expOccur,         /* expected number of occurences of the method */
+        String ownerClass,    /* name of class defining method */
+        String testedClass    /* name of tested class */
+                             ) {
+
+        Paragrep grep = new Paragrep(reply);
+        Vector v = new Vector();
 
         v.add(ownerClass);
         v.add(methodName);
         int j = grep.find(v);
         if (j != expOccur) {
             failure("Wrong number of occurences of method " + methodName +
-                    "\n\t of class " + ownerClass +
-                    "\n\t in class " + testedClass +
-                    "\n\t expected number: " + expOccur + " got: " + j);
+                "\n\t of class " + ownerClass +
+                "\n\t in class " + testedClass +
+                "\n\t expected number: " + expOccur + " got: " + j);
         }
     }
 
-    private String[] toStringArray(String[] arr) {
-        var v = new Vector<String>();
-        for (String s : arr) {
-            StringTokenizer st = new StringTokenizer(s, "\r\n");
+    private String[] toStringArray (String[] arr) {
+        Vector v = new Vector();
+        for (int i = 0; i < arr.length; i++) {
+            StringTokenizer st = new StringTokenizer(arr[i], "\r\n");
             while (st.hasMoreTokens()) {
                 v.add(st.nextToken());
             }
@@ -192,16 +197,15 @@ public class methods002 extends JdbTest {
         Object[] objects = v.toArray();
         String[] results = new String[objects.length];
         for (int i = 0; i < objects.length; i++) {
-            results[i] = (String) objects[i];
+            results[i] = (String)objects[i];
         }
         return results;
     }
 
-    private String intToString(int i) {
+    private String intToString (int i) {
         String s = String.valueOf(i);
-        if (s.length() == 1) {
+        if (s.length()==1)
             s = "0" + s;
-        }
         return s;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
@@ -45,9 +45,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.monitor.monitor001.monitor001
- *        nsk.jdb.monitor.monitor001.monitor001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.monitor.monitor001.monitor001
+ * @build nsk.jdb.monitor.monitor001.monitor001a
+ * @run main/othervm
+ *      nsk.jdb.monitor.monitor001.monitor001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
@@ -95,8 +95,6 @@ public class monitor001 extends JdbTest {
     };
 
     protected void runCases() {
-        String[] reply;
-
         jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
 
         for (String checkedCommand : CHECKED_COMMANDS) {
@@ -106,7 +104,7 @@ public class monitor001 extends JdbTest {
         int repliesCount = CHECKED_COMMANDS.length + 1;
         jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
 
-        reply = jdb.receiveReplyFor(JdbCommand.monitor);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.monitor);
         if (!checkMonitors(reply)) {
             success = false;
         }
@@ -120,13 +118,12 @@ public class monitor001 extends JdbTest {
     }
 
     private boolean checkMonitors(String[] reply) {
-        Paragrep grep;
         boolean result = true;
-        int count;
 
-        grep = new Paragrep(reply);
+        var grep = new Paragrep(reply);
         for (String checkedCommand : CHECKED_COMMANDS) {
-            if ((count = grep.find(checkedCommand)) != 1) {
+            int count =  grep.find(checkedCommand);
+            if (count != 1) {
                 log.complain("Wrong number of monitor command: " + checkedCommand);
                 log.complain("    Expected: 1; found: " + count);
                 result = false;
@@ -137,14 +134,13 @@ public class monitor001 extends JdbTest {
     }
 
     private boolean checkCommands(String[] reply) {
-        Paragrep grep;
-        Vector<String> v = new Vector<>();
         boolean result = true;
+
+        var grep = new Paragrep(reply);
         int count;
 
-        grep = new Paragrep(reply);
-
         // check 'threads'
+        var v = new Vector<String>();
         v.add("java.lang.Thread");
         v.add("main");
         if ((count = grep.find(v)) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
@@ -60,20 +60,21 @@
 
 package nsk.jdb.monitor.monitor001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class monitor001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new monitor001().runTest(argv, out);
@@ -82,32 +83,28 @@ public class monitor001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.monitor.monitor001";
     static final String TEST_CLASS = PACKAGE_NAME + ".monitor001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final int    LINE_NUMBER        = 47;
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final int LINE_NUMBER = 47;
 
     static final String[] CHECKED_COMMANDS = {
-        JdbCommand.threads,
-        JdbCommand.methods + DEBUGGEE_CLASS,
-        JdbCommand.fields  + DEBUGGEE_CLASS,
-        JdbCommand.eval + "(new java.lang.String(\"Hello, World\")).length()"
-                                             };
+            JdbCommand.threads,
+            JdbCommand.methods + DEBUGGEE_CLASS,
+            JdbCommand.fields + DEBUGGEE_CLASS,
+            JdbCommand.eval + "(new java.lang.String(\"Hello, World\")).length()"
+    };
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
-        reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
+        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
 
-        for (int i = 0; i < CHECKED_COMMANDS.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[i]);
+        for (String checkedCommand : CHECKED_COMMANDS) {
+            jdb.receiveReplyFor(JdbCommand.monitor + checkedCommand);
         }
 
         int repliesCount = CHECKED_COMMANDS.length + 1;
-        reply = jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
+        jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
 
         reply = jdb.receiveReplyFor(JdbCommand.monitor);
         if (!checkMonitors(reply)) {
@@ -124,15 +121,13 @@ public class monitor001 extends JdbTest {
 
     private boolean checkMonitors(String[] reply) {
         Paragrep grep;
-        String found;
-        Vector v;
         boolean result = true;
         int count;
 
         grep = new Paragrep(reply);
-        for (int i = 0; i < CHECKED_COMMANDS.length; i++) {
-            if ((count = grep.find(CHECKED_COMMANDS[i])) != 1) {
-                log.complain("Wrong number of monitor command: " + CHECKED_COMMANDS[i]);
+        for (String checkedCommand : CHECKED_COMMANDS) {
+            if ((count = grep.find(checkedCommand)) != 1) {
+                log.complain("Wrong number of monitor command: " + checkedCommand);
                 log.complain("    Expected: 1; found: " + count);
                 result = false;
             }
@@ -143,8 +138,7 @@ public class monitor001 extends JdbTest {
 
     private boolean checkCommands(String[] reply) {
         Paragrep grep;
-        String found;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
         boolean result = true;
         int count;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
@@ -60,21 +60,20 @@
 
 package nsk.jdb.monitor.monitor001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class monitor001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new monitor001().runTest(argv, out);
@@ -83,28 +82,34 @@ public class monitor001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.monitor.monitor001";
     static final String TEST_CLASS = PACKAGE_NAME + ".monitor001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
-    static final int LINE_NUMBER = 47;
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final int    LINE_NUMBER        = 47;
 
     static final String[] CHECKED_COMMANDS = {
-            JdbCommand.threads,
-            JdbCommand.methods + DEBUGGEE_CLASS,
-            JdbCommand.fields + DEBUGGEE_CLASS,
-            JdbCommand.eval + "(new java.lang.String(\"Hello, World\")).length()"
-    };
+        JdbCommand.threads,
+        JdbCommand.methods + DEBUGGEE_CLASS,
+        JdbCommand.fields  + DEBUGGEE_CLASS,
+        JdbCommand.eval + "(new java.lang.String(\"Hello, World\")).length()"
+                                             };
 
     protected void runCases() {
-        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
 
-        for (String checkedCommand : CHECKED_COMMANDS) {
-            jdb.receiveReplyFor(JdbCommand.monitor + checkedCommand);
+        reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
+
+        for (int i = 0; i < CHECKED_COMMANDS.length; i++) {
+            reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[i]);
         }
 
         int repliesCount = CHECKED_COMMANDS.length + 1;
-        jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
+        reply = jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.monitor);
+        reply = jdb.receiveReplyFor(JdbCommand.monitor);
         if (!checkMonitors(reply)) {
             success = false;
         }
@@ -118,13 +123,16 @@ public class monitor001 extends JdbTest {
     }
 
     private boolean checkMonitors(String[] reply) {
+        Paragrep grep;
+        String found;
+        Vector v;
         boolean result = true;
+        int count;
 
-        var grep = new Paragrep(reply);
-        for (String checkedCommand : CHECKED_COMMANDS) {
-            int count =  grep.find(checkedCommand);
-            if (count != 1) {
-                log.complain("Wrong number of monitor command: " + checkedCommand);
+        grep = new Paragrep(reply);
+        for (int i = 0; i < CHECKED_COMMANDS.length; i++) {
+            if ((count = grep.find(CHECKED_COMMANDS[i])) != 1) {
+                log.complain("Wrong number of monitor command: " + CHECKED_COMMANDS[i]);
                 log.complain("    Expected: 1; found: " + count);
                 result = false;
             }
@@ -134,13 +142,15 @@ public class monitor001 extends JdbTest {
     }
 
     private boolean checkCommands(String[] reply) {
+        Paragrep grep;
+        String found;
+        Vector v = new Vector();
         boolean result = true;
-
-        var grep = new Paragrep(reply);
         int count;
 
+        grep = new Paragrep(reply);
+
         // check 'threads'
-        var v = new Vector<String>();
         v.add("java.lang.Thread");
         v.add("main");
         if ((count = grep.find(v)) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002.java
@@ -41,9 +41,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.monitor.monitor002.monitor002
- *        nsk.jdb.monitor.monitor002.monitor002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.monitor.monitor002.monitor002
+ * @build nsk.jdb.monitor.monitor002.monitor002a
+ * @run main/othervm
+ *      nsk.jdb.monitor.monitor002.monitor002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002.java
@@ -87,8 +87,6 @@ public class monitor002 extends JdbTest {
     };
 
     protected void runCases() {
-        String[] reply;
-
         jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
 
         for (String checkedCommand : CHECKED_COMMANDS) {
@@ -98,7 +96,7 @@ public class monitor002 extends JdbTest {
         int repliesCount = CHECKED_COMMANDS.length + 1;
         jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
 
-        reply = jdb.receiveReplyFor(JdbCommand.monitor);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.monitor);
         if (reply.length != 1) {
             log.complain("Expected no active monitors after exectuting monitored command: " + CHECKED_COMMANDS[0]);
             success = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002.java
@@ -56,20 +56,20 @@
 
 package nsk.jdb.monitor.monitor002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class monitor002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new monitor002().runTest(argv, out);
@@ -78,25 +78,31 @@ public class monitor002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.monitor.monitor002";
     static final String TEST_CLASS = PACKAGE_NAME + ".monitor002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
-    static final int LINE_NUMBER = 47;
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final int    LINE_NUMBER        = 47;
 
     static final String[] CHECKED_COMMANDS = {
-            JdbCommand.unmonitor + "1"
-    };
+        JdbCommand.unmonitor + "1"
+                                             };
 
     protected void runCases() {
-        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
 
-        for (String checkedCommand : CHECKED_COMMANDS) {
-            jdb.receiveReplyFor(JdbCommand.monitor + checkedCommand);
+        reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
+
+        for (int i = 0; i < CHECKED_COMMANDS.length; i++) {
+            reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[i]);
         }
 
         int repliesCount = CHECKED_COMMANDS.length + 1;
-        jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
+        reply = jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.monitor);
+        reply = jdb.receiveReplyFor(JdbCommand.monitor);
         if (reply.length != 1) {
             log.complain("Expected no active monitors after exectuting monitored command: " + CHECKED_COMMANDS[0]);
             success = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002.java
@@ -56,20 +56,20 @@
 
 package nsk.jdb.monitor.monitor002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class monitor002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new monitor002().runTest(argv, out);
@@ -78,29 +78,25 @@ public class monitor002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.monitor.monitor002";
     static final String TEST_CLASS = PACKAGE_NAME + ".monitor002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final int    LINE_NUMBER        = 47;
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final int LINE_NUMBER = 47;
 
     static final String[] CHECKED_COMMANDS = {
-        JdbCommand.unmonitor + "1"
-                                             };
+            JdbCommand.unmonitor + "1"
+    };
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
-        reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
+        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
 
-        for (int i = 0; i < CHECKED_COMMANDS.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[i]);
+        for (String checkedCommand : CHECKED_COMMANDS) {
+            jdb.receiveReplyFor(JdbCommand.monitor + checkedCommand);
         }
 
         int repliesCount = CHECKED_COMMANDS.length + 1;
-        reply = jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
+        jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
 
         reply = jdb.receiveReplyFor(JdbCommand.monitor);
         if (reply.length != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001.java
@@ -45,9 +45,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.next.next001.next001
- *        nsk.jdb.next.next001.next001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.next.next001.next001
+ * @build nsk.jdb.next.next001.next001a
+ * @run main/othervm
+ *      nsk.jdb.next.next001.next001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001.java
@@ -60,54 +60,47 @@
 
 package nsk.jdb.next.next001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class next001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new next001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.next.next001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".next001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.next.next001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".next001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String[] checkedMethods = {"func1", "func2", "func3"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-        String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
 
-        int breakCount = 0;
         int nextCount = 0;
         for (int i = 0; i < next001a.numThreads; i++) {
             reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (jdb.isAtBreakpoint(reply, LAST_BREAK)) {
-                breakCount++;
-                reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
+                jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
 
-                reply = jdb.receiveReplyFor(JdbCommand.next);
+                jdb.receiveReplyFor(JdbCommand.next);
                 if (!checkNext()) {
                     success = false;
                 } else {
@@ -126,9 +119,8 @@ public class next001 extends JdbTest {
     }
 
 
-    private boolean checkNext () {
+    private boolean checkNext() {
         Paragrep grep;
-        String found;
         int count;
         boolean result = true;
         String[] reply;
@@ -139,13 +131,13 @@ public class next001 extends JdbTest {
         count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[2]);
         if (count > 0) {
             log.complain("Debuggee is suspended in wrong method after 'next' command: " + DEBUGGEE_THREAD + "." + checkedMethods[2]);
-            result= false;
+            result = false;
         }
 
         count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[1]);
         if (count != 1) {
             log.complain("Checked method does not exist in thread stack trace: " + DEBUGGEE_THREAD + "." + checkedMethods[1]);
-            result= false;
+            result = false;
         }
 
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001.java
@@ -60,45 +60,54 @@
 
 package nsk.jdb.next.next001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class next001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new next001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.next.next001";
-    static final String TEST_CLASS = PACKAGE_NAME + ".next001";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
-    static final String MYTHREAD = "MyThread";
+    static final String PACKAGE_NAME    = "nsk.jdb.next.next001";
+    static final String TEST_CLASS      = PACKAGE_NAME + ".next001";
+    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
+    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final String MYTHREAD        = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String[] checkedMethods = {"func1", "func2", "func3"};
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+        String[] threads;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
 
+        int breakCount = 0;
         int nextCount = 0;
         for (int i = 0; i < next001a.numThreads; i++) {
-            String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
+            reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (jdb.isAtBreakpoint(reply, LAST_BREAK)) {
-                jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
+                breakCount++;
+                reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
 
-                jdb.receiveReplyFor(JdbCommand.next);
+                reply = jdb.receiveReplyFor(JdbCommand.next);
                 if (!checkNext()) {
                     success = false;
                 } else {
@@ -117,21 +126,26 @@ public class next001 extends JdbTest {
     }
 
 
-    private boolean checkNext() {
+    private boolean checkNext () {
+        Paragrep grep;
+        String found;
+        int count;
         boolean result = true;
+        String[] reply;
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.where);
-        var grep = new Paragrep(reply);
-        int count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[2]);
+        reply = jdb.receiveReplyFor(JdbCommand.where);
+
+        grep = new Paragrep(reply);
+        count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[2]);
         if (count > 0) {
             log.complain("Debuggee is suspended in wrong method after 'next' command: " + DEBUGGEE_THREAD + "." + checkedMethods[2]);
-            result = false;
+            result= false;
         }
 
         count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[1]);
         if (count != 1) {
             log.complain("Checked method does not exist in thread stack trace: " + DEBUGGEE_THREAD + "." + checkedMethods[1]);
-            result = false;
+            result= false;
         }
 
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001.java
@@ -90,13 +90,11 @@ public class next001 extends JdbTest {
     static final String[] checkedMethods = {"func1", "func2", "func3"};
 
     protected void runCases() {
-        String[] reply;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
 
         int nextCount = 0;
         for (int i = 0; i < next001a.numThreads; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (jdb.isAtBreakpoint(reply, LAST_BREAK)) {
                 jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
 
@@ -120,15 +118,11 @@ public class next001 extends JdbTest {
 
 
     private boolean checkNext() {
-        Paragrep grep;
-        int count;
         boolean result = true;
-        String[] reply;
 
-        reply = jdb.receiveReplyFor(JdbCommand.where);
-
-        grep = new Paragrep(reply);
-        count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[2]);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.where);
+        var grep = new Paragrep(reply);
+        int count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[2]);
         if (count > 0) {
             log.complain("Debuggee is suspended in wrong method after 'next' command: " + DEBUGGEE_THREAD + "." + checkedMethods[2]);
             result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001.java
@@ -45,9 +45,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.options.connect.connect001.connect001
- *        nsk.jdb.options.connect.connect001.connect001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.options.connect.connect001.connect001
+ * @build nsk.jdb.options.connect.connect001.connect001a
+ * @run main/othervm
+ *      nsk.jdb.options.connect.connect001.connect001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001.java
@@ -62,20 +62,21 @@
 
 package nsk.jdb.options.connect.connect001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class connect001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect001().runTest(argv, out);
@@ -84,8 +85,8 @@ public class connect001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect001";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.CommandLineLaunch";
@@ -99,16 +100,14 @@ public class connect001 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
             reply = jdb.getTotalReply();
             grep = new Paragrep(reply);
-            v = new Vector();
+            v = new Vector<>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001.java
@@ -98,16 +98,12 @@ public class connect001 extends JdbTest {
     }
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        Vector<String> v;
-
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
-            reply = jdb.getTotalReply();
-            grep = new Paragrep(reply);
-            v = new Vector<>();
+            String[] reply = jdb.getTotalReply();
+            var grep = new Paragrep(reply);
+            var v = new Vector<String>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001.java
@@ -62,21 +62,20 @@
 
 package nsk.jdb.options.connect.connect001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class connect001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect001().runTest(argv, out);
@@ -85,8 +84,8 @@ public class connect001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect001";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.CommandLineLaunch";
@@ -98,12 +97,18 @@ public class connect001 extends JdbTest {
     }
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
-            String[] reply = jdb.getTotalReply();
-            var grep = new Paragrep(reply);
-            var v = new Vector<String>();
+            reply = jdb.getTotalReply();
+            grep = new Paragrep(reply);
+            v = new Vector();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002.java
@@ -45,9 +45,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.options.connect.connect002.connect002
- *        nsk.jdb.options.connect.connect002.connect002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.options.connect.connect002.connect002
+ * @build nsk.jdb.options.connect.connect002.connect002a
+ * @run main/othervm
+ *      nsk.jdb.options.connect.connect002.connect002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002.java
@@ -62,20 +62,21 @@
 
 package nsk.jdb.options.connect.connect002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class connect002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect002().runTest(argv, out);
@@ -84,8 +85,8 @@ public class connect002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect002";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.SocketAttach";
@@ -99,16 +100,14 @@ public class connect002 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
             reply = jdb.getTotalReply();
             grep = new Paragrep(reply);
-            v = new Vector();
+            v = new Vector<>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002.java
@@ -98,16 +98,12 @@ public class connect002 extends JdbTest {
     }
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        Vector<String> v;
-
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
-            reply = jdb.getTotalReply();
-            grep = new Paragrep(reply);
-            v = new Vector<>();
+            String[] reply = jdb.getTotalReply();
+            var grep = new Paragrep(reply);
+            var v = new Vector<String>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002.java
@@ -62,21 +62,20 @@
 
 package nsk.jdb.options.connect.connect002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class connect002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect002().runTest(argv, out);
@@ -85,8 +84,8 @@ public class connect002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect002";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.SocketAttach";
@@ -98,12 +97,18 @@ public class connect002 extends JdbTest {
     }
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
-            String[] reply = jdb.getTotalReply();
-            var grep = new Paragrep(reply);
-            var v = new Vector<String>();
+            reply = jdb.getTotalReply();
+            grep = new Paragrep(reply);
+            v = new Vector();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003.java
@@ -45,9 +45,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.options.connect.connect003.connect003
- *        nsk.jdb.options.connect.connect003.connect003a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.options.connect.connect003.connect003
+ * @build nsk.jdb.options.connect.connect003.connect003a
+ * @run main/othervm
+ *      nsk.jdb.options.connect.connect003.connect003
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003.java
@@ -62,20 +62,21 @@
 
 package nsk.jdb.options.connect.connect003;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class connect003 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect003().runTest(argv, out);
@@ -84,8 +85,8 @@ public class connect003 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect003";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect003";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.SharedMemoryAttach";
@@ -99,16 +100,14 @@ public class connect003 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
             reply = jdb.getTotalReply();
             grep = new Paragrep(reply);
-            v = new Vector();
+            v = new Vector<>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003.java
@@ -98,16 +98,12 @@ public class connect003 extends JdbTest {
     }
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        Vector<String> v;
-
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
-            reply = jdb.getTotalReply();
-            grep = new Paragrep(reply);
-            v = new Vector<>();
+            String[] reply = jdb.getTotalReply();
+            var grep = new Paragrep(reply);
+            var v = new Vector<String>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003.java
@@ -62,21 +62,20 @@
 
 package nsk.jdb.options.connect.connect003;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class connect003 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect003().runTest(argv, out);
@@ -85,8 +84,8 @@ public class connect003 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect003";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect003";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.SharedMemoryAttach";
@@ -98,12 +97,18 @@ public class connect003 extends JdbTest {
     }
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
-            String[] reply = jdb.getTotalReply();
-            var grep = new Paragrep(reply);
-            var v = new Vector<String>();
+            reply = jdb.getTotalReply();
+            grep = new Paragrep(reply);
+            v = new Vector();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004.java
@@ -45,9 +45,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.options.connect.connect004.connect004
- *        nsk.jdb.options.connect.connect004.connect004a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.options.connect.connect004.connect004
+ * @build nsk.jdb.options.connect.connect004.connect004a
+ * @run main/othervm
+ *      nsk.jdb.options.connect.connect004.connect004
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004.java
@@ -98,16 +98,12 @@ public class connect004 extends JdbTest {
     }
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        Vector<String> v;
-
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
-            reply = jdb.getTotalReply();
-            grep = new Paragrep(reply);
-            v = new Vector<>();
+            String[] reply = jdb.getTotalReply();
+            var grep = new Paragrep(reply);
+            var v = new Vector<String>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004.java
@@ -62,20 +62,21 @@
 
 package nsk.jdb.options.connect.connect004;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class connect004 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect004().runTest(argv, out);
@@ -84,8 +85,8 @@ public class connect004 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect004";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect004";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.SocketListen";
@@ -99,16 +100,14 @@ public class connect004 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
             reply = jdb.getTotalReply();
             grep = new Paragrep(reply);
-            v = new Vector();
+            v = new Vector<>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004.java
@@ -62,21 +62,20 @@
 
 package nsk.jdb.options.connect.connect004;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class connect004 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect004().runTest(argv, out);
@@ -85,8 +84,8 @@ public class connect004 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect004";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect004";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.SocketListen";
@@ -98,12 +97,18 @@ public class connect004 extends JdbTest {
     }
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
-            String[] reply = jdb.getTotalReply();
-            var grep = new Paragrep(reply);
-            var v = new Vector<String>();
+            reply = jdb.getTotalReply();
+            grep = new Paragrep(reply);
+            v = new Vector();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005.java
@@ -45,9 +45,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.options.connect.connect005.connect005
- *        nsk.jdb.options.connect.connect005.connect005a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.options.connect.connect005.connect005
+ * @build nsk.jdb.options.connect.connect005.connect005a
+ * @run main/othervm
+ *      nsk.jdb.options.connect.connect005.connect005
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005.java
@@ -62,20 +62,21 @@
 
 package nsk.jdb.options.connect.connect005;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class connect005 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect005().runTest(argv, out);
@@ -84,8 +85,8 @@ public class connect005 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect005";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect005";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.SharedMemoryListen";
@@ -99,16 +100,14 @@ public class connect005 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
             reply = jdb.getTotalReply();
             grep = new Paragrep(reply);
-            v = new Vector();
+            v = new Vector<>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005.java
@@ -98,16 +98,12 @@ public class connect005 extends JdbTest {
     }
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        Vector<String> v;
-
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
-            reply = jdb.getTotalReply();
-            grep = new Paragrep(reply);
-            v = new Vector<>();
+            String[] reply = jdb.getTotalReply();
+            var grep = new Paragrep(reply);
+            var v = new Vector<String>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005.java
@@ -62,21 +62,20 @@
 
 package nsk.jdb.options.connect.connect005;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class connect005 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect005().runTest(argv, out);
@@ -85,8 +84,8 @@ public class connect005 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect005";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect005";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.SharedMemoryListen";
@@ -98,12 +97,18 @@ public class connect005 extends JdbTest {
     }
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
-            String[] reply = jdb.getTotalReply();
-            var grep = new Paragrep(reply);
-            var v = new Vector<String>();
+            reply = jdb.getTotalReply();
+            grep = new Paragrep(reply);
+            v = new Vector();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/listconnectors/listconnectors001/listconnectors001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/listconnectors/listconnectors001/listconnectors001.java
@@ -51,8 +51,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.options.listconnectors.listconnectors001.listconnectors001
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdb.options.listconnectors.listconnectors001.listconnectors001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/listconnectors/listconnectors001/listconnectors001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/listconnectors/listconnectors001/listconnectors001.java
@@ -126,9 +126,9 @@ public class listconnectors001 extends JdbTest {
         for (int i = 0; i < TESTED_CONNECTORS_COUNT; i++) {
             String connector = TESTED_CONNECTORS_LIST[i * 2];
             String transport = TESTED_CONNECTORS_LIST[i * 2 + 1];
-            Paragrep grep = new Paragrep(reply);
+            var grep = new Paragrep(reply);
 
-            Vector<String> v = new Vector<>();
+            var v = new Vector<String>();
             v.add(Jdb.SUPPORTED_CONNECTOR_NAME);
             v.add(connector);
             v.add(Jdb.SUPPORTED_TRANSPORT_NAME);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/listconnectors/listconnectors001/listconnectors001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/listconnectors/listconnectors001/listconnectors001.java
@@ -66,39 +66,41 @@
 
 package nsk.jdb.options.listconnectors.listconnectors001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.Jdb;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class listconnectors001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new listconnectors001().runTest(argv, out);
     }
 
+    static final String PACKAGE_NAME = "nsk.jdb.options.connect";
+    static final String TEST_CLASS = PACKAGE_NAME + ".connect001";
     static final String DEBUGGEE_CLASS = null;
-    static final String FIRST_BREAK = null;
-    static final String LAST_BREAK = null;
+    static final String FIRST_BREAK    = null;
+    static final String LAST_BREAK     = null;
 
+    static final String TESTED_OPTION = "-listconnectors";
     static final String TESTED_CONNECTORS_LIST[] = {
-            "com.sun.jdi.CommandLineLaunch", "dt_socket",
-            "com.sun.jdi.CommandLineLaunch", "dt_shmem",
-            "com.sun.jdi.RawCommandLineLaunch", "dt_socket",
-            "com.sun.jdi.RawCommandLineLaunch", "dt_shmem",
-            "com.sun.jdi.SocketAttach", "dt_socket",
-            "com.sun.jdi.SocketListen", "dt_socket",
-            "com.sun.jdi.SharedMemoryAttach", "dt_shmem",
-            "com.sun.jdi.SharedMemoryListen", "dt_shmem",
+        "com.sun.jdi.CommandLineLaunch", "dt_socket",
+        "com.sun.jdi.CommandLineLaunch", "dt_shmem",
+        "com.sun.jdi.RawCommandLineLaunch", "dt_socket",
+        "com.sun.jdi.RawCommandLineLaunch", "dt_shmem",
+        "com.sun.jdi.SocketAttach", "dt_socket",
+        "com.sun.jdi.SocketListen", "dt_socket",
+        "com.sun.jdi.SharedMemoryAttach", "dt_shmem",
+        "com.sun.jdi.SharedMemoryListen", "dt_shmem",
     };
     static final int TESTED_CONNECTORS_COUNT = TESTED_CONNECTORS_LIST.length / 2;
 /*
@@ -124,11 +126,11 @@ public class listconnectors001 extends JdbTest {
         String[] reply = jdb.getTotalReply();
 
         for (int i = 0; i < TESTED_CONNECTORS_COUNT; i++) {
-            String connector = TESTED_CONNECTORS_LIST[i * 2];
-            String transport = TESTED_CONNECTORS_LIST[i * 2 + 1];
-            var grep = new Paragrep(reply);
+            String connector = TESTED_CONNECTORS_LIST[i*2 + 0];
+            String transport = TESTED_CONNECTORS_LIST[i*2 + 1];
+            Paragrep grep = new Paragrep(reply);
 
-            var v = new Vector<String>();
+            Vector<String> v = new Vector<String>();
             v.add(Jdb.SUPPORTED_CONNECTOR_NAME);
             v.add(connector);
             v.add(Jdb.SUPPORTED_TRANSPORT_NAME);
@@ -148,7 +150,7 @@ public class listconnectors001 extends JdbTest {
                         + "  transport: " + transport
                         + "  found: " + found);
             } else if (argumentHandler.shouldPass(connector)
-                    || argumentHandler.shouldPass(connector, transport)) {
+                            || argumentHandler.shouldPass(connector, transport)) {
                 display("unsupported connector not found:\n"
                         + "  connector: " + connector
                         + "  transport: " + transport

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/listconnectors/listconnectors001/listconnectors001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/listconnectors/listconnectors001/listconnectors001.java
@@ -66,41 +66,39 @@
 
 package nsk.jdb.options.listconnectors.listconnectors001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.Jdb;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class listconnectors001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new listconnectors001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.options.connect";
-    static final String TEST_CLASS = PACKAGE_NAME + ".connect001";
     static final String DEBUGGEE_CLASS = null;
-    static final String FIRST_BREAK    = null;
-    static final String LAST_BREAK     = null;
+    static final String FIRST_BREAK = null;
+    static final String LAST_BREAK = null;
 
-    static final String TESTED_OPTION = "-listconnectors";
     static final String TESTED_CONNECTORS_LIST[] = {
-        "com.sun.jdi.CommandLineLaunch", "dt_socket",
-        "com.sun.jdi.CommandLineLaunch", "dt_shmem",
-        "com.sun.jdi.RawCommandLineLaunch", "dt_socket",
-        "com.sun.jdi.RawCommandLineLaunch", "dt_shmem",
-        "com.sun.jdi.SocketAttach", "dt_socket",
-        "com.sun.jdi.SocketListen", "dt_socket",
-        "com.sun.jdi.SharedMemoryAttach", "dt_shmem",
-        "com.sun.jdi.SharedMemoryListen", "dt_shmem",
+            "com.sun.jdi.CommandLineLaunch", "dt_socket",
+            "com.sun.jdi.CommandLineLaunch", "dt_shmem",
+            "com.sun.jdi.RawCommandLineLaunch", "dt_socket",
+            "com.sun.jdi.RawCommandLineLaunch", "dt_shmem",
+            "com.sun.jdi.SocketAttach", "dt_socket",
+            "com.sun.jdi.SocketListen", "dt_socket",
+            "com.sun.jdi.SharedMemoryAttach", "dt_shmem",
+            "com.sun.jdi.SharedMemoryListen", "dt_shmem",
     };
     static final int TESTED_CONNECTORS_COUNT = TESTED_CONNECTORS_LIST.length / 2;
 /*
@@ -126,11 +124,11 @@ public class listconnectors001 extends JdbTest {
         String[] reply = jdb.getTotalReply();
 
         for (int i = 0; i < TESTED_CONNECTORS_COUNT; i++) {
-            String connector = TESTED_CONNECTORS_LIST[i*2 + 0];
-            String transport = TESTED_CONNECTORS_LIST[i*2 + 1];
+            String connector = TESTED_CONNECTORS_LIST[i * 2];
+            String transport = TESTED_CONNECTORS_LIST[i * 2 + 1];
             Paragrep grep = new Paragrep(reply);
 
-            Vector<String> v = new Vector<String>();
+            Vector<String> v = new Vector<>();
             v.add(Jdb.SUPPORTED_CONNECTOR_NAME);
             v.add(connector);
             v.add(Jdb.SUPPORTED_TRANSPORT_NAME);
@@ -150,7 +148,7 @@ public class listconnectors001 extends JdbTest {
                         + "  transport: " + transport
                         + "  found: " + found);
             } else if (argumentHandler.shouldPass(connector)
-                            || argumentHandler.shouldPass(connector, transport)) {
+                    || argumentHandler.shouldPass(connector, transport)) {
                 display("unsupported connector not found:\n"
                         + "  connector: " + connector
                         + "  transport: " + transport

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
@@ -46,9 +46,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.pop.pop001.pop001
- *        nsk.jdb.pop.pop001.pop001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.pop.pop001.pop001
+ * @build nsk.jdb.pop.pop001.pop001a
+ * @run main/othervm
+ *      nsk.jdb.pop.pop001.pop001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
@@ -61,20 +61,21 @@
 
 package nsk.jdb.pop.pop001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class pop001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new pop001().runTest(argv, out);
@@ -82,23 +83,19 @@ public class pop001 extends JdbTest {
 
     static final String PACKAGE_NAME = "nsk.jdb.pop.pop001";
     static final String TEST_CLASS = PACKAGE_NAME + ".pop001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String MYTHREAD        = "MyThread";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
-    static final String[] CHECKED_METHODS = {"func1", "func2", "func3", "func4", "func5"};
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         while (true) {
             String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
@@ -109,22 +106,22 @@ public class pop001 extends JdbTest {
                 break;
             }
 
-            reply = jdb.receiveReplyFor(JdbCommand.thread + threads[0]);
+            jdb.receiveReplyFor(JdbCommand.thread + threads[0]);
 
-            reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
+            jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func5", "[1]", "lastBreak", false)) {
-                 success = false;
+                success = false;
             }
-            reply = jdb.receiveReplyFor(JdbCommand.up + " 3");
+            jdb.receiveReplyFor(JdbCommand.up + " 3");
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func2", "[4]", "func3", false)) {
                 success = false;
             }
 
-            reply = jdb.receiveReplyFor(JdbCommand.pop);
+            jdb.receiveReplyFor(JdbCommand.pop);
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func1", "[1]", "func2", true)) {
@@ -135,8 +132,8 @@ public class pop001 extends JdbTest {
             grep = new Paragrep(reply);
             if (grep.find("Internal exception") > 0) {
                 log.complain("Internal exception was thrown while 'locals' command");
-                for (int i = 0; i < reply.length; i++) {
-                    log.complain(reply[i]);
+                for (String s : reply) {
+                    log.complain(s);
                 }
                 success = false;
             }
@@ -147,10 +144,9 @@ public class pop001 extends JdbTest {
         jdb.contToExit(2);
     }
 
-    private boolean checkStack (String[] reply, String shouldBe, String frameNum, String shouldNotBe, boolean pop ) {
+    private boolean checkStack(String[] reply, String shouldBe, String frameNum, String shouldNotBe, boolean pop) {
         Paragrep grep;
-        String found;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
         boolean result = true;
         int count;
 
@@ -158,14 +154,14 @@ public class pop001 extends JdbTest {
         v.add(frameNum);
         v.add(DEBUGGEE_THREAD + "." + shouldBe);
         if ((count = grep.find(v)) != 1) {
-            log.complain("Contents of stack trace is incorrect " + ( pop? "after 'pop' command": ""));
+            log.complain("Contents of stack trace is incorrect " + (pop ? "after 'pop' command" : ""));
             log.complain("Searched for: " + DEBUGGEE_THREAD + "." + shouldBe);
             log.complain("Count : " + count);
             result = false;
         }
 
         if (grep.find(DEBUGGEE_THREAD + "." + shouldNotBe) > 0) {
-            log.complain("Contents of stack trace is incorrect " + ( pop? "after 'pop' command": ""));
+            log.complain("Contents of stack trace is incorrect " + (pop ? "after 'pop' command" : ""));
             log.complain("Found wrong frame: " + DEBUGGEE_THREAD + "." + shouldNotBe);
             result = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
@@ -91,9 +91,6 @@ public class pop001 extends JdbTest {
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
@@ -110,7 +107,7 @@ public class pop001 extends JdbTest {
 
             jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
 
-            reply = jdb.receiveReplyFor(JdbCommand.where);
+            String[]  reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func5", "[1]", "lastBreak", false)) {
                 success = false;
             }
@@ -129,7 +126,7 @@ public class pop001 extends JdbTest {
             }
 
             reply = jdb.receiveReplyFor(JdbCommand.locals);
-            grep = new Paragrep(reply);
+            var grep = new Paragrep(reply);
             if (grep.find("Internal exception") > 0) {
                 log.complain("Internal exception was thrown while 'locals' command");
                 for (String s : reply) {
@@ -145,15 +142,14 @@ public class pop001 extends JdbTest {
     }
 
     private boolean checkStack(String[] reply, String shouldBe, String frameNum, String shouldNotBe, boolean pop) {
-        Paragrep grep;
-        Vector<String> v = new Vector<>();
         boolean result = true;
-        int count;
 
-        grep = new Paragrep(reply);
+        var grep = new Paragrep(reply);
+        var v = new Vector<String>();
         v.add(frameNum);
         v.add(DEBUGGEE_THREAD + "." + shouldBe);
-        if ((count = grep.find(v)) != 1) {
+        int count = grep.find(v);
+        if (count != 1) {
             log.complain("Contents of stack trace is incorrect " + (pop ? "after 'pop' command" : ""));
             log.complain("Searched for: " + DEBUGGEE_THREAD + "." + shouldBe);
             log.complain("Count : " + count);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
@@ -33,9 +33,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.pop_exception.pop_exception001.pop_exception001
- *        nsk.jdb.pop_exception.pop_exception001.pop_exception001a
- * @run main/othervm PropertyResolvingWrapper
+ * @build nsk.jdb.pop_exception.pop_exception001.pop_exception001a
+ * @run main/othervm
  *      nsk.jdb.pop_exception.pop_exception001.pop_exception001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
@@ -75,7 +75,6 @@ public class pop_exception001 extends JdbTest {
 
 
     protected void runCases() {
-
         jdb.receiveReplyFor(JdbCommand._catch + "java.lang.NullPointerException");
         jdb.receiveReplyFor(JdbCommand.cont);
         // exception

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
@@ -48,36 +48,38 @@
 
 package nsk.jdb.pop_exception.pop_exception001;
 
-import nsk.share.Failure;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class pop_exception001 extends JdbTest {
 
-    static final String PACKAGE_NAME = "nsk.jdb.pop_exception.pop_exception001";
-    static final String TEST_CLASS = PACKAGE_NAME + ".pop_exception001";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME    = "nsk.jdb.pop_exception.pop_exception001";
+    static final String TEST_CLASS      = PACKAGE_NAME + ".pop_exception001";
+    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
+    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new pop_exception001().runTest(argv, out);
     }
 
 
+
     protected void runCases() {
+
         jdb.receiveReplyFor(JdbCommand._catch + "java.lang.NullPointerException");
         jdb.receiveReplyFor(JdbCommand.cont);
-        // exception
+        //exception
         jdb.receiveReplyFor(JdbCommand.pop);
         jdb.receiveReplyFor(JdbCommand.pop);
         jdb.receiveReplyFor(JdbCommand.ignore + "java.lang.NullPointerException");
@@ -91,11 +93,11 @@ public class pop_exception001 extends JdbTest {
     }
 
     private void checkJdbReply(String[] jdbReply) {
-        StringBuilder replyString = new StringBuilder();
-        for (String s : jdbReply) {
-            replyString.append(s);
-            if (s.contains("line=")) {
-                if (!s.contains("line=" + pop_exception001a.expectedFinish)) {
+        String replyString = "";
+        for(String s: jdbReply) {
+            replyString += s;
+            if(s.contains("line=")){
+                if(!s.contains("line=" + pop_exception001a.expectedFinish)) {
                     throw new Failure("FAILED: Expected location: line=" + pop_exception001a.expectedFinish + "\n found: " + s);
                 } else {
                     return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
@@ -48,38 +48,37 @@
 
 package nsk.jdb.pop_exception.pop_exception001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Failure;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class pop_exception001 extends JdbTest {
 
-    static final String PACKAGE_NAME    = "nsk.jdb.pop_exception.pop_exception001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".pop_exception001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.pop_exception.pop_exception001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".pop_exception001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new pop_exception001().runTest(argv, out);
     }
 
 
-
     protected void runCases() {
 
         jdb.receiveReplyFor(JdbCommand._catch + "java.lang.NullPointerException");
         jdb.receiveReplyFor(JdbCommand.cont);
-        //exception
+        // exception
         jdb.receiveReplyFor(JdbCommand.pop);
         jdb.receiveReplyFor(JdbCommand.pop);
         jdb.receiveReplyFor(JdbCommand.ignore + "java.lang.NullPointerException");
@@ -93,11 +92,11 @@ public class pop_exception001 extends JdbTest {
     }
 
     private void checkJdbReply(String[] jdbReply) {
-        String replyString = "";
-        for(String s: jdbReply) {
-            replyString += s;
-            if(s.contains("line=")){
-                if(!s.contains("line=" + pop_exception001a.expectedFinish)) {
+        StringBuilder replyString = new StringBuilder();
+        for (String s : jdbReply) {
+            replyString.append(s);
+            if (s.contains("line=")) {
+                if (!s.contains("line=" + pop_exception001a.expectedFinish)) {
                     throw new Failure("FAILED: Expected location: line=" + pop_exception001a.expectedFinish + "\n found: " + s);
                 } else {
                     return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002.java
@@ -52,7 +52,8 @@
  * @clean nsk.jdb.print.print002.print002a
  * @compile -g:lines,source,vars print002a.java
  *
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.print.print002.print002
+ * @run main/othervm
+ *      nsk.jdb.print.print002.print002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002.java
@@ -66,21 +66,20 @@
 
 package nsk.jdb.print.print002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class print002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new print002().runTest(argv, out);
@@ -89,14 +88,14 @@ public class print002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.print.print002";
     static final String TEST_CLASS = PACKAGE_NAME + ".print002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String[][] checkedExpr = {
-            {"i + j", "8"},
-            {"j - i", "4"},
-            {"j * i", "12"},
-            {"j / i", "3"},
+        { "i + j", "8"},
+        { "j - i", "4"},
+        { "j * i", "12"},
+        { "j / i", "3"},
 //        { "j % i", "0"},
 //        { "i++",   "2"},
 //        { "++i",   "3"},
@@ -105,18 +104,24 @@ public class print002 extends JdbTest {
 //        { "!b1 ",   "false"},
 //        { "b2 && b1", "false"},
 //        { "b2 || b1", "true"},
-            {"a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.s", "foo"}
-    };
+        { "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.s", "foo" }
+                                          };
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         // to get out of lastBreak()
-        jdb.receiveReplyFor(JdbCommand.step);
+        reply = jdb.receiveReplyFor(JdbCommand.step);
 
-        for (String[] strings : checkedExpr) {
-            if (!checkValue(strings[0], strings[1])) {
+        for (int i = 0; i < checkedExpr.length; i++) {
+            if (!checkValue(checkedExpr[i][0], checkedExpr[i][1])) {
                 success = false;
             }
         }
@@ -124,15 +129,19 @@ public class print002 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkValue(String expr, String value) {
+    private boolean checkValue (String expr, String value) {
+        Paragrep grep;
+        String[] reply;
+        String found;
+        Vector v;
         boolean result = true;
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.print + expr);
-        var grep = new Paragrep(reply);
-        String found = grep.findFirst(value);
+        reply = jdb.receiveReplyFor(JdbCommand.print + expr);
+        grep = new Paragrep(reply);
+        found = grep.findFirst(value);
         if (found.length() <= 0) {
             log.complain("jdb failed to report value of expression: " + expr);
-            log.complain("\t expected : " + value + " ;\n\t reported: " + (reply.length > 0 ? reply[0] : ""));
+            log.complain("\t expected : " + value + " ;\n\t reported: " + (reply.length > 0? reply[0]: ""));
             result = false;
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002.java
@@ -66,20 +66,21 @@
 
 package nsk.jdb.print.print002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class print002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new print002().runTest(argv, out);
@@ -88,14 +89,14 @@ public class print002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.print.print002";
     static final String TEST_CLASS = PACKAGE_NAME + ".print002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String[][] checkedExpr = {
-        { "i + j", "8"},
-        { "j - i", "4"},
-        { "j * i", "12"},
-        { "j / i", "3"},
+            {"i + j", "8"},
+            {"j - i", "4"},
+            {"j * i", "12"},
+            {"j / i", "3"},
 //        { "j % i", "0"},
 //        { "i++",   "2"},
 //        { "++i",   "3"},
@@ -104,24 +105,18 @@ public class print002 extends JdbTest {
 //        { "!b1 ",   "false"},
 //        { "b2 && b1", "false"},
 //        { "b2 || b1", "true"},
-        { "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.s", "foo" }
-                                          };
+            {"a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.s", "foo"}
+    };
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // to get out of lastBreak()
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
 
-        for (int i = 0; i < checkedExpr.length; i++) {
-            if (!checkValue(checkedExpr[i][0], checkedExpr[i][1])) {
+        for (String[] strings : checkedExpr) {
+            if (!checkValue(strings[0], strings[1])) {
                 success = false;
             }
         }
@@ -129,11 +124,10 @@ public class print002 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkValue (String expr, String value) {
+    private boolean checkValue(String expr, String value) {
         Paragrep grep;
         String[] reply;
         String found;
-        Vector v;
         boolean result = true;
 
         reply = jdb.receiveReplyFor(JdbCommand.print + expr);
@@ -141,7 +135,7 @@ public class print002 extends JdbTest {
         found = grep.findFirst(value);
         if (found.length() <= 0) {
             log.complain("jdb failed to report value of expression: " + expr);
-            log.complain("\t expected : " + value + " ;\n\t reported: " + (reply.length > 0? reply[0]: ""));
+            log.complain("\t expected : " + value + " ;\n\t reported: " + (reply.length > 0 ? reply[0] : ""));
             result = false;
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002.java
@@ -125,14 +125,11 @@ public class print002 extends JdbTest {
     }
 
     private boolean checkValue(String expr, String value) {
-        Paragrep grep;
-        String[] reply;
-        String found;
         boolean result = true;
 
-        reply = jdb.receiveReplyFor(JdbCommand.print + expr);
-        grep = new Paragrep(reply);
-        found = grep.findFirst(value);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.print + expr);
+        var grep = new Paragrep(reply);
+        String found = grep.findFirst(value);
         if (found.length() <= 0) {
             log.complain("jdb failed to report value of expression: " + expr);
             log.complain("\t expected : " + value + " ;\n\t reported: " + (reply.length > 0 ? reply[0] : ""));

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
@@ -52,7 +52,8 @@
  * @clean nsk.jdb.read.read001.read001a
  * @compile -g:lines,source,vars read001a.java
  *
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.read.read001.read001
+ * @run main/othervm
+ *      nsk.jdb.read.read001.read001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
@@ -66,21 +66,22 @@
 
 package nsk.jdb.read.read001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
 import jdk.test.lib.Utils;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.PrintStream;
 
 public class read001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new read001().runTest(argv, out);
@@ -89,8 +90,8 @@ public class read001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.read.read001";
     static final String TEST_CLASS = PACKAGE_NAME + ".read001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK    = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK     = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String SCENARIO_FILE = "jdb.scenario";
     static final int SCENARIO_COMMANDS_COUNT = 5;
@@ -101,10 +102,10 @@ public class read001 extends JdbTest {
 
         // stop in lastBreak() method
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // return to testedInstanceMethod()
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
 
         String command = JdbCommand.read + srcdir + File.separator + SCENARIO_FILE;
         int count = SCENARIO_COMMANDS_COUNT + 1;
@@ -119,8 +120,6 @@ public class read001 extends JdbTest {
 
     private boolean checkCommands(String[] reply) {
         Paragrep grep;
-        String found;
-        Vector v = new Vector();
         boolean result = true;
         int count;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
@@ -97,7 +97,6 @@ public class read001 extends JdbTest {
     static final int SCENARIO_COMMANDS_COUNT = 5;
 
     protected void runCases() {
-        String[] reply;
         String srcdir = Utils.TEST_SRC;
 
         // stop in lastBreak() method
@@ -109,7 +108,7 @@ public class read001 extends JdbTest {
 
         String command = JdbCommand.read + srcdir + File.separator + SCENARIO_FILE;
         int count = SCENARIO_COMMANDS_COUNT + 1;
-        reply = jdb.receiveReplyFor(command, true, count);
+        String[] reply = jdb.receiveReplyFor(command, true, count);
 
         if (!checkCommands(reply)) {
             success = false;
@@ -119,11 +118,10 @@ public class read001 extends JdbTest {
     }
 
     private boolean checkCommands(String[] reply) {
-        Paragrep grep;
         boolean result = true;
         int count;
 
-        grep = new Paragrep(reply);
+        var grep = new Paragrep(reply);
 
         // check 'threads'
         log.display("Check reply for command: classes");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
@@ -66,22 +66,21 @@
 
 package nsk.jdb.read.read001;
 
+import nsk.share.*;
+import nsk.share.jdb.*;
 import jdk.test.lib.Utils;
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
 
-import java.io.File;
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class read001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new read001().runTest(argv, out);
@@ -90,25 +89,26 @@ public class read001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.read.read001";
     static final String TEST_CLASS = PACKAGE_NAME + ".read001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK    = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK     = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String SCENARIO_FILE = "jdb.scenario";
     static final int SCENARIO_COMMANDS_COUNT = 5;
 
     protected void runCases() {
+        String[] reply;
         String srcdir = Utils.TEST_SRC;
 
         // stop in lastBreak() method
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         // return to testedInstanceMethod()
-        jdb.receiveReplyFor(JdbCommand.step);
+        reply = jdb.receiveReplyFor(JdbCommand.step);
 
         String command = JdbCommand.read + srcdir + File.separator + SCENARIO_FILE;
         int count = SCENARIO_COMMANDS_COUNT + 1;
-        String[] reply = jdb.receiveReplyFor(command, true, count);
+        reply = jdb.receiveReplyFor(command, true, count);
 
         if (!checkCommands(reply)) {
             success = false;
@@ -118,10 +118,13 @@ public class read001 extends JdbTest {
     }
 
     private boolean checkCommands(String[] reply) {
+        Paragrep grep;
+        String found;
+        Vector v = new Vector();
         boolean result = true;
         int count;
 
-        var grep = new Paragrep(reply);
+        grep = new Paragrep(reply);
 
         // check 'threads'
         log.display("Check reply for command: classes");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001.java
@@ -45,19 +45,19 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.redefine.redefine001.redefine001
- *        nsk.jdb.redefine.redefine001.redefine001a
+ * @build nsk.jdb.redefine.redefine001.redefine001a
  *
  * @comment compile newclass_g/RedefinedClass.java to newclass_g
- * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver
+ *      ExecDriver --cmd
  *      ${compile.jdk}/bin/javac
  *      -d ${test.classes}/newclass_g
  *      -g:lines,source,vars
  *      -cp ${test.class.path}
  *      ${test.src}/newclass_g/RedefinedClass.java
  *
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.redefine.redefine001.redefine001
+ * @run main/othervm
+ *      nsk.jdb.redefine.redefine001.redefine001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001.java
@@ -103,16 +103,13 @@ public class redefine001 extends JdbTest {
     static final String SECOND_REDEFINITION = BEFORE_REDEFINITION;
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
         jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
 
-        reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_CLASS + ".flag");
-        grep = new Paragrep(reply);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_CLASS + ".flag");
+        var grep = new Paragrep(reply);
         if (grep.find(BEFORE_REDEFINITION) == 0) {
             log.complain("Wrong value of redefine001a.flag before redefinition: " + (reply.length > 0 ? reply[0] : ""));
             success = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001.java
@@ -70,22 +70,21 @@
 
 package nsk.jdb.redefine.redefine001;
 
-import nsk.share.Paragrep;
+import nsk.share.*;
+import nsk.share.jdb.*;
 import nsk.share.classload.ClassLoadUtils;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
 
-import java.io.File;
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class redefine001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new redefine001().runTest(argv, out);
@@ -94,38 +93,44 @@ public class redefine001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.redefine.redefine001";
     static final String TEST_CLASS = PACKAGE_NAME + ".redefine001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String REDEFINED_CLASS = PACKAGE_NAME + ".RedefinedClass";
+    static final String REDEFINED_CLASS    = PACKAGE_NAME + ".RedefinedClass";
     static final String BEFORE_REDEFINITION = "BEFORE_REDEFINITION";
-    static final String FIRST_REDEFINITION = "AFTER_REDEFINITION";
+    static final String FIRST_REDEFINITION  = "AFTER_REDEFINITION";
     static final String SECOND_REDEFINITION = BEFORE_REDEFINITION;
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
+        reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_CLASS + ".flag");
-        var grep = new Paragrep(reply);
+        reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_CLASS + ".flag");
+        grep = new Paragrep(reply);
         if (grep.find(BEFORE_REDEFINITION) == 0) {
-            log.complain("Wrong value of redefine001a.flag before redefinition: " + (reply.length > 0 ? reply[0] : ""));
+            log.complain("Wrong value of redefine001a.flag before redefinition: " + (reply.length > 0? reply[0]: ""));
             success = false;
         }
 
         String className = RedefinedClass.class.getName();
         String pathToRedefFile1 = ClassLoadUtils.getRedefineClassFileName("newclass_g", className);
         if (new File(pathToRedefFile1).exists()) {
-            jdb.receiveReplyFor(JdbCommand.redefine + REDEFINED_CLASS + " " + pathToRedefFile1);
+            reply = jdb.receiveReplyFor(JdbCommand.redefine + REDEFINED_CLASS + " " + pathToRedefFile1);
 
-            jdb.receiveReplyFor(JdbCommand.cont);
+            reply = jdb.receiveReplyFor(JdbCommand.cont);
 
             reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_CLASS + ".flag");
             grep = new Paragrep(reply);
             if (grep.find(FIRST_REDEFINITION) == 0) {
-                log.complain("Wrong value of redefine001a.flag after first redefinition: " + (reply.length > 0 ? reply[0] : ""));
+                log.complain("Wrong value of redefine001a.flag after first redefinition: " + (reply.length > 0? reply[0]: ""));
                 success = false;
             }
         } else {
@@ -135,14 +140,14 @@ public class redefine001 extends JdbTest {
 
         String pathToRedefFile2 = ClassLoadUtils.getClassPathFileName(className);
         if (new File(pathToRedefFile2).exists()) {
-            jdb.receiveReplyFor(JdbCommand.redefine + REDEFINED_CLASS + " " + pathToRedefFile2);
+            reply = jdb.receiveReplyFor(JdbCommand.redefine + REDEFINED_CLASS + " " + pathToRedefFile2);
 
-            jdb.receiveReplyFor(JdbCommand.cont);
+            reply = jdb.receiveReplyFor(JdbCommand.cont);
 
             reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_CLASS + ".flag");
             grep = new Paragrep(reply);
             if (grep.find(SECOND_REDEFINITION) == 0) {
-                log.complain("Wrong value of redefine001a.flag after second redefinition: " + (reply.length > 0 ? reply[0] : ""));
+                log.complain("Wrong value of redefine001a.flag after second redefinition: " + (reply.length > 0? reply[0]: ""));
                 success = false;
             }
         } else {
@@ -151,5 +156,15 @@ public class redefine001 extends JdbTest {
         }
 
         jdb.contToExit(2);
+    }
+
+    private boolean checkStop () {
+        Paragrep grep;
+        String[] reply;
+        String found;
+        Vector v;
+        boolean result = true;
+
+        return result;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001.java
@@ -70,21 +70,22 @@
 
 package nsk.jdb.redefine.redefine001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
 import nsk.share.classload.ClassLoadUtils;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.PrintStream;
 
 public class redefine001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new redefine001().runTest(argv, out);
@@ -93,44 +94,41 @@ public class redefine001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.redefine.redefine001";
     static final String TEST_CLASS = PACKAGE_NAME + ".redefine001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String REDEFINED_CLASS    = PACKAGE_NAME + ".RedefinedClass";
+    static final String REDEFINED_CLASS = PACKAGE_NAME + ".RedefinedClass";
     static final String BEFORE_REDEFINITION = "BEFORE_REDEFINITION";
-    static final String FIRST_REDEFINITION  = "AFTER_REDEFINITION";
+    static final String FIRST_REDEFINITION = "AFTER_REDEFINITION";
     static final String SECOND_REDEFINITION = BEFORE_REDEFINITION;
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
-        reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
+        jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
 
         reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_CLASS + ".flag");
         grep = new Paragrep(reply);
         if (grep.find(BEFORE_REDEFINITION) == 0) {
-            log.complain("Wrong value of redefine001a.flag before redefinition: " + (reply.length > 0? reply[0]: ""));
+            log.complain("Wrong value of redefine001a.flag before redefinition: " + (reply.length > 0 ? reply[0] : ""));
             success = false;
         }
 
         String className = RedefinedClass.class.getName();
         String pathToRedefFile1 = ClassLoadUtils.getRedefineClassFileName("newclass_g", className);
         if (new File(pathToRedefFile1).exists()) {
-            reply = jdb.receiveReplyFor(JdbCommand.redefine + REDEFINED_CLASS + " " + pathToRedefFile1);
+            jdb.receiveReplyFor(JdbCommand.redefine + REDEFINED_CLASS + " " + pathToRedefFile1);
 
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            jdb.receiveReplyFor(JdbCommand.cont);
 
             reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_CLASS + ".flag");
             grep = new Paragrep(reply);
             if (grep.find(FIRST_REDEFINITION) == 0) {
-                log.complain("Wrong value of redefine001a.flag after first redefinition: " + (reply.length > 0? reply[0]: ""));
+                log.complain("Wrong value of redefine001a.flag after first redefinition: " + (reply.length > 0 ? reply[0] : ""));
                 success = false;
             }
         } else {
@@ -140,14 +138,14 @@ public class redefine001 extends JdbTest {
 
         String pathToRedefFile2 = ClassLoadUtils.getClassPathFileName(className);
         if (new File(pathToRedefFile2).exists()) {
-            reply = jdb.receiveReplyFor(JdbCommand.redefine + REDEFINED_CLASS + " " + pathToRedefFile2);
+            jdb.receiveReplyFor(JdbCommand.redefine + REDEFINED_CLASS + " " + pathToRedefFile2);
 
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            jdb.receiveReplyFor(JdbCommand.cont);
 
             reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_CLASS + ".flag");
             grep = new Paragrep(reply);
             if (grep.find(SECOND_REDEFINITION) == 0) {
-                log.complain("Wrong value of redefine001a.flag after second redefinition: " + (reply.length > 0? reply[0]: ""));
+                log.complain("Wrong value of redefine001a.flag after second redefinition: " + (reply.length > 0 ? reply[0] : ""));
                 success = false;
             }
         } else {
@@ -156,15 +154,5 @@ public class redefine001 extends JdbTest {
         }
 
         jdb.contToExit(2);
-    }
-
-    private boolean checkStop () {
-        Paragrep grep;
-        String[] reply;
-        String found;
-        Vector v;
-        boolean result = true;
-
-        return result;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
@@ -45,9 +45,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.reenter.reenter001.reenter001
- *        nsk.jdb.reenter.reenter001.reenter001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.reenter.reenter001.reenter001
+ * @build nsk.jdb.reenter.reenter001.reenter001a
+ * @run main/othervm
+ *      nsk.jdb.reenter.reenter001.reenter001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
@@ -60,21 +60,20 @@
 
 package nsk.jdb.reenter.reenter001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class reenter001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new reenter001().runTest(argv, out);
@@ -82,16 +81,23 @@ public class reenter001 extends JdbTest {
 
     static final String PACKAGE_NAME = "nsk.jdb.reenter.reenter001";
     static final String TEST_CLASS = PACKAGE_NAME + ".reenter001";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
+    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String MYTHREAD = "MyThread";
+    static final String MYTHREAD        = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
+    static final String[] CHECKED_METHODS = {"func1", "func2", "func3", "func4", "func5"};
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         while (true) {
             String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
@@ -102,23 +108,23 @@ public class reenter001 extends JdbTest {
                 break;
             }
 
-            jdb.receiveReplyFor(JdbCommand.thread + threads[0]);
+            reply = jdb.receiveReplyFor(JdbCommand.thread + threads[0]);
 
-            jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
+            reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
 
-            String[] reply = jdb.receiveReplyFor(JdbCommand.where);
+            reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func5", "[1]", "lastBreak", false)) {
                 success = false;
             }
 
-            jdb.receiveReplyFor(JdbCommand.up + " 3");
+            reply = jdb.receiveReplyFor(JdbCommand.up + " 3");
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func2", "[4]", "func3", false)) {
                 success = false;
             }
 
-            jdb.receiveReplyFor(JdbCommand.reenter);
+            reply = jdb.receiveReplyFor(JdbCommand.reenter);
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func2", "[1]", "func3", true)) {
@@ -126,11 +132,11 @@ public class reenter001 extends JdbTest {
             }
 
             reply = jdb.receiveReplyFor(JdbCommand.locals);
-            var grep = new Paragrep(reply);
+            grep = new Paragrep(reply);
             if (grep.find("Internal exception") > 0) {
                 log.complain("Internal exception was thrown while 'locals' command");
-                for (String s : reply) {
-                    log.complain(s);
+                for (int i = 0; i < reply.length; i++) {
+                    log.complain(reply[i]);
                 }
                 success = false;
             }
@@ -141,23 +147,25 @@ public class reenter001 extends JdbTest {
         jdb.contToExit(2);
     }
 
-    private boolean checkStack(String[] reply, String shouldBe, String frameNum, String shouldNotBe, boolean reenter) {
+    private boolean checkStack (String[] reply, String shouldBe, String frameNum, String shouldNotBe, boolean reenter ) {
+        Paragrep grep;
+        String found;
+        Vector v = new Vector();
         boolean result = true;
         int count;
 
-        var grep = new Paragrep(reply);
-        var v = new Vector<String>();
+        grep = new Paragrep(reply);
         v.add(frameNum);
         v.add(DEBUGGEE_THREAD + "." + shouldBe);
         if ((count = grep.find(v)) != 1) {
-            log.complain("Contents of stack trace is incorrect " + (reenter ? "after 'reenter' command" : ""));
+            log.complain("Contents of stack trace is incorrect " + ( reenter? "after 'reenter' command": ""));
             log.complain("Searched for: " + DEBUGGEE_THREAD + "." + shouldBe);
             log.complain("Count : " + count);
             result = false;
         }
 
         if (grep.find(DEBUGGEE_THREAD + "." + shouldNotBe) > 0) {
-            log.complain("Contents of stack trace is incorrect " + (reenter ? "after 'reenter' command" : ""));
+            log.complain("Contents of stack trace is incorrect " + ( reenter? "after 'reenter' command": ""));
             log.complain("Found wrong frame: " + DEBUGGEE_THREAD + "." + shouldNotBe);
             result = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
@@ -60,20 +60,21 @@
 
 package nsk.jdb.reenter.reenter001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class reenter001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new reenter001().runTest(argv, out);
@@ -81,23 +82,19 @@ public class reenter001 extends JdbTest {
 
     static final String PACKAGE_NAME = "nsk.jdb.reenter.reenter001";
     static final String TEST_CLASS = PACKAGE_NAME + ".reenter001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String MYTHREAD        = "MyThread";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
-    static final String[] CHECKED_METHODS = {"func1", "func2", "func3", "func4", "func5"};
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         while (true) {
             String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
@@ -108,23 +105,23 @@ public class reenter001 extends JdbTest {
                 break;
             }
 
-            reply = jdb.receiveReplyFor(JdbCommand.thread + threads[0]);
+            jdb.receiveReplyFor(JdbCommand.thread + threads[0]);
 
-            reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
+            jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func5", "[1]", "lastBreak", false)) {
                 success = false;
             }
 
-            reply = jdb.receiveReplyFor(JdbCommand.up + " 3");
+            jdb.receiveReplyFor(JdbCommand.up + " 3");
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func2", "[4]", "func3", false)) {
                 success = false;
             }
 
-            reply = jdb.receiveReplyFor(JdbCommand.reenter);
+            jdb.receiveReplyFor(JdbCommand.reenter);
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func2", "[1]", "func3", true)) {
@@ -135,8 +132,8 @@ public class reenter001 extends JdbTest {
             grep = new Paragrep(reply);
             if (grep.find("Internal exception") > 0) {
                 log.complain("Internal exception was thrown while 'locals' command");
-                for (int i = 0; i < reply.length; i++) {
-                    log.complain(reply[i]);
+                for (String s : reply) {
+                    log.complain(s);
                 }
                 success = false;
             }
@@ -147,10 +144,9 @@ public class reenter001 extends JdbTest {
         jdb.contToExit(2);
     }
 
-    private boolean checkStack (String[] reply, String shouldBe, String frameNum, String shouldNotBe, boolean reenter ) {
+    private boolean checkStack(String[] reply, String shouldBe, String frameNum, String shouldNotBe, boolean reenter) {
         Paragrep grep;
-        String found;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
         boolean result = true;
         int count;
 
@@ -158,14 +154,14 @@ public class reenter001 extends JdbTest {
         v.add(frameNum);
         v.add(DEBUGGEE_THREAD + "." + shouldBe);
         if ((count = grep.find(v)) != 1) {
-            log.complain("Contents of stack trace is incorrect " + ( reenter? "after 'reenter' command": ""));
+            log.complain("Contents of stack trace is incorrect " + (reenter ? "after 'reenter' command" : ""));
             log.complain("Searched for: " + DEBUGGEE_THREAD + "." + shouldBe);
             log.complain("Count : " + count);
             result = false;
         }
 
         if (grep.find(DEBUGGEE_THREAD + "." + shouldNotBe) > 0) {
-            log.complain("Contents of stack trace is incorrect " + ( reenter? "after 'reenter' command": ""));
+            log.complain("Contents of stack trace is incorrect " + (reenter ? "after 'reenter' command" : ""));
             log.complain("Found wrong frame: " + DEBUGGEE_THREAD + "." + shouldNotBe);
             result = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
@@ -90,9 +90,6 @@ public class reenter001 extends JdbTest {
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
@@ -109,7 +106,7 @@ public class reenter001 extends JdbTest {
 
             jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
 
-            reply = jdb.receiveReplyFor(JdbCommand.where);
+            String[] reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func5", "[1]", "lastBreak", false)) {
                 success = false;
             }
@@ -129,7 +126,7 @@ public class reenter001 extends JdbTest {
             }
 
             reply = jdb.receiveReplyFor(JdbCommand.locals);
-            grep = new Paragrep(reply);
+            var grep = new Paragrep(reply);
             if (grep.find("Internal exception") > 0) {
                 log.complain("Internal exception was thrown while 'locals' command");
                 for (String s : reply) {
@@ -145,12 +142,11 @@ public class reenter001 extends JdbTest {
     }
 
     private boolean checkStack(String[] reply, String shouldBe, String frameNum, String shouldNotBe, boolean reenter) {
-        Paragrep grep;
-        Vector<String> v = new Vector<>();
         boolean result = true;
         int count;
 
-        grep = new Paragrep(reply);
+        var grep = new Paragrep(reply);
+        var v = new Vector<String>();
         v.add(frameNum);
         v.add(DEBUGGEE_THREAD + "." + shouldBe);
         if ((count = grep.find(v)) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395.java
@@ -94,14 +94,15 @@
  *        nsk.jdb.regression.b4689395.b4689395a
  *
  * @comment compile newclass/b4689395a.java to newclass
- * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver
+ *      ExecDriver --cmd
  *      ${compile.jdk}/bin/javac
  *      -d ${test.classes}/newclass
  *      -cp ${test.class.path}
  *      ${test.src}/newclass/b4689395a.java
  *
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.regression.b4689395.b4689395
+ * @run main/othervm
+ *      nsk.jdb.regression.b4689395.b4689395
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395.java
@@ -115,59 +115,58 @@
 
 package nsk.jdb.regression.b4689395;
 
-import nsk.share.Paragrep;
-import nsk.share.TestFailure;
+import nsk.share.*;
+import nsk.share.jdb.*;
 import nsk.share.classload.ClassLoadUtils;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
 
-import java.io.File;
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class b4689395 extends JdbTest {
-    final static String TEST_CLASS = b4689395.class.getName();
-    final static String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    final static String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    final static String ERROR_MESSAGE = "ERROR_M";
-    final static int LINE_NUMBER = 54;
-    private String classFile;
+        final static String TEST_CLASS     = b4689395.class.getName();
+        final static String DEBUGGEE_CLASS = TEST_CLASS + "a";
+        final static String FIRST_BREAK    = DEBUGGEE_CLASS + ".main";
+        final static String ERROR_MESSAGE  = "ERROR_M";
+        final static int    LINE_NUMBER    = 54;
+        private String classFile;
 
-    public static void main(String[] argv) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
-        firstBreak = FIRST_BREAK;
-        return new b4689395().runTest(argv, out);
-    }
-
-    public b4689395() {
-        classFile = ClassLoadUtils.getRedefineClassFileName(DEBUGGEE_CLASS);
-        if (classFile == null) {
-            throw new TestFailure("Unable to find redefine class file in classpath for: " + DEBUGGEE_CLASS);
-        }
-    }
-
-    protected void runCases() {
-        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
-        jdb.receiveReplyFor(JdbCommand.cont);
-
-        if (new File(classFile).exists()) {
-            jdb.receiveReplyFor(JdbCommand.redefine + DEBUGGEE_CLASS + " " + classFile);
-            String[] reply = jdb.receiveReplyFor(JdbCommand.next);
-
-            var grep = new Paragrep(reply);
-            if (grep.find(ERROR_MESSAGE) != 0) {
-                log.complain("'" + ERROR_MESSAGE + "' is not expected to be "
-                        + "printed after 'next' command.");
-                success = false;
-            }
-        } else {
-            log.complain("File does not exist: " + classFile);
-            success = false;
+        public static void main (String argv[]) {
+                System.exit(run(argv, System.out) + JCK_STATUS_BASE);
         }
 
-        jdb.contToExit(1);
-    }
+        public static int run(String argv[], PrintStream out) {
+                debuggeeClass =  DEBUGGEE_CLASS;
+                firstBreak = FIRST_BREAK;
+                return new b4689395().runTest(argv, out);
+        }
+
+        public b4689395() {
+                classFile = ClassLoadUtils.getRedefineClassFileName(DEBUGGEE_CLASS);
+                if (classFile == null)
+                        throw new TestFailure("Unable to find redefine class file in classpath for: " + DEBUGGEE_CLASS);
+        }
+
+        protected void runCases() {
+                String[] reply;
+                reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
+                reply = jdb.receiveReplyFor(JdbCommand.cont);
+
+                if (new File(classFile).exists()) {
+                        reply = jdb.receiveReplyFor(JdbCommand.redefine + DEBUGGEE_CLASS
+                                        + " " + classFile);
+                        reply = jdb.receiveReplyFor(JdbCommand.next);
+
+                        Paragrep grep = new Paragrep(reply);
+                        if (grep.find(ERROR_MESSAGE) != 0) {
+                                log.complain("'" + ERROR_MESSAGE + "' is not expected to be "
+                                                + "printed after 'next' command.");
+                                success = false;
+                        }
+                } else {
+                        log.complain("File does not exist: " + classFile);
+                        success = false;
+                }
+
+                jdb.contToExit(1);
+        }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395.java
@@ -144,20 +144,20 @@ public class b4689395 extends JdbTest {
 
     public b4689395() {
         classFile = ClassLoadUtils.getRedefineClassFileName(DEBUGGEE_CLASS);
-        if (classFile == null)
+        if (classFile == null) {
             throw new TestFailure("Unable to find redefine class file in classpath for: " + DEBUGGEE_CLASS);
+        }
     }
 
     protected void runCases() {
-        String[] reply;
         jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
         jdb.receiveReplyFor(JdbCommand.cont);
 
         if (new File(classFile).exists()) {
             jdb.receiveReplyFor(JdbCommand.redefine + DEBUGGEE_CLASS + " " + classFile);
-            reply = jdb.receiveReplyFor(JdbCommand.next);
+            String[] reply = jdb.receiveReplyFor(JdbCommand.next);
 
-            Paragrep grep = new Paragrep(reply);
+            var grep = new Paragrep(reply);
             if (grep.find(ERROR_MESSAGE) != 0) {
                 log.complain("'" + ERROR_MESSAGE + "' is not expected to be "
                         + "printed after 'next' command.");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395.java
@@ -115,58 +115,59 @@
 
 package nsk.jdb.regression.b4689395;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.TestFailure;
 import nsk.share.classload.ClassLoadUtils;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.PrintStream;
 
 public class b4689395 extends JdbTest {
-        final static String TEST_CLASS     = b4689395.class.getName();
-        final static String DEBUGGEE_CLASS = TEST_CLASS + "a";
-        final static String FIRST_BREAK    = DEBUGGEE_CLASS + ".main";
-        final static String ERROR_MESSAGE  = "ERROR_M";
-        final static int    LINE_NUMBER    = 54;
-        private String classFile;
+    final static String TEST_CLASS = b4689395.class.getName();
+    final static String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    final static String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    final static String ERROR_MESSAGE = "ERROR_M";
+    final static int LINE_NUMBER = 54;
+    private String classFile;
 
-        public static void main (String argv[]) {
-                System.exit(run(argv, System.out) + JCK_STATUS_BASE);
+    public static void main(String[] argv) {
+        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
+    }
+
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
+        firstBreak = FIRST_BREAK;
+        return new b4689395().runTest(argv, out);
+    }
+
+    public b4689395() {
+        classFile = ClassLoadUtils.getRedefineClassFileName(DEBUGGEE_CLASS);
+        if (classFile == null)
+            throw new TestFailure("Unable to find redefine class file in classpath for: " + DEBUGGEE_CLASS);
+    }
+
+    protected void runCases() {
+        String[] reply;
+        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
+        jdb.receiveReplyFor(JdbCommand.cont);
+
+        if (new File(classFile).exists()) {
+            jdb.receiveReplyFor(JdbCommand.redefine + DEBUGGEE_CLASS + " " + classFile);
+            reply = jdb.receiveReplyFor(JdbCommand.next);
+
+            Paragrep grep = new Paragrep(reply);
+            if (grep.find(ERROR_MESSAGE) != 0) {
+                log.complain("'" + ERROR_MESSAGE + "' is not expected to be "
+                        + "printed after 'next' command.");
+                success = false;
+            }
+        } else {
+            log.complain("File does not exist: " + classFile);
+            success = false;
         }
 
-        public static int run(String argv[], PrintStream out) {
-                debuggeeClass =  DEBUGGEE_CLASS;
-                firstBreak = FIRST_BREAK;
-                return new b4689395().runTest(argv, out);
-        }
-
-        public b4689395() {
-                classFile = ClassLoadUtils.getRedefineClassFileName(DEBUGGEE_CLASS);
-                if (classFile == null)
-                        throw new TestFailure("Unable to find redefine class file in classpath for: " + DEBUGGEE_CLASS);
-        }
-
-        protected void runCases() {
-                String[] reply;
-                reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
-                reply = jdb.receiveReplyFor(JdbCommand.cont);
-
-                if (new File(classFile).exists()) {
-                        reply = jdb.receiveReplyFor(JdbCommand.redefine + DEBUGGEE_CLASS
-                                        + " " + classFile);
-                        reply = jdb.receiveReplyFor(JdbCommand.next);
-
-                        Paragrep grep = new Paragrep(reply);
-                        if (grep.find(ERROR_MESSAGE) != 0) {
-                                log.complain("'" + ERROR_MESSAGE + "' is not expected to be "
-                                                + "printed after 'next' command.");
-                                success = false;
-                        }
-                } else {
-                        log.complain("File does not exist: " + classFile);
-                        success = false;
-                }
-
-                jdb.contToExit(1);
-        }
+        jdb.contToExit(1);
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
@@ -49,9 +49,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.resume.resume002.resume002
- *        nsk.jdb.resume.resume002.resume002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.resume.resume002.resume002
+ * @build nsk.jdb.resume.resume002.resume002a
+ * @run main/othervm
+ *      nsk.jdb.resume.resume002.resume002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
@@ -64,39 +64,36 @@
 
 package nsk.jdb.resume.resume002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class resume002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new resume002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.resume.resume002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".resume002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.resume.resume002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".resume002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String THREAD_NAME      = "MyThread";
+    static final String THREAD_NAME = "MyThread";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
@@ -92,19 +92,17 @@ public class resume002 extends JdbTest {
     static final String THREAD_NAME = "MyThread";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
         String[] threadIds = jdb.getThreadIds(PACKAGE_NAME + "." + THREAD_NAME);
 
-        reply = jdb.receiveReplyFor(JdbCommand.suspend);
-        grep = new Paragrep(reply);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.suspend);
+        var grep = new Paragrep(reply);
         if (grep.find("All threads suspended") == 0) {
             failure("jdb cannot suspend all threads");
         }
+
         reply = jdb.receiveReplyFor(JdbCommand.resume, false);
         grep = new Paragrep(reply);
         if (grep.find("All threads resumed") == 0) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
@@ -64,45 +64,50 @@
 
 package nsk.jdb.resume.resume002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class resume002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new resume002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.resume.resume002";
-    static final String TEST_CLASS = PACKAGE_NAME + ".resume002";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME     = "nsk.jdb.resume.resume002";
+    static final String TEST_CLASS       = PACKAGE_NAME + ".resume002";
+    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String THREAD_NAME = "MyThread";
+    static final String THREAD_NAME      = "MyThread";
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
         String[] threadIds = jdb.getThreadIds(PACKAGE_NAME + "." + THREAD_NAME);
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.suspend);
-        var grep = new Paragrep(reply);
+        reply = jdb.receiveReplyFor(JdbCommand.suspend);
+        grep = new Paragrep(reply);
         if (grep.find("All threads suspended") == 0) {
             failure("jdb cannot suspend all threads");
         }
-
         reply = jdb.receiveReplyFor(JdbCommand.resume, false);
         grep = new Paragrep(reply);
         if (grep.find("All threads resumed") == 0) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002.java
@@ -43,9 +43,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.run.run002.run002
- *        nsk.jdb.run.run002.run002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.run.run002.run002
+ * @build nsk.jdb.run.run002.run002a
+ * @run main/othervm
+ *      nsk.jdb.run.run002.run002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002.java
@@ -85,16 +85,12 @@ public class run002 extends JdbTest {
     static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        Vector<String> v;
-
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
-            reply = jdb.getTotalReply();
-            grep = new Paragrep(reply);
-            v = new Vector<>();
+            String[] reply = jdb.getTotalReply();
+            var grep = new Paragrep(reply);
+            var v = new Vector<String>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002.java
@@ -58,20 +58,21 @@
 
 package nsk.jdb.run.run002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class run002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new run002().runTest(argv, out);
@@ -80,22 +81,20 @@ public class run002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.run.run002";
     static final String TEST_CLASS = PACKAGE_NAME + ".run002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
             reply = jdb.getTotalReply();
             grep = new Paragrep(reply);
-            v = new Vector();
+            v = new Vector<>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002.java
@@ -58,21 +58,20 @@
 
 package nsk.jdb.run.run002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class run002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new run002().runTest(argv, out);
@@ -81,16 +80,22 @@ public class run002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.run.run002";
     static final String TEST_CLASS = PACKAGE_NAME + ".run002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
-            String[] reply = jdb.getTotalReply();
-            var grep = new Paragrep(reply);
-            var v = new Vector<String>();
+            reply = jdb.getTotalReply();
+            grep = new Paragrep(reply);
+            v = new Vector();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001.java
@@ -53,7 +53,8 @@
  * @clean nsk.jdb.set.set001.set001a
  * @compile -g:lines,source,vars set001a.java
  *
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.set.set001.set001
+ * @run main/othervm
+ *      nsk.jdb.set.set001.set001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001.java
@@ -67,19 +67,20 @@
 
 package nsk.jdb.set.set001;
 
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class set001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new set001().runTest(argv, out);
@@ -88,37 +89,43 @@ public class set001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.set.set001";
     static final String TEST_CLASS = PACKAGE_NAME + ".set001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String ERROR_MESSAGE = DEBUGGEE_CLASS + ".errorMessage";
 
     static final String[][] checkedExpr = {
-            {DEBUGGEE_CLASS + ".myStaticField", "-2147483648"},
-            {DEBUGGEE_CLASS + "._set001a.myInstanceField", "9223372036854775807"},
-    };
+        { DEBUGGEE_CLASS + ".myStaticField", "-2147483648" },
+        { DEBUGGEE_CLASS + "._set001a.myInstanceField", "9223372036854775807" },
+                                          };
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         // to get out of lastBreak()
-        jdb.receiveReplyFor(JdbCommand.step);
+        reply = jdb.receiveReplyFor(JdbCommand.step);
 
         // set values
-        for (String[] strings : checkedExpr) {
-            jdb.receiveReplyFor(JdbCommand.set + strings[0] + " = " + strings[1]);
+        for (int i = 0; i < checkedExpr.length; i++) {
+            reply = jdb.receiveReplyFor(JdbCommand.set + checkedExpr[i][0] + " = " + checkedExpr[i][1]);
         }
 
-        jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
         // check value of debuggeeResult
-        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + ERROR_MESSAGE);
-        // if everything is OK reply will look like this
-        //   nsk.jdb.set.set001.set001a.errorMessage = ""
+        reply = jdb.receiveReplyFor(JdbCommand.eval + ERROR_MESSAGE);
+        //if everything is OK reply will look like this
+        //  nsk.jdb.set.set001.set001a.errorMessage = ""
         if (!reply[0].contains("\"\"")) {
             log.complain("jdb failed to set value for expression(s): ");
-            for (String s : reply) {
-                log.complain(s);
+            for (int i = 0; i < reply.length; i++) {
+                log.complain(reply[i]);
             }
             success = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001.java
@@ -67,20 +67,19 @@
 
 package nsk.jdb.set.set001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class set001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new set001().runTest(argv, out);
@@ -89,43 +88,39 @@ public class set001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.set.set001";
     static final String TEST_CLASS = PACKAGE_NAME + ".set001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String ERROR_MESSAGE = DEBUGGEE_CLASS + ".errorMessage";
 
     static final String[][] checkedExpr = {
-        { DEBUGGEE_CLASS + ".myStaticField", "-2147483648" },
-        { DEBUGGEE_CLASS + "._set001a.myInstanceField", "9223372036854775807" },
-                                          };
+            {DEBUGGEE_CLASS + ".myStaticField", "-2147483648"},
+            {DEBUGGEE_CLASS + "._set001a.myInstanceField", "9223372036854775807"},
+    };
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // to get out of lastBreak()
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
 
         // set values
-        for (int i = 0; i < checkedExpr.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.set + checkedExpr[i][0] + " = " + checkedExpr[i][1]);
+        for (String[] strings : checkedExpr) {
+            jdb.receiveReplyFor(JdbCommand.set + strings[0] + " = " + strings[1]);
         }
 
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
         // check value of debuggeeResult
         reply = jdb.receiveReplyFor(JdbCommand.eval + ERROR_MESSAGE);
-        //if everything is OK reply will look like this
-        //  nsk.jdb.set.set001.set001a.errorMessage = ""
+        // if everything is OK reply will look like this
+        //   nsk.jdb.set.set001.set001a.errorMessage = ""
         if (!reply[0].contains("\"\"")) {
             log.complain("jdb failed to set value for expression(s): ");
-            for (int i = 0; i < reply.length; i++) {
-                log.complain(reply[i]);
+            for (String s : reply) {
+                log.complain(s);
             }
             success = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001.java
@@ -99,8 +99,6 @@ public class set001 extends JdbTest {
     };
 
     protected void runCases() {
-        String[] reply;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
@@ -114,7 +112,7 @@ public class set001 extends JdbTest {
 
         jdb.receiveReplyFor(JdbCommand.cont);
         // check value of debuggeeResult
-        reply = jdb.receiveReplyFor(JdbCommand.eval + ERROR_MESSAGE);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + ERROR_MESSAGE);
         // if everything is OK reply will look like this
         //   nsk.jdb.set.set001.set001a.errorMessage = ""
         if (!reply[0].contains("\"\"")) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002.java
@@ -53,7 +53,8 @@
  * @clean nsk.jdb.set.set002.set002a
  * @compile -g:lines,source,vars set002a.java
  *
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.set.set002.set002
+ * @run main/othervm
+ *      nsk.jdb.set.set002.set002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002.java
@@ -67,21 +67,20 @@
 
 package nsk.jdb.set.set002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class set002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
 
@@ -91,38 +90,44 @@ public class set002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.set.set002";
     static final String TEST_CLASS = PACKAGE_NAME + ".set002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String ERROR_MESSAGE = DEBUGGEE_CLASS + ".errorMessage";
 
     static final String[][] checkedExpr = {  //not broken, can be run safely even if 4660158 is not fixed
-            {DEBUGGEE_CLASS + "._set002a.myArrayField[0][0].line", "\"ABCDE\""},
-            {"localInt", "java.lang.Integer.MIN_VALUE"}
-    };
+        { DEBUGGEE_CLASS + "._set002a.myArrayField[0][0].line", "\"ABCDE\"" },
+        { "localInt", "java.lang.Integer.MIN_VALUE"}
+                                          };
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         // to get out of lastBreak()
-        jdb.receiveReplyFor(JdbCommand.step);
+        reply = jdb.receiveReplyFor(JdbCommand.step);
 
         // set values
-        for (String[] strings : checkedExpr) {
-            jdb.receiveReplyFor(JdbCommand.set + strings[0] + " = " + strings[1]);
+        for (int i = 0; i < checkedExpr.length; i++) {
+            reply = jdb.receiveReplyFor(JdbCommand.set + checkedExpr[i][0] + " = " + checkedExpr[i][1]);
         }
 
-        jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
         // check value of debuggeeResult
-        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + ERROR_MESSAGE);
+        reply = jdb.receiveReplyFor(JdbCommand.eval + ERROR_MESSAGE);
 
-        // if everything is OK reply will look like this
-        //   nsk.jdb.set.set002.set002a.errorMessage = ""
+        //if everything is OK reply will look like this
+        //  nsk.jdb.set.set002.set002a.errorMessage = ""
         if (!reply[0].contains("\"\"")) {
             log.complain("jdb failed to set value for expression(s): ");
-            for (String s : reply) {
-                log.complain(s);
+            for (int i = 0; i < reply.length; i++) {
+                log.complain(reply[i]);
             }
             success = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002.java
@@ -102,8 +102,6 @@ public class set002 extends JdbTest {
     };
 
     protected void runCases() {
-        String[] reply;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
@@ -117,7 +115,7 @@ public class set002 extends JdbTest {
 
         jdb.receiveReplyFor(JdbCommand.cont);
         // check value of debuggeeResult
-        reply = jdb.receiveReplyFor(JdbCommand.eval + ERROR_MESSAGE);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + ERROR_MESSAGE);
 
         // if everything is OK reply will look like this
         //   nsk.jdb.set.set002.set002a.errorMessage = ""

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002.java
@@ -67,20 +67,21 @@
 
 package nsk.jdb.set.set002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class set002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
 
@@ -90,44 +91,40 @@ public class set002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.set.set002";
     static final String TEST_CLASS = PACKAGE_NAME + ".set002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String ERROR_MESSAGE = DEBUGGEE_CLASS + ".errorMessage";
 
     static final String[][] checkedExpr = {  //not broken, can be run safely even if 4660158 is not fixed
-        { DEBUGGEE_CLASS + "._set002a.myArrayField[0][0].line", "\"ABCDE\"" },
-        { "localInt", "java.lang.Integer.MIN_VALUE"}
-                                          };
+            {DEBUGGEE_CLASS + "._set002a.myArrayField[0][0].line", "\"ABCDE\""},
+            {"localInt", "java.lang.Integer.MIN_VALUE"}
+    };
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // to get out of lastBreak()
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
 
         // set values
-        for (int i = 0; i < checkedExpr.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.set + checkedExpr[i][0] + " = " + checkedExpr[i][1]);
+        for (String[] strings : checkedExpr) {
+            jdb.receiveReplyFor(JdbCommand.set + strings[0] + " = " + strings[1]);
         }
 
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
         // check value of debuggeeResult
         reply = jdb.receiveReplyFor(JdbCommand.eval + ERROR_MESSAGE);
 
-        //if everything is OK reply will look like this
-        //  nsk.jdb.set.set002.set002a.errorMessage = ""
+        // if everything is OK reply will look like this
+        //   nsk.jdb.set.set002.set002a.errorMessage = ""
         if (!reply[0].contains("\"\"")) {
             log.complain("jdb failed to set value for expression(s): ");
-            for (int i = 0; i < reply.length; i++) {
-                log.complain(reply[i]);
+            for (String s : reply) {
+                log.complain(s);
             }
             success = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002.java
@@ -56,7 +56,8 @@
  * @clean nsk.jdb.step.step002.step002a
  * @compile -g:lines,source,vars step002a.java
  *
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.step.step002.step002
+ * @run main/othervm
+ *      nsk.jdb.step.step002.step002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002.java
@@ -97,16 +97,13 @@ public class step002 extends JdbTest {
     static final int BREAKPOINT_LINE = 50;
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-
         jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
         jdb.receiveReplyFor(JdbCommand.cont);
 
         // case #1 : step inside frame;
         jdb.receiveReplyFor(JdbCommand.step);
-        reply = jdb.receiveReplyFor(JdbCommand.eval + "intVar");
-        grep = new Paragrep(reply);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + "intVar");
+        var grep = new Paragrep(reply);
         if (grep.find("1234") == 0) {
             failure("CASE #1 FAILED: Wrong location after step inside current method");
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002.java
@@ -70,46 +70,53 @@
 
 package nsk.jdb.step.step002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class step002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new step002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.step.step002";
-    static final String TEST_CLASS = PACKAGE_NAME + ".step002";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
-    static final int BREAKPOINT_LINE = 50;
+    static final String PACKAGE_NAME    = "nsk.jdb.step.step002";
+    static final String TEST_CLASS      = PACKAGE_NAME + ".step002";
+    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
+    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final int    BREAKPOINT_LINE = 50;
 
     protected void runCases() {
-        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+        String[] threads;
+
+        reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         // case #1 : step inside frame;
-        jdb.receiveReplyFor(JdbCommand.step);
-        String[] reply = jdb.receiveReplyFor(JdbCommand.eval + "intVar");
-        var grep = new Paragrep(reply);
+        reply = jdb.receiveReplyFor(JdbCommand.step);
+        reply = jdb.receiveReplyFor(JdbCommand.eval + "intVar");
+        grep = new Paragrep(reply);
         if (grep.find("1234") == 0) {
             failure("CASE #1 FAILED: Wrong location after step inside current method");
         }
 
         // case #1 : step into called frame;
-        jdb.receiveReplyFor(JdbCommand.step);
+        reply = jdb.receiveReplyFor(JdbCommand.step);
         reply = jdb.receiveReplyFor(JdbCommand.where);
         grep = new Paragrep(reply);
         if (grep.find("foo") == 0) {
@@ -117,7 +124,7 @@ public class step002 extends JdbTest {
         }
 
         // case #1 : step out to calling frame;
-        jdb.receiveReplyFor(JdbCommand.step);
+        reply = jdb.receiveReplyFor(JdbCommand.step);
         reply = jdb.receiveReplyFor(JdbCommand.where);
         grep = new Paragrep(reply);
         if (grep.find("foo") > 0) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002.java
@@ -70,45 +70,41 @@
 
 package nsk.jdb.step.step002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class step002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new step002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.step.step002";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".step002";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
-    static final int    BREAKPOINT_LINE = 50;
+    static final String PACKAGE_NAME = "nsk.jdb.step.step002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".step002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final int BREAKPOINT_LINE = 50;
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-        String[] threads;
 
-        reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // case #1 : step inside frame;
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
         reply = jdb.receiveReplyFor(JdbCommand.eval + "intVar");
         grep = new Paragrep(reply);
         if (grep.find("1234") == 0) {
@@ -116,7 +112,7 @@ public class step002 extends JdbTest {
         }
 
         // case #1 : step into called frame;
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
         reply = jdb.receiveReplyFor(JdbCommand.where);
         grep = new Paragrep(reply);
         if (grep.find("foo") == 0) {
@@ -124,7 +120,7 @@ public class step002 extends JdbTest {
         }
 
         // case #1 : step out to calling frame;
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
         reply = jdb.receiveReplyFor(JdbCommand.where);
         grep = new Paragrep(reply);
         if (grep.find("foo") > 0) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001.java
@@ -44,9 +44,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.step_up.step_up001.step_up001
- *        nsk.jdb.step_up.step_up001.step_up001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.step_up.step_up001.step_up001
+ * @build nsk.jdb.step_up.step_up001.step_up001a
+ * @run main/othervm
+ *      nsk.jdb.step_up.step_up001.step_up001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001.java
@@ -59,45 +59,54 @@
 
 package nsk.jdb.step_up.step_up001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class step_up001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new step_up001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.step_up.step_up001";
-    static final String TEST_CLASS = PACKAGE_NAME + ".step_up001";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
-    static final String MYTHREAD = "MyThread";
+    static final String PACKAGE_NAME    = "nsk.jdb.step_up.step_up001";
+    static final String TEST_CLASS      = PACKAGE_NAME + ".step_up001";
+    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
+    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final String MYTHREAD        = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String[] checkedMethods = {"func1", "func2", "func3"};
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+        String[] threads;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
 
+        int breakCount = 0;
         int stepupCount = 0;
         for (int i = 0; i < step_up001a.numThreads; i++) {
-            String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
+            reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (jdb.isAtBreakpoint(reply, LAST_BREAK)) {
-                jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
+                breakCount++;
+                reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
 
-                jdb.receiveReplyFor(JdbCommand.step_up);
+                reply = jdb.receiveReplyFor(JdbCommand.step_up);
                 if (!checkSteppedUp()) {
                     success = false;
                 } else {
@@ -116,8 +125,9 @@ public class step_up001 extends JdbTest {
     }
 
 
-    private boolean checkSteppedUp() {
+    private boolean checkSteppedUp () {
         Paragrep grep;
+        String found;
         int count;
         boolean result = true;
         String[] reply;
@@ -129,14 +139,14 @@ public class step_up001 extends JdbTest {
             count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[i]);
             if (count > 0) {
                 log.complain("Wrong method in thread stack trace: " + DEBUGGEE_THREAD + "." + checkedMethods[i]);
-                result = false;
+                result= false;
             }
         }
 
         count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[0]);
         if (count != 1) {
             log.complain("Checked method does not exist in thread stack trace: " + DEBUGGEE_THREAD + "." + checkedMethods[0]);
-            result = false;
+            result= false;
         }
 
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001.java
@@ -89,13 +89,11 @@ public class step_up001 extends JdbTest {
     static final String[] checkedMethods = {"func1", "func2", "func3"};
 
     protected void runCases() {
-        String[] reply;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
 
         int stepupCount = 0;
         for (int i = 0; i < step_up001a.numThreads; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (jdb.isAtBreakpoint(reply, LAST_BREAK)) {
                 jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001.java
@@ -59,54 +59,47 @@
 
 package nsk.jdb.step_up.step_up001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class step_up001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new step_up001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.step_up.step_up001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".step_up001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.step_up.step_up001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".step_up001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String[] checkedMethods = {"func1", "func2", "func3"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-        String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
 
-        int breakCount = 0;
         int stepupCount = 0;
         for (int i = 0; i < step_up001a.numThreads; i++) {
             reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (jdb.isAtBreakpoint(reply, LAST_BREAK)) {
-                breakCount++;
-                reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
+                jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
 
-                reply = jdb.receiveReplyFor(JdbCommand.step_up);
+                jdb.receiveReplyFor(JdbCommand.step_up);
                 if (!checkSteppedUp()) {
                     success = false;
                 } else {
@@ -125,9 +118,8 @@ public class step_up001 extends JdbTest {
     }
 
 
-    private boolean checkSteppedUp () {
+    private boolean checkSteppedUp() {
         Paragrep grep;
-        String found;
         int count;
         boolean result = true;
         String[] reply;
@@ -139,14 +131,14 @@ public class step_up001 extends JdbTest {
             count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[i]);
             if (count > 0) {
                 log.complain("Wrong method in thread stack trace: " + DEBUGGEE_THREAD + "." + checkedMethods[i]);
-                result= false;
+                result = false;
             }
         }
 
         count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[0]);
         if (count != 1) {
             log.complain("Checked method does not exist in thread stack trace: " + DEBUGGEE_THREAD + "." + checkedMethods[0]);
-            result= false;
+            result = false;
         }
 
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java
@@ -36,9 +36,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.stop_at.stop_at002.stop_at002
- *        nsk.jdb.stop_at.stop_at002.stop_at002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.stop_at.stop_at002.stop_at002
+ * @build nsk.jdb.stop_at.stop_at002.stop_at002a
+ * @run main/othervm
+ *      nsk.jdb.stop_at.stop_at002.stop_at002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java
@@ -51,26 +51,27 @@
 
 package nsk.jdb.stop_at.stop_at002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 /*
  * Regression test for:
  * Bug ID: 4299394
  * Synopsis: TTY: Deferred breakpoints can't be set on inner classes
+ *
  */
 
 public class stop_at002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new stop_at002().runTest(argv, out);
@@ -79,13 +80,19 @@ public class stop_at002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.stop_at.stop_at002";
     static final String TEST_CLASS = PACKAGE_NAME + ".stop_at002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
     static final String DEBUGGEE_LOCATION1 = DEBUGGEE_CLASS + "$Nested$DeeperNested$DeepestNested:43";
     static final String DEBUGGEE_LOCATION2 = DEBUGGEE_CLASS + "$Inner$MoreInner:57";
     static final String FAILURE_PATTERN = "Unable to set";
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         if (!checkStop(DEBUGGEE_LOCATION1)) {
             success = false;
         }
@@ -97,14 +104,17 @@ public class stop_at002 extends JdbTest {
         jdb.contToExit(3);
     }
 
-    private boolean checkStop(String location) {
+    private boolean checkStop (String location) {
+        Paragrep grep;
+        String[] reply;
+        String found;
         boolean result = true;
 
         log.display("Trying to set breakpoint at line: " + location);
-        String[] reply = jdb.receiveReplyFor(JdbCommand.stop_at + location);
+        reply = jdb.receiveReplyFor(JdbCommand.stop_at + location);
 
-        var grep = new Paragrep(reply);
-        String found = grep.findFirst(FAILURE_PATTERN);
+        grep = new Paragrep(reply);
+        found = grep.findFirst(FAILURE_PATTERN);
         if (found.length() > 0) {
             log.complain("jdb failed to set line breakpoint at line: " + found);
             result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java
@@ -51,27 +51,26 @@
 
 package nsk.jdb.stop_at.stop_at002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 /*
  * Regression test for:
  * Bug ID: 4299394
  * Synopsis: TTY: Deferred breakpoints can't be set on inner classes
- *
  */
 
 public class stop_at002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new stop_at002().runTest(argv, out);
@@ -80,19 +79,13 @@ public class stop_at002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.stop_at.stop_at002";
     static final String TEST_CLASS = PACKAGE_NAME + ".stop_at002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
     static final String DEBUGGEE_LOCATION1 = DEBUGGEE_CLASS + "$Nested$DeeperNested$DeepestNested:43";
     static final String DEBUGGEE_LOCATION2 = DEBUGGEE_CLASS + "$Inner$MoreInner:57";
     static final String FAILURE_PATTERN = "Unable to set";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-
         if (!checkStop(DEBUGGEE_LOCATION1)) {
             success = false;
         }
@@ -104,7 +97,7 @@ public class stop_at002 extends JdbTest {
         jdb.contToExit(3);
     }
 
-    private boolean checkStop (String location) {
+    private boolean checkStop(String location) {
         Paragrep grep;
         String[] reply;
         String found;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java
@@ -98,16 +98,13 @@ public class stop_at002 extends JdbTest {
     }
 
     private boolean checkStop(String location) {
-        Paragrep grep;
-        String[] reply;
-        String found;
         boolean result = true;
 
         log.display("Trying to set breakpoint at line: " + location);
-        reply = jdb.receiveReplyFor(JdbCommand.stop_at + location);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.stop_at + location);
 
-        grep = new Paragrep(reply);
-        found = grep.findFirst(FAILURE_PATTERN);
+        var grep = new Paragrep(reply);
+        String found = grep.findFirst(FAILURE_PATTERN);
         if (found.length() > 0) {
             log.complain("jdb failed to set line breakpoint at line: " + found);
             result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003.java
@@ -48,9 +48,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.stop_at.stop_at003.stop_at003
- *        nsk.jdb.stop_at.stop_at003.stop_at003a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.stop_at.stop_at003.stop_at003
+ * @build nsk.jdb.stop_at.stop_at003.stop_at003a
+ * @run main/othervm
+ *      nsk.jdb.stop_at.stop_at003.stop_at003
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003.java
@@ -63,27 +63,26 @@
 
 package nsk.jdb.stop_at.stop_at003;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 /*
  * Regression test for:
  * Bug ID: 4299394
  * Synopsis: TTY: Deferred breakpoints can't be set on inner classes
- *
  */
 
 public class stop_at003 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new stop_at003().runTest(argv, out);
@@ -92,40 +91,36 @@ public class stop_at003 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.stop_at.stop_at003";
     static final String TEST_CLASS = PACKAGE_NAME + ".stop_at003";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final String[][] LOCATIONS = new String[][] {
-        { PACKAGE_NAME + ".stop_at003b:61", PACKAGE_NAME + ".stop_at003b.<clinit>()" },
-        { PACKAGE_NAME + ".stop_at003b:63", PACKAGE_NAME + ".stop_at003b.<init>()" },
-        { PACKAGE_NAME + ".stop_at003b:66", PACKAGE_NAME + ".stop_at003b.<init>()" },
-        { PACKAGE_NAME + ".stop_at003b:72", PACKAGE_NAME + ".stop_at003b.foo()" }
-                                                   };
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String[][] LOCATIONS = new String[][]{
+            {PACKAGE_NAME + ".stop_at003b:61", PACKAGE_NAME + ".stop_at003b.<clinit>()"},
+            {PACKAGE_NAME + ".stop_at003b:63", PACKAGE_NAME + ".stop_at003b.<init>()"},
+            {PACKAGE_NAME + ".stop_at003b:66", PACKAGE_NAME + ".stop_at003b.<init>()"},
+            {PACKAGE_NAME + ".stop_at003b:72", PACKAGE_NAME + ".stop_at003b.foo()"}
+    };
     static final String FAILURE_PATTERN = "Unable to set";
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
-        for (int i = 0; i < LOCATIONS.length; i++) {
-            if (!checkStop(LOCATIONS[i][0])) {
-                failure("jdb failed to set line breakpoint at : " + LOCATIONS[i][0]);
+        for (String[] location : LOCATIONS) {
+            if (!checkStop(location[0])) {
+                failure("jdb failed to set line breakpoint at : " + location[0]);
             }
         }
 
-        for (int i = 0; i < LOCATIONS.length; i++) {
+        for (String[] location : LOCATIONS) {
             reply = jdb.receiveReplyFor(JdbCommand.cont);
-            if (!jdb.isAtBreakpoint(reply, LOCATIONS[i][1])) {
-                failure("Missed breakpoint at : " + LOCATIONS[i][0]);
+            if (!jdb.isAtBreakpoint(reply, location[1])) {
+                failure("Missed breakpoint at : " + location[0]);
             }
         }
 
         jdb.contToExit(1);
     }
 
-    private boolean checkStop (String location) {
+    private boolean checkStop(String location) {
         Paragrep grep;
         String[] reply;
         String found;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003.java
@@ -102,8 +102,6 @@ public class stop_at003 extends JdbTest {
     static final String FAILURE_PATTERN = "Unable to set";
 
     protected void runCases() {
-        String[] reply;
-
         for (String[] location : LOCATIONS) {
             if (!checkStop(location[0])) {
                 failure("jdb failed to set line breakpoint at : " + location[0]);
@@ -111,7 +109,7 @@ public class stop_at003 extends JdbTest {
         }
 
         for (String[] location : LOCATIONS) {
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (!jdb.isAtBreakpoint(reply, location[1])) {
                 failure("Missed breakpoint at : " + location[0]);
             }
@@ -121,16 +119,13 @@ public class stop_at003 extends JdbTest {
     }
 
     private boolean checkStop(String location) {
-        Paragrep grep;
-        String[] reply;
-        String found;
         boolean result = true;
 
         log.display("Trying to set breakpoint at line: " + location);
-        reply = jdb.receiveReplyFor(JdbCommand.stop_at + location);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.stop_at + location);
 
-        grep = new Paragrep(reply);
-        found = grep.findFirst(FAILURE_PATTERN);
+        var grep = new Paragrep(reply);
+        String found = grep.findFirst(FAILURE_PATTERN);
         if (found.length() > 0) {
             result = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003.java
@@ -63,26 +63,27 @@
 
 package nsk.jdb.stop_at.stop_at003;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 /*
  * Regression test for:
  * Bug ID: 4299394
  * Synopsis: TTY: Deferred breakpoints can't be set on inner classes
+ *
  */
 
 public class stop_at003 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new stop_at003().runTest(argv, out);
@@ -91,41 +92,50 @@ public class stop_at003 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.stop_at.stop_at003";
     static final String TEST_CLASS = PACKAGE_NAME + ".stop_at003";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
-    static final String[][] LOCATIONS = new String[][]{
-            {PACKAGE_NAME + ".stop_at003b:61", PACKAGE_NAME + ".stop_at003b.<clinit>()"},
-            {PACKAGE_NAME + ".stop_at003b:63", PACKAGE_NAME + ".stop_at003b.<init>()"},
-            {PACKAGE_NAME + ".stop_at003b:66", PACKAGE_NAME + ".stop_at003b.<init>()"},
-            {PACKAGE_NAME + ".stop_at003b:72", PACKAGE_NAME + ".stop_at003b.foo()"}
-    };
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String[][] LOCATIONS = new String[][] {
+        { PACKAGE_NAME + ".stop_at003b:61", PACKAGE_NAME + ".stop_at003b.<clinit>()" },
+        { PACKAGE_NAME + ".stop_at003b:63", PACKAGE_NAME + ".stop_at003b.<init>()" },
+        { PACKAGE_NAME + ".stop_at003b:66", PACKAGE_NAME + ".stop_at003b.<init>()" },
+        { PACKAGE_NAME + ".stop_at003b:72", PACKAGE_NAME + ".stop_at003b.foo()" }
+                                                   };
     static final String FAILURE_PATTERN = "Unable to set";
 
     protected void runCases() {
-        for (String[] location : LOCATIONS) {
-            if (!checkStop(location[0])) {
-                failure("jdb failed to set line breakpoint at : " + location[0]);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
+        for (int i = 0; i < LOCATIONS.length; i++) {
+            if (!checkStop(LOCATIONS[i][0])) {
+                failure("jdb failed to set line breakpoint at : " + LOCATIONS[i][0]);
             }
         }
 
-        for (String[] location : LOCATIONS) {
-            String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
-            if (!jdb.isAtBreakpoint(reply, location[1])) {
-                failure("Missed breakpoint at : " + location[0]);
+        for (int i = 0; i < LOCATIONS.length; i++) {
+            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            if (!jdb.isAtBreakpoint(reply, LOCATIONS[i][1])) {
+                failure("Missed breakpoint at : " + LOCATIONS[i][0]);
             }
         }
 
         jdb.contToExit(1);
     }
 
-    private boolean checkStop(String location) {
+    private boolean checkStop (String location) {
+        Paragrep grep;
+        String[] reply;
+        String found;
         boolean result = true;
 
         log.display("Trying to set breakpoint at line: " + location);
-        String[] reply = jdb.receiveReplyFor(JdbCommand.stop_at + location);
+        reply = jdb.receiveReplyFor(JdbCommand.stop_at + location);
 
-        var grep = new Paragrep(reply);
-        String found = grep.findFirst(FAILURE_PATTERN);
+        grep = new Paragrep(reply);
+        found = grep.findFirst(FAILURE_PATTERN);
         if (found.length() > 0) {
             result = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002.java
@@ -49,9 +49,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.stop_in.stop_in002.stop_in002
- *        nsk.jdb.stop_in.stop_in002.stop_in002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.stop_in.stop_in002.stop_in002
+ * @build nsk.jdb.stop_in.stop_in002.stop_in002a
+ * @run main/othervm
+ *      nsk.jdb.stop_in.stop_in002.stop_in002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002.java
@@ -105,8 +105,6 @@ public class stop_in002 extends JdbTest {
     static final String FAILURE_PATTERN = "Unable to set";
 
     protected void runCases() {
-        String[] reply;
-
         for (String location : LOCATIONS) {
             if (!checkStop(location)) {
                 failure("jdb failed to set line breakpoint at : " + location);
@@ -114,7 +112,7 @@ public class stop_in002 extends JdbTest {
         }
 
         for (String location : LOCATIONS) {
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (!jdb.isAtBreakpoint(reply, location)) {
                 failure("Missed breakpoint at : " + location);
             }
@@ -124,16 +122,13 @@ public class stop_in002 extends JdbTest {
     }
 
     private boolean checkStop(String location) {
-        Paragrep grep;
-        String[] reply;
-        String found;
         boolean result = true;
 
         log.display("Trying to set breakpoint at : " + location);
-        reply = jdb.receiveReplyFor(JdbCommand.stop_in + location);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.stop_in + location);
 
-        grep = new Paragrep(reply);
-        found = grep.findFirst(FAILURE_PATTERN);
+        var grep = new Paragrep(reply);
+        String found = grep.findFirst(FAILURE_PATTERN);
         if (found.length() > 0) {
             result = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002.java
@@ -64,11 +64,11 @@
 
 package nsk.jdb.stop_in.stop_in002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 /*
  * Regression test for:
@@ -79,12 +79,12 @@ import java.util.*;
 
 public class stop_in002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new stop_in002().runTest(argv, out);
@@ -93,41 +93,37 @@ public class stop_in002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.stop_in.stop_in002";
     static final String TEST_CLASS = PACKAGE_NAME + ".stop_in002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final String[] LOCATIONS = new String[] {
-        PACKAGE_NAME + ".stop_in002b.<clinit>",
-        PACKAGE_NAME + ".stop_in002b.<init>",
-        PACKAGE_NAME + ".stop_in002b$StaticNested.m1",
-        PACKAGE_NAME + ".stop_in002b$Inner.m2",
-        PACKAGE_NAME + ".stop_in002b.foo"
-                                                   };
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String[] LOCATIONS = new String[]{
+            PACKAGE_NAME + ".stop_in002b.<clinit>",
+            PACKAGE_NAME + ".stop_in002b.<init>",
+            PACKAGE_NAME + ".stop_in002b$StaticNested.m1",
+            PACKAGE_NAME + ".stop_in002b$Inner.m2",
+            PACKAGE_NAME + ".stop_in002b.foo"
+    };
     static final String FAILURE_PATTERN = "Unable to set";
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
-        for (int i = 0; i < LOCATIONS.length; i++) {
-            if (!checkStop(LOCATIONS[i])) {
-                failure("jdb failed to set line breakpoint at : " + LOCATIONS[i]);
+        for (String location : LOCATIONS) {
+            if (!checkStop(location)) {
+                failure("jdb failed to set line breakpoint at : " + location);
             }
         }
 
-        for (int i = 0; i < LOCATIONS.length; i++) {
+        for (String location : LOCATIONS) {
             reply = jdb.receiveReplyFor(JdbCommand.cont);
-            if (!jdb.isAtBreakpoint(reply, LOCATIONS[i])) {
-                failure("Missed breakpoint at : " + LOCATIONS[i]);
+            if (!jdb.isAtBreakpoint(reply, location)) {
+                failure("Missed breakpoint at : " + location);
             }
         }
 
         jdb.contToExit(1);
     }
 
-    private boolean checkStop (String location) {
+    private boolean checkStop(String location) {
         Paragrep grep;
         String[] reply;
         String found;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002.java
@@ -64,11 +64,11 @@
 
 package nsk.jdb.stop_in.stop_in002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 /*
  * Regression test for:
@@ -79,12 +79,12 @@ import java.io.PrintStream;
 
 public class stop_in002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new stop_in002().runTest(argv, out);
@@ -93,42 +93,51 @@ public class stop_in002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.stop_in.stop_in002";
     static final String TEST_CLASS = PACKAGE_NAME + ".stop_in002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
-    static final String[] LOCATIONS = new String[]{
-            PACKAGE_NAME + ".stop_in002b.<clinit>",
-            PACKAGE_NAME + ".stop_in002b.<init>",
-            PACKAGE_NAME + ".stop_in002b$StaticNested.m1",
-            PACKAGE_NAME + ".stop_in002b$Inner.m2",
-            PACKAGE_NAME + ".stop_in002b.foo"
-    };
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String[] LOCATIONS = new String[] {
+        PACKAGE_NAME + ".stop_in002b.<clinit>",
+        PACKAGE_NAME + ".stop_in002b.<init>",
+        PACKAGE_NAME + ".stop_in002b$StaticNested.m1",
+        PACKAGE_NAME + ".stop_in002b$Inner.m2",
+        PACKAGE_NAME + ".stop_in002b.foo"
+                                                   };
     static final String FAILURE_PATTERN = "Unable to set";
 
     protected void runCases() {
-        for (String location : LOCATIONS) {
-            if (!checkStop(location)) {
-                failure("jdb failed to set line breakpoint at : " + location);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
+        for (int i = 0; i < LOCATIONS.length; i++) {
+            if (!checkStop(LOCATIONS[i])) {
+                failure("jdb failed to set line breakpoint at : " + LOCATIONS[i]);
             }
         }
 
-        for (String location : LOCATIONS) {
-            String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
-            if (!jdb.isAtBreakpoint(reply, location)) {
-                failure("Missed breakpoint at : " + location);
+        for (int i = 0; i < LOCATIONS.length; i++) {
+            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            if (!jdb.isAtBreakpoint(reply, LOCATIONS[i])) {
+                failure("Missed breakpoint at : " + LOCATIONS[i]);
             }
         }
 
         jdb.contToExit(1);
     }
 
-    private boolean checkStop(String location) {
+    private boolean checkStop (String location) {
+        Paragrep grep;
+        String[] reply;
+        String found;
         boolean result = true;
 
         log.display("Trying to set breakpoint at : " + location);
-        String[] reply = jdb.receiveReplyFor(JdbCommand.stop_in + location);
+        reply = jdb.receiveReplyFor(JdbCommand.stop_in + location);
 
-        var grep = new Paragrep(reply);
-        String found = grep.findFirst(FAILURE_PATTERN);
+        grep = new Paragrep(reply);
+        found = grep.findFirst(FAILURE_PATTERN);
         if (found.length() > 0) {
             result = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
@@ -45,9 +45,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.suspend.suspend001.suspend001
- *        nsk.jdb.suspend.suspend001.suspend001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.suspend.suspend001.suspend001
+ * @build nsk.jdb.suspend.suspend001.suspend001a
+ * @run main/othervm
+ *      nsk.jdb.suspend.suspend001.suspend001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
@@ -60,21 +60,20 @@
 
 package nsk.jdb.suspend.suspend001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class suspend001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new suspend001().runTest(argv, out);
@@ -83,18 +82,25 @@ public class suspend001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.suspend.suspend001";
     static final String TEST_CLASS = PACKAGE_NAME + ".suspend001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
+    static final String FIRST_BREAK    = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK     = DEBUGGEE_CLASS + ".breakHere";
 
-    static final String SUSPENDED = "Suspended";
+    static final String SUSPENDED       = "Suspended";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + SUSPENDED;
     static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notSuspended";
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+        String[] threads;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
         while (true) {
-            String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+            threads = jdb.getThreadIds(DEBUGGEE_THREAD);
             if (threads.length != 1) {
                 log.complain("jdb should report 1 instance of " + DEBUGGEE_THREAD);
                 log.complain("Found: " + threads.length);
@@ -102,9 +108,9 @@ public class suspend001 extends JdbTest {
                 break;
             }
 
-            jdb.receiveReplyFor(JdbCommand.suspend + threads[0]);
+            reply = jdb.receiveReplyFor(JdbCommand.suspend + threads[0]);
 
-            String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
+            reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (!jdb.isAtBreakpoint(reply)) {
                 log.complain("Debugge does not reached second breakHere breakpoint");
                 success = false;
@@ -112,13 +118,13 @@ public class suspend001 extends JdbTest {
             }
 
             reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_RESULT);
-            var grep = new Paragrep(reply);
-            String found = grep.findFirst(DEBUGGEE_RESULT + " =");
-            if (found.length() > 0 && !found.contains(DEBUGGEE_RESULT + " = null")) {
-                if (!found.contains(DEBUGGEE_RESULT + " = 1")) {
-                    log.complain("Wrong value of " + DEBUGGEE_RESULT);
-                    log.complain(found);
-                    success = false;
+            grep = new Paragrep(reply);
+            found = grep.findFirst(DEBUGGEE_RESULT + " =" );
+            if (found.length() > 0 && found.indexOf(DEBUGGEE_RESULT + " = null") < 0) {
+                if (found.indexOf(DEBUGGEE_RESULT + " = 1") < 0) {
+                   log.complain("Wrong value of " + DEBUGGEE_RESULT);
+                   log.complain(found);
+                   success = false;
                 }
             } else {
                 log.complain("TEST BUG: not found value for " + DEBUGGEE_RESULT);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
@@ -60,20 +60,21 @@
 
 package nsk.jdb.suspend.suspend001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class suspend001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new suspend001().runTest(argv, out);
@@ -82,23 +83,21 @@ public class suspend001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.suspend.suspend001";
     static final String TEST_CLASS = PACKAGE_NAME + ".suspend001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK    = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK     = DEBUGGEE_CLASS + ".breakHere";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
 
-    static final String SUSPENDED       = "Suspended";
+    static final String SUSPENDED = "Suspended";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + SUSPENDED;
     static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notSuspended";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
         String found;
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
         while (true) {
             threads = jdb.getThreadIds(DEBUGGEE_THREAD);
             if (threads.length != 1) {
@@ -108,7 +107,7 @@ public class suspend001 extends JdbTest {
                 break;
             }
 
-            reply = jdb.receiveReplyFor(JdbCommand.suspend + threads[0]);
+            jdb.receiveReplyFor(JdbCommand.suspend + threads[0]);
 
             reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (!jdb.isAtBreakpoint(reply)) {
@@ -119,12 +118,12 @@ public class suspend001 extends JdbTest {
 
             reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_RESULT);
             grep = new Paragrep(reply);
-            found = grep.findFirst(DEBUGGEE_RESULT + " =" );
-            if (found.length() > 0 && found.indexOf(DEBUGGEE_RESULT + " = null") < 0) {
-                if (found.indexOf(DEBUGGEE_RESULT + " = 1") < 0) {
-                   log.complain("Wrong value of " + DEBUGGEE_RESULT);
-                   log.complain(found);
-                   success = false;
+            found = grep.findFirst(DEBUGGEE_RESULT + " =");
+            if (found.length() > 0 && !found.contains(DEBUGGEE_RESULT + " = null")) {
+                if (!found.contains(DEBUGGEE_RESULT + " = 1")) {
+                    log.complain("Wrong value of " + DEBUGGEE_RESULT);
+                    log.complain(found);
+                    success = false;
                 }
             } else {
                 log.complain("TEST BUG: not found value for " + DEBUGGEE_RESULT);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
@@ -91,15 +91,10 @@ public class suspend001 extends JdbTest {
     static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notSuspended";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        String found;
-        String[] threads;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
         while (true) {
-            threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+            String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
             if (threads.length != 1) {
                 log.complain("jdb should report 1 instance of " + DEBUGGEE_THREAD);
                 log.complain("Found: " + threads.length);
@@ -109,7 +104,7 @@ public class suspend001 extends JdbTest {
 
             jdb.receiveReplyFor(JdbCommand.suspend + threads[0]);
 
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (!jdb.isAtBreakpoint(reply)) {
                 log.complain("Debugge does not reached second breakHere breakpoint");
                 success = false;
@@ -117,8 +112,8 @@ public class suspend001 extends JdbTest {
             }
 
             reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_RESULT);
-            grep = new Paragrep(reply);
-            found = grep.findFirst(DEBUGGEE_RESULT + " =");
+            var grep = new Paragrep(reply);
+            String found = grep.findFirst(DEBUGGEE_RESULT + " =");
             if (found.length() > 0 && !found.contains(DEBUGGEE_RESULT + " = null")) {
                 if (!found.contains(DEBUGGEE_RESULT + " = 1")) {
                     log.complain("Wrong value of " + DEBUGGEE_RESULT);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
@@ -42,9 +42,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.thread.thread002.thread002
- *        nsk.jdb.thread.thread002.thread002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.thread.thread002.thread002
+ * @build nsk.jdb.thread.thread002.thread002a
+ * @run main/othervm
+ *      nsk.jdb.thread.thread002.thread002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
@@ -57,34 +57,40 @@
 
 package nsk.jdb.thread.thread002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class thread002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new thread002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.thread.thread002";
-    static final String TEST_CLASS = PACKAGE_NAME + ".thread002";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME     = "nsk.jdb.thread.thread002";
+    static final String TEST_CLASS       = PACKAGE_NAME + ".thread002";
+    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String THREAD_NAME = "MyThread";
+    static final String THREAD_NAME      = "MyThread";
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
@@ -97,12 +103,12 @@ public class thread002 extends JdbTest {
 
         jdb.contToExit(1);
 
-        String[] reply = jdb.getTotalReply();
-        var grep = new Paragrep(reply);
+        reply = jdb.getTotalReply();
+        grep = new Paragrep(reply);
         for (int i = 0; i < threadIds.length; i++) {
-            int count = grep.find(THREAD_NAME + "#" + i);
+            count = grep.find(THREAD_NAME + "#" + i);
             if (count != 1) {
-                failure("jdb failed to switch to thread: " + threadIds[i]);
+                 failure("jdb failed to switch to thread: " + threadIds[i]);
             }
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
@@ -85,10 +85,6 @@ public class thread002 extends JdbTest {
     static final String THREAD_NAME = "MyThread";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
@@ -101,10 +97,10 @@ public class thread002 extends JdbTest {
 
         jdb.contToExit(1);
 
-        reply = jdb.getTotalReply();
-        grep = new Paragrep(reply);
+        String[] reply = jdb.getTotalReply();
+        var grep = new Paragrep(reply);
         for (int i = 0; i < threadIds.length; i++) {
-            count = grep.find(THREAD_NAME + "#" + i);
+            int count = grep.find(THREAD_NAME + "#" + i);
             if (count != 1) {
                 failure("jdb failed to switch to thread: " + threadIds[i]);
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
@@ -57,39 +57,37 @@
 
 package nsk.jdb.thread.thread002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class thread002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new thread002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.thread.thread002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".thread002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.thread.thread002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".thread002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String THREAD_NAME      = "MyThread";
+    static final String THREAD_NAME = "MyThread";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
@@ -108,7 +106,7 @@ public class thread002 extends JdbTest {
         for (int i = 0; i < threadIds.length; i++) {
             count = grep.find(THREAD_NAME + "#" + i);
             if (count != 1) {
-                 failure("jdb failed to switch to thread: " + threadIds[i]);
+                failure("jdb failed to switch to thread: " + threadIds[i]);
             }
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
@@ -40,9 +40,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.threadgroup.threadgroup002.threadgroup002
- *        nsk.jdb.threadgroup.threadgroup002.threadgroup002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.threadgroup.threadgroup002.threadgroup002
+ * @build nsk.jdb.threadgroup.threadgroup002.threadgroup002a
+ * @run main/othervm
+ *      nsk.jdb.threadgroup.threadgroup002.threadgroup002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
@@ -55,40 +55,46 @@
 
 package nsk.jdb.threadgroup.threadgroup002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class threadgroup002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new threadgroup002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.threadgroup.threadgroup002";
-    static final String TEST_CLASS = PACKAGE_NAME + ".threadgroup002";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME     = "nsk.jdb.threadgroup.threadgroup002";
+    static final String TEST_CLASS       = PACKAGE_NAME + ".threadgroup002";
+    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
         jdb.receiveReplyFor(JdbCommand.threadgroups);
 
         for (int i = 0; i < threadgroup002a.numThreadGroups; i++) {
-            String[] reply = jdb.receiveReplyFor(JdbCommand.threadgroup + threadgroup002a.THREADGROUP_NAME + i);
-            var grep = new Paragrep(reply);
-            int count = grep.find("not a valid threadgroup name");
+            reply = jdb.receiveReplyFor(JdbCommand.threadgroup + threadgroup002a.THREADGROUP_NAME + i);
+            grep = new Paragrep(reply);
+            count = grep.find("not a valid threadgroup name");
             if (count > 0) {
                 failure("jdb cannot switch to valid threadgroup: " + threadgroup002a.THREADGROUP_NAME + i);
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
@@ -81,18 +81,14 @@ public class threadgroup002 extends JdbTest {
     static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
         jdb.receiveReplyFor(JdbCommand.threadgroups);
 
         for (int i = 0; i < threadgroup002a.numThreadGroups; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.threadgroup + threadgroup002a.THREADGROUP_NAME + i);
-            grep = new Paragrep(reply);
-            count = grep.find("not a valid threadgroup name");
+            String[] reply = jdb.receiveReplyFor(JdbCommand.threadgroup + threadgroup002a.THREADGROUP_NAME + i);
+            var grep = new Paragrep(reply);
+            int count = grep.find("not a valid threadgroup name");
             if (count > 0) {
                 failure("jdb cannot switch to valid threadgroup: " + threadgroup002a.THREADGROUP_NAME + i);
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
@@ -55,37 +55,35 @@
 
 package nsk.jdb.threadgroup.threadgroup002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class threadgroup002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new threadgroup002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.threadgroup.threadgroup002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".threadgroup002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.threadgroup.threadgroup002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".threadgroup002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002.java
@@ -40,9 +40,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.threadgroups.threadgroups002.threadgroups002
- *        nsk.jdb.threadgroups.threadgroups002.threadgroups002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.threadgroups.threadgroups002.threadgroups002
+ * @build nsk.jdb.threadgroups.threadgroups002.threadgroups002a
+ * @run main/othervm
+ *      nsk.jdb.threadgroups.threadgroups002.threadgroups002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002.java
@@ -55,41 +55,47 @@
 
 package nsk.jdb.threadgroups.threadgroups002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class threadgroups002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new threadgroups002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.threadgroups.threadgroups002";
-    static final String TEST_CLASS = PACKAGE_NAME + ".threadgroups002";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME     = "nsk.jdb.threadgroups.threadgroups002";
+    static final String TEST_CLASS       = PACKAGE_NAME + ".threadgroups002";
+    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.threadgroups);
-        var grep = new Paragrep(reply);
-        int count = grep.find(threadgroups002a.THREADGROUP_NAME);
-        if (count != threadgroups002a.numThreadGroups) {
+        reply = jdb.receiveReplyFor(JdbCommand.threadgroups);
+        grep = new Paragrep(reply);
+        count = grep.find(threadgroups002a.THREADGROUP_NAME);
+        if (count != threadgroups002a.numThreadGroups ) {
             failure("Unexpected number of " + threadgroups002a.THREADGROUP_NAME + " was listed: " + count +
-                    "\n\texpected value: " + threadgroups002a.numThreadGroups);
+                "\n\texpected value: " + threadgroups002a.numThreadGroups);
         }
 
         jdb.contToExit(1);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002.java
@@ -55,37 +55,35 @@
 
 package nsk.jdb.threadgroups.threadgroups002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class threadgroups002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new threadgroups002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.threadgroups.threadgroups002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".threadgroups002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.threadgroups.threadgroups002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".threadgroups002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
@@ -93,9 +91,9 @@ public class threadgroups002 extends JdbTest {
         reply = jdb.receiveReplyFor(JdbCommand.threadgroups);
         grep = new Paragrep(reply);
         count = grep.find(threadgroups002a.THREADGROUP_NAME);
-        if (count != threadgroups002a.numThreadGroups ) {
+        if (count != threadgroups002a.numThreadGroups) {
             failure("Unexpected number of " + threadgroups002a.THREADGROUP_NAME + " was listed: " + count +
-                "\n\texpected value: " + threadgroups002a.numThreadGroups);
+                    "\n\texpected value: " + threadgroups002a.numThreadGroups);
         }
 
         jdb.contToExit(1);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002.java
@@ -81,16 +81,12 @@ public class threadgroups002 extends JdbTest {
     static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        reply = jdb.receiveReplyFor(JdbCommand.threadgroups);
-        grep = new Paragrep(reply);
-        count = grep.find(threadgroups002a.THREADGROUP_NAME);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.threadgroups);
+        var grep = new Paragrep(reply);
+        int count = grep.find(threadgroups002a.THREADGROUP_NAME);
         if (count != threadgroups002a.numThreadGroups) {
             failure("Unexpected number of " + threadgroups002a.THREADGROUP_NAME + " was listed: " + count +
                     "\n\texpected value: " + threadgroups002a.numThreadGroups);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
@@ -39,9 +39,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.threads.threads002.threads002
- *        nsk.jdb.threads.threads002.threads002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.threads.threads002.threads002
+ * @build nsk.jdb.threads.threads002.threads002a
+ * @run main/othervm
+ *      nsk.jdb.threads.threads002.threads002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
@@ -82,16 +82,12 @@ public class threads002 extends JdbTest {
     static final String THREAD_NAME = PACKAGE_NAME + ".MyThread";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        reply = jdb.receiveReplyFor(JdbCommand.threads);
-        grep = new Paragrep(reply);
-        count = grep.find(THREAD_NAME);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.threads);
+        var grep = new Paragrep(reply);
+        int count = grep.find(THREAD_NAME);
         if (count != threads002a.numThreads) {
             failure("Unexpected number of " + THREAD_NAME + " was listed: " + count +
                     "\n\texpected value: " + threads002a.numThreads);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
@@ -54,39 +54,37 @@
 
 package nsk.jdb.threads.threads002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class threads002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new threads002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.threads.threads002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".threads002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.threads.threads002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".threads002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String THREAD_NAME      = PACKAGE_NAME + ".MyThread";
+    static final String THREAD_NAME = PACKAGE_NAME + ".MyThread";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
@@ -94,9 +92,9 @@ public class threads002 extends JdbTest {
         reply = jdb.receiveReplyFor(JdbCommand.threads);
         grep = new Paragrep(reply);
         count = grep.find(THREAD_NAME);
-        if (count != threads002a.numThreads ) {
+        if (count != threads002a.numThreads) {
             failure("Unexpected number of " + THREAD_NAME + " was listed: " + count +
-                "\n\texpected value: " + threads002a.numThreads);
+                    "\n\texpected value: " + threads002a.numThreads);
         }
 
         jdb.contToExit(1);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
@@ -54,43 +54,49 @@
 
 package nsk.jdb.threads.threads002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class threads002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new threads002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.threads.threads002";
-    static final String TEST_CLASS = PACKAGE_NAME + ".threads002";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME     = "nsk.jdb.threads.threads002";
+    static final String TEST_CLASS       = PACKAGE_NAME + ".threads002";
+    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String THREAD_NAME = PACKAGE_NAME + ".MyThread";
+    static final String THREAD_NAME      = PACKAGE_NAME + ".MyThread";
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.threads);
-        var grep = new Paragrep(reply);
-        int count = grep.find(THREAD_NAME);
-        if (count != threads002a.numThreads) {
+        reply = jdb.receiveReplyFor(JdbCommand.threads);
+        grep = new Paragrep(reply);
+        count = grep.find(THREAD_NAME);
+        if (count != threads002a.numThreads ) {
             failure("Unexpected number of " + THREAD_NAME + " was listed: " + count +
-                    "\n\texpected value: " + threads002a.numThreads);
+                "\n\texpected value: " + threads002a.numThreads);
         }
 
         jdb.contToExit(1);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
@@ -46,9 +46,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.trace.trace001.trace001
- *        nsk.jdb.trace.trace001.trace001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.trace.trace001.trace001
+ * @build nsk.jdb.trace.trace001.trace001a
+ * @run main/othervm
+ *      nsk.jdb.trace.trace001.trace001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
@@ -61,45 +61,42 @@
 
 package nsk.jdb.trace.trace001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class trace001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new trace001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.trace.trace001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".trace001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.trace.trace001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".trace001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String[] CHECKED_METHODS = {"func1", "func2", "func3"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
@@ -109,11 +106,11 @@ public class trace001 extends JdbTest {
             success = false;
         }
 
-        for (int i = 0; i < threads.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.trace + "methods " + threads[i]);
+        for (String thread : threads) {
+            jdb.receiveReplyFor(JdbCommand.trace + "methods " + thread);
         }
 
-        jdb.contToExit(CHECKED_METHODS.length*threads.length*2 + 3);
+        jdb.contToExit(CHECKED_METHODS.length * threads.length * 2 + 3);
 
         reply = jdb.getTotalReply();
         if (!checkTrace(CHECKED_METHODS, reply)) {
@@ -121,33 +118,32 @@ public class trace001 extends JdbTest {
         }
     }
 
-    private boolean checkTrace (String[] checkedMethods, String[] reply) {
+    private boolean checkTrace(String[] checkedMethods, String[] reply) {
         Paragrep grep;
-        String found;
         int count;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
         boolean result = true;
 
         grep = new Paragrep(reply);
-        for (int i = 0; i < checkedMethods.length; i++) {
+        for (String checkedMethod : checkedMethods) {
             v.removeAllElements();
-            v.add(DEBUGGEE_THREAD + "." + checkedMethods[i]);
+            v.add(DEBUGGEE_THREAD + "." + checkedMethod);
             v.add("Method entered");
             count = grep.find(v);
             if (count != 2) {
-                log.complain("Count of method enter is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethods[i]);
+                log.complain("Count of method enter is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethod);
                 log.complain("Should be 2 trace messages, found : " + count);
-                result= false;
+                result = false;
             }
 
             v.removeAllElements();
-            v.add(DEBUGGEE_THREAD + "." + checkedMethods[i]);
+            v.add(DEBUGGEE_THREAD + "." + checkedMethod);
             v.add("Method exited");
             count = grep.find(v);
             if (count != 2) {
-                log.complain("Count of method exit is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethods[i]);
+                log.complain("Count of method exit is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethod);
                 log.complain("Should be 2 trace messages, found : " + count);
-                result= false;
+                result = false;
             }
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
@@ -92,13 +92,10 @@ public class trace001 extends JdbTest {
     static final String[] CHECKED_METHODS = {"func1", "func2", "func3"};
 
     protected void runCases() {
-        String[] reply;
-        String[] threads;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
         if (threads.length != 2) {
             log.complain("jdb should report 2 instance of " + DEBUGGEE_THREAD);
@@ -112,24 +109,22 @@ public class trace001 extends JdbTest {
 
         jdb.contToExit(CHECKED_METHODS.length * threads.length * 2 + 3);
 
-        reply = jdb.getTotalReply();
+        String[] reply = jdb.getTotalReply();
         if (!checkTrace(CHECKED_METHODS, reply)) {
             success = false;
         }
     }
 
     private boolean checkTrace(String[] checkedMethods, String[] reply) {
-        Paragrep grep;
-        int count;
-        Vector<String> v = new Vector<>();
+        var v = new Vector<String>();
         boolean result = true;
 
-        grep = new Paragrep(reply);
+        var grep = new Paragrep(reply);
         for (String checkedMethod : checkedMethods) {
             v.removeAllElements();
             v.add(DEBUGGEE_THREAD + "." + checkedMethod);
             v.add("Method entered");
-            count = grep.find(v);
+            int count = grep.find(v);
             if (count != 2) {
                 log.complain("Count of method enter is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethod);
                 log.complain("Should be 2 trace messages, found : " + count);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
@@ -61,41 +61,47 @@
 
 package nsk.jdb.trace.trace001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class trace001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new trace001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.trace.trace001";
-    static final String TEST_CLASS = PACKAGE_NAME + ".trace001";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
-    static final String MYTHREAD = "MyThread";
+    static final String PACKAGE_NAME    = "nsk.jdb.trace.trace001";
+    static final String TEST_CLASS      = PACKAGE_NAME + ".trace001";
+    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
+    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final String MYTHREAD        = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String[] CHECKED_METHODS = {"func1", "func2", "func3"};
 
     protected void runCases() {
-        jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+        String[] threads;
 
-        String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        jdb.setBreakpointInMethod(LAST_BREAK);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
+
+        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
         if (threads.length != 2) {
             log.complain("jdb should report 2 instance of " + DEBUGGEE_THREAD);
@@ -103,42 +109,45 @@ public class trace001 extends JdbTest {
             success = false;
         }
 
-        for (String thread : threads) {
-            jdb.receiveReplyFor(JdbCommand.trace + "methods " + thread);
+        for (int i = 0; i < threads.length; i++) {
+            reply = jdb.receiveReplyFor(JdbCommand.trace + "methods " + threads[i]);
         }
 
-        jdb.contToExit(CHECKED_METHODS.length * threads.length * 2 + 3);
+        jdb.contToExit(CHECKED_METHODS.length*threads.length*2 + 3);
 
-        String[] reply = jdb.getTotalReply();
+        reply = jdb.getTotalReply();
         if (!checkTrace(CHECKED_METHODS, reply)) {
             success = false;
         }
     }
 
-    private boolean checkTrace(String[] checkedMethods, String[] reply) {
-        var v = new Vector<String>();
+    private boolean checkTrace (String[] checkedMethods, String[] reply) {
+        Paragrep grep;
+        String found;
+        int count;
+        Vector v = new Vector();
         boolean result = true;
 
-        var grep = new Paragrep(reply);
-        for (String checkedMethod : checkedMethods) {
+        grep = new Paragrep(reply);
+        for (int i = 0; i < checkedMethods.length; i++) {
             v.removeAllElements();
-            v.add(DEBUGGEE_THREAD + "." + checkedMethod);
+            v.add(DEBUGGEE_THREAD + "." + checkedMethods[i]);
             v.add("Method entered");
-            int count = grep.find(v);
+            count = grep.find(v);
             if (count != 2) {
-                log.complain("Count of method enter is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethod);
+                log.complain("Count of method enter is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethods[i]);
                 log.complain("Should be 2 trace messages, found : " + count);
-                result = false;
+                result= false;
             }
 
             v.removeAllElements();
-            v.add(DEBUGGEE_THREAD + "." + checkedMethod);
+            v.add(DEBUGGEE_THREAD + "." + checkedMethods[i]);
             v.add("Method exited");
             count = grep.find(v);
             if (count != 2) {
-                log.complain("Count of method exit is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethod);
+                log.complain("Count of method exit is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethods[i]);
                 log.complain("Should be 2 trace messages, found : " + count);
-                result = false;
+                result= false;
             }
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002.java
@@ -52,7 +52,7 @@
  * @clean nsk.jdb.uncaught_exception.uncaught_exception002.uncaught_exception002a
  * @compile -g:lines,source,vars uncaught_exception002a.java
  *
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdb.uncaught_exception.uncaught_exception002.uncaught_exception002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002.java
@@ -97,18 +97,14 @@ public class uncaught_exception002 extends JdbTest {
     }
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        Vector<String> v;
-
         jdb.receiveReplyFor(JdbCommand.cont);
         jdb.receiveReplyFor(JdbCommand.locals);
         jdb.contToExit(1);
 
-        reply = jdb.getTotalReply();
-        grep = new Paragrep(reply);
+        String[] reply = jdb.getTotalReply();
+        var grep = new Paragrep(reply);
 
-        v = new Vector<>();
+        var v = new Vector<String>();
         v.add("Exception occurred");
         v.add(PACKAGE_NAME + ".TenMultipleException");
         if (grep.find(v) == 0) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002.java
@@ -66,20 +66,21 @@
 
 package nsk.jdb.uncaught_exception.uncaught_exception002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class uncaught_exception002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new uncaught_exception002(true).runTest(argv, out);
@@ -88,24 +89,17 @@ public class uncaught_exception002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.uncaught_exception.uncaught_exception002";
     static final String TEST_CLASS = PACKAGE_NAME + ".uncaught_exception002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[] FRAMES = new String[] {
-        DEBUGGEE_CLASS + ".func",
-        DEBUGGEE_CLASS + ".runIt",
-        DEBUGGEE_CLASS + ".main"                };
-
-    public uncaught_exception002 (boolean debuggeeShouldFail) {
+    public uncaught_exception002(boolean debuggeeShouldFail) {
         super(debuggeeShouldFail);
     }
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.receiveReplyFor(JdbCommand.cont);
         jdb.receiveReplyFor(JdbCommand.locals);
@@ -114,29 +108,19 @@ public class uncaught_exception002 extends JdbTest {
         reply = jdb.getTotalReply();
         grep = new Paragrep(reply);
 
-        v = new Vector();
+        v = new Vector<>();
         v.add("Exception occurred");
         v.add(PACKAGE_NAME + ".TenMultipleException");
         if (grep.find(v) == 0) {
             failure("jdb does not reported of TenMultipleException occurence");
         }
 
-        v = new Vector();
+        v = new Vector<>();
         v.add("localVar");
         v.add("1234");
         if (grep.find(v) == 0) {
             failure("Local variable of stack frame the exception was thrown " +
-                "is not accessible");
+                    "is not accessible");
         }
-    }
-
-    private boolean checkStop () {
-        Paragrep grep;
-        String[] reply;
-        String found;
-        Vector v;
-        boolean result = true;
-
-        return result;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002.java
@@ -66,21 +66,20 @@
 
 package nsk.jdb.uncaught_exception.uncaught_exception002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class uncaught_exception002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new uncaught_exception002(true).runTest(argv, out);
@@ -89,34 +88,55 @@ public class uncaught_exception002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.uncaught_exception.uncaught_exception002";
     static final String TEST_CLASS = PACKAGE_NAME + ".uncaught_exception002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
-    public uncaught_exception002(boolean debuggeeShouldFail) {
+    static final String[] FRAMES = new String[] {
+        DEBUGGEE_CLASS + ".func",
+        DEBUGGEE_CLASS + ".runIt",
+        DEBUGGEE_CLASS + ".main"                };
+
+    public uncaught_exception002 (boolean debuggeeShouldFail) {
         super(debuggeeShouldFail);
     }
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.receiveReplyFor(JdbCommand.cont);
         jdb.receiveReplyFor(JdbCommand.locals);
         jdb.contToExit(1);
 
-        String[] reply = jdb.getTotalReply();
-        var grep = new Paragrep(reply);
+        reply = jdb.getTotalReply();
+        grep = new Paragrep(reply);
 
-        var v = new Vector<String>();
+        v = new Vector();
         v.add("Exception occurred");
         v.add(PACKAGE_NAME + ".TenMultipleException");
         if (grep.find(v) == 0) {
             failure("jdb does not reported of TenMultipleException occurence");
         }
 
-        v = new Vector<>();
+        v = new Vector();
         v.add("localVar");
         v.add("1234");
         if (grep.find(v) == 0) {
             failure("Local variable of stack frame the exception was thrown " +
-                    "is not accessible");
+                "is not accessible");
         }
+    }
+
+    private boolean checkStop () {
+        Paragrep grep;
+        String[] reply;
+        String found;
+        Vector v;
+        boolean result = true;
+
+        return result;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
@@ -56,7 +56,8 @@
  * @clean nsk.jdb.unmonitor.unmonitor001.unmonitor001a
  * @compile -g:lines,source,vars unmonitor001a.java
  *
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.unmonitor.unmonitor001.unmonitor001
+ * @run main/othervm
+ *      nsk.jdb.unmonitor.unmonitor001.unmonitor001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
@@ -70,21 +70,20 @@
 
 package nsk.jdb.unmonitor.unmonitor001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class unmonitor001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[])  {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new unmonitor001().runTest(argv, out);
@@ -93,37 +92,43 @@ public class unmonitor001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.unmonitor.unmonitor001";
     static final String TEST_CLASS = PACKAGE_NAME + ".unmonitor001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
-    static final int BREAKPOINT_LINE = 47;
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final int    BREAKPOINT_LINE    = 47;
 
     static final String[] CHECKED_COMMANDS = {
-            JdbCommand.locals,
-            JdbCommand.threads,
-            JdbCommand.methods + DEBUGGEE_CLASS,
-            JdbCommand.fields + DEBUGGEE_CLASS,
-            JdbCommand.eval + "(new java.lang.String(\"Hello, World\")).length()"
-    };
+        JdbCommand.locals,
+        JdbCommand.threads,
+        JdbCommand.methods + DEBUGGEE_CLASS,
+        JdbCommand.fields  + DEBUGGEE_CLASS,
+        JdbCommand.eval + "(new java.lang.String(\"Hello, World\")).length()"
+                                             };
 
     protected void runCases() {
-        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
+        reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
 
         // set first three monitors
-        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[0]);
-        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[1]);
-        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[2]);
+        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[0]);
+        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[1]);
+        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[2]);
 
         // delete first monitor
-        jdb.receiveReplyFor(JdbCommand.unmonitor + " 1");
+        reply = jdb.receiveReplyFor(JdbCommand.unmonitor + " 1");
 
         // set first last two monitors
-        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[3]);
-        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[4]);
+        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[3]);
+        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[4]);
 
         int repliesCount = 4 + 1;
-        jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
+        reply = jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.monitor);
+        reply = jdb.receiveReplyFor(JdbCommand.monitor);
         if (!checkMonitors(reply)) {
             success = false;
         }
@@ -140,10 +145,13 @@ public class unmonitor001 extends JdbTest {
     }
 
     private boolean checkMonitors(String[] reply) {
+        Paragrep grep;
+        String found;
+        Vector v;
         boolean result = true;
         int count;
 
-        var grep = new Paragrep(reply);
+        grep = new Paragrep(reply);
         for (int i = 1; i < CHECKED_COMMANDS.length; i++) {
             if ((count = grep.find(CHECKED_COMMANDS[i])) != 1) {
                 log.complain("Wrong number of monitor command: " + CHECKED_COMMANDS[i]);
@@ -162,9 +170,13 @@ public class unmonitor001 extends JdbTest {
     }
 
     private boolean checkCommands(String[] reply) {
+        Paragrep grep;
+        String found;
+        Vector v = new Vector();;
         boolean result = true;
-        var grep = new Paragrep(reply);
         int count;
+
+        grep = new Paragrep(reply);
 
         // check deleted 'locals'
         if ((count = grep.find("Local variables")) > 0) {
@@ -173,7 +185,6 @@ public class unmonitor001 extends JdbTest {
         }
 
         // check 'threads'
-        var v = new Vector<String>();
         v.add("java.lang.Thread");
         v.add("main");
         if ((count = grep.find(v)) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
@@ -106,8 +106,6 @@ public class unmonitor001 extends JdbTest {
     };
 
     protected void runCases() {
-        String[] reply;
-
         jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
 
         // set first three monitors
@@ -125,7 +123,7 @@ public class unmonitor001 extends JdbTest {
         int repliesCount = 4 + 1;
         jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
 
-        reply = jdb.receiveReplyFor(JdbCommand.monitor);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.monitor);
         if (!checkMonitors(reply)) {
             success = false;
         }
@@ -142,11 +140,10 @@ public class unmonitor001 extends JdbTest {
     }
 
     private boolean checkMonitors(String[] reply) {
-        Paragrep grep;
         boolean result = true;
         int count;
 
-        grep = new Paragrep(reply);
+        var grep = new Paragrep(reply);
         for (int i = 1; i < CHECKED_COMMANDS.length; i++) {
             if ((count = grep.find(CHECKED_COMMANDS[i])) != 1) {
                 log.complain("Wrong number of monitor command: " + CHECKED_COMMANDS[i]);
@@ -165,12 +162,9 @@ public class unmonitor001 extends JdbTest {
     }
 
     private boolean checkCommands(String[] reply) {
-        Paragrep grep;
-        Vector<String> v = new Vector<>();
         boolean result = true;
+        var grep = new Paragrep(reply);
         int count;
-
-        grep = new Paragrep(reply);
 
         // check deleted 'locals'
         if ((count = grep.find("Local variables")) > 0) {
@@ -179,6 +173,7 @@ public class unmonitor001 extends JdbTest {
         }
 
         // check 'threads'
+        var v = new Vector<String>();
         v.add("java.lang.Thread");
         v.add("main");
         if ((count = grep.find(v)) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
@@ -70,20 +70,21 @@
 
 package nsk.jdb.unmonitor.unmonitor001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class unmonitor001 extends JdbTest {
 
-    public static void main (String argv[])  {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new unmonitor001().runTest(argv, out);
@@ -92,41 +93,37 @@ public class unmonitor001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.unmonitor.unmonitor001";
     static final String TEST_CLASS = PACKAGE_NAME + ".unmonitor001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final int    BREAKPOINT_LINE    = 47;
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final int BREAKPOINT_LINE = 47;
 
     static final String[] CHECKED_COMMANDS = {
-        JdbCommand.locals,
-        JdbCommand.threads,
-        JdbCommand.methods + DEBUGGEE_CLASS,
-        JdbCommand.fields  + DEBUGGEE_CLASS,
-        JdbCommand.eval + "(new java.lang.String(\"Hello, World\")).length()"
-                                             };
+            JdbCommand.locals,
+            JdbCommand.threads,
+            JdbCommand.methods + DEBUGGEE_CLASS,
+            JdbCommand.fields + DEBUGGEE_CLASS,
+            JdbCommand.eval + "(new java.lang.String(\"Hello, World\")).length()"
+    };
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
-        reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
+        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
 
         // set first three monitors
-        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[0]);
-        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[1]);
-        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[2]);
+        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[0]);
+        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[1]);
+        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[2]);
 
         // delete first monitor
-        reply = jdb.receiveReplyFor(JdbCommand.unmonitor + " 1");
+        jdb.receiveReplyFor(JdbCommand.unmonitor + " 1");
 
         // set first last two monitors
-        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[3]);
-        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[4]);
+        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[3]);
+        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[4]);
 
         int repliesCount = 4 + 1;
-        reply = jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
+        jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
 
         reply = jdb.receiveReplyFor(JdbCommand.monitor);
         if (!checkMonitors(reply)) {
@@ -146,8 +143,6 @@ public class unmonitor001 extends JdbTest {
 
     private boolean checkMonitors(String[] reply) {
         Paragrep grep;
-        String found;
-        Vector v;
         boolean result = true;
         int count;
 
@@ -171,8 +166,7 @@ public class unmonitor001 extends JdbTest {
 
     private boolean checkCommands(String[] reply) {
         Paragrep grep;
-        String found;
-        Vector v = new Vector();;
+        Vector<String> v = new Vector<>();
         boolean result = true;
         int count;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
@@ -53,9 +53,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.untrace.untrace001.untrace001
- *        nsk.jdb.untrace.untrace001.untrace001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.untrace.untrace001.untrace001
+ * @build nsk.jdb.untrace.untrace001.untrace001a
+ * @run main/othervm
+ *      nsk.jdb.untrace.untrace001.untrace001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
@@ -68,45 +68,42 @@
 
 package nsk.jdb.untrace.untrace001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class untrace001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new untrace001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.untrace.untrace001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".untrace001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.untrace.untrace001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".untrace001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String[] CHECKED_METHODS = {"func1", "func2", "func3"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
@@ -116,20 +113,20 @@ public class untrace001 extends JdbTest {
             success = false;
         }
 
-        for (int i = 0; i < threads.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.trace + "methods " + threads[i]);
+        for (String thread : threads) {
+            jdb.receiveReplyFor(JdbCommand.trace + "methods " + thread);
         }
 
         // resumes debuggee suspended on method enter and exit until hit of the breakpoint
-        for (int i = 0; i < (CHECKED_METHODS.length*threads.length*2 + 1); i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+        for (int i = 0; i < (CHECKED_METHODS.length * threads.length * 2 + 1); i++) {
+            jdb.receiveReplyFor(JdbCommand.cont);
         }
 
-        for (int i = 0; i < threads.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.untrace + "methods " + threads[i]);
+        for (String thread : threads) {
+            jdb.receiveReplyFor(JdbCommand.untrace + "methods " + thread);
         }
 
-        jdb.contToExit(CHECKED_METHODS.length*threads.length*2 + 2);
+        jdb.contToExit(CHECKED_METHODS.length * threads.length * 2 + 2);
 
         reply = jdb.getTotalReply();
         if (!checkTrace(CHECKED_METHODS, reply)) {
@@ -137,33 +134,32 @@ public class untrace001 extends JdbTest {
         }
     }
 
-    private boolean checkTrace (String[] checkedMethods, String[] reply) {
+    private boolean checkTrace(String[] checkedMethods, String[] reply) {
         Paragrep grep;
-        String found;
         int count;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
         boolean result = true;
 
         grep = new Paragrep(reply);
-        for (int i = 0; i < checkedMethods.length; i++) {
+        for (String checkedMethod : checkedMethods) {
             v.removeAllElements();
-            v.add(DEBUGGEE_THREAD + "." + checkedMethods[i]);
+            v.add(DEBUGGEE_THREAD + "." + checkedMethod);
             v.add("Method entered");
             count = grep.find(v);
             if (count != 1) {
-                log.complain("Count of method enter is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethods[i]);
+                log.complain("Count of method enter is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethod);
                 log.complain("Should be 1 trace messages, found : " + count);
-                result= false;
+                result = false;
             }
 
             v.removeAllElements();
-            v.add(DEBUGGEE_THREAD + "." + checkedMethods[i]);
+            v.add(DEBUGGEE_THREAD + "." + checkedMethod);
             v.add("Method exited");
             count = grep.find(v);
             if (count != 1) {
-                log.complain("Count of method exit is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethods[i]);
+                log.complain("Count of method exit is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethod);
                 log.complain("Should be 1 trace messages, found : " + count);
-                result= false;
+                result = false;
             }
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
@@ -99,13 +99,10 @@ public class untrace001 extends JdbTest {
     static final String[] CHECKED_METHODS = {"func1", "func2", "func3"};
 
     protected void runCases() {
-        String[] reply;
-        String[] threads;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
         if (threads.length != 1) {
             log.complain("jdb should report 1 instance of " + DEBUGGEE_THREAD);
@@ -128,24 +125,22 @@ public class untrace001 extends JdbTest {
 
         jdb.contToExit(CHECKED_METHODS.length * threads.length * 2 + 2);
 
-        reply = jdb.getTotalReply();
+        String[] reply = jdb.getTotalReply();
         if (!checkTrace(CHECKED_METHODS, reply)) {
             success = false;
         }
     }
 
     private boolean checkTrace(String[] checkedMethods, String[] reply) {
-        Paragrep grep;
-        int count;
-        Vector<String> v = new Vector<>();
+        var v = new Vector<String>();
         boolean result = true;
+        var grep = new Paragrep(reply);
 
-        grep = new Paragrep(reply);
         for (String checkedMethod : checkedMethods) {
             v.removeAllElements();
             v.add(DEBUGGEE_THREAD + "." + checkedMethod);
             v.add("Method entered");
-            count = grep.find(v);
+            int count = grep.find(v);
             if (count != 1) {
                 log.complain("Count of method enter is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethod);
                 log.complain("Should be 1 trace messages, found : " + count);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001.java
@@ -49,9 +49,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.unwatch.unwatch001.unwatch001
- *        nsk.jdb.unwatch.unwatch001.unwatch001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.unwatch.unwatch001.unwatch001
+ * @build nsk.jdb.unwatch.unwatch001.unwatch001a
+ * @run main/othervm
+ *      nsk.jdb.unwatch.unwatch001.unwatch001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001.java
@@ -95,8 +95,6 @@ public class unwatch001 extends JdbTest {
     static String[] checkedFields2 = {"fP1", "fU1", "fR1"};
 
     protected void runCases() {
-        String[] reply;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
 
         jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
@@ -116,7 +114,7 @@ public class unwatch001 extends JdbTest {
         // excessive number of cont commands in case if unwatch command does not work.
         jdb.contToExit(checkedFields.length + checkedFields2.length + 1);
 
-        reply = jdb.getTotalReply();
+        String[] reply = jdb.getTotalReply();
         if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields)) {
             success = false;
         }
@@ -138,19 +136,16 @@ public class unwatch001 extends JdbTest {
     }
 
     private boolean checkFields(String className, String[] reply, String[] checkedFields) {
-        Paragrep grep;
         boolean result = true;
-        int count;
-        Vector<String> v = new Vector<>();
+        var v = new Vector<String>();
+        var grep = new Paragrep(reply);
 
-        grep = new Paragrep(reply);
-        v.add("access encountered");
         for (String checkedField : checkedFields) {
             v.removeAllElements();
             v.add("access encountered");
             v.add(className + "." + checkedField);
 
-            count = grep.find(v);
+            int count = grep.find(v);
             if (count != 1) {
                 log.complain("jdb reported wrong number of access to the field " + className + "." + checkedField);
                 log.complain("Should be 1, reported: " + count);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001.java
@@ -64,105 +64,95 @@
 
 package nsk.jdb.unwatch.unwatch001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class unwatch001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new unwatch001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.unwatch.unwatch001";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".unwatch001";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String DEBUGGEE_CLASS2    = DEBUGGEE_CLASS + "$CheckedFields";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".breakHere";
+    static final String PACKAGE_NAME = "nsk.jdb.unwatch.unwatch001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".unwatch001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String DEBUGGEE_CLASS2 = DEBUGGEE_CLASS + "$CheckedFields";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
 
-    static String[] checkedFields  = { "fS1", "FS0" };
-    static String[] checkedFields2 = { "fP1", "fU1", "fR1"};
+    static String[] checkedFields = {"fS1", "FS0"};
+    static String[] checkedFields2 = {"fP1", "fU1", "fR1"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
 
-        watchFields (DEBUGGEE_CLASS, checkedFields);
-        watchFields (DEBUGGEE_CLASS2, checkedFields2);
+        watchFields(DEBUGGEE_CLASS, checkedFields);
+        watchFields(DEBUGGEE_CLASS2, checkedFields2);
 
         for (int i = 0; i < (checkedFields.length + checkedFields2.length + 2); i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            jdb.receiveReplyFor(JdbCommand.cont);
         }
 
-        unwatchFields (DEBUGGEE_CLASS, checkedFields);
-        unwatchFields (DEBUGGEE_CLASS2, checkedFields2);
+        unwatchFields(DEBUGGEE_CLASS, checkedFields);
+        unwatchFields(DEBUGGEE_CLASS2, checkedFields2);
 
         // excessive number of cont commands in case if unwatch command does not work.
         jdb.contToExit(checkedFields.length + checkedFields2.length + 1);
 
         reply = jdb.getTotalReply();
-        if (!checkFields (DEBUGGEE_CLASS, reply, checkedFields)) {
+        if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields)) {
             success = false;
         }
-        if (!checkFields (DEBUGGEE_CLASS2, reply, checkedFields2)) {
+        if (!checkFields(DEBUGGEE_CLASS2, reply, checkedFields2)) {
             success = false;
         }
     }
 
-    private void watchFields (String className, String[] checkedFields) {
-        String[] reply;
-
-        for (int i = 0; i < checkedFields.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.watch + " access " + className + "." + checkedFields[i]);
+    private void watchFields(String className, String[] checkedFields) {
+        for (String checkedField : checkedFields) {
+            jdb.receiveReplyFor(JdbCommand.watch + " access " + className + "." + checkedField);
         }
-
     }
 
-    private void unwatchFields (String className, String[] checkedFields) {
-        String[] reply;
-
-        for (int i = 0; i < checkedFields.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.unwatch + " access " + className + "." + checkedFields[i]);
+    private void unwatchFields(String className, String[] checkedFields) {
+        for (String checkedField : checkedFields) {
+            jdb.receiveReplyFor(JdbCommand.unwatch + " access " + className + "." + checkedField);
         }
-
     }
 
-    private boolean checkFields (String className, String[] reply, String[] checkedFields) {
+    private boolean checkFields(String className, String[] reply, String[] checkedFields) {
         Paragrep grep;
-        String found;
         boolean result = true;
         int count;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         grep = new Paragrep(reply);
         v.add("access encountered");
-        for (int i = 0; i < checkedFields.length; i++) {
+        for (String checkedField : checkedFields) {
             v.removeAllElements();
             v.add("access encountered");
-            v.add(className + "." + checkedFields[i]);
+            v.add(className + "." + checkedField);
 
             count = grep.find(v);
             if (count != 1) {
-                log.complain("jdb reported wrong number of access to the field " + className + "." + checkedFields[i]);
+                log.complain("jdb reported wrong number of access to the field " + className + "." + checkedField);
                 log.complain("Should be 1, reported: " + count);
                 result = false;
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java
@@ -50,9 +50,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.unwatch.unwatch002.unwatch002
- *        nsk.jdb.unwatch.unwatch002.unwatch002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.unwatch.unwatch002.unwatch002
+ * @build nsk.jdb.unwatch.unwatch002.unwatch002a
+ * @run main/othervm
+ *      nsk.jdb.unwatch.unwatch002.unwatch002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java
@@ -97,8 +97,6 @@ public class unwatch002 extends JdbTest {
     static String[] checkedFields2 = {"FT1", "FV1"};
 
     protected void runCases() {
-        String[] reply;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
 
         jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
@@ -119,7 +117,7 @@ public class unwatch002 extends JdbTest {
         // excessive number of cont commands in case if unwatch command does not work.
         jdb.contToExit(checkedFields.length * 2 + checkedFields2.length * 2 + 1);
 
-        reply = jdb.getTotalReply();
+        String[] reply = jdb.getTotalReply();
         if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields)) {
             success = false;
         }
@@ -141,19 +139,16 @@ public class unwatch002 extends JdbTest {
     }
 
     private boolean checkFields(String className, String[] reply, String[] checkedFields) {
-        Paragrep grep;
         boolean result = true;
-        int count;
-        Vector<String> v = new Vector<>();
+        var v = new Vector<String>();
+        var grep = new Paragrep(reply);
 
-        grep = new Paragrep(reply);
-        v.add("access encountered");
         for (String checkedField : checkedFields) {
             v.removeAllElements();
             v.add("access encountered");
             v.add(className + "." + checkedField);
 
-            count = grep.find(v);
+            int count = grep.find(v);
             if (count != 1) {
                 log.complain("jdb reported wrong number of access to the field " + className + "." + checkedField);
                 log.complain("Should be 1, reported: " + count);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java
@@ -65,118 +65,108 @@
 
 package nsk.jdb.unwatch.unwatch002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class unwatch002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new unwatch002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.unwatch.unwatch002";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".unwatch002";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String DEBUGGEE_CLASS2    = DEBUGGEE_CLASS + "$CheckedFields";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".breakHere";
-    static final String expectedPrompt     = "main[1]";
+    static final String PACKAGE_NAME = "nsk.jdb.unwatch.unwatch002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".unwatch002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String DEBUGGEE_CLASS2 = DEBUGGEE_CLASS + "$CheckedFields";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
+    static final String expectedPrompt = "main[1]";
 
-    static String[] checkedFields  = { "FS1" };
-    static String[] checkedFields2 = { "FT1", "FV1" };
+    static String[] checkedFields = {"FS1"};
+    static String[] checkedFields2 = {"FT1", "FV1"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
 
-        watchFields (DEBUGGEE_CLASS, checkedFields);
-        watchFields (DEBUGGEE_CLASS2, checkedFields2);
+        watchFields(DEBUGGEE_CLASS, checkedFields);
+        watchFields(DEBUGGEE_CLASS2, checkedFields2);
 
 //        jdb.contToExit((checkedFields.length *2)  + (checkedFields2.length *2) + 2);
-        for (int i = 0; i < (checkedFields.length *2 + checkedFields2.length*2 + 2); i++) {
-            reply = jdb.receiveReplyForWithMessageWait(JdbCommand.cont, expectedPrompt);
+        for (int i = 0; i < (checkedFields.length * 2 + checkedFields2.length * 2 + 2); i++) {
+            jdb.receiveReplyForWithMessageWait(JdbCommand.cont, expectedPrompt);
         }
 
-        unwatchFields (DEBUGGEE_CLASS, checkedFields);
-        unwatchFields (DEBUGGEE_CLASS2, checkedFields2);
+        unwatchFields(DEBUGGEE_CLASS, checkedFields);
+        unwatchFields(DEBUGGEE_CLASS2, checkedFields2);
 
         // excessive number of cont commands in case if unwatch command does not work.
-        jdb.contToExit(checkedFields.length*2 + checkedFields2.length*2 + 1);
+        jdb.contToExit(checkedFields.length * 2 + checkedFields2.length * 2 + 1);
 
         reply = jdb.getTotalReply();
-        if (!checkFields (DEBUGGEE_CLASS, reply, checkedFields)) {
+        if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields)) {
             success = false;
         }
-        if (!checkFields (DEBUGGEE_CLASS2, reply, checkedFields2)) {
+        if (!checkFields(DEBUGGEE_CLASS2, reply, checkedFields2)) {
             success = false;
         }
     }
 
-    private void watchFields (String className, String[] checkedFields) {
-        String[] reply;
-
-        for (int i = 0; i < checkedFields.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.watch + " all " + className + "." + checkedFields[i]);
+    private void watchFields(String className, String[] checkedFields) {
+        for (String checkedField : checkedFields) {
+            jdb.receiveReplyFor(JdbCommand.watch + " all " + className + "." + checkedField);
         }
-
     }
 
-    private void unwatchFields (String className, String[] checkedFields) {
-        String[] reply;
-
-        for (int i = 0; i < checkedFields.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.unwatch + " all " + className + "." + checkedFields[i]);
+    private void unwatchFields(String className, String[] checkedFields) {
+        for (String checkedField : checkedFields) {
+            jdb.receiveReplyFor(JdbCommand.unwatch + " all " + className + "." + checkedField);
         }
-
     }
 
-    private boolean checkFields (String className, String[] reply, String[] checkedFields) {
+    private boolean checkFields(String className, String[] reply, String[] checkedFields) {
         Paragrep grep;
-        String found;
         boolean result = true;
         int count;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         grep = new Paragrep(reply);
         v.add("access encountered");
-        for (int i = 0; i < checkedFields.length; i++) {
+        for (String checkedField : checkedFields) {
             v.removeAllElements();
             v.add("access encountered");
-            v.add(className + "." + checkedFields[i]);
+            v.add(className + "." + checkedField);
 
             count = grep.find(v);
             if (count != 1) {
-                log.complain("jdb reported wrong number of access to the field " + className + "." + checkedFields[i]);
+                log.complain("jdb reported wrong number of access to the field " + className + "." + checkedField);
                 log.complain("Should be 1, reported: " + count);
                 result = false;
             }
 
             v.removeAllElements();
-            v.add(className + "." + checkedFields[i]);
+            v.add(className + "." + checkedField);
             v.add("will be instance");
 
             count = grep.find(v);
             if (count != 1) {
-                log.complain("jdb reported wrong number of modification of the field " + className + "." + checkedFields[i]);
+                log.complain("jdb reported wrong number of modification of the field " + className + "." + checkedField);
                 log.complain("Should be 1, reported: " + count);
                 result = false;
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002.java
@@ -42,9 +42,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.up.up002.up002
- *        nsk.jdb.up.up002.up002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.up.up002.up002
+ * @build nsk.jdb.up.up002.up002a
+ * @run main/othervm
+ *      nsk.jdb.up.up002.up002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002.java
@@ -94,11 +94,6 @@ public class up002 extends JdbTest {
     };
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector<String> v;
-
         jdb.receiveReplyFor(JdbCommand.stop_in + DEBUGGEE_CLASS + ".func5");
         jdb.receiveReplyFor(JdbCommand.cont);
 
@@ -109,14 +104,14 @@ public class up002 extends JdbTest {
 
         jdb.contToExit(1);
 
-        reply = jdb.getTotalReply();
-        grep = new Paragrep(reply);
+        String[] reply = jdb.getTotalReply();
+        var grep = new Paragrep(reply);
 
         for (int i = 1; i < (FRAMES.length - 1); i++) {
-            v = new Vector<>();
+            var v = new Vector<String>();
             v.add(FRAMES[i][0]);
             v.add(FRAMES[i][1]);
-            count = grep.find(v);
+            int count = grep.find(v);
             if (count != (i + 1)) {
                 failure("Unexpected number of the stack frame: " + FRAMES[i][1] +
                         "\n\texpected value : " + (i + 1) + ", got : " + count);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002.java
@@ -57,47 +57,47 @@
 
 package nsk.jdb.up.up002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class up002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new up002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.up.up002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".up002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.up.up002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".up002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][] {
-        {"[1]", DEBUGGEE_CLASS + ".func5"},
-        {"[2]", DEBUGGEE_CLASS + ".func4"},
-        {"[3]", DEBUGGEE_CLASS + ".func3"},
-        {"[4]", DEBUGGEE_CLASS + ".func2"},
-        {"[5]", DEBUGGEE_CLASS + ".func1"},
-        {"[6]", DEBUGGEE_CLASS + ".runIt"},
-        {"[7]", DEBUGGEE_CLASS + ".main"}
-                                                };
+    static final String[][] FRAMES = new String[][]{
+            {"[1]", DEBUGGEE_CLASS + ".func5"},
+            {"[2]", DEBUGGEE_CLASS + ".func4"},
+            {"[3]", DEBUGGEE_CLASS + ".func3"},
+            {"[4]", DEBUGGEE_CLASS + ".func2"},
+            {"[5]", DEBUGGEE_CLASS + ".func1"},
+            {"[6]", DEBUGGEE_CLASS + ".runIt"},
+            {"[7]", DEBUGGEE_CLASS + ".main"}
+    };
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.receiveReplyFor(JdbCommand.stop_in + DEBUGGEE_CLASS + ".func5");
         jdb.receiveReplyFor(JdbCommand.cont);
@@ -112,14 +112,14 @@ public class up002 extends JdbTest {
         reply = jdb.getTotalReply();
         grep = new Paragrep(reply);
 
-        for (int i = 1; i < (FRAMES.length-1); i++) {
-            v = new Vector();
+        for (int i = 1; i < (FRAMES.length - 1); i++) {
+            v = new Vector<>();
             v.add(FRAMES[i][0]);
             v.add(FRAMES[i][1]);
             count = grep.find(v);
-            if (count != (i+1)) {
+            if (count != (i + 1)) {
                 failure("Unexpected number of the stack frame: " + FRAMES[i][1] +
-                    "\n\texpected value : " + (i+1) + ", got : " + count);
+                        "\n\texpected value : " + (i + 1) + ", got : " + count);
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002.java
@@ -57,43 +57,48 @@
 
 package nsk.jdb.up.up002;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class up002 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new up002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.up.up002";
-    static final String TEST_CLASS = PACKAGE_NAME + ".up002";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME     = "nsk.jdb.up.up002";
+    static final String TEST_CLASS       = PACKAGE_NAME + ".up002";
+    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][]{
-            {"[1]", DEBUGGEE_CLASS + ".func5"},
-            {"[2]", DEBUGGEE_CLASS + ".func4"},
-            {"[3]", DEBUGGEE_CLASS + ".func3"},
-            {"[4]", DEBUGGEE_CLASS + ".func2"},
-            {"[5]", DEBUGGEE_CLASS + ".func1"},
-            {"[6]", DEBUGGEE_CLASS + ".runIt"},
-            {"[7]", DEBUGGEE_CLASS + ".main"}
-    };
+    static final String[][] FRAMES = new String[][] {
+        {"[1]", DEBUGGEE_CLASS + ".func5"},
+        {"[2]", DEBUGGEE_CLASS + ".func4"},
+        {"[3]", DEBUGGEE_CLASS + ".func3"},
+        {"[4]", DEBUGGEE_CLASS + ".func2"},
+        {"[5]", DEBUGGEE_CLASS + ".func1"},
+        {"[6]", DEBUGGEE_CLASS + ".runIt"},
+        {"[7]", DEBUGGEE_CLASS + ".main"}
+                                                };
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.receiveReplyFor(JdbCommand.stop_in + DEBUGGEE_CLASS + ".func5");
         jdb.receiveReplyFor(JdbCommand.cont);
 
@@ -104,17 +109,17 @@ public class up002 extends JdbTest {
 
         jdb.contToExit(1);
 
-        String[] reply = jdb.getTotalReply();
-        var grep = new Paragrep(reply);
+        reply = jdb.getTotalReply();
+        grep = new Paragrep(reply);
 
-        for (int i = 1; i < (FRAMES.length - 1); i++) {
-            var v = new Vector<String>();
+        for (int i = 1; i < (FRAMES.length-1); i++) {
+            v = new Vector();
             v.add(FRAMES[i][0]);
             v.add(FRAMES[i][1]);
-            int count = grep.find(v);
-            if (count != (i + 1)) {
+            count = grep.find(v);
+            if (count != (i+1)) {
                 failure("Unexpected number of the stack frame: " + FRAMES[i][1] +
-                        "\n\texpected value : " + (i + 1) + ", got : " + count);
+                    "\n\texpected value : " + (i+1) + ", got : " + count);
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001.java
@@ -42,9 +42,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.use.use001.use001
- *        nsk.jdb.use.use001.use001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.use.use001.use001
+ * @build nsk.jdb.use.use001.use001a
+ * @run main/othervm
+ *      nsk.jdb.use.use001.use001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001.java
@@ -57,22 +57,21 @@
 
 package nsk.jdb.use.use001;
 
+import nsk.share.*;
+import nsk.share.jdb.*;
 import jdk.test.lib.Utils;
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
 
-import java.io.File;
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class use001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new use001().runTest(argv, out);
@@ -81,10 +80,16 @@ public class use001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.use.use001";
     static final String TEST_CLASS = PACKAGE_NAME + ".use001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         String path = "";
         String srcdir = Utils.TEST_SRC;
 
@@ -92,7 +97,7 @@ public class use001 extends JdbTest {
 //        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         while (true) {
-            String[] reply = jdb.receiveReplyFor(JdbCommand.use);
+            reply = jdb.receiveReplyFor(JdbCommand.use);
 /*
             if (reply.length == 0) {
                 log.complain("Empty reply on first 'use' command");
@@ -120,7 +125,7 @@ public class use001 extends JdbTest {
             }
 
             reply = jdb.receiveReplyFor(JdbCommand.use);
-            var grep = new Paragrep(reply);
+            grep = new Paragrep(reply);
             if (grep.find(srcdir) == 0) {
                 log.complain("Current source directory should be in source file path");
                 success = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001.java
@@ -85,9 +85,6 @@ public class use001 extends JdbTest {
     static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-
         String path = "";
         String srcdir = Utils.TEST_SRC;
 
@@ -95,7 +92,7 @@ public class use001 extends JdbTest {
 //        reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         while (true) {
-            reply = jdb.receiveReplyFor(JdbCommand.use);
+            String[] reply = jdb.receiveReplyFor(JdbCommand.use);
 /*
             if (reply.length == 0) {
                 log.complain("Empty reply on first 'use' command");
@@ -123,7 +120,7 @@ public class use001 extends JdbTest {
             }
 
             reply = jdb.receiveReplyFor(JdbCommand.use);
-            grep = new Paragrep(reply);
+            var grep = new Paragrep(reply);
             if (grep.find(srcdir) == 0) {
                 log.complain("Current source directory should be in source file path");
                 success = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001.java
@@ -57,21 +57,22 @@
 
 package nsk.jdb.use.use001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
 import jdk.test.lib.Utils;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.PrintStream;
 
 public class use001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new use001().runTest(argv, out);
@@ -80,15 +81,12 @@ public class use001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.use.use001";
     static final String TEST_CLASS = PACKAGE_NAME + ".use001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         String path = "";
         String srcdir = Utils.TEST_SRC;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001.java
@@ -47,9 +47,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.watch.watch001.watch001
- *        nsk.jdb.watch.watch001.watch001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.watch.watch001.watch001
+ * @build nsk.jdb.watch.watch001.watch001a
+ * @run main/othervm
+ *      nsk.jdb.watch.watch001.watch001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001.java
@@ -95,8 +95,6 @@ public class watch001 extends JdbTest {
     static String[] checkedFields2 = {"FP0", "FU1", "FR0", "FT1", "FV0"};
 
     protected void runCases() {
-        String[] reply;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
 
         jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
@@ -108,7 +106,7 @@ public class watch001 extends JdbTest {
 
         jdb.contToExit(checkedFields.length + checkedFields2.length + 2);
 
-        reply = jdb.getTotalReply();
+        String[] reply = jdb.getTotalReply();
         if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields)) {
             success = false;
         }
@@ -125,19 +123,16 @@ public class watch001 extends JdbTest {
     }
 
     private boolean checkFields(String className, String[] reply, String[] checkedFields) {
-        Paragrep grep;
-        String found;
         boolean result = true;
-        Vector<String> v = new Vector<>();
+        var v = new Vector<String>();
+        var grep = new Paragrep(reply);
 
-        grep = new Paragrep(reply);
-        v.add("access encountered");
         for (String checkedField : checkedFields) {
             v.removeAllElements();
             v.add("access encountered");
             v.add(className + "." + checkedField);
 
-            found = grep.findFirst(v);
+            String found = grep.findFirst(v);
             if (found.length() == 0) {
                 log.complain("Failed to report access to field " + className + "." + checkedField);
                 result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001.java
@@ -62,90 +62,84 @@
 
 package nsk.jdb.watch.watch001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class watch001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
         return new watch001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.watch.watch001";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".watch001";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String DEBUGGEE_CLASS2    = DEBUGGEE_CLASS + "$CheckedFields";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".breakHere";
+    static final String PACKAGE_NAME = "nsk.jdb.watch.watch001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".watch001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String DEBUGGEE_CLASS2 = DEBUGGEE_CLASS + "$CheckedFields";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
     static final String COMPOUND_PROMPT_IDENT = "main";
 
-    static String[] checkedFields  = { "fS0", "FS1" };
-    static String[] checkedFields2 = { "FP0", "FU1", "FR0", "FT1", "FV0" };
+    static String[] checkedFields = {"fS0", "FS1"};
+    static String[] checkedFields2 = {"FP0", "FU1", "FR0", "FT1", "FV0"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
 
-        watchFields (DEBUGGEE_CLASS, checkedFields);
-        watchFields (DEBUGGEE_CLASS2, checkedFields2);
+        watchFields(DEBUGGEE_CLASS, checkedFields);
+        watchFields(DEBUGGEE_CLASS2, checkedFields2);
 
         jdb.contToExit(checkedFields.length + checkedFields2.length + 2);
 
         reply = jdb.getTotalReply();
-        if (!checkFields (DEBUGGEE_CLASS, reply, checkedFields)) {
+        if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields)) {
             success = false;
         }
-        if (!checkFields (DEBUGGEE_CLASS2, reply, checkedFields2)) {
+        if (!checkFields(DEBUGGEE_CLASS2, reply, checkedFields2)) {
             success = false;
         }
     }
 
-    private void watchFields (String className, String[] checkedFields) {
-        String[] reply;
-
-        for (int i = 0; i < checkedFields.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.watch + " access " + className + "." + checkedFields[i]);
+    private void watchFields(String className, String[] checkedFields) {
+        for (String checkedField : checkedFields) {
+            jdb.receiveReplyFor(JdbCommand.watch + " access " + className + "." + checkedField);
         }
 
     }
 
-    private boolean checkFields (String className, String[] reply, String[] checkedFields) {
+    private boolean checkFields(String className, String[] reply, String[] checkedFields) {
         Paragrep grep;
         String found;
         boolean result = true;
-        int count;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         grep = new Paragrep(reply);
         v.add("access encountered");
-        for (int i = 0; i < checkedFields.length; i++) {
+        for (String checkedField : checkedFields) {
             v.removeAllElements();
             v.add("access encountered");
-            v.add(className + "." + checkedFields[i]);
+            v.add(className + "." + checkedField);
 
             found = grep.findFirst(v);
             if (found.length() == 0) {
-                log.complain("Failed to report access to field " + className + "." + checkedFields[i]);
+                log.complain("Failed to report access to field " + className + "." + checkedField);
                 result = false;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001.java
@@ -62,79 +62,90 @@
 
 package nsk.jdb.watch.watch001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class watch001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
         return new watch001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.watch.watch001";
-    static final String TEST_CLASS = PACKAGE_NAME + ".watch001";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String DEBUGGEE_CLASS2 = DEBUGGEE_CLASS + "$CheckedFields";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
+    static final String PACKAGE_NAME       = "nsk.jdb.watch.watch001";
+    static final String TEST_CLASS         = PACKAGE_NAME + ".watch001";
+    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
+    static final String DEBUGGEE_CLASS2    = DEBUGGEE_CLASS + "$CheckedFields";
+    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".breakHere";
     static final String COMPOUND_PROMPT_IDENT = "main";
 
-    static String[] checkedFields = {"fS0", "FS1"};
-    static String[] checkedFields2 = {"FP0", "FU1", "FR0", "FT1", "FV0"};
+    static String[] checkedFields  = { "fS0", "FS1" };
+    static String[] checkedFields2 = { "FP0", "FU1", "FR0", "FT1", "FV0" };
 
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
 
-        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
+        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
 
-        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
+        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
 
-        watchFields(DEBUGGEE_CLASS, checkedFields);
-        watchFields(DEBUGGEE_CLASS2, checkedFields2);
+        watchFields (DEBUGGEE_CLASS, checkedFields);
+        watchFields (DEBUGGEE_CLASS2, checkedFields2);
 
         jdb.contToExit(checkedFields.length + checkedFields2.length + 2);
 
-        String[] reply = jdb.getTotalReply();
-        if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields)) {
+        reply = jdb.getTotalReply();
+        if (!checkFields (DEBUGGEE_CLASS, reply, checkedFields)) {
             success = false;
         }
-        if (!checkFields(DEBUGGEE_CLASS2, reply, checkedFields2)) {
+        if (!checkFields (DEBUGGEE_CLASS2, reply, checkedFields2)) {
             success = false;
         }
     }
 
-    private void watchFields(String className, String[] checkedFields) {
-        for (String checkedField : checkedFields) {
-            jdb.receiveReplyFor(JdbCommand.watch + " access " + className + "." + checkedField);
+    private void watchFields (String className, String[] checkedFields) {
+        String[] reply;
+
+        for (int i = 0; i < checkedFields.length; i++) {
+            reply = jdb.receiveReplyFor(JdbCommand.watch + " access " + className + "." + checkedFields[i]);
         }
 
     }
 
-    private boolean checkFields(String className, String[] reply, String[] checkedFields) {
+    private boolean checkFields (String className, String[] reply, String[] checkedFields) {
+        Paragrep grep;
+        String found;
         boolean result = true;
-        var v = new Vector<String>();
-        var grep = new Paragrep(reply);
+        int count;
+        Vector v = new Vector();
 
-        for (String checkedField : checkedFields) {
+        grep = new Paragrep(reply);
+        v.add("access encountered");
+        for (int i = 0; i < checkedFields.length; i++) {
             v.removeAllElements();
             v.add("access encountered");
-            v.add(className + "." + checkedField);
+            v.add(className + "." + checkedFields[i]);
 
-            String found = grep.findFirst(v);
+            found = grep.findFirst(v);
             if (found.length() == 0) {
-                log.complain("Failed to report access to field " + className + "." + checkedField);
+                log.complain("Failed to report access to field " + className + "." + checkedFields[i]);
                 result = false;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002.java
@@ -47,9 +47,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.watch.watch002.watch002
- *        nsk.jdb.watch.watch002.watch002a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.watch.watch002.watch002
+ * @build nsk.jdb.watch.watch002.watch002a
+ * @run main/othervm
+ *      nsk.jdb.watch.watch002.watch002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002.java
@@ -62,100 +62,94 @@
 
 package nsk.jdb.watch.watch002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class watch002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
         return new watch002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.watch.watch002";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".watch002";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String DEBUGGEE_CLASS2    = DEBUGGEE_CLASS + "$CheckedFields";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".breakHere";
+    static final String PACKAGE_NAME = "nsk.jdb.watch.watch002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".watch002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String DEBUGGEE_CLASS2 = DEBUGGEE_CLASS + "$CheckedFields";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
     static final String COMPOUND_PROMPT_IDENT = "main";
 
-    static String[] checkedFields  = { "FS0", "FS1" };
-    static String[] checkedFields2 = { "FP1", "FU1", "FR1", "FT1", "FV1" };
+    static String[] checkedFields = {"FS0", "FS1"};
+    static String[] checkedFields2 = {"FP1", "FU1", "FR1", "FT1", "FV1"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
 
-        watchFields (DEBUGGEE_CLASS, checkedFields);
-        watchFields (DEBUGGEE_CLASS2, checkedFields2);
+        watchFields(DEBUGGEE_CLASS, checkedFields);
+        watchFields(DEBUGGEE_CLASS2, checkedFields2);
 
-        jdb.contToExit((checkedFields.length *2)  + (checkedFields2.length *2) + 2);
+        jdb.contToExit((checkedFields.length * 2) + (checkedFields2.length * 2) + 2);
 
         reply = jdb.getTotalReply();
-        if (!checkFields (DEBUGGEE_CLASS, reply, checkedFields)) {
+        if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields)) {
             success = false;
         }
-        if (!checkFields (DEBUGGEE_CLASS2, reply, checkedFields2)) {
+        if (!checkFields(DEBUGGEE_CLASS2, reply, checkedFields2)) {
             success = false;
         }
     }
 
-    private void watchFields (String className, String[] checkedFields) {
-        String[] reply;
-
-        for (int i = 0; i < checkedFields.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.watch + " all " + className + "." + checkedFields[i]);
+    private void watchFields(String className, String[] checkedFields) {
+        for (String checkedField : checkedFields) {
+            jdb.receiveReplyFor(JdbCommand.watch + " all " + className + "." + checkedField);
         }
 
     }
 
-    private boolean checkFields (String className, String[] reply, String[] checkedFields) {
+    private boolean checkFields(String className, String[] reply, String[] checkedFields) {
         Paragrep grep;
         String found;
         boolean result = true;
-        int count;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         grep = new Paragrep(reply);
         v.add("access encountered");
-        for (int i = 0; i < checkedFields.length; i++) {
+        for (String checkedField : checkedFields) {
             v.removeAllElements();
             v.add("access encountered");
-            v.add(className + "." + checkedFields[i]);
+            v.add(className + "." + checkedField);
 
             found = grep.findFirst(v);
             if (found.length() == 0) {
-                log.complain("Failed to report access to field " + className + "." + checkedFields[i]);
+                log.complain("Failed to report access to field " + className + "." + checkedField);
                 result = false;
             }
 
             v.removeAllElements();
             v.add("will be");
-            v.add(className + "." + checkedFields[i]);
+            v.add(className + "." + checkedField);
 
             found = grep.findFirst(v);
             if (found.length() == 0) {
-                log.complain("Failed to report modification of field " + className + "." + checkedFields[i]);
+                log.complain("Failed to report modification of field " + className + "." + checkedField);
                 result = false;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002.java
@@ -95,8 +95,6 @@ public class watch002 extends JdbTest {
     static String[] checkedFields2 = {"FP1", "FU1", "FR1", "FT1", "FV1"};
 
     protected void runCases() {
-        String[] reply;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
 
         jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
@@ -108,7 +106,7 @@ public class watch002 extends JdbTest {
 
         jdb.contToExit((checkedFields.length * 2) + (checkedFields2.length * 2) + 2);
 
-        reply = jdb.getTotalReply();
+        String[] reply = jdb.getTotalReply();
         if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields)) {
             success = false;
         }
@@ -125,19 +123,16 @@ public class watch002 extends JdbTest {
     }
 
     private boolean checkFields(String className, String[] reply, String[] checkedFields) {
-        Paragrep grep;
-        String found;
         boolean result = true;
-        Vector<String> v = new Vector<>();
+        var v = new Vector<String>();
+        var grep = new Paragrep(reply);
 
-        grep = new Paragrep(reply);
-        v.add("access encountered");
         for (String checkedField : checkedFields) {
             v.removeAllElements();
             v.add("access encountered");
             v.add(className + "." + checkedField);
 
-            found = grep.findFirst(v);
+            String found = grep.findFirst(v);
             if (found.length() == 0) {
                 log.complain("Failed to report access to field " + className + "." + checkedField);
                 result = false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004.java
@@ -40,9 +40,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.where.where004.where004
- *        nsk.jdb.where.where004.where004a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.where.where004.where004
+ * @build nsk.jdb.where.where004.where004a
+ * @run main/othervm
+ *      nsk.jdb.where.where004.where004
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004.java
@@ -55,57 +55,61 @@
 
 package nsk.jdb.where.where004;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class where004 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new where004().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.where.where004";
-    static final String TEST_CLASS = PACKAGE_NAME + ".where004";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME     = "nsk.jdb.where.where004";
+    static final String TEST_CLASS       = PACKAGE_NAME + ".where004";
+    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][]{
-            {DEBUGGEE_CLASS + ".func5", "71"},
-            {DEBUGGEE_CLASS + ".func4", "67"},
-            {DEBUGGEE_CLASS + ".func3", "63"},
-            {DEBUGGEE_CLASS + ".func2", "59"},
-            {DEBUGGEE_CLASS + ".func1", "55"},
-            {DEBUGGEE_CLASS + ".runIt", "48"},
-            {DEBUGGEE_CLASS + ".main", "39"}
-    };
-
+    static final String[][] FRAMES = new String[][] {
+        {DEBUGGEE_CLASS + ".func5", "71"},
+        {DEBUGGEE_CLASS + ".func4", "67"},
+        {DEBUGGEE_CLASS + ".func3", "63"},
+        {DEBUGGEE_CLASS + ".func2", "59"},
+        {DEBUGGEE_CLASS + ".func1", "55"},
+        {DEBUGGEE_CLASS + ".runIt", "48"},
+        {DEBUGGEE_CLASS + ".main",  "39"}
+                                                };
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.receiveReplyFor(JdbCommand.stop_in + DEBUGGEE_CLASS + ".func5");
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        String[] reply = jdb.receiveReplyFor(JdbCommand.where);
-        var grep = new Paragrep(reply);
+        reply = jdb.receiveReplyFor(JdbCommand.where);
+        grep = new Paragrep(reply);
 
-        for (String[] frame : FRAMES) {
-            var v = new Vector<String>();
-            v.add(frame[0]);
-            v.add(frame[1]);
-            int count = grep.find(v);
+        for (int i = 0; i < FRAMES.length; i++) {
+            v = new Vector();
+            v.add(FRAMES[i][0]);
+            v.add(FRAMES[i][1]);
+            count = grep.find(v);
             if (count != 1) {
-                failure("Unexpected number or location of the stack frame: " + frame[0] +
-                        "\n\texpected value : 1, got one: " + count);
+                failure("Unexpected number or location of the stack frame: " + FRAMES[i][0] +
+                    "\n\texpected value : 1, got one: " + count);
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004.java
@@ -92,22 +92,17 @@ public class where004 extends JdbTest {
     };
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector<String> v;
-
         jdb.receiveReplyFor(JdbCommand.stop_in + DEBUGGEE_CLASS + ".func5");
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        reply = jdb.receiveReplyFor(JdbCommand.where);
-        grep = new Paragrep(reply);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.where);
+        var grep = new Paragrep(reply);
 
         for (String[] frame : FRAMES) {
-            v = new Vector<>();
+            var v = new Vector<String>();
             v.add(frame[0]);
             v.add(frame[1]);
-            count = grep.find(v);
+            int count = grep.find(v);
             if (count != 1) {
                 failure("Unexpected number or location of the stack frame: " + frame[0] +
                         "\n\texpected value : 1, got one: " + count);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004.java
@@ -55,46 +55,47 @@
 
 package nsk.jdb.where.where004;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class where004 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new where004().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.where.where004";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".where004";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.where.where004";
+    static final String TEST_CLASS = PACKAGE_NAME + ".where004";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][] {
-        {DEBUGGEE_CLASS + ".func5", "71"},
-        {DEBUGGEE_CLASS + ".func4", "67"},
-        {DEBUGGEE_CLASS + ".func3", "63"},
-        {DEBUGGEE_CLASS + ".func2", "59"},
-        {DEBUGGEE_CLASS + ".func1", "55"},
-        {DEBUGGEE_CLASS + ".runIt", "48"},
-        {DEBUGGEE_CLASS + ".main",  "39"}
-                                                };
+    static final String[][] FRAMES = new String[][]{
+            {DEBUGGEE_CLASS + ".func5", "71"},
+            {DEBUGGEE_CLASS + ".func4", "67"},
+            {DEBUGGEE_CLASS + ".func3", "63"},
+            {DEBUGGEE_CLASS + ".func2", "59"},
+            {DEBUGGEE_CLASS + ".func1", "55"},
+            {DEBUGGEE_CLASS + ".runIt", "48"},
+            {DEBUGGEE_CLASS + ".main", "39"}
+    };
+
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.receiveReplyFor(JdbCommand.stop_in + DEBUGGEE_CLASS + ".func5");
         jdb.receiveReplyFor(JdbCommand.cont);
@@ -102,14 +103,14 @@ public class where004 extends JdbTest {
         reply = jdb.receiveReplyFor(JdbCommand.where);
         grep = new Paragrep(reply);
 
-        for (int i = 0; i < FRAMES.length; i++) {
-            v = new Vector();
-            v.add(FRAMES[i][0]);
-            v.add(FRAMES[i][1]);
+        for (String[] frame : FRAMES) {
+            v = new Vector<>();
+            v.add(frame[0]);
+            v.add(frame[1]);
             count = grep.find(v);
             if (count != 1) {
-                failure("Unexpected number or location of the stack frame: " + FRAMES[i][0] +
-                    "\n\texpected value : 1, got one: " + count);
+                failure("Unexpected number or location of the stack frame: " + frame[0] +
+                        "\n\texpected value : 1, got one: " + count);
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005.java
@@ -41,9 +41,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.where.where005.where005
- *        nsk.jdb.where.where005.where005a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.where.where005.where005
+ * @build nsk.jdb.where.where005.where005a
+ * @run main/othervm
+ *      nsk.jdb.where.where005.where005
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005.java
@@ -56,51 +56,52 @@
 
 package nsk.jdb.where.where005;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class where005 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new where005(true).runTest(argv, out);
     }
 
-    public where005 (boolean debuggeeShouldFail) {
+    public where005(boolean debuggeeShouldFail) {
         super(debuggeeShouldFail);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.where.where005";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".where005";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.where.where005";
+    static final String TEST_CLASS = PACKAGE_NAME + ".where005";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][] {
-        {DEBUGGEE_CLASS + ".func6", "76"},
-        {DEBUGGEE_CLASS + ".func5", "71"},
-        {DEBUGGEE_CLASS + ".func4", "67"},
-        {DEBUGGEE_CLASS + ".func3", "63"},
-        {DEBUGGEE_CLASS + ".func2", "59"},
-        {DEBUGGEE_CLASS + ".func1", "55"},
-        {DEBUGGEE_CLASS + ".runIt", "48"},
-        {DEBUGGEE_CLASS + ".main",  "39"}
-                                                };
+    static final String[][] FRAMES = new String[][]{
+            {DEBUGGEE_CLASS + ".func6", "76"},
+            {DEBUGGEE_CLASS + ".func5", "71"},
+            {DEBUGGEE_CLASS + ".func4", "67"},
+            {DEBUGGEE_CLASS + ".func3", "63"},
+            {DEBUGGEE_CLASS + ".func2", "59"},
+            {DEBUGGEE_CLASS + ".func1", "55"},
+            {DEBUGGEE_CLASS + ".runIt", "48"},
+            {DEBUGGEE_CLASS + ".main", "39"}
+    };
+
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         reply = jdb.receiveReplyFor(JdbCommand.cont);
         grep = new Paragrep(reply);
@@ -111,14 +112,14 @@ public class where005 extends JdbTest {
             reply = jdb.receiveReplyFor(JdbCommand.where);
             grep = new Paragrep(reply);
 
-            for (int i = 0; i < FRAMES.length; i++) {
-                v = new Vector();
-                v.add(FRAMES[i][0]);
-                v.add(FRAMES[i][1]);
+            for (String[] frame : FRAMES) {
+                v = new Vector<>();
+                v.add(frame[0]);
+                v.add(frame[1]);
                 count = grep.find(v);
                 if (count != 1) {
-                    failure("Unexpected number or location of the stack frame: " + FRAMES[i][0] +
-                        "\n\texpected value : 1, got one: " + count);
+                    failure("Unexpected number or location of the stack frame: " + frame[0] +
+                            "\n\texpected value : 1, got one: " + count);
                 }
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005.java
@@ -98,13 +98,8 @@ public class where005 extends JdbTest {
     };
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector<String> v;
-
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
-        grep = new Paragrep(reply);
+        String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
+        var grep = new Paragrep(reply);
 
         if (grep.find("NullPointerException") == 0) {
             failure("Expected NullPointerException is not thrown");
@@ -113,10 +108,10 @@ public class where005 extends JdbTest {
             grep = new Paragrep(reply);
 
             for (String[] frame : FRAMES) {
-                v = new Vector<>();
+                var v = new Vector<String>();
                 v.add(frame[0]);
                 v.add(frame[1]);
-                count = grep.find(v);
+                int count = grep.find(v);
                 if (count != 1) {
                     failure("Unexpected number or location of the stack frame: " + frame[0] +
                             "\n\texpected value : 1, got one: " + count);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005.java
@@ -56,50 +56,54 @@
 
 package nsk.jdb.where.where005;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
-import java.util.Vector;
+import java.io.*;
+import java.util.*;
 
 public class where005 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new where005(true).runTest(argv, out);
     }
 
-    public where005(boolean debuggeeShouldFail) {
+    public where005 (boolean debuggeeShouldFail) {
         super(debuggeeShouldFail);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.where.where005";
-    static final String TEST_CLASS = PACKAGE_NAME + ".where005";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME     = "nsk.jdb.where.where005";
+    static final String TEST_CLASS       = PACKAGE_NAME + ".where005";
+    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][]{
-            {DEBUGGEE_CLASS + ".func6", "76"},
-            {DEBUGGEE_CLASS + ".func5", "71"},
-            {DEBUGGEE_CLASS + ".func4", "67"},
-            {DEBUGGEE_CLASS + ".func3", "63"},
-            {DEBUGGEE_CLASS + ".func2", "59"},
-            {DEBUGGEE_CLASS + ".func1", "55"},
-            {DEBUGGEE_CLASS + ".runIt", "48"},
-            {DEBUGGEE_CLASS + ".main", "39"}
-    };
-
+    static final String[][] FRAMES = new String[][] {
+        {DEBUGGEE_CLASS + ".func6", "76"},
+        {DEBUGGEE_CLASS + ".func5", "71"},
+        {DEBUGGEE_CLASS + ".func4", "67"},
+        {DEBUGGEE_CLASS + ".func3", "63"},
+        {DEBUGGEE_CLASS + ".func2", "59"},
+        {DEBUGGEE_CLASS + ".func1", "55"},
+        {DEBUGGEE_CLASS + ".runIt", "48"},
+        {DEBUGGEE_CLASS + ".main",  "39"}
+                                                };
     protected void runCases() {
-        String[] reply = jdb.receiveReplyFor(JdbCommand.cont);
-        var grep = new Paragrep(reply);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        grep = new Paragrep(reply);
 
         if (grep.find("NullPointerException") == 0) {
             failure("Expected NullPointerException is not thrown");
@@ -107,14 +111,14 @@ public class where005 extends JdbTest {
             reply = jdb.receiveReplyFor(JdbCommand.where);
             grep = new Paragrep(reply);
 
-            for (String[] frame : FRAMES) {
-                var v = new Vector<String>();
-                v.add(frame[0]);
-                v.add(frame[1]);
-                int count = grep.find(v);
+            for (int i = 0; i < FRAMES.length; i++) {
+                v = new Vector();
+                v.add(FRAMES[i][0]);
+                v.add(FRAMES[i][1]);
+                count = grep.find(v);
                 if (count != 1) {
-                    failure("Unexpected number or location of the stack frame: " + frame[0] +
-                            "\n\texpected value : 1, got one: " + count);
+                    failure("Unexpected number or location of the stack frame: " + FRAMES[i][0] +
+                        "\n\texpected value : 1, got one: " + count);
                 }
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
@@ -41,9 +41,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.where.where006.where006
- *        nsk.jdb.where.where006.where006a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.where.where006.where006
+ * @build nsk.jdb.where.where006.where006a
+ * @run main/othervm
+ *      nsk.jdb.where.where006.where006
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
@@ -91,13 +91,11 @@ public class where006 extends JdbTest {
     };
 
     protected void runCases() {
-        String[] reply;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
         String[] threadIds = jdb.getThreadIds(PACKAGE_NAME + ".MyThread");
-        reply = jdb.receiveReplyFor(JdbCommand.where + "all");
+        String[] reply = jdb.receiveReplyFor(JdbCommand.where + "all");
         for (int i = 0; i < where006a.numThreads; i++) {
             checkFrames(threadIds[i], reply, 5);
         }
@@ -111,19 +109,15 @@ public class where006 extends JdbTest {
     }
 
     void checkFrames(String threadId, String[] reply, int expectedVal) {
-        Paragrep grep;
-        int count;
-        String found;
-
-        grep = new Paragrep(reply);
+        var grep = new Paragrep(reply);
         for (String[] frame : FRAMES) {
-            count = grep.find(frame[0]);
+            int count = grep.find(frame[0]);
             if (count != expectedVal) {
                 failure("Unexpected number of occurencies of the stack frame: " + frame[0] +
                         " for thread " + threadId +
                         "\n\t Expected number of occurence: " + expectedVal + ", got : " + count);
                 if (count > 0) {
-                    found = grep.findFirst(frame[0]);
+                    String found = grep.findFirst(frame[0]);
                     if (!found.contains(frame[1])) {
                         failure("Unexpected location in the stack frame: " + frame[0] +
                                 " for thread " + threadId +

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
@@ -56,46 +56,51 @@
 
 package nsk.jdb.where.where006;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class where006 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new where006().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.where.where006";
-    static final String TEST_CLASS = PACKAGE_NAME + ".where006";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME     = "nsk.jdb.where.where006";
+    static final String TEST_CLASS       = PACKAGE_NAME + ".where006";
+    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][]{
-            {PACKAGE_NAME + ".MyThread.func5", "111"},
-            {PACKAGE_NAME + ".MyThread.func4", "103"},
-            {PACKAGE_NAME + ".MyThread.func3", "99"},
-            {PACKAGE_NAME + ".MyThread.func2", "95"},
-            {PACKAGE_NAME + ".MyThread.func1", "91"},
-            {PACKAGE_NAME + ".MyThread.run", "85"},
-    };
-
+    static final String[][] FRAMES = new String[][] {
+        {PACKAGE_NAME + ".MyThread.func5", "111"},
+        {PACKAGE_NAME + ".MyThread.func4", "103"},
+        {PACKAGE_NAME + ".MyThread.func3", "99"},
+        {PACKAGE_NAME + ".MyThread.func2", "95"},
+        {PACKAGE_NAME + ".MyThread.func1", "91"},
+        {PACKAGE_NAME + ".MyThread.run", "85"},
+                                                };
     protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
         String[] threadIds = jdb.getThreadIds(PACKAGE_NAME + ".MyThread");
-        String[] reply = jdb.receiveReplyFor(JdbCommand.where + "all");
+        reply = jdb.receiveReplyFor(JdbCommand.where + "all");
         for (int i = 0; i < where006a.numThreads; i++) {
             checkFrames(threadIds[i], reply, 5);
         }
@@ -108,20 +113,25 @@ public class where006 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    void checkFrames(String threadId, String[] reply, int expectedVal) {
-        var grep = new Paragrep(reply);
-        for (String[] frame : FRAMES) {
-            int count = grep.find(frame[0]);
+    void checkFrames (String threadId, String[] reply, int expectedVal) {
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+
+        grep = new Paragrep(reply);
+        for (int j = 0; j < FRAMES.length; j++) {
+            count = grep.find(FRAMES[j][0]);
             if (count != expectedVal) {
-                failure("Unexpected number of occurencies of the stack frame: " + frame[0] +
-                        " for thread " + threadId +
-                        "\n\t Expected number of occurence: " + expectedVal + ", got : " + count);
+                failure("Unexpected number of occurencies of the stack frame: " + FRAMES[j][0] +
+                    " for thread " + threadId +
+                    "\n\t Expected number of occurence: " + expectedVal +", got : " + count);
                 if (count > 0) {
-                    String found = grep.findFirst(frame[0]);
-                    if (!found.contains(frame[1])) {
-                        failure("Unexpected location in the stack frame: " + frame[0] +
-                                " for thread " + threadId +
-                                "\n\t Expected location: " + frame[1] + ", got :\n\t" + found);
+                    found = grep.findFirst(FRAMES[j][0]);
+                    if (found.indexOf(FRAMES[j][1]) < 0) {
+                        failure("Unexpected location in the stack frame: " + FRAMES[j][0] +
+                            " for thread " + threadId +
+                            "\n\t Expected location: " + FRAMES[j][1] + ", got :\n\t" + found);
                     }
                 }
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
@@ -56,45 +56,42 @@
 
 package nsk.jdb.where.where006;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class where006 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new where006().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.where.where006";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".where006";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.where.where006";
+    static final String TEST_CLASS = PACKAGE_NAME + ".where006";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][] {
-        {PACKAGE_NAME + ".MyThread.func5", "111"},
-        {PACKAGE_NAME + ".MyThread.func4", "103"},
-        {PACKAGE_NAME + ".MyThread.func3", "99"},
-        {PACKAGE_NAME + ".MyThread.func2", "95"},
-        {PACKAGE_NAME + ".MyThread.func1", "91"},
-        {PACKAGE_NAME + ".MyThread.run", "85"},
-                                                };
+    static final String[][] FRAMES = new String[][]{
+            {PACKAGE_NAME + ".MyThread.func5", "111"},
+            {PACKAGE_NAME + ".MyThread.func4", "103"},
+            {PACKAGE_NAME + ".MyThread.func3", "99"},
+            {PACKAGE_NAME + ".MyThread.func2", "95"},
+            {PACKAGE_NAME + ".MyThread.func1", "91"},
+            {PACKAGE_NAME + ".MyThread.run", "85"},
+    };
+
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
@@ -113,25 +110,24 @@ public class where006 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    void checkFrames (String threadId, String[] reply, int expectedVal) {
+    void checkFrames(String threadId, String[] reply, int expectedVal) {
         Paragrep grep;
         int count;
-        Vector v;
         String found;
 
         grep = new Paragrep(reply);
-        for (int j = 0; j < FRAMES.length; j++) {
-            count = grep.find(FRAMES[j][0]);
+        for (String[] frame : FRAMES) {
+            count = grep.find(frame[0]);
             if (count != expectedVal) {
-                failure("Unexpected number of occurencies of the stack frame: " + FRAMES[j][0] +
-                    " for thread " + threadId +
-                    "\n\t Expected number of occurence: " + expectedVal +", got : " + count);
+                failure("Unexpected number of occurencies of the stack frame: " + frame[0] +
+                        " for thread " + threadId +
+                        "\n\t Expected number of occurence: " + expectedVal + ", got : " + count);
                 if (count > 0) {
-                    found = grep.findFirst(FRAMES[j][0]);
-                    if (found.indexOf(FRAMES[j][1]) < 0) {
-                        failure("Unexpected location in the stack frame: " + FRAMES[j][0] +
-                            " for thread " + threadId +
-                            "\n\t Expected location: " + FRAMES[j][1] + ", got :\n\t" + found);
+                    found = grep.findFirst(frame[0]);
+                    if (!found.contains(frame[1])) {
+                        failure("Unexpected location in the stack frame: " + frame[0] +
+                                " for thread " + threadId +
+                                "\n\t Expected location: " + frame[1] + ", got :\n\t" + found);
                     }
                 }
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
@@ -36,9 +36,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build nsk.jdb.wherei.wherei001.wherei001
- *        nsk.jdb.wherei.wherei001.wherei001a
- * @run main/othervm PropertyResolvingWrapper nsk.jdb.wherei.wherei001.wherei001
+ * @build nsk.jdb.wherei.wherei001.wherei001a
+ * @run main/othervm
+ *      nsk.jdb.wherei.wherei001.wherei001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
  *      -debugee.vmkind=java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
@@ -78,12 +78,10 @@ public class wherei001 extends JdbTest {
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + ".MyThread";
 
     protected void runCases() {
-        String[] threads;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
         if (threads.length != 5) {
             log.complain("jdb should report 5 instance of " + DEBUGGEE_THREAD);
@@ -101,17 +99,13 @@ public class wherei001 extends JdbTest {
     }
 
     private boolean checkStack(String threadId) {
-        Paragrep grep;
-        String[] reply;
-        int count;
         boolean result = true;
         String[] func = {"func5", "func4", "func3", "func2", "func1", "run"};
+        String[] reply = jdb.receiveReplyFor(JdbCommand.wherei + threadId);
 
-        reply = jdb.receiveReplyFor(JdbCommand.wherei + threadId);
-
-        grep = new Paragrep(reply);
+        var grep = new Paragrep(reply);
         for (String s : func) {
-            count = grep.find(DEBUGGEE_THREAD + "." + s);
+            int count = grep.find(DEBUGGEE_THREAD + "." + s);
             if (count != 1) {
                 log.complain("Contents of stack trace is incorrect for thread " + threadId);
                 log.complain("Searched for: " + DEBUGGEE_THREAD + "." + s);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
@@ -51,42 +51,37 @@
 
 package nsk.jdb.wherei.wherei001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class wherei001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new wherei001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.wherei.wherei001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".wherei001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.wherei.wherei001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".wherei001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + ".MyThread";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
@@ -96,8 +91,8 @@ public class wherei001 extends JdbTest {
             success = false;
         }
 
-        for (int i = 0; i < threads.length; i++) {
-            if (!checkStack(threads[i])) {
+        for (String thread : threads) {
+            if (!checkStack(thread)) {
                 success = false;
             }
         }
@@ -105,25 +100,23 @@ public class wherei001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkStack (String threadId) {
+    private boolean checkStack(String threadId) {
         Paragrep grep;
         String[] reply;
-        String found;
         int count;
-        Vector v;
         boolean result = true;
-        String[] func = { "func5", "func4", "func3", "func2", "func1", "run" };
+        String[] func = {"func5", "func4", "func3", "func2", "func1", "run"};
 
         reply = jdb.receiveReplyFor(JdbCommand.wherei + threadId);
 
         grep = new Paragrep(reply);
-        for (int i = 0; i < func.length; i++) {
-            count = grep.find(DEBUGGEE_THREAD + "." + func[i]);
+        for (String s : func) {
+            count = grep.find(DEBUGGEE_THREAD + "." + s);
             if (count != 1) {
                 log.complain("Contents of stack trace is incorrect for thread " + threadId);
-                log.complain("Searched for: " + DEBUGGEE_THREAD + "." + func[i]);
+                log.complain("Searched for: " + DEBUGGEE_THREAD + "." + s);
                 log.complain("Count : " + count);
-                result= false;
+                result = false;
             }
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
@@ -51,37 +51,44 @@
 
 package nsk.jdb.wherei.wherei001;
 
-import nsk.share.Paragrep;
-import nsk.share.jdb.JdbCommand;
-import nsk.share.jdb.JdbTest;
+import nsk.share.*;
+import nsk.share.jdb.*;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.util.*;
 
 public class wherei001 extends JdbTest {
 
-    public static void main(String[] argv) {
+    public static void main (String argv[]) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String[] argv, PrintStream out) {
-        debuggeeClass = DEBUGGEE_CLASS;
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new wherei001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.wherei.wherei001";
-    static final String TEST_CLASS = PACKAGE_NAME + ".wherei001";
-    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME    = "nsk.jdb.wherei.wherei001";
+    static final String TEST_CLASS      = PACKAGE_NAME + ".wherei001";
+    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
+    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + ".MyThread";
 
     protected void runCases() {
-        jdb.setBreakpointInMethod(LAST_BREAK);
-        jdb.receiveReplyFor(JdbCommand.cont);
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String found;
+        String[] threads;
 
-        String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        jdb.setBreakpointInMethod(LAST_BREAK);
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
+
+        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
         if (threads.length != 5) {
             log.complain("jdb should report 5 instance of " + DEBUGGEE_THREAD);
@@ -89,8 +96,8 @@ public class wherei001 extends JdbTest {
             success = false;
         }
 
-        for (String thread : threads) {
-            if (!checkStack(thread)) {
+        for (int i = 0; i < threads.length; i++) {
+            if (!checkStack(threads[i])) {
                 success = false;
             }
         }
@@ -98,19 +105,25 @@ public class wherei001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkStack(String threadId) {
+    private boolean checkStack (String threadId) {
+        Paragrep grep;
+        String[] reply;
+        String found;
+        int count;
+        Vector v;
         boolean result = true;
-        String[] func = {"func5", "func4", "func3", "func2", "func1", "run"};
-        String[] reply = jdb.receiveReplyFor(JdbCommand.wherei + threadId);
+        String[] func = { "func5", "func4", "func3", "func2", "func1", "run" };
 
-        var grep = new Paragrep(reply);
-        for (String s : func) {
-            int count = grep.find(DEBUGGEE_THREAD + "." + s);
+        reply = jdb.receiveReplyFor(JdbCommand.wherei + threadId);
+
+        grep = new Paragrep(reply);
+        for (int i = 0; i < func.length; i++) {
+            count = grep.find(DEBUGGEE_THREAD + "." + func[i]);
             if (count != 1) {
                 log.complain("Contents of stack trace is incorrect for thread " + threadId);
-                log.complain("Searched for: " + DEBUGGEE_THREAD + "." + s);
+                log.complain("Searched for: " + DEBUGGEE_THREAD + "." + func[i]);
                 log.complain("Count : " + count);
-                result = false;
+                result= false;
             }
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbArgumentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbArgumentHandler.java
@@ -149,7 +149,6 @@ public class JdbArgumentHandler extends nsk.share.jdi.ArgumentHandler {
      * @see #parseArguments()
      */
     protected void checkOptions() {
-
         super.checkOptions();
     }
 
@@ -182,9 +181,11 @@ public class JdbArgumentHandler extends nsk.share.jdi.ArgumentHandler {
      */
     public static List<String> enwrapJavaOptions(String javaOptions) {
         List<String> result = new ArrayList<String>();
-        for (String option : javaOptions.split("\\s+"))
-            if (option.length() > 0)
+        for (String option : javaOptions.split("\\s+")) {
+            if (option.length() > 0) {
                 result.add("-J" + option);
+            }
+        }
         return result;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbArgumentHandler.java
@@ -181,7 +181,11 @@ public class JdbArgumentHandler extends nsk.share.jdi.ArgumentHandler {
      * Returns command line options <code>jdb</code> was launched with.
      */
     public String getJdbOptions() {
-        return options.getProperty("jdb.option", "");
+        String value = options.getProperty("jdb.option", "").trim();
+        if (value.length() > 1 && value.startsWith("\"") && value.endsWith("\"")) {
+            value = value.substring(1, value.length() - 1).trim();
+        }
+        return value;
     }
 
     /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbArgumentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,8 @@
 
 package nsk.share.jdb;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdi.ArgumentHandler;
-
-import java.io.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Parser for <code>jdb</code> test's specific command-line arguments.
@@ -70,15 +66,13 @@ public class JdbArgumentHandler extends nsk.share.jdi.ArgumentHandler {
      * Keep a copy of raw command-line arguments and parse them;
      * but throw an exception on parsing error.
      *
-     * @param  args  Array of the raw command-line arguments.
-     *
-     * @throws  NullPointerException  If <code>args==null</code>.
-     * @throws  IllegalArgumentException  If Binder or Log options
-     *                                    are set incorrectly.
-     *
+     * @param args Array of the raw command-line arguments.
+     * @throws NullPointerException     If <code>args==null</code>.
+     * @throws IllegalArgumentException If Binder or Log options
+     *                                  are set incorrectly.
      * @see #setRawArguments(String[])
      */
-    public JdbArgumentHandler(String args[]) {
+    public JdbArgumentHandler(String[] args) {
         super(args);
     }
 
@@ -88,13 +82,11 @@ public class JdbArgumentHandler extends nsk.share.jdi.ArgumentHandler {
      * This method is invoked by <code>parseArguments()</code>
      *
      * @param option option name
-     * @param value string representation of value (could be an empty string)
-     *              null if this option has no value
+     * @param value  string representation of value (could be an empty string)
+     *               null if this option has no value
      * @return <i>true</i> if option is admissible and has proper value
-     *         <i>false</i> if option is not admissible
-     *
+     * <i>false</i> if option is not admissible
      * @throws <i>BadOption</i> if option has illegal value
-     *
      * @see #parseArguments()
      */
     protected boolean checkOption(String option, String value) {
@@ -123,7 +115,7 @@ public class JdbArgumentHandler extends nsk.share.jdi.ArgumentHandler {
                     throw new BadOption("jdb option -attach is not admissible: " + value);
                 }
                 if (value.indexOf("-listen") > 0) {
-                    throw new BadOption("jdb option -listen is not admissible: "  + value);
+                    throw new BadOption("jdb option -listen is not admissible: " + value);
                 }
                 if (value.indexOf("-connect") > 0) {
                     throw new BadOption("jdb option -connect is not admissible: " + value);
@@ -171,7 +163,6 @@ public class JdbArgumentHandler extends nsk.share.jdi.ArgumentHandler {
 
     /**
      * Return sfull path to jdb executable.
-     *
      */
     public String getJdbExecPath() {
         return options.getProperty("jdb");
@@ -182,10 +173,7 @@ public class JdbArgumentHandler extends nsk.share.jdi.ArgumentHandler {
      */
     public String getJdbOptions() {
         String value = options.getProperty("jdb.option", "").trim();
-        if (value.length() > 1 && value.startsWith("\"") && value.endsWith("\"")) {
-            value = value.substring(1, value.length() - 1).trim();
-        }
-        return value;
+        return removeSurroundingQuotes(value);
     }
 
     /**
@@ -206,9 +194,7 @@ public class JdbArgumentHandler extends nsk.share.jdi.ArgumentHandler {
     public String getDebuggeeOptions() {
         StringBuilder sb = new StringBuilder();
         String value = options.getProperty("debugee.vmkeys", "").trim();
-        if (value.length() > 1 && value.startsWith("\"") && value.endsWith("\"")) {
-            value = value.substring(1, value.length() - 1).trim();
-        }
+        value = removeSurroundingQuotes(value);
         for (String option : value.split("\\s+")) {
             if (option.length() > 0) {
                 sb.append(checkAndQuote(option, ","));
@@ -223,54 +209,14 @@ public class JdbArgumentHandler extends nsk.share.jdi.ArgumentHandler {
      */
     public String getJavaOptions() {
         String value = options.getProperty("java.options", "").trim();
-        if (value.length() > 1 && value.startsWith("\"") && value.endsWith("\"")) {
-            value = value.substring(1, value.length() - 1).trim();
-        }
-        return value;
-    }
-
-    /**
-     * Remove "<code>-server</code>" or "<code>-client</code>" from options string,
-     * if anything of them are presented.
-     */
-    public static String removeVMFlavorOption(String javaOptions) {
-        StringBuffer result = new StringBuffer();
-        StringTokenizer tokenizer = new StringTokenizer(javaOptions);
-        while (tokenizer.hasMoreTokens()) {
-            String option = tokenizer.nextToken();
-            if (!option.equals("-server") && !option.equals("-client")) {
-                result.append( (result.length() > 0 ? " " : "") + option);
-            }
-        };
-        return result.toString();
-    }
-
-    /**
-     * @return "<code>-tserver</code>" if "<code>-server</code>" is presented in options string.
-     * @return "<code>-tclient</code>" if "<code>-client</code>" is presented in options string.
-     * @return empty string otherwise.
-     */
-    public static String stripVMFlavorOption(String javaOptions) {
-        String result = "";
-        StringTokenizer tokenizer = new StringTokenizer(javaOptions);
-        while (tokenizer.hasMoreTokens()) {
-            String option = tokenizer.nextToken();
-            if (option.equals("-server")) {
-                result = "-tserver";
-                break;
-            } else if (option.equals("-client")) {
-                result = "-tclient";
-                break;
-            }
-        };
-        return result;
+        return removeSurroundingQuotes(value);
     }
 
     // check if target substring exists and quote value if needed
     // ex for subString == "," and value == disk=true,dumponexit=true
     // return 'disk=true,dumponexit=true'
     private static String checkAndQuote(String value, String subString) {
-        if (NO_SUBSTR_MATCH == value.indexOf(subString)) {
+        if (!value.contains(subString)) {
             // return as-is
             return value;
         }
@@ -297,10 +243,15 @@ public class JdbArgumentHandler extends nsk.share.jdi.ArgumentHandler {
                 return true;
             }
             //only a single quote? subString outside quotes? Wrongly quoted, needs fix
-            throw new BadOption(value +  " not correctly quoted");
+            throw new BadOption(value + " not correctly quoted");
         }
         return false;
     }
 
-    private static final int NO_SUBSTR_MATCH = -1;
+    private static String removeSurroundingQuotes(String value) {
+        if (value.length() > 1 && value.startsWith("\"") && value.endsWith("\"")) {
+            value = value.substring(1, value.length() - 1).trim();
+        }
+        return value;
+    }
 }


### PR DESCRIPTION
the patch
- removes `PropertyResolvingWrapper` from `vmTestbase/nsk/jdb` tests
- updates `JdbArgumentHandler` to remove `"` from `jdb.option` option
- reformats code

testing:
✅ `vmTestbase/nsk/jdb` on {macosx,linux,windows}-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252000](https://bugs.openjdk.java.net/browse/JDK-8252000): remove usage of PropertyResolvingWrapper in vmTestbase/nsk/jdb


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 2cd3ef188433225139e90fef3bf71cb9f3170451
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/350/head:pull/350`
`$ git checkout pull/350`
