### PR TITLE
8252002: remove usage of PropertyResolvingWrapper in vmTestbase/nsk/jdwp

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/GetValues/getvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/GetValues/getvalues001/TestDescription.java
@@ -59,7 +59,7 @@
  *          /test/lib
  * @build nsk.jdwp.ArrayReference.GetValues.getvalues001
  *        nsk.jdwp.ArrayReference.GetValues.getvalues001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ArrayReference.GetValues.getvalues001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/GetValues/getvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/GetValues/getvalues001/TestDescription.java
@@ -57,8 +57,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ArrayReference.GetValues.getvalues001
- *        nsk.jdwp.ArrayReference.GetValues.getvalues001a
+ * @build nsk.jdwp.ArrayReference.GetValues.getvalues001a
  * @run main/othervm
  *      nsk.jdwp.ArrayReference.GetValues.getvalues001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/GetValues/getvalues002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/GetValues/getvalues002/TestDescription.java
@@ -59,8 +59,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ArrayReference.GetValues.getvalues002
- *        nsk.jdwp.ArrayReference.GetValues.getvalues002a
+ * @build nsk.jdwp.ArrayReference.GetValues.getvalues002a
  * @run main/othervm
  *      nsk.jdwp.ArrayReference.GetValues.getvalues002
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/GetValues/getvalues002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/GetValues/getvalues002/TestDescription.java
@@ -61,7 +61,7 @@
  *          /test/lib
  * @build nsk.jdwp.ArrayReference.GetValues.getvalues002
  *        nsk.jdwp.ArrayReference.GetValues.getvalues002a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ArrayReference.GetValues.getvalues002
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/Length/length001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/Length/length001/TestDescription.java
@@ -56,8 +56,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ArrayReference.Length.length001
- *        nsk.jdwp.ArrayReference.Length.length001a
+ * @build nsk.jdwp.ArrayReference.Length.length001a
  * @run main/othervm
  *      nsk.jdwp.ArrayReference.Length.length001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/Length/length001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/Length/length001/TestDescription.java
@@ -58,7 +58,7 @@
  *          /test/lib
  * @build nsk.jdwp.ArrayReference.Length.length001
  *        nsk.jdwp.ArrayReference.Length.length001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ArrayReference.Length.length001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/SetValues/setvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/SetValues/setvalues001/TestDescription.java
@@ -61,7 +61,7 @@
  *          /test/lib
  * @build nsk.jdwp.ArrayReference.SetValues.setvalues001
  *        nsk.jdwp.ArrayReference.SetValues.setvalues001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ArrayReference.SetValues.setvalues001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/SetValues/setvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayReference/SetValues/setvalues001/TestDescription.java
@@ -59,8 +59,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ArrayReference.SetValues.setvalues001
- *        nsk.jdwp.ArrayReference.SetValues.setvalues001a
+ * @build nsk.jdwp.ArrayReference.SetValues.setvalues001a
  * @run main/othervm
  *      nsk.jdwp.ArrayReference.SetValues.setvalues001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayType/NewInstance/newinstance001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayType/NewInstance/newinstance001/TestDescription.java
@@ -56,7 +56,7 @@
  *          /test/lib
  * @build nsk.jdwp.ArrayType.NewInstance.newinstance001
  *        nsk.jdwp.ArrayType.NewInstance.newinstance001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ArrayType.NewInstance.newinstance001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayType/NewInstance/newinstance001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ArrayType/NewInstance/newinstance001/TestDescription.java
@@ -54,8 +54,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ArrayType.NewInstance.newinstance001
- *        nsk.jdwp.ArrayType.NewInstance.newinstance001a
+ * @build nsk.jdwp.ArrayType.NewInstance.newinstance001a
  * @run main/othervm
  *      nsk.jdwp.ArrayType.NewInstance.newinstance001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassLoaderReference/VisibleClasses/visibclasses001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassLoaderReference/VisibleClasses/visibclasses001/TestDescription.java
@@ -56,8 +56,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ClassLoaderReference.VisibleClasses.visibclasses001
- *        nsk.jdwp.ClassLoaderReference.VisibleClasses.visibclasses001a
+ * @build nsk.jdwp.ClassLoaderReference.VisibleClasses.visibclasses001a
  * @run main/othervm
  *      nsk.jdwp.ClassLoaderReference.VisibleClasses.visibclasses001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassLoaderReference/VisibleClasses/visibclasses001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassLoaderReference/VisibleClasses/visibclasses001/TestDescription.java
@@ -58,7 +58,7 @@
  *          /test/lib
  * @build nsk.jdwp.ClassLoaderReference.VisibleClasses.visibclasses001
  *        nsk.jdwp.ClassLoaderReference.VisibleClasses.visibclasses001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ClassLoaderReference.VisibleClasses.visibclasses001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassObjectReference/ReflectedType/reflectype001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassObjectReference/ReflectedType/reflectype001/TestDescription.java
@@ -59,8 +59,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ClassObjectReference.ReflectedType.reflectype001
- *        nsk.jdwp.ClassObjectReference.ReflectedType.reflectype001a
+ * @build nsk.jdwp.ClassObjectReference.ReflectedType.reflectype001a
  * @run main/othervm
  *      nsk.jdwp.ClassObjectReference.ReflectedType.reflectype001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassObjectReference/ReflectedType/reflectype001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassObjectReference/ReflectedType/reflectype001/TestDescription.java
@@ -61,7 +61,7 @@
  *          /test/lib
  * @build nsk.jdwp.ClassObjectReference.ReflectedType.reflectype001
  *        nsk.jdwp.ClassObjectReference.ReflectedType.reflectype001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ClassObjectReference.ReflectedType.reflectype001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/InvokeMethod/invokemeth001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/InvokeMethod/invokemeth001/TestDescription.java
@@ -61,7 +61,7 @@
  *          /test/lib
  * @build nsk.jdwp.ClassType.InvokeMethod.invokemeth001
  *        nsk.jdwp.ClassType.InvokeMethod.invokemeth001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ClassType.InvokeMethod.invokemeth001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/InvokeMethod/invokemeth001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/InvokeMethod/invokemeth001/TestDescription.java
@@ -59,8 +59,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ClassType.InvokeMethod.invokemeth001
- *        nsk.jdwp.ClassType.InvokeMethod.invokemeth001a
+ * @build nsk.jdwp.ClassType.InvokeMethod.invokemeth001a
  * @run main/othervm
  *      nsk.jdwp.ClassType.InvokeMethod.invokemeth001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/NewInstance/newinst001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/NewInstance/newinst001/TestDescription.java
@@ -61,7 +61,7 @@
  *          /test/lib
  * @build nsk.jdwp.ClassType.NewInstance.newinst001
  *        nsk.jdwp.ClassType.NewInstance.newinst001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ClassType.NewInstance.newinst001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/NewInstance/newinst001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/NewInstance/newinst001/TestDescription.java
@@ -59,8 +59,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ClassType.NewInstance.newinst001
- *        nsk.jdwp.ClassType.NewInstance.newinst001a
+ * @build nsk.jdwp.ClassType.NewInstance.newinst001a
  * @run main/othervm
  *      nsk.jdwp.ClassType.NewInstance.newinst001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001/TestDescription.java
@@ -65,8 +65,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ClassType.SetValues.setvalues001
- *        nsk.jdwp.ClassType.SetValues.setvalues001a
+ * @build nsk.jdwp.ClassType.SetValues.setvalues001a
  * @run main/othervm
  *      nsk.jdwp.ClassType.SetValues.setvalues001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/SetValues/setvalues001/TestDescription.java
@@ -67,7 +67,7 @@
  *          /test/lib
  * @build nsk.jdwp.ClassType.SetValues.setvalues001
  *        nsk.jdwp.ClassType.SetValues.setvalues001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ClassType.SetValues.setvalues001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/Superclass/superclass001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/Superclass/superclass001/TestDescription.java
@@ -55,8 +55,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ClassType.Superclass.superclass001
- *        nsk.jdwp.ClassType.Superclass.superclass001a
+ * @build nsk.jdwp.ClassType.Superclass.superclass001a
  * @run main/othervm
  *      nsk.jdwp.ClassType.Superclass.superclass001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/Superclass/superclass001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ClassType/Superclass/superclass001/TestDescription.java
@@ -57,7 +57,7 @@
  *          /test/lib
  * @build nsk.jdwp.ClassType.Superclass.superclass001
  *        nsk.jdwp.ClassType.Superclass.superclass001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ClassType.Superclass.superclass001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/BREAKPOINT/breakpoint001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/BREAKPOINT/breakpoint001/TestDescription.java
@@ -61,7 +61,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.BREAKPOINT.breakpoint001
  *        nsk.jdwp.Event.BREAKPOINT.breakpoint001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.BREAKPOINT.breakpoint001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/BREAKPOINT/breakpoint001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/BREAKPOINT/breakpoint001/TestDescription.java
@@ -59,8 +59,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.BREAKPOINT.breakpoint001
- *        nsk.jdwp.Event.BREAKPOINT.breakpoint001a
+ * @build nsk.jdwp.Event.BREAKPOINT.breakpoint001a
  * @run main/othervm
  *      nsk.jdwp.Event.BREAKPOINT.breakpoint001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/CLASS_PREPARE/clsprepare001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/CLASS_PREPARE/clsprepare001/TestDescription.java
@@ -59,8 +59,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.CLASS_PREPARE.clsprepare001
- *        nsk.jdwp.Event.CLASS_PREPARE.clsprepare001a
+ * @build nsk.jdwp.Event.CLASS_PREPARE.clsprepare001a
  * @run main/othervm
  *      nsk.jdwp.Event.CLASS_PREPARE.clsprepare001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/CLASS_PREPARE/clsprepare001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/CLASS_PREPARE/clsprepare001/TestDescription.java
@@ -61,7 +61,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.CLASS_PREPARE.clsprepare001
  *        nsk.jdwp.Event.CLASS_PREPARE.clsprepare001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.CLASS_PREPARE.clsprepare001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/CLASS_UNLOAD/clsunload001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/CLASS_UNLOAD/clsunload001/TestDescription.java
@@ -61,8 +61,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.CLASS_UNLOAD.clsunload001
- *        nsk.jdwp.Event.CLASS_UNLOAD.clsunload001a
+ * @build nsk.jdwp.Event.CLASS_UNLOAD.clsunload001a
  * @run main/othervm
  *      nsk.jdwp.Event.CLASS_UNLOAD.clsunload001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/CLASS_UNLOAD/clsunload001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/CLASS_UNLOAD/clsunload001/TestDescription.java
@@ -63,7 +63,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.CLASS_UNLOAD.clsunload001
  *        nsk.jdwp.Event.CLASS_UNLOAD.clsunload001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.CLASS_UNLOAD.clsunload001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/Composite/composite001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/Composite/composite001/TestDescription.java
@@ -50,7 +50,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.Composite.composite001
  *        nsk.jdwp.Event.Composite.composite001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.Composite.composite001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/Composite/composite001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/Composite/composite001/TestDescription.java
@@ -48,8 +48,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.Composite.composite001
- *        nsk.jdwp.Event.Composite.composite001a
+ * @build nsk.jdwp.Event.Composite.composite001a
  * @run main/othervm
  *      nsk.jdwp.Event.Composite.composite001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/EXCEPTION/exception001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/EXCEPTION/exception001/TestDescription.java
@@ -65,7 +65,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.EXCEPTION.exception001
  *        nsk.jdwp.Event.EXCEPTION.exception001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.EXCEPTION.exception001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/EXCEPTION/exception001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/EXCEPTION/exception001/TestDescription.java
@@ -63,8 +63,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.EXCEPTION.exception001
- *        nsk.jdwp.Event.EXCEPTION.exception001a
+ * @build nsk.jdwp.Event.EXCEPTION.exception001a
  * @run main/othervm
  *      nsk.jdwp.Event.EXCEPTION.exception001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/FIELD_ACCESS/fldaccess001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/FIELD_ACCESS/fldaccess001/TestDescription.java
@@ -62,8 +62,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.FIELD_ACCESS.fldaccess001
- *        nsk.jdwp.Event.FIELD_ACCESS.fldaccess001a
+ * @build nsk.jdwp.Event.FIELD_ACCESS.fldaccess001a
  * @run main/othervm
  *      nsk.jdwp.Event.FIELD_ACCESS.fldaccess001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/FIELD_ACCESS/fldaccess001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/FIELD_ACCESS/fldaccess001/TestDescription.java
@@ -64,7 +64,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.FIELD_ACCESS.fldaccess001
  *        nsk.jdwp.Event.FIELD_ACCESS.fldaccess001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.FIELD_ACCESS.fldaccess001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/FIELD_MODIFICATION/fldmodification001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/FIELD_MODIFICATION/fldmodification001/TestDescription.java
@@ -63,8 +63,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.FIELD_MODIFICATION.fldmodification001
- *        nsk.jdwp.Event.FIELD_MODIFICATION.fldmodification001a
+ * @build nsk.jdwp.Event.FIELD_MODIFICATION.fldmodification001a
  * @run main/othervm
  *      nsk.jdwp.Event.FIELD_MODIFICATION.fldmodification001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/FIELD_MODIFICATION/fldmodification001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/FIELD_MODIFICATION/fldmodification001/TestDescription.java
@@ -65,7 +65,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.FIELD_MODIFICATION.fldmodification001
  *        nsk.jdwp.Event.FIELD_MODIFICATION.fldmodification001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.FIELD_MODIFICATION.fldmodification001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/METHOD_ENTRY/methentry001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/METHOD_ENTRY/methentry001/TestDescription.java
@@ -62,7 +62,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.METHOD_ENTRY.methentry001
  *        nsk.jdwp.Event.METHOD_ENTRY.methentry001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.METHOD_ENTRY.methentry001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/METHOD_ENTRY/methentry001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/METHOD_ENTRY/methentry001/TestDescription.java
@@ -60,8 +60,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.METHOD_ENTRY.methentry001
- *        nsk.jdwp.Event.METHOD_ENTRY.methentry001a
+ * @build nsk.jdwp.Event.METHOD_ENTRY.methentry001a
  * @run main/othervm
  *      nsk.jdwp.Event.METHOD_ENTRY.methentry001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/METHOD_EXIT/methexit001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/METHOD_EXIT/methexit001/TestDescription.java
@@ -62,7 +62,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.METHOD_EXIT.methexit001
  *        nsk.jdwp.Event.METHOD_EXIT.methexit001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.METHOD_EXIT.methexit001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/METHOD_EXIT/methexit001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/METHOD_EXIT/methexit001/TestDescription.java
@@ -60,8 +60,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.METHOD_EXIT.methexit001
- *        nsk.jdwp.Event.METHOD_EXIT.methexit001a
+ * @build nsk.jdwp.Event.METHOD_EXIT.methexit001a
  * @run main/othervm
  *      nsk.jdwp.Event.METHOD_EXIT.methexit001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep001/TestDescription.java
@@ -64,7 +64,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.SINGLE_STEP.singlestep001
  *        nsk.jdwp.Event.SINGLE_STEP.singlestep001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.SINGLE_STEP.singlestep001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep001/TestDescription.java
@@ -62,8 +62,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.SINGLE_STEP.singlestep001
- *        nsk.jdwp.Event.SINGLE_STEP.singlestep001a
+ * @build nsk.jdwp.Event.SINGLE_STEP.singlestep001a
  * @run main/othervm
  *      nsk.jdwp.Event.SINGLE_STEP.singlestep001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep002/TestDescription.java
@@ -62,8 +62,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.SINGLE_STEP.singlestep002
- *        nsk.jdwp.Event.SINGLE_STEP.singlestep002a
+ * @build nsk.jdwp.Event.SINGLE_STEP.singlestep002a
  * @run main/othervm
  *      nsk.jdwp.Event.SINGLE_STEP.singlestep002
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep002/TestDescription.java
@@ -64,7 +64,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.SINGLE_STEP.singlestep002
  *        nsk.jdwp.Event.SINGLE_STEP.singlestep002a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.SINGLE_STEP.singlestep002
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep003/TestDescription.java
@@ -62,8 +62,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.SINGLE_STEP.singlestep003
- *        nsk.jdwp.Event.SINGLE_STEP.singlestep003a
+ * @build nsk.jdwp.Event.SINGLE_STEP.singlestep003a
  * @run main/othervm
  *      nsk.jdwp.Event.SINGLE_STEP.singlestep003
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/SINGLE_STEP/singlestep003/TestDescription.java
@@ -64,7 +64,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.SINGLE_STEP.singlestep003
  *        nsk.jdwp.Event.SINGLE_STEP.singlestep003a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.SINGLE_STEP.singlestep003
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/THREAD_DEATH/thrdeath001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/THREAD_DEATH/thrdeath001/TestDescription.java
@@ -62,7 +62,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.THREAD_DEATH.thrdeath001
  *        nsk.jdwp.Event.THREAD_DEATH.thrdeath001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.THREAD_DEATH.thrdeath001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/THREAD_DEATH/thrdeath001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/THREAD_DEATH/thrdeath001/TestDescription.java
@@ -60,8 +60,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.THREAD_DEATH.thrdeath001
- *        nsk.jdwp.Event.THREAD_DEATH.thrdeath001a
+ * @build nsk.jdwp.Event.THREAD_DEATH.thrdeath001a
  * @run main/othervm
  *      nsk.jdwp.Event.THREAD_DEATH.thrdeath001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/THREAD_START/thrstart001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/THREAD_START/thrstart001/TestDescription.java
@@ -62,7 +62,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.THREAD_START.thrstart001
  *        nsk.jdwp.Event.THREAD_START.thrstart001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.THREAD_START.thrstart001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/THREAD_START/thrstart001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/THREAD_START/thrstart001/TestDescription.java
@@ -60,8 +60,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.THREAD_START.thrstart001
- *        nsk.jdwp.Event.THREAD_START.thrstart001a
+ * @build nsk.jdwp.Event.THREAD_START.thrstart001a
  * @run main/othervm
  *      nsk.jdwp.Event.THREAD_START.thrstart001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/VM_DEATH/vmdeath001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/VM_DEATH/vmdeath001/TestDescription.java
@@ -52,8 +52,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.VM_DEATH.vmdeath001
- *        nsk.jdwp.Event.VM_DEATH.vmdeath001a
+ * @build nsk.jdwp.Event.VM_DEATH.vmdeath001a
  * @run main/othervm
  *      nsk.jdwp.Event.VM_DEATH.vmdeath001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/VM_DEATH/vmdeath001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/VM_DEATH/vmdeath001/TestDescription.java
@@ -54,7 +54,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.VM_DEATH.vmdeath001
  *        nsk.jdwp.Event.VM_DEATH.vmdeath001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.VM_DEATH.vmdeath001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/VM_DEATH/vmdeath002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/VM_DEATH/vmdeath002/TestDescription.java
@@ -61,7 +61,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.VM_DEATH.vmdeath002
  *        nsk.jdwp.Event.VM_DEATH.vmdeath002a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.VM_DEATH.vmdeath002
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/VM_DEATH/vmdeath002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/VM_DEATH/vmdeath002/TestDescription.java
@@ -59,8 +59,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.VM_DEATH.vmdeath002
- *        nsk.jdwp.Event.VM_DEATH.vmdeath002a
+ * @build nsk.jdwp.Event.VM_DEATH.vmdeath002a
  * @run main/othervm
  *      nsk.jdwp.Event.VM_DEATH.vmdeath002
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/VM_START/vmstart001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/VM_START/vmstart001/TestDescription.java
@@ -52,7 +52,7 @@
  *          /test/lib
  * @build nsk.jdwp.Event.VM_START.vmstart001
  *        nsk.jdwp.Event.VM_START.vmstart001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Event.VM_START.vmstart001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/VM_START/vmstart001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/VM_START/vmstart001/TestDescription.java
@@ -50,8 +50,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Event.VM_START.vmstart001
- *        nsk.jdwp.Event.VM_START.vmstart001a
+ * @build nsk.jdwp.Event.VM_START.vmstart001a
  * @run main/othervm
  *      nsk.jdwp.Event.VM_START.vmstart001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/Clear/clear001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/Clear/clear001/TestDescription.java
@@ -57,8 +57,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.EventRequest.Clear.clear001
- *        nsk.jdwp.EventRequest.Clear.clear001a
+ * @build nsk.jdwp.EventRequest.Clear.clear001a
  * @run main/othervm
  *      nsk.jdwp.EventRequest.Clear.clear001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/Clear/clear001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/Clear/clear001/TestDescription.java
@@ -59,7 +59,7 @@
  *          /test/lib
  * @build nsk.jdwp.EventRequest.Clear.clear001
  *        nsk.jdwp.EventRequest.Clear.clear001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.EventRequest.Clear.clear001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/ClearAllBreakpoints/clrallbreakp001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/ClearAllBreakpoints/clrallbreakp001/TestDescription.java
@@ -55,8 +55,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp001
- *        nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp001a
+ * @build nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp001a
  * @run main/othervm
  *      nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/ClearAllBreakpoints/clrallbreakp001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/ClearAllBreakpoints/clrallbreakp001/TestDescription.java
@@ -57,7 +57,7 @@
  *          /test/lib
  * @build nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp001
  *        nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/ClearAllBreakpoints/clrallbreakp002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/ClearAllBreakpoints/clrallbreakp002/TestDescription.java
@@ -51,7 +51,7 @@
  *          /test/lib
  * @build nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp002
  *        nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp002a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp002
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/ClearAllBreakpoints/clrallbreakp002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/ClearAllBreakpoints/clrallbreakp002/TestDescription.java
@@ -49,8 +49,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp002
- *        nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp002a
+ * @build nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp002a
  * @run main/othervm
  *      nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp002
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/ClearAllBreakpoints/clrallbreakp003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/ClearAllBreakpoints/clrallbreakp003/TestDescription.java
@@ -52,8 +52,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp003
- *        nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp003a
+ * @build nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp003a
  * @run main/othervm
  *      nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp003
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/ClearAllBreakpoints/clrallbreakp003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/ClearAllBreakpoints/clrallbreakp003/TestDescription.java
@@ -54,7 +54,7 @@
  *          /test/lib
  * @build nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp003
  *        nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp003a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.EventRequest.ClearAllBreakpoints.clrallbreakp003
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/Set/set001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/Set/set001/TestDescription.java
@@ -58,8 +58,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.EventRequest.Set.set001
- *        nsk.jdwp.EventRequest.Set.set001a
+ * @build nsk.jdwp.EventRequest.Set.set001a
  * @run main/othervm
  *      nsk.jdwp.EventRequest.Set.set001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/Set/set001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/Set/set001/TestDescription.java
@@ -60,7 +60,7 @@
  *          /test/lib
  * @build nsk.jdwp.EventRequest.Set.set001
  *        nsk.jdwp.EventRequest.Set.set001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.EventRequest.Set.set001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/Set/set002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/Set/set002/TestDescription.java
@@ -60,8 +60,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.EventRequest.Set.set002
- *        nsk.jdwp.EventRequest.Set.set002a
+ * @build nsk.jdwp.EventRequest.Set.set002a
  * @run main/othervm
  *      nsk.jdwp.EventRequest.Set.set002
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/Set/set002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/EventRequest/Set/set002/TestDescription.java
@@ -62,7 +62,7 @@
  *          /test/lib
  * @build nsk.jdwp.EventRequest.Set.set002
  *        nsk.jdwp.EventRequest.Set.set002a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.EventRequest.Set.set002
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/Bytecodes/bytecodes001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/Bytecodes/bytecodes001/TestDescription.java
@@ -53,8 +53,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Method.Bytecodes.bytecodes001
- *        nsk.jdwp.Method.Bytecodes.bytecodes001a
+ * @build nsk.jdwp.Method.Bytecodes.bytecodes001a
  * @run main/othervm
  *      nsk.jdwp.Method.Bytecodes.bytecodes001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/Bytecodes/bytecodes001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/Bytecodes/bytecodes001/TestDescription.java
@@ -55,7 +55,7 @@
  *          /test/lib
  * @build nsk.jdwp.Method.Bytecodes.bytecodes001
  *        nsk.jdwp.Method.Bytecodes.bytecodes001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Method.Bytecodes.bytecodes001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/IsObsolete/isobsolete001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/IsObsolete/isobsolete001/TestDescription.java
@@ -58,7 +58,7 @@
  *          /test/lib
  * @build nsk.jdwp.Method.IsObsolete.isobsolete001
  *        nsk.jdwp.Method.IsObsolete.isobsolete001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Method.IsObsolete.isobsolete001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/IsObsolete/isobsolete001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/IsObsolete/isobsolete001/TestDescription.java
@@ -56,8 +56,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Method.IsObsolete.isobsolete001
- *        nsk.jdwp.Method.IsObsolete.isobsolete001a
+ * @build nsk.jdwp.Method.IsObsolete.isobsolete001a
  * @run main/othervm
  *      nsk.jdwp.Method.IsObsolete.isobsolete001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/IsObsolete/isobsolete002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/IsObsolete/isobsolete002/TestDescription.java
@@ -73,7 +73,7 @@
  *        nsk.jdwp.Method.IsObsolete.isobsolete002b
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Method.IsObsolete.isobsolete002
  *      .
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/IsObsolete/isobsolete002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/IsObsolete/isobsolete002/TestDescription.java
@@ -68,8 +68,7 @@
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
  * @build ExecDriver
- * @build nsk.jdwp.Method.IsObsolete.isobsolete002
- *        nsk.jdwp.Method.IsObsolete.isobsolete002a
+ * @build nsk.jdwp.Method.IsObsolete.isobsolete002a
  *        nsk.jdwp.Method.IsObsolete.isobsolete002b
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/LineTable/linetable001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/LineTable/linetable001/TestDescription.java
@@ -67,8 +67,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Method.LineTable.linetable001
- *        nsk.jdwp.Method.LineTable.linetable001a
+ * @build nsk.jdwp.Method.LineTable.linetable001a
  * @run main/othervm
  *      nsk.jdwp.Method.LineTable.linetable001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/LineTable/linetable001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/LineTable/linetable001/TestDescription.java
@@ -69,7 +69,7 @@
  *          /test/lib
  * @build nsk.jdwp.Method.LineTable.linetable001
  *        nsk.jdwp.Method.LineTable.linetable001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Method.LineTable.linetable001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/VariableTable/vartable001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/VariableTable/vartable001/TestDescription.java
@@ -61,7 +61,7 @@
  * @comment debuggee should be compiled w/ debug info
  * @clean nsk.jdwp.Method.VariableTable.vartable001a
  * @compile -g:lines,source,vars ../vartable001a.java
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Method.VariableTable.vartable001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/VariableTable/vartable001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/VariableTable/vartable001/TestDescription.java
@@ -56,8 +56,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Method.VariableTable.vartable001
- *        nsk.jdwp.Method.VariableTable.vartable001a
+ * @build nsk.jdwp.Method.VariableTable.vartable001a
  * @comment debuggee should be compiled w/ debug info
  * @clean nsk.jdwp.Method.VariableTable.vartable001a
  * @compile -g:lines,source,vars ../vartable001a.java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/VariableTableWithGeneric/vartblwithgen001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/VariableTableWithGeneric/vartblwithgen001/TestDescription.java
@@ -61,7 +61,7 @@
  * @comment debuggee should be compiled w/ debug info
  * @clean nsk.jdwp.Method.VariableTableWithGeneric.vartblwithgen001a
  * @compile -g:lines,source,vars ../vartblwithgen001a.java
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.Method.VariableTableWithGeneric.vartblwithgen001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/VariableTableWithGeneric/vartblwithgen001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Method/VariableTableWithGeneric/vartblwithgen001/TestDescription.java
@@ -56,8 +56,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.Method.VariableTableWithGeneric.vartblwithgen001
- *        nsk.jdwp.Method.VariableTableWithGeneric.vartblwithgen001a
+ * @build nsk.jdwp.Method.VariableTableWithGeneric.vartblwithgen001a
  * @comment debuggee should be compiled w/ debug info
  * @clean nsk.jdwp.Method.VariableTableWithGeneric.vartblwithgen001a
  * @compile -g:lines,source,vars ../vartblwithgen001a.java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/DisableCollection/disablecol001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/DisableCollection/disablecol001/TestDescription.java
@@ -55,7 +55,7 @@
  *          /test/lib
  * @build nsk.jdwp.ObjectReference.DisableCollection.disablecol001
  *        nsk.jdwp.ObjectReference.DisableCollection.disablecol001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ObjectReference.DisableCollection.disablecol001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/DisableCollection/disablecol001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/DisableCollection/disablecol001/TestDescription.java
@@ -53,8 +53,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ObjectReference.DisableCollection.disablecol001
- *        nsk.jdwp.ObjectReference.DisableCollection.disablecol001a
+ * @build nsk.jdwp.ObjectReference.DisableCollection.disablecol001a
  * @run main/othervm
  *      nsk.jdwp.ObjectReference.DisableCollection.disablecol001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/EnableCollection/enablecol001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/EnableCollection/enablecol001/TestDescription.java
@@ -54,8 +54,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ObjectReference.EnableCollection.enablecol001
- *        nsk.jdwp.ObjectReference.EnableCollection.enablecol001a
+ * @build nsk.jdwp.ObjectReference.EnableCollection.enablecol001a
  * @run main/othervm
  *      nsk.jdwp.ObjectReference.EnableCollection.enablecol001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/EnableCollection/enablecol001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/EnableCollection/enablecol001/TestDescription.java
@@ -56,7 +56,7 @@
  *          /test/lib
  * @build nsk.jdwp.ObjectReference.EnableCollection.enablecol001
  *        nsk.jdwp.ObjectReference.EnableCollection.enablecol001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ObjectReference.EnableCollection.enablecol001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/GetValues/getvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/GetValues/getvalues001/TestDescription.java
@@ -59,7 +59,7 @@
  *          /test/lib
  * @build nsk.jdwp.ObjectReference.GetValues.getvalues001
  *        nsk.jdwp.ObjectReference.GetValues.getvalues001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ObjectReference.GetValues.getvalues001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/GetValues/getvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/GetValues/getvalues001/TestDescription.java
@@ -57,8 +57,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ObjectReference.GetValues.getvalues001
- *        nsk.jdwp.ObjectReference.GetValues.getvalues001a
+ * @build nsk.jdwp.ObjectReference.GetValues.getvalues001a
  * @run main/othervm
  *      nsk.jdwp.ObjectReference.GetValues.getvalues001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/InvokeMethod/invokemeth001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/InvokeMethod/invokemeth001/TestDescription.java
@@ -60,8 +60,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ObjectReference.InvokeMethod.invokemeth001
- *        nsk.jdwp.ObjectReference.InvokeMethod.invokemeth001a
+ * @build nsk.jdwp.ObjectReference.InvokeMethod.invokemeth001a
  * @run main/othervm
  *      nsk.jdwp.ObjectReference.InvokeMethod.invokemeth001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/InvokeMethod/invokemeth001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/InvokeMethod/invokemeth001/TestDescription.java
@@ -62,7 +62,7 @@
  *          /test/lib
  * @build nsk.jdwp.ObjectReference.InvokeMethod.invokemeth001
  *        nsk.jdwp.ObjectReference.InvokeMethod.invokemeth001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ObjectReference.InvokeMethod.invokemeth001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/IsCollected/iscollected001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/IsCollected/iscollected001/TestDescription.java
@@ -56,8 +56,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ObjectReference.IsCollected.iscollected001
- *        nsk.jdwp.ObjectReference.IsCollected.iscollected001a
+ * @build nsk.jdwp.ObjectReference.IsCollected.iscollected001a
  * @run main/othervm
  *      nsk.jdwp.ObjectReference.IsCollected.iscollected001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/IsCollected/iscollected001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/IsCollected/iscollected001/TestDescription.java
@@ -58,7 +58,7 @@
  *          /test/lib
  * @build nsk.jdwp.ObjectReference.IsCollected.iscollected001
  *        nsk.jdwp.ObjectReference.IsCollected.iscollected001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ObjectReference.IsCollected.iscollected001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/MonitorInfo/monitorinfo001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/MonitorInfo/monitorinfo001/TestDescription.java
@@ -70,7 +70,7 @@
  *          /test/lib
  * @build nsk.jdwp.ObjectReference.MonitorInfo.monitorinfo001
  *        nsk.jdwp.ObjectReference.MonitorInfo.monitorinfo001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ObjectReference.MonitorInfo.monitorinfo001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/MonitorInfo/monitorinfo001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/MonitorInfo/monitorinfo001/TestDescription.java
@@ -68,8 +68,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ObjectReference.MonitorInfo.monitorinfo001
- *        nsk.jdwp.ObjectReference.MonitorInfo.monitorinfo001a
+ * @build nsk.jdwp.ObjectReference.MonitorInfo.monitorinfo001a
  * @run main/othervm
  *      nsk.jdwp.ObjectReference.MonitorInfo.monitorinfo001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferenceType/referencetype001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferenceType/referencetype001/TestDescription.java
@@ -58,8 +58,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ObjectReference.ReferenceType.referencetype001
- *        nsk.jdwp.ObjectReference.ReferenceType.referencetype001a
+ * @build nsk.jdwp.ObjectReference.ReferenceType.referencetype001a
  * @run main/othervm
  *      nsk.jdwp.ObjectReference.ReferenceType.referencetype001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferenceType/referencetype001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferenceType/referencetype001/TestDescription.java
@@ -60,7 +60,7 @@
  *          /test/lib
  * @build nsk.jdwp.ObjectReference.ReferenceType.referencetype001
  *        nsk.jdwp.ObjectReference.ReferenceType.referencetype001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ObjectReference.ReferenceType.referencetype001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferringObjects/referringObjects001/referringObjects001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferringObjects/referringObjects001/referringObjects001.java
@@ -69,7 +69,6 @@
  * @requires !vm.graal.enabled
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ObjectReference.ReferringObjects.referringObjects001.referringObjects001
  * @run main/othervm/native
  *      nsk.jdwp.ObjectReference.ReferringObjects.referringObjects001.referringObjects001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferringObjects/referringObjects001/referringObjects001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferringObjects/referringObjects001/referringObjects001.java
@@ -70,7 +70,7 @@
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
  * @build nsk.jdwp.ObjectReference.ReferringObjects.referringObjects001.referringObjects001
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.jdwp.ObjectReference.ReferringObjects.referringObjects001.referringObjects001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferringObjects/referringObjects001/referringObjects001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferringObjects/referringObjects001/referringObjects001.java
@@ -81,10 +81,13 @@
 
 package nsk.jdwp.ObjectReference.ReferringObjects.referringObjects001;
 
-import java.io.*;
 import nsk.share.Consts;
-import nsk.share.jdwp.*;
-import nsk.share.jpda.AbstractDebuggeeTest;
+import nsk.share.jdwp.CommandPacket;
+import nsk.share.jdwp.JDWP;
+import nsk.share.jdwp.ReplyPacket;
+import nsk.share.jdwp.TestDebuggerType1;
+
+import java.io.PrintStream;
 
 public class referringObjects001 extends TestDebuggerType1 {
 
@@ -92,11 +95,11 @@ public class referringObjects001 extends TestDebuggerType1 {
         return nsk.jdwp.ObjectReference.ReferringObjects.referringObjects001.referringObjects001a.class.getName();
     }
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + Consts.JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
+    public static int run(String[] argv, PrintStream out) {
         return new referringObjects001().runIt(argv, out);
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferringObjects/referringObjects002/referringObjects002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferringObjects/referringObjects002/referringObjects002.java
@@ -58,7 +58,6 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ObjectReference.ReferringObjects.referringObjects002.referringObjects002
  * @run main/othervm/native
  *      nsk.jdwp.ObjectReference.ReferringObjects.referringObjects002.referringObjects002
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferringObjects/referringObjects002/referringObjects002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferringObjects/referringObjects002/referringObjects002.java
@@ -59,7 +59,7 @@
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
  * @build nsk.jdwp.ObjectReference.ReferringObjects.referringObjects002.referringObjects002
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.jdwp.ObjectReference.ReferringObjects.referringObjects002.referringObjects002
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferringObjects/referringObjects002/referringObjects002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/ReferringObjects/referringObjects002/referringObjects002.java
@@ -70,20 +70,24 @@
 
 package nsk.jdwp.ObjectReference.ReferringObjects.referringObjects002;
 
-import java.io.PrintStream;
 import nsk.share.Consts;
-import nsk.share.jdwp.*;
+import nsk.share.jdwp.CommandPacket;
+import nsk.share.jdwp.JDWP;
+import nsk.share.jdwp.ReplyPacket;
+import nsk.share.jdwp.TestDebuggerType1;
+
+import java.io.PrintStream;
 
 public class referringObjects002 extends TestDebuggerType1 {
     protected String getDebugeeClassName() {
         return nsk.jdwp.ObjectReference.ReferringObjects.referringObjects002.referringObjects002a.class.getName();
     }
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + Consts.JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
+    public static int run(String[] argv, PrintStream out) {
         return new referringObjects002().runIt(argv, out);
     }
 
@@ -123,7 +127,7 @@ public class referringObjects002 extends TestDebuggerType1 {
                 setSuccess(false);
             }
 
-            long expectedReferrersID[] = new long[expectedReferrersCount];
+            long[] expectedReferrersID = new long[expectedReferrersCount];
 
             // initialize expected IDs of referrers
             for (int i = 0; i < expectedReferrersCount; i++) {
@@ -131,21 +135,21 @@ public class referringObjects002 extends TestDebuggerType1 {
                         + (i + 1));
             }
 
-            long receivedReferrersID[] = new long[referringObjects];
+            long[] receivedReferrersID = new long[referringObjects];
 
             for (int i = 0; i < referringObjects; i++) {
                 JDWP.Value value = reply.getValue();
                 log.display("tagged-ObjectID = " + value);
 
-                receivedReferrersID[i] = ((Long) value.getValue()).longValue();
+                receivedReferrersID[i] = (Long) value.getValue();
             }
 
             // check that correct IDs of referrers was received
             for (int i = 0; i < referringObjects; i++) {
                 boolean isIDExpected = false;
 
-                for (int j = 0; j < expectedReferrersID.length; j++) {
-                    if (receivedReferrersID[i] == expectedReferrersID[j]) {
+                for (long l : expectedReferrersID) {
+                    if (receivedReferrersID[i] == l) {
                         isIDExpected = true;
                         break;
                     }
@@ -159,8 +163,9 @@ public class referringObjects002 extends TestDebuggerType1 {
 
             if (!getSuccess()) {
                 log.complain("Expected IDs:");
-                for (int i = 0; i < expectedReferrersID.length; i++)
-                    log.complain("" + expectedReferrersID[i]);
+                for (long l : expectedReferrersID) {
+                    log.complain("" + l);
+                }
             }
 
             if (!reply.isParsed()) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001/TestDescription.java
@@ -67,8 +67,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ObjectReference.SetValues.setvalues001
- *        nsk.jdwp.ObjectReference.SetValues.setvalues001a
+ * @build nsk.jdwp.ObjectReference.SetValues.setvalues001a
  * @run main/othervm
  *      nsk.jdwp.ObjectReference.SetValues.setvalues001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/SetValues/setvalues001/TestDescription.java
@@ -69,7 +69,7 @@
  *          /test/lib
  * @build nsk.jdwp.ObjectReference.SetValues.setvalues001
  *        nsk.jdwp.ObjectReference.SetValues.setvalues001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ObjectReference.SetValues.setvalues001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/ClassLoader/classloader001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/ClassLoader/classloader001/TestDescription.java
@@ -55,7 +55,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.ClassLoader.classloader001
  *        nsk.jdwp.ReferenceType.ClassLoader.classloader001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.ClassLoader.classloader001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/ClassLoader/classloader001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/ClassLoader/classloader001/TestDescription.java
@@ -53,8 +53,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.ClassLoader.classloader001
- *        nsk.jdwp.ReferenceType.ClassLoader.classloader001a
+ * @build nsk.jdwp.ReferenceType.ClassLoader.classloader001a
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.ClassLoader.classloader001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/ClassObject/classobj001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/ClassObject/classobj001/TestDescription.java
@@ -53,8 +53,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.ClassObject.classobj001
- *        nsk.jdwp.ReferenceType.ClassObject.classobj001a
+ * @build nsk.jdwp.ReferenceType.ClassObject.classobj001a
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.ClassObject.classobj001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/ClassObject/classobj001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/ClassObject/classobj001/TestDescription.java
@@ -55,7 +55,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.ClassObject.classobj001
  *        nsk.jdwp.ReferenceType.ClassObject.classobj001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.ClassObject.classobj001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Fields/fields001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Fields/fields001/TestDescription.java
@@ -55,8 +55,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.Fields.fields001
- *        nsk.jdwp.ReferenceType.Fields.fields001a
+ * @build nsk.jdwp.ReferenceType.Fields.fields001a
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.Fields.fields001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Fields/fields001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Fields/fields001/TestDescription.java
@@ -57,7 +57,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.Fields.fields001
  *        nsk.jdwp.ReferenceType.Fields.fields001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.Fields.fields001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/FieldsWithGeneric/fldwithgeneric001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/FieldsWithGeneric/fldwithgeneric001/TestDescription.java
@@ -46,7 +46,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.FieldsWithGeneric.fldwithgeneric001
  *        nsk.jdwp.ReferenceType.FieldsWithGeneric.fldwithgeneric001t
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.FieldsWithGeneric.fldwithgeneric001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/FieldsWithGeneric/fldwithgeneric001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/FieldsWithGeneric/fldwithgeneric001/TestDescription.java
@@ -44,8 +44,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.FieldsWithGeneric.fldwithgeneric001
- *        nsk.jdwp.ReferenceType.FieldsWithGeneric.fldwithgeneric001t
+ * @build nsk.jdwp.ReferenceType.FieldsWithGeneric.fldwithgeneric001t
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.FieldsWithGeneric.fldwithgeneric001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/GetValues/getvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/GetValues/getvalues001/TestDescription.java
@@ -58,7 +58,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.GetValues.getvalues001
  *        nsk.jdwp.ReferenceType.GetValues.getvalues001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.GetValues.getvalues001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/GetValues/getvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/GetValues/getvalues001/TestDescription.java
@@ -56,8 +56,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.GetValues.getvalues001
- *        nsk.jdwp.ReferenceType.GetValues.getvalues001a
+ * @build nsk.jdwp.ReferenceType.GetValues.getvalues001a
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.GetValues.getvalues001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Instances/instances001/instances001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Instances/instances001/instances001.java
@@ -64,7 +64,6 @@
  * @requires !vm.graal.enabled
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.Instances.instances001.instances001
  * @run main/othervm/native
  *      nsk.jdwp.ReferenceType.Instances.instances001.instances001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Instances/instances001/instances001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Instances/instances001/instances001.java
@@ -76,21 +76,24 @@
 
 package nsk.jdwp.ReferenceType.Instances.instances001;
 
-import java.io.*;
 import nsk.share.Consts;
-import nsk.share.jdwp.*;
-import nsk.share.jpda.AbstractDebuggeeTest;
+import nsk.share.jdwp.CommandPacket;
+import nsk.share.jdwp.JDWP;
+import nsk.share.jdwp.ReplyPacket;
+import nsk.share.jdwp.TestDebuggerType1;
+
+import java.io.PrintStream;
 
 public class instances001 extends TestDebuggerType1 {
     protected String getDebugeeClassName() {
         return nsk.jdwp.ReferenceType.Instances.instances001.instances001a.class.getName();
     }
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + Consts.JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
+    public static int run(String[] argv, PrintStream out) {
         return new instances001().runIt(argv, out);
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Instances/instances001/instances001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Instances/instances001/instances001.java
@@ -65,7 +65,7 @@
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.Instances.instances001.instances001
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.jdwp.ReferenceType.Instances.instances001.instances001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Instances/instances002/instances002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Instances/instances002/instances002.java
@@ -58,7 +58,7 @@
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.Instances.instances002.instances002
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.Instances.instances002.instances002
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Instances/instances002/instances002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Instances/instances002/instances002.java
@@ -69,20 +69,24 @@
 
 package nsk.jdwp.ReferenceType.Instances.instances002;
 
-import java.io.*;
 import nsk.share.Consts;
-import nsk.share.jdwp.*;
+import nsk.share.jdwp.CommandPacket;
+import nsk.share.jdwp.JDWP;
+import nsk.share.jdwp.ReplyPacket;
+import nsk.share.jdwp.TestDebuggerType1;
+
+import java.io.PrintStream;
 
 public class instances002 extends TestDebuggerType1 {
     protected String getDebugeeClassName() {
         return nsk.jdwp.ReferenceType.Instances.instances002.instances002a.class.getName();
     }
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + Consts.JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
+    public static int run(String[] argv, PrintStream out) {
         return new instances002().runIt(argv, out);
     }
 
@@ -117,7 +121,7 @@ public class instances002 extends TestDebuggerType1 {
                 log.complain("Unexpected 'instances' value: " + instances + ", expected is " + expectedInstances);
             }
 
-            long expectedInstancesID[] = new long[expectedInstances];
+            long[] expectedInstancesID = new long[expectedInstances];
 
             // initialize expected IDs of instances
             for (int i = 0; i < expectedInstances; i++) {
@@ -125,21 +129,21 @@ public class instances002 extends TestDebuggerType1 {
                         JDWP.Tag.OBJECT);
             }
 
-            long receivedInstancesID[] = new long[instances];
+            long[] receivedInstancesID = new long[instances];
 
             for (int i = 0; i < instances; i++) {
                 JDWP.Value value = reply.getValue();
                 log.display("tagged-ObjectID = " + value);
 
-                receivedInstancesID[i] = ((Long) value.getValue()).longValue();
+                receivedInstancesID[i] = (Long) value.getValue();
             }
 
             // check that correct IDs of instances was received
             for (int i = 0; i < instances; i++) {
                 boolean isIDExpected = false;
 
-                for (int j = 0; j < expectedInstancesID.length; j++) {
-                    if (receivedInstancesID[i] == expectedInstancesID[j]) {
+                for (long l : expectedInstancesID) {
+                    if (receivedInstancesID[i] == l) {
                         isIDExpected = true;
                         break;
                     }
@@ -153,8 +157,9 @@ public class instances002 extends TestDebuggerType1 {
 
             if (!getSuccess()) {
                 log.complain("Expected IDs:");
-                for (int i = 0; i < expectedInstancesID.length; i++)
-                    log.complain("" + expectedInstancesID[i]);
+                for (long l : expectedInstancesID) {
+                    log.complain("" + l);
+                }
             }
 
             if (!reply.isParsed()) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Instances/instances002/instances002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Instances/instances002/instances002.java
@@ -57,7 +57,6 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.Instances.instances002.instances002
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.Instances.instances002.instances002
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001/TestDescription.java
@@ -59,7 +59,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.Interfaces.interfaces001
  *        nsk.jdwp.ReferenceType.Interfaces.interfaces001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.Interfaces.interfaces001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001/TestDescription.java
@@ -57,8 +57,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.Interfaces.interfaces001
- *        nsk.jdwp.ReferenceType.Interfaces.interfaces001a
+ * @build nsk.jdwp.ReferenceType.Interfaces.interfaces001a
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.Interfaces.interfaces001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Methods/methods001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Methods/methods001/TestDescription.java
@@ -57,7 +57,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.Methods.methods001
  *        nsk.jdwp.ReferenceType.Methods.methods001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.Methods.methods001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Methods/methods001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Methods/methods001/TestDescription.java
@@ -55,8 +55,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.Methods.methods001
- *        nsk.jdwp.ReferenceType.Methods.methods001a
+ * @build nsk.jdwp.ReferenceType.Methods.methods001a
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.Methods.methods001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/MethodsWithGeneric/methwithgeneric001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/MethodsWithGeneric/methwithgeneric001/TestDescription.java
@@ -44,8 +44,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.MethodsWithGeneric.methwithgeneric001
- *        nsk.jdwp.ReferenceType.MethodsWithGeneric.methwithgeneric001t
+ * @build nsk.jdwp.ReferenceType.MethodsWithGeneric.methwithgeneric001t
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.MethodsWithGeneric.methwithgeneric001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/MethodsWithGeneric/methwithgeneric001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/MethodsWithGeneric/methwithgeneric001/TestDescription.java
@@ -46,7 +46,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.MethodsWithGeneric.methwithgeneric001
  *        nsk.jdwp.ReferenceType.MethodsWithGeneric.methwithgeneric001t
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.MethodsWithGeneric.methwithgeneric001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Modifiers/modifiers001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Modifiers/modifiers001/TestDescription.java
@@ -55,8 +55,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.Modifiers.modifiers001
- *        nsk.jdwp.ReferenceType.Modifiers.modifiers001a
+ * @build nsk.jdwp.ReferenceType.Modifiers.modifiers001a
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.Modifiers.modifiers001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Modifiers/modifiers001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Modifiers/modifiers001/TestDescription.java
@@ -57,7 +57,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.Modifiers.modifiers001
  *        nsk.jdwp.ReferenceType.Modifiers.modifiers001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.Modifiers.modifiers001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/NestedTypes/nestedtypes001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/NestedTypes/nestedtypes001/TestDescription.java
@@ -62,7 +62,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.NestedTypes.nestedtypes001
  *        nsk.jdwp.ReferenceType.NestedTypes.nestedtypes001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.NestedTypes.nestedtypes001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/NestedTypes/nestedtypes001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/NestedTypes/nestedtypes001/TestDescription.java
@@ -60,8 +60,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.NestedTypes.nestedtypes001
- *        nsk.jdwp.ReferenceType.NestedTypes.nestedtypes001a
+ * @build nsk.jdwp.ReferenceType.NestedTypes.nestedtypes001a
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.NestedTypes.nestedtypes001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Signature/signature001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Signature/signature001/TestDescription.java
@@ -51,8 +51,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.Signature.signature001
- *        nsk.jdwp.ReferenceType.Signature.signature001a
+ * @build nsk.jdwp.ReferenceType.Signature.signature001a
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.Signature.signature001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Signature/signature001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Signature/signature001/TestDescription.java
@@ -53,7 +53,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.Signature.signature001
  *        nsk.jdwp.ReferenceType.Signature.signature001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.Signature.signature001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/SignatureWithGeneric/sigwithgeneric001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/SignatureWithGeneric/sigwithgeneric001/TestDescription.java
@@ -43,8 +43,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.SignatureWithGeneric.sigwithgeneric001
- *        nsk.jdwp.ReferenceType.SignatureWithGeneric.sigwithgeneric001t
+ * @build nsk.jdwp.ReferenceType.SignatureWithGeneric.sigwithgeneric001t
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.SignatureWithGeneric.sigwithgeneric001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/SignatureWithGeneric/sigwithgeneric001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/SignatureWithGeneric/sigwithgeneric001/TestDescription.java
@@ -45,7 +45,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.SignatureWithGeneric.sigwithgeneric001
  *        nsk.jdwp.ReferenceType.SignatureWithGeneric.sigwithgeneric001t
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.SignatureWithGeneric.sigwithgeneric001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/SourceDebugExtension/srcdebugext001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/SourceDebugExtension/srcdebugext001/TestDescription.java
@@ -40,7 +40,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.SourceDebugExtension.srcdebugext001
  *        nsk.jdwp.ReferenceType.SourceDebugExtension.srcdebugext001t
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.SourceDebugExtension.srcdebugext001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/SourceDebugExtension/srcdebugext001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/SourceDebugExtension/srcdebugext001/TestDescription.java
@@ -38,8 +38,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.SourceDebugExtension.srcdebugext001
- *        nsk.jdwp.ReferenceType.SourceDebugExtension.srcdebugext001t
+ * @build nsk.jdwp.ReferenceType.SourceDebugExtension.srcdebugext001t
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.SourceDebugExtension.srcdebugext001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/SourceFile/srcfile001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/SourceFile/srcfile001/TestDescription.java
@@ -51,8 +51,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.SourceFile.srcfile001
- *        nsk.jdwp.ReferenceType.SourceFile.srcfile001a
+ * @build nsk.jdwp.ReferenceType.SourceFile.srcfile001a
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.SourceFile.srcfile001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/SourceFile/srcfile001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/SourceFile/srcfile001/TestDescription.java
@@ -53,7 +53,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.SourceFile.srcfile001
  *        nsk.jdwp.ReferenceType.SourceFile.srcfile001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.SourceFile.srcfile001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Status/status001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Status/status001/TestDescription.java
@@ -55,7 +55,7 @@
  *          /test/lib
  * @build nsk.jdwp.ReferenceType.Status.status001
  *        nsk.jdwp.ReferenceType.Status.status001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ReferenceType.Status.status001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Status/status001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Status/status001/TestDescription.java
@@ -53,8 +53,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ReferenceType.Status.status001
- *        nsk.jdwp.ReferenceType.Status.status001a
+ * @build nsk.jdwp.ReferenceType.Status.status001a
  * @run main/othervm
  *      nsk.jdwp.ReferenceType.Status.status001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/GetValues/getvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/GetValues/getvalues001/TestDescription.java
@@ -60,8 +60,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.StackFrame.GetValues.getvalues001
- *        nsk.jdwp.StackFrame.GetValues.getvalues001a
+ * @build nsk.jdwp.StackFrame.GetValues.getvalues001a
  * @comment debuggee should be compiled w/ debug info
  * @clean nsk.jdwp.StackFrame.GetValues.getvalues001a
  * @compile -g:lines,source,vars ../getvalues001a.java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/GetValues/getvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/GetValues/getvalues001/TestDescription.java
@@ -65,7 +65,7 @@
  * @comment debuggee should be compiled w/ debug info
  * @clean nsk.jdwp.StackFrame.GetValues.getvalues001a
  * @compile -g:lines,source,vars ../getvalues001a.java
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.StackFrame.GetValues.getvalues001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/PopFrames/popframes001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/PopFrames/popframes001/TestDescription.java
@@ -61,7 +61,7 @@
  *          /test/lib
  * @build nsk.jdwp.StackFrame.PopFrames.popframes001
  *        nsk.jdwp.StackFrame.PopFrames.popframes001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.StackFrame.PopFrames.popframes001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/PopFrames/popframes001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/PopFrames/popframes001/TestDescription.java
@@ -59,8 +59,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.StackFrame.PopFrames.popframes001
- *        nsk.jdwp.StackFrame.PopFrames.popframes001a
+ * @build nsk.jdwp.StackFrame.PopFrames.popframes001a
  * @run main/othervm
  *      nsk.jdwp.StackFrame.PopFrames.popframes001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/SetValues/setvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/SetValues/setvalues001/TestDescription.java
@@ -71,8 +71,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.StackFrame.SetValues.setvalues001
- *        nsk.jdwp.StackFrame.SetValues.setvalues001a
+ * @build nsk.jdwp.StackFrame.SetValues.setvalues001a
  * @comment debuggee should be compiled w/ debug info
  * @clean nsk.jdwp.StackFrame.SetValues.setvalues001a
  * @compile -g:lines,source,vars ../setvalues001a.java

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/SetValues/setvalues001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/SetValues/setvalues001/TestDescription.java
@@ -76,7 +76,7 @@
  * @comment debuggee should be compiled w/ debug info
  * @clean nsk.jdwp.StackFrame.SetValues.setvalues001a
  * @compile -g:lines,source,vars ../setvalues001a.java
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.StackFrame.SetValues.setvalues001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/ThisObject/thisobject001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/ThisObject/thisobject001/TestDescription.java
@@ -60,7 +60,7 @@
  *          /test/lib
  * @build nsk.jdwp.StackFrame.ThisObject.thisobject001
  *        nsk.jdwp.StackFrame.ThisObject.thisobject001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.StackFrame.ThisObject.thisobject001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/ThisObject/thisobject001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StackFrame/ThisObject/thisobject001/TestDescription.java
@@ -58,8 +58,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.StackFrame.ThisObject.thisobject001
- *        nsk.jdwp.StackFrame.ThisObject.thisobject001a
+ * @build nsk.jdwp.StackFrame.ThisObject.thisobject001a
  * @run main/othervm
  *      nsk.jdwp.StackFrame.ThisObject.thisobject001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StringReference/Value/value001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StringReference/Value/value001/TestDescription.java
@@ -51,8 +51,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.StringReference.Value.value001
- *        nsk.jdwp.StringReference.Value.value001a
+ * @build nsk.jdwp.StringReference.Value.value001a
  * @run main/othervm
  *      nsk.jdwp.StringReference.Value.value001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StringReference/Value/value001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/StringReference/Value/value001/TestDescription.java
@@ -53,7 +53,7 @@
  *          /test/lib
  * @build nsk.jdwp.StringReference.Value.value001
  *        nsk.jdwp.StringReference.Value.value001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.StringReference.Value.value001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8252002 is fixed
-allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadGroupReference/Children/children001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadGroupReference/Children/children001/TestDescription.java
@@ -50,7 +50,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadGroupReference.Children.children001
  *        nsk.jdwp.ThreadGroupReference.Children.children001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadGroupReference.Children.children001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadGroupReference/Children/children001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadGroupReference/Children/children001/TestDescription.java
@@ -48,8 +48,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadGroupReference.Children.children001
- *        nsk.jdwp.ThreadGroupReference.Children.children001a
+ * @build nsk.jdwp.ThreadGroupReference.Children.children001a
  * @run main/othervm
  *      nsk.jdwp.ThreadGroupReference.Children.children001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadGroupReference/Name/name001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadGroupReference/Name/name001/TestDescription.java
@@ -50,7 +50,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadGroupReference.Name.name001
  *        nsk.jdwp.ThreadGroupReference.Name.name001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadGroupReference.Name.name001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadGroupReference/Name/name001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadGroupReference/Name/name001/TestDescription.java
@@ -48,8 +48,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadGroupReference.Name.name001
- *        nsk.jdwp.ThreadGroupReference.Name.name001a
+ * @build nsk.jdwp.ThreadGroupReference.Name.name001a
  * @run main/othervm
  *      nsk.jdwp.ThreadGroupReference.Name.name001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadGroupReference/Parent/parent001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadGroupReference/Parent/parent001/TestDescription.java
@@ -51,8 +51,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadGroupReference.Parent.parent001
- *        nsk.jdwp.ThreadGroupReference.Parent.parent001a
+ * @build nsk.jdwp.ThreadGroupReference.Parent.parent001a
  * @run main/othervm
  *      nsk.jdwp.ThreadGroupReference.Parent.parent001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadGroupReference/Parent/parent001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadGroupReference/Parent/parent001/TestDescription.java
@@ -53,7 +53,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadGroupReference.Parent.parent001
  *        nsk.jdwp.ThreadGroupReference.Parent.parent001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadGroupReference.Parent.parent001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/CurrentContendedMonitor/curcontmonitor001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/CurrentContendedMonitor/curcontmonitor001/TestDescription.java
@@ -63,7 +63,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.CurrentContendedMonitor.curcontmonitor001
  *        nsk.jdwp.ThreadReference.CurrentContendedMonitor.curcontmonitor001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.CurrentContendedMonitor.curcontmonitor001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/CurrentContendedMonitor/curcontmonitor001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/CurrentContendedMonitor/curcontmonitor001/TestDescription.java
@@ -61,8 +61,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.CurrentContendedMonitor.curcontmonitor001
- *        nsk.jdwp.ThreadReference.CurrentContendedMonitor.curcontmonitor001a
+ * @build nsk.jdwp.ThreadReference.CurrentContendedMonitor.curcontmonitor001a
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.CurrentContendedMonitor.curcontmonitor001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java
@@ -86,21 +86,21 @@
 
 package nsk.jdwp.ThreadReference.ForceEarlyReturn.forceEarlyReturn001;
 
-import java.io.*;
 import nsk.share.Consts;
-import nsk.share.jdwp.*;
+import nsk.share.jdwp.CommandPacket;
+import nsk.share.jdwp.JDWP;
 import nsk.share.jdwp.JDWP.Value;
+import nsk.share.jdwp.ReplyPacket;
+import nsk.share.jdwp.TestDebuggerType1;
 import nsk.share.jpda.ForceEarlyReturnTestThread;
 
-public class forceEarlyReturn001
-extends TestDebuggerType1
-{
+import java.io.PrintStream;
+
+public class forceEarlyReturn001 extends TestDebuggerType1 {
     // data needed to create JDWP command,
     // also this class create breakpoint in method which should be forced to return
-    class TestData
-    {
-        public TestData(long classID, String methodName, int lineNumber, long threadID, Value value, Value invalidValue)
-        {
+    class TestData {
+        public TestData(long classID, String methodName, int lineNumber, long threadID, Value value, Value invalidValue) {
             breakpointID = debuggee.requestBreakpointEvent(
                     JDWP.TypeTag.CLASS,
                     classID,
@@ -119,27 +119,22 @@ extends TestDebuggerType1
         public long threadID;
     }
 
-    protected String getDebugeeClassName()
-    {
+    protected String getDebugeeClassName() {
         return "nsk.jdwp.ThreadReference.ForceEarlyReturn.forceEarlyReturn001.forceEarlyReturn001a";
     }
 
-    public static void main (String argv[])
-    {
-        System.exit(run(argv,System.out) + Consts.JCK_STATUS_BASE);
+    public static void main(String[] argv) {
+        System.exit(run(argv, System.out) + Consts.JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out)
-    {
+    public static int run(String[] argv, PrintStream out) {
         return new forceEarlyReturn001().runIt(argv, out);
     }
 
     // send command and receive empty reply
     // all asserts should be done in debuggee
-    private void sendCommand(long threadID, Value value, boolean expectError, int errorCode)
-    {
-        try
-        {
+    private void sendCommand(long threadID, Value value, boolean expectError, int errorCode) {
+        try {
             int JDWP_COMMAND_ID = JDWP.Command.ThreadReference.ForceEarlyReturn;
 
             log.display("Create command: " + JDWP.commandNames.get(JDWP_COMMAND_ID));
@@ -158,19 +153,16 @@ extends TestDebuggerType1
 
             reply = getReply(command, expectError, errorCode);
 
-            if(expectError)
+            if (expectError)
                 return;
 
             log.display("Empty reply");
 
-            if(!reply.isParsed())
-            {
+            if (!reply.isParsed()) {
                 setSuccess(false);
                 log.complain("Extra trailing bytes found in reply packet at: " + reply.currentPosition());
             }
-        }
-        catch(Exception e)
-        {
+        } catch (Exception e) {
             setSuccess(false);
             log.complain("Caught exception while testing JDWP command: " + e);
             e.printStackTrace(log.getOutStream());
@@ -181,24 +173,21 @@ extends TestDebuggerType1
 
     // create Value objects which should be send in command packet and
     // initialize breapoints in tested methods
-    private void initTestData()
-    {
+    private void initTestData() {
         long classID = debuggee.getReferenceTypeID(createTypeSignature(ForceEarlyReturnTestThread.class.getName()));
 
-        Value testValues[] = new Value[ForceEarlyReturnTestThread.testedTypesNames.length + 1];
-        Value testInvalidValues[] = new Value[ForceEarlyReturnTestThread.testedTypesNames.length + 1];
+        Value[] testValues = new Value[ForceEarlyReturnTestThread.testedTypesNames.length + 1];
+        Value[] testInvalidValues = new Value[ForceEarlyReturnTestThread.testedTypesNames.length + 1];
 
-        testValues[0] = new JDWP.Value(JDWP.Tag.VOID, new Long(0));
+        testValues[0] = new JDWP.Value(JDWP.Tag.VOID, 0L);
 
-        for(int i = 1; i < ForceEarlyReturnTestThread.testedTypesNames.length; i++)
-        {
+        for (int i = 1; i < ForceEarlyReturnTestThread.testedTypesNames.length; i++) {
             testValues[i] = debuggee.getStaticFieldValue(
                     classID,
                     debuggee.getClassFieldID(classID, "expected" + ForceEarlyReturnTestThread.testedTypesNames[i] + "Value", true));
         }
 
-        for(int i = 0; i < ForceEarlyReturnTestThread.testedTypesNames.length; i++)
-        {
+        for (int i = 0; i < ForceEarlyReturnTestThread.testedTypesNames.length; i++) {
             testInvalidValues[i] = debuggee.getStaticFieldValue(
                     classID,
                     debuggee.getClassFieldID(classID, "invalid" + ForceEarlyReturnTestThread.testedTypesNames[i] + "Value", true));
@@ -208,8 +197,7 @@ extends TestDebuggerType1
 
         testData = new TestData[ForceEarlyReturnTestThread.testedTypesNames.length];
 
-        for(int i = 0; i < ForceEarlyReturnTestThread.testedTypesNames.length; i++)
-        {
+        for (int i = 0; i < ForceEarlyReturnTestThread.testedTypesNames.length; i++) {
             testData[i] = new TestData(classID,
                     ForceEarlyReturnTestThread.testedTypesNames[i] + "Method",
                     ForceEarlyReturnTestThread.breakpointLines[i],
@@ -219,27 +207,25 @@ extends TestDebuggerType1
         }
     }
 
-    public void doTest()
-    {
+    public void doTest() {
         initTestData();
 
         pipe.println(forceEarlyReturn001a.COMMAND_START_EXECUTION);
 
-        if(!isDebuggeeReady())
+        if (!isDebuggeeReady())
             return;
 
-        for(int i = 0; i < testData.length; i++)
-        {
+        for (TestData testDatum : testData) {
             // wait when tested thread call method with breapoint
-            debuggee.waitForBreakpointEvent(testData[i].breakpointID);
+            debuggee.waitForBreakpointEvent(testDatum.breakpointID);
 
-            log.display("Send invalid command: valid value: " + testData[i].value + " invalid value: " + testData[i].invalidValue);
+            log.display("Send invalid command: valid value: " + testDatum.value + " invalid value: " + testDatum.invalidValue);
             // send ForceEarlyReturn command with invalid value
-            sendCommand(testData[i].threadID, testData[i].invalidValue, true, JDWP.Error.TYPE_MISMATCH);
+            sendCommand(testDatum.threadID, testDatum.invalidValue, true, JDWP.Error.TYPE_MISMATCH);
 
-            log.display("Send valid command: valid value: " + testData[i].value);
+            log.display("Send valid command: valid value: " + testDatum.value);
             // send ForceEarlyReturn command
-            sendCommand(testData[i].threadID, testData[i].value, false, 0);
+            sendCommand(testDatum.threadID, testDatum.value, false, 0);
 
             // resume debuggee
             debuggee.resume();
@@ -247,7 +233,7 @@ extends TestDebuggerType1
 
         pipe.println(forceEarlyReturn001a.COMMAND_END_EXECUTION);
 
-        if(!isDebuggeeReady())
+        if (!isDebuggeeReady())
             return;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java
@@ -75,7 +75,7 @@
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.ForceEarlyReturn.forceEarlyReturn001.forceEarlyReturn001
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.ForceEarlyReturn.forceEarlyReturn001.forceEarlyReturn001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java
@@ -74,7 +74,6 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.ForceEarlyReturn.forceEarlyReturn001.forceEarlyReturn001
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.ForceEarlyReturn.forceEarlyReturn001.forceEarlyReturn001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
@@ -66,7 +66,6 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.ForceEarlyReturn.forceEarlyReturn002.forceEarlyReturn002
  * @run main/othervm/native
  *      nsk.jdwp.ThreadReference.ForceEarlyReturn.forceEarlyReturn002.forceEarlyReturn002
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
@@ -78,24 +78,28 @@
 
 package nsk.jdwp.ThreadReference.ForceEarlyReturn.forceEarlyReturn002;
 
-import java.io.*;
-
 import nsk.share.Consts;
-import nsk.share.jdwp.*;
+import nsk.share.jdwp.CommandPacket;
+import nsk.share.jdwp.EventPacket;
+import nsk.share.jdwp.JDWP;
 import nsk.share.jdwp.JDWP.Value;
+import nsk.share.jdwp.ReplyPacket;
+import nsk.share.jdwp.TestDebuggerType1;
 import nsk.share.jpda.AbstractDebuggeeTest;
 import nsk.share.jpda.StateTestThread;
+
+import java.io.PrintStream;
 
 public class forceEarlyReturn002 extends TestDebuggerType1 {
     protected String getDebugeeClassName() {
         return "nsk.jdwp.ThreadReference.ForceEarlyReturn.forceEarlyReturn002.forceEarlyReturn002a";
     }
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + Consts.JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
+    public static int run(String[] argv, PrintStream out) {
         return new forceEarlyReturn002().runIt(argv, out);
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
@@ -67,7 +67,7 @@
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.ForceEarlyReturn.forceEarlyReturn002.forceEarlyReturn002
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.jdwp.ThreadReference.ForceEarlyReturn.forceEarlyReturn002.forceEarlyReturn002
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/FrameCount/framecnt001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/FrameCount/framecnt001/TestDescription.java
@@ -56,8 +56,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.FrameCount.framecnt001
- *        nsk.jdwp.ThreadReference.FrameCount.framecnt001a
+ * @build nsk.jdwp.ThreadReference.FrameCount.framecnt001a
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.FrameCount.framecnt001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/FrameCount/framecnt001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/FrameCount/framecnt001/TestDescription.java
@@ -58,7 +58,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.FrameCount.framecnt001
  *        nsk.jdwp.ThreadReference.FrameCount.framecnt001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.FrameCount.framecnt001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Frames/frames001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Frames/frames001/TestDescription.java
@@ -61,8 +61,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.Frames.frames001
- *        nsk.jdwp.ThreadReference.Frames.frames001a
+ * @build nsk.jdwp.ThreadReference.Frames.frames001a
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.Frames.frames001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Frames/frames001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Frames/frames001/TestDescription.java
@@ -63,7 +63,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.Frames.frames001
  *        nsk.jdwp.ThreadReference.Frames.frames001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.Frames.frames001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Interrupt/interrupt001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Interrupt/interrupt001/TestDescription.java
@@ -67,7 +67,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.Interrupt.interrupt001
  *        nsk.jdwp.ThreadReference.Interrupt.interrupt001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.Interrupt.interrupt001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Interrupt/interrupt001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Interrupt/interrupt001/TestDescription.java
@@ -65,8 +65,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.Interrupt.interrupt001
- *        nsk.jdwp.ThreadReference.Interrupt.interrupt001a
+ * @build nsk.jdwp.ThreadReference.Interrupt.interrupt001a
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.Interrupt.interrupt001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Name/name001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Name/name001/TestDescription.java
@@ -57,7 +57,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.Name.name001
  *        nsk.jdwp.ThreadReference.Name.name001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.Name.name001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Name/name001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Name/name001/TestDescription.java
@@ -55,8 +55,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.Name.name001
- *        nsk.jdwp.ThreadReference.Name.name001a
+ * @build nsk.jdwp.ThreadReference.Name.name001a
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.Name.name001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitors/ownmonitors001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitors/ownmonitors001/TestDescription.java
@@ -61,8 +61,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.OwnedMonitors.ownmonitors001
- *        nsk.jdwp.ThreadReference.OwnedMonitors.ownmonitors001a
+ * @build nsk.jdwp.ThreadReference.OwnedMonitors.ownmonitors001a
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.OwnedMonitors.ownmonitors001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitors/ownmonitors001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitors/ownmonitors001/TestDescription.java
@@ -63,7 +63,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.OwnedMonitors.ownmonitors001
  *        nsk.jdwp.ThreadReference.OwnedMonitors.ownmonitors001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.OwnedMonitors.ownmonitors001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitorsStackDepthInfo/ownedMonitorsStackDepthInfo001/ownedMonitorsStackDepthInfo001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitorsStackDepthInfo/ownedMonitorsStackDepthInfo001/ownedMonitorsStackDepthInfo001.java
@@ -63,7 +63,7 @@
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.OwnedMonitorsStackDepthInfo.ownedMonitorsStackDepthInfo001.ownedMonitorsStackDepthInfo001
- * @run main/othervm/native/timeout=420 PropertyResolvingWrapper
+ * @run main/othervm/native/timeout=420
  *      nsk.jdwp.ThreadReference.OwnedMonitorsStackDepthInfo.ownedMonitorsStackDepthInfo001.ownedMonitorsStackDepthInfo001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitorsStackDepthInfo/ownedMonitorsStackDepthInfo001/ownedMonitorsStackDepthInfo001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitorsStackDepthInfo/ownedMonitorsStackDepthInfo001/ownedMonitorsStackDepthInfo001.java
@@ -62,7 +62,6 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.OwnedMonitorsStackDepthInfo.ownedMonitorsStackDepthInfo001.ownedMonitorsStackDepthInfo001
  * @run main/othervm/native/timeout=420
  *      nsk.jdwp.ThreadReference.OwnedMonitorsStackDepthInfo.ownedMonitorsStackDepthInfo001.ownedMonitorsStackDepthInfo001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitorsStackDepthInfo/ownedMonitorsStackDepthInfo001/ownedMonitorsStackDepthInfo001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitorsStackDepthInfo/ownedMonitorsStackDepthInfo001/ownedMonitorsStackDepthInfo001.java
@@ -74,20 +74,24 @@
 
 package nsk.jdwp.ThreadReference.OwnedMonitorsStackDepthInfo.ownedMonitorsStackDepthInfo001;
 
-import java.io.*;
 import nsk.share.Consts;
-import nsk.share.jdwp.*;
+import nsk.share.jdwp.CommandPacket;
+import nsk.share.jdwp.JDWP;
+import nsk.share.jdwp.ReplyPacket;
+import nsk.share.jdwp.TestDebuggerType1;
+
+import java.io.PrintStream;
 
 public class ownedMonitorsStackDepthInfo001 extends TestDebuggerType1 {
     protected String getDebugeeClassName() {
         return nsk.jdwp.ThreadReference.OwnedMonitorsStackDepthInfo.ownedMonitorsStackDepthInfo001.ownedMonitorsStackDepthInfo001a.class.getName();
     }
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + Consts.JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
+    public static int run(String[] argv, PrintStream out) {
         return new ownedMonitorsStackDepthInfo001().runIt(argv, out);
     }
 
@@ -125,14 +129,14 @@ public class ownedMonitorsStackDepthInfo001 extends TestDebuggerType1 {
 
             reply = getReply(command);
 
-            MonitorInfo expectedMonitors[] = new MonitorInfo[ownedMonitorsStackDepthInfo001a.expectedMonitorCounts];
+            MonitorInfo[] expectedMonitors = new MonitorInfo[ownedMonitorsStackDepthInfo001a.expectedMonitorCounts];
 
             long classID = debuggee.getReferenceTypeID(createTypeSignature(getDebugeeClassName()));
 
             // obtain information about aquired monitors
             for (int i = 0; i < ownedMonitorsStackDepthInfo001a.expectedMonitorCounts; i++) {
                 long monitorID = queryObjectID(classID, "monitor" + (i + 1));
-                int depth = ((Integer) debuggee.getStaticFieldValue(classID, "depth" + (i + 1), JDWP.Tag.INT).getValue()).intValue();
+                int depth = (Integer) debuggee.getStaticFieldValue(classID, "depth" + (i + 1), JDWP.Tag.INT).getValue();
 
                 expectedMonitors[i] = new MonitorInfo(monitorID, depth);
             }
@@ -147,7 +151,7 @@ public class ownedMonitorsStackDepthInfo001 extends TestDebuggerType1 {
                 log.complain("Unexpected value of 'owned': " + owned + ", expected value is " + expectedMonitors.length);
             }
 
-            MonitorInfo receivedMonitors[] = new MonitorInfo[owned];
+            MonitorInfo[] receivedMonitors = new MonitorInfo[owned];
 
             for (int i = 0; i < owned; i++) {
                 JDWP.Value value = reply.getValue();
@@ -156,21 +160,21 @@ public class ownedMonitorsStackDepthInfo001 extends TestDebuggerType1 {
                 int stack_depth = reply.getInt();
                 log.display("stack_depth = " + stack_depth);
 
-                receivedMonitors[i] = new MonitorInfo(((Long) value.getValue()).longValue(), stack_depth);
+                receivedMonitors[i] = new MonitorInfo((Long) value.getValue(), stack_depth);
             }
 
             // check that correct information about acquired monitors was received
             for (int i = 0; i < owned; i++) {
                 boolean monitorFound = false;
 
-                for (int j = 0; j < expectedMonitors.length; j++) {
-                    if (receivedMonitors[i].monitorObjectID == expectedMonitors[j].monitorObjectID) {
+                for (MonitorInfo expectedMonitor : expectedMonitors) {
+                    if (receivedMonitors[i].monitorObjectID == expectedMonitor.monitorObjectID) {
                         monitorFound = true;
 
-                        if (receivedMonitors[i].depth != expectedMonitors[j].depth) {
+                        if (receivedMonitors[i].depth != expectedMonitor.depth) {
                             setSuccess(false);
                             log.complain("Unexpected monitor depth for monitor " + receivedMonitors[i].monitorObjectID + ": "
-                                    + receivedMonitors[i].depth + ", expected value is " + expectedMonitors[j].depth);
+                                    + receivedMonitors[i].depth + ", expected value is " + expectedMonitor.depth);
                         }
 
                         break;
@@ -185,8 +189,8 @@ public class ownedMonitorsStackDepthInfo001 extends TestDebuggerType1 {
 
             if (!getSuccess()) {
                 log.complain("Expected monitors: ");
-                for (int i = 0; i < expectedMonitors.length; i++) {
-                    log.complain("monitor: " + expectedMonitors[i].monitorObjectID + " " + expectedMonitors[i].depth);
+                for (MonitorInfo expectedMonitor : expectedMonitors) {
+                    log.complain("monitor: " + expectedMonitor.monitorObjectID + " " + expectedMonitor.depth);
                 }
             }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitorsStackDepthInfo/ownedMonitorsStackDepthInfo002/ownedMonitorsStackDepthInfo002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitorsStackDepthInfo/ownedMonitorsStackDepthInfo002/ownedMonitorsStackDepthInfo002.java
@@ -62,22 +62,26 @@
 
 package nsk.jdwp.ThreadReference.OwnedMonitorsStackDepthInfo.ownedMonitorsStackDepthInfo002;
 
-import java.io.*;
 import nsk.share.Consts;
-import nsk.share.jdwp.*;
+import nsk.share.jdwp.AbstractJDWPDebuggee;
+import nsk.share.jdwp.CommandPacket;
+import nsk.share.jdwp.JDWP;
+import nsk.share.jdwp.TestDebuggerType1;
 import nsk.share.jpda.AbstractDebuggeeTest;
 import nsk.share.jpda.StateTestThread;
+
+import java.io.PrintStream;
 
 public class ownedMonitorsStackDepthInfo002 extends TestDebuggerType1 {
     protected String getDebugeeClassName() {
         return AbstractJDWPDebuggee.class.getName();
     }
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + Consts.JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
+    public static int run(String[] argv, PrintStream out) {
         return new ownedMonitorsStackDepthInfo002().runIt(argv, out);
     }
 
@@ -101,8 +105,6 @@ public class ownedMonitorsStackDepthInfo002 extends TestDebuggerType1 {
 
             // in this test always expect reply with error
             getReply(command, true, errorCode);
-
-            return;
         } catch (Exception e) {
             setSuccess(false);
             log.complain("Caught exception while testing JDWP command: " + e);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitorsStackDepthInfo/ownedMonitorsStackDepthInfo002/ownedMonitorsStackDepthInfo002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitorsStackDepthInfo/ownedMonitorsStackDepthInfo002/ownedMonitorsStackDepthInfo002.java
@@ -51,7 +51,7 @@
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.OwnedMonitorsStackDepthInfo.ownedMonitorsStackDepthInfo002.ownedMonitorsStackDepthInfo002
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.OwnedMonitorsStackDepthInfo.ownedMonitorsStackDepthInfo002.ownedMonitorsStackDepthInfo002
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitorsStackDepthInfo/ownedMonitorsStackDepthInfo002/ownedMonitorsStackDepthInfo002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/OwnedMonitorsStackDepthInfo/ownedMonitorsStackDepthInfo002/ownedMonitorsStackDepthInfo002.java
@@ -50,7 +50,6 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.OwnedMonitorsStackDepthInfo.ownedMonitorsStackDepthInfo002.ownedMonitorsStackDepthInfo002
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.OwnedMonitorsStackDepthInfo.ownedMonitorsStackDepthInfo002.ownedMonitorsStackDepthInfo002
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Resume/resume001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Resume/resume001/TestDescription.java
@@ -58,8 +58,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.Resume.resume001
- *        nsk.jdwp.ThreadReference.Resume.resume001a
+ * @build nsk.jdwp.ThreadReference.Resume.resume001a
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.Resume.resume001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Resume/resume001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Resume/resume001/TestDescription.java
@@ -60,7 +60,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.Resume.resume001
  *        nsk.jdwp.ThreadReference.Resume.resume001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.Resume.resume001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Status/status001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Status/status001/TestDescription.java
@@ -57,7 +57,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.Status.status001
  *        nsk.jdwp.ThreadReference.Status.status001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.Status.status001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Status/status001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Status/status001/TestDescription.java
@@ -55,8 +55,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.Status.status001
- *        nsk.jdwp.ThreadReference.Status.status001a
+ * @build nsk.jdwp.ThreadReference.Status.status001a
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.Status.status001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Stop/stop001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Stop/stop001/TestDescription.java
@@ -60,7 +60,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.Stop.stop001
  *        nsk.jdwp.ThreadReference.Stop.stop001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.Stop.stop001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Stop/stop001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Stop/stop001/TestDescription.java
@@ -58,8 +58,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.Stop.stop001
- *        nsk.jdwp.ThreadReference.Stop.stop001a
+ * @build nsk.jdwp.ThreadReference.Stop.stop001a
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.Stop.stop001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Suspend/suspend001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Suspend/suspend001/TestDescription.java
@@ -57,8 +57,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.Suspend.suspend001
- *        nsk.jdwp.ThreadReference.Suspend.suspend001a
+ * @build nsk.jdwp.ThreadReference.Suspend.suspend001a
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.Suspend.suspend001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Suspend/suspend001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/Suspend/suspend001/TestDescription.java
@@ -59,7 +59,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.Suspend.suspend001
  *        nsk.jdwp.ThreadReference.Suspend.suspend001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.Suspend.suspend001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/SuspendCount/suspendcnt001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/SuspendCount/suspendcnt001/TestDescription.java
@@ -59,7 +59,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.SuspendCount.suspendcnt001
  *        nsk.jdwp.ThreadReference.SuspendCount.suspendcnt001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.SuspendCount.suspendcnt001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/SuspendCount/suspendcnt001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/SuspendCount/suspendcnt001/TestDescription.java
@@ -57,8 +57,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.SuspendCount.suspendcnt001
- *        nsk.jdwp.ThreadReference.SuspendCount.suspendcnt001a
+ * @build nsk.jdwp.ThreadReference.SuspendCount.suspendcnt001a
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.SuspendCount.suspendcnt001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ThreadGroup/threadgroup001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ThreadGroup/threadgroup001/TestDescription.java
@@ -57,8 +57,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.ThreadReference.ThreadGroup.threadgroup001
- *        nsk.jdwp.ThreadReference.ThreadGroup.threadgroup001a
+ * @build nsk.jdwp.ThreadReference.ThreadGroup.threadgroup001a
  * @run main/othervm
  *      nsk.jdwp.ThreadReference.ThreadGroup.threadgroup001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ThreadGroup/threadgroup001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ThreadGroup/threadgroup001/TestDescription.java
@@ -59,7 +59,7 @@
  *          /test/lib
  * @build nsk.jdwp.ThreadReference.ThreadGroup.threadgroup001
  *        nsk.jdwp.ThreadReference.ThreadGroup.threadgroup001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.ThreadReference.ThreadGroup.threadgroup001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/AllClasses/allclasses001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/AllClasses/allclasses001/TestDescription.java
@@ -48,8 +48,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.AllClasses.allclasses001
- *        nsk.jdwp.VirtualMachine.AllClasses.allclasses001a
+ * @build nsk.jdwp.VirtualMachine.AllClasses.allclasses001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.AllClasses.allclasses001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/AllClasses/allclasses001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/AllClasses/allclasses001/TestDescription.java
@@ -50,7 +50,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.AllClasses.allclasses001
  *        nsk.jdwp.VirtualMachine.AllClasses.allclasses001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.AllClasses.allclasses001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/AllClassesWithGeneric/allclswithgeneric001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/AllClassesWithGeneric/allclswithgeneric001/TestDescription.java
@@ -44,8 +44,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.AllClassesWithGeneric.allclswithgeneric001
- *        nsk.jdwp.VirtualMachine.AllClassesWithGeneric.allclswithgeneric001t
+ * @build nsk.jdwp.VirtualMachine.AllClassesWithGeneric.allclswithgeneric001t
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.AllClassesWithGeneric.allclswithgeneric001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/AllClassesWithGeneric/allclswithgeneric001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/AllClassesWithGeneric/allclswithgeneric001/TestDescription.java
@@ -46,7 +46,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.AllClassesWithGeneric.allclswithgeneric001
  *        nsk.jdwp.VirtualMachine.AllClassesWithGeneric.allclswithgeneric001t
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.AllClassesWithGeneric.allclswithgeneric001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/AllThreads/allthreads001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/AllThreads/allthreads001/TestDescription.java
@@ -46,8 +46,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.AllThreads.allthreads001
- *        nsk.jdwp.VirtualMachine.AllThreads.allthreads001a
+ * @build nsk.jdwp.VirtualMachine.AllThreads.allthreads001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.AllThreads.allthreads001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/AllThreads/allthreads001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/AllThreads/allthreads001/TestDescription.java
@@ -48,7 +48,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.AllThreads.allthreads001
  *        nsk.jdwp.VirtualMachine.AllThreads.allthreads001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.AllThreads.allthreads001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Capabilities/capabilities001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Capabilities/capabilities001/TestDescription.java
@@ -48,7 +48,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.Capabilities.capabilities001
  *        nsk.jdwp.VirtualMachine.Capabilities.capabilities001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.Capabilities.capabilities001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Capabilities/capabilities001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Capabilities/capabilities001/TestDescription.java
@@ -46,8 +46,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.Capabilities.capabilities001
- *        nsk.jdwp.VirtualMachine.Capabilities.capabilities001a
+ * @build nsk.jdwp.VirtualMachine.Capabilities.capabilities001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.Capabilities.capabilities001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/CapabilitiesNew/capabilitiesnew001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/CapabilitiesNew/capabilitiesnew001/TestDescription.java
@@ -50,7 +50,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.CapabilitiesNew.capabilitiesnew001
  *        nsk.jdwp.VirtualMachine.CapabilitiesNew.capabilitiesnew001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.CapabilitiesNew.capabilitiesnew001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/CapabilitiesNew/capabilitiesnew001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/CapabilitiesNew/capabilitiesnew001/TestDescription.java
@@ -48,8 +48,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.CapabilitiesNew.capabilitiesnew001
- *        nsk.jdwp.VirtualMachine.CapabilitiesNew.capabilitiesnew001a
+ * @build nsk.jdwp.VirtualMachine.CapabilitiesNew.capabilitiesnew001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.CapabilitiesNew.capabilitiesnew001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ClassPaths/classpaths001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ClassPaths/classpaths001/TestDescription.java
@@ -39,8 +39,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.ClassPaths.classpaths001
- *        nsk.jdwp.VirtualMachine.ClassPaths.classpaths001a
+ * @build nsk.jdwp.VirtualMachine.ClassPaths.classpaths001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.ClassPaths.classpaths001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ClassPaths/classpaths001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ClassPaths/classpaths001/TestDescription.java
@@ -41,7 +41,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.ClassPaths.classpaths001
  *        nsk.jdwp.VirtualMachine.ClassPaths.classpaths001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.ClassPaths.classpaths001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ClassesBySignature/classbysig001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ClassesBySignature/classbysig001/TestDescription.java
@@ -46,8 +46,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.ClassesBySignature.classbysig001
- *        nsk.jdwp.VirtualMachine.ClassesBySignature.classbysig001a
+ * @build nsk.jdwp.VirtualMachine.ClassesBySignature.classbysig001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.ClassesBySignature.classbysig001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ClassesBySignature/classbysig001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ClassesBySignature/classbysig001/TestDescription.java
@@ -48,7 +48,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.ClassesBySignature.classbysig001
  *        nsk.jdwp.VirtualMachine.ClassesBySignature.classbysig001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.ClassesBySignature.classbysig001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/CreateString/createstr001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/CreateString/createstr001/TestDescription.java
@@ -42,8 +42,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.CreateString.createstr001
- *        nsk.jdwp.VirtualMachine.CreateString.createstr001a
+ * @build nsk.jdwp.VirtualMachine.CreateString.createstr001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.CreateString.createstr001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/CreateString/createstr001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/CreateString/createstr001/TestDescription.java
@@ -44,7 +44,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.CreateString.createstr001
  *        nsk.jdwp.VirtualMachine.CreateString.createstr001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.CreateString.createstr001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Dispose/dispose001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Dispose/dispose001/TestDescription.java
@@ -52,7 +52,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.Dispose.dispose001
  *        nsk.jdwp.VirtualMachine.Dispose.dispose001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.Dispose.dispose001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Dispose/dispose001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Dispose/dispose001/TestDescription.java
@@ -50,8 +50,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.Dispose.dispose001
- *        nsk.jdwp.VirtualMachine.Dispose.dispose001a
+ * @build nsk.jdwp.VirtualMachine.Dispose.dispose001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.Dispose.dispose001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/DisposeObjects/disposeobj001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/DisposeObjects/disposeobj001/TestDescription.java
@@ -54,8 +54,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.DisposeObjects.disposeobj001
- *        nsk.jdwp.VirtualMachine.DisposeObjects.disposeobj001a
+ * @build nsk.jdwp.VirtualMachine.DisposeObjects.disposeobj001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.DisposeObjects.disposeobj001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/DisposeObjects/disposeobj001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/DisposeObjects/disposeobj001/TestDescription.java
@@ -56,7 +56,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.DisposeObjects.disposeobj001
  *        nsk.jdwp.VirtualMachine.DisposeObjects.disposeobj001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.DisposeObjects.disposeobj001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Exit/exit001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Exit/exit001/TestDescription.java
@@ -52,8 +52,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.Exit.exit001
- *        nsk.jdwp.VirtualMachine.Exit.exit001a
+ * @build nsk.jdwp.VirtualMachine.Exit.exit001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.Exit.exit001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Exit/exit001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Exit/exit001/TestDescription.java
@@ -54,7 +54,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.Exit.exit001
  *        nsk.jdwp.VirtualMachine.Exit.exit001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.Exit.exit001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/HoldEvents/holdevents001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/HoldEvents/holdevents001/TestDescription.java
@@ -53,7 +53,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.HoldEvents.holdevents001
  *        nsk.jdwp.VirtualMachine.HoldEvents.holdevents001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.HoldEvents.holdevents001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/HoldEvents/holdevents001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/HoldEvents/holdevents001/TestDescription.java
@@ -51,8 +51,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.HoldEvents.holdevents001
- *        nsk.jdwp.VirtualMachine.HoldEvents.holdevents001a
+ * @build nsk.jdwp.VirtualMachine.HoldEvents.holdevents001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.HoldEvents.holdevents001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/HoldEvents/holdevents002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/HoldEvents/holdevents002/TestDescription.java
@@ -54,7 +54,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.HoldEvents.holdevents002
  *        nsk.jdwp.VirtualMachine.HoldEvents.holdevents002a
- * @run main/othervm/timeout=420 PropertyResolvingWrapper
+ * @run main/othervm/timeout=420
  *      nsk.jdwp.VirtualMachine.HoldEvents.holdevents002
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/HoldEvents/holdevents002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/HoldEvents/holdevents002/TestDescription.java
@@ -52,8 +52,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.HoldEvents.holdevents002
- *        nsk.jdwp.VirtualMachine.HoldEvents.holdevents002a
+ * @build nsk.jdwp.VirtualMachine.HoldEvents.holdevents002a
  * @run main/othervm/timeout=420
  *      nsk.jdwp.VirtualMachine.HoldEvents.holdevents002
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/IDSizes/idsizes001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/IDSizes/idsizes001/TestDescription.java
@@ -41,7 +41,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.IDSizes.idsizes001
  *        nsk.jdwp.VirtualMachine.IDSizes.idsizes001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.IDSizes.idsizes001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/IDSizes/idsizes001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/IDSizes/idsizes001/TestDescription.java
@@ -39,8 +39,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.IDSizes.idsizes001
- *        nsk.jdwp.VirtualMachine.IDSizes.idsizes001a
+ * @build nsk.jdwp.VirtualMachine.IDSizes.idsizes001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.IDSizes.idsizes001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/InstanceCounts/instanceCounts001/instanceCounts001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/InstanceCounts/instanceCounts001/instanceCounts001.java
@@ -78,25 +78,28 @@
 
 package nsk.jdwp.VirtualMachine.InstanceCounts.instanceCounts001;
 
-import java.io.*;
 import nsk.share.Consts;
-import nsk.share.jdwp.*;
-import nsk.share.jpda.AbstractDebuggeeTest;
+import nsk.share.jdwp.CommandPacket;
+import nsk.share.jdwp.JDWP;
+import nsk.share.jdwp.ReplyPacket;
+import nsk.share.jdwp.TestDebuggerType1;
+
+import java.io.PrintStream;
 
 public class instanceCounts001 extends TestDebuggerType1 {
     protected String getDebugeeClassName() {
         return "nsk.jdwp.VirtualMachine.InstanceCounts.instanceCounts001.instanceCounts001a";
     }
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + Consts.JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
+    public static int run(String[] argv, PrintStream out) {
         return new instanceCounts001().runIt(argv, out);
     }
 
-    private void testCommand(long typeIDs[], int refTypesCount, int[] expectedInstanceCounts, boolean expectError, int errorCode) {
+    private void testCommand(long[] typeIDs, int refTypesCount, int[] expectedInstanceCounts, boolean expectError, int errorCode) {
         try {
             int JDWP_COMMAND_ID = JDWP.Command.VirtualMachine.InstanceCounts;
 
@@ -108,8 +111,9 @@ public class instanceCounts001 extends TestDebuggerType1 {
             CommandPacket command = new CommandPacket(JDWP_COMMAND_ID);
             command.addInt(refTypesCount);
 
-            for (int i = 0; i < refTypesCount; i++)
+            for (int i = 0; i < refTypesCount; i++) {
                 command.addReferenceTypeID(typeIDs[i]);
+            }
 
             command.setLength();
 
@@ -171,11 +175,11 @@ public class instanceCounts001 extends TestDebuggerType1 {
 
         int expectedCount = instanceCounts001a.expectedCount;
 
-        String classNames[];
+        String[] classNames;
 
-        classNames = new String[] { createTypeSignature(testClass1) };
+        classNames = new String[]{createTypeSignature(testClass1)};
 
-        long typeIDs[];
+        long[] typeIDs;
 
         typeIDs = new long[classNames.length];
 
@@ -183,9 +187,9 @@ public class instanceCounts001 extends TestDebuggerType1 {
         for (int i = 0; i < classNames.length; i++)
             typeIDs[i] = debuggee.getReferenceTypeID(classNames[i]);
 
-        testCommand(typeIDs, typeIDs.length, new int[] { expectedCount }, false, 0);
+        testCommand(typeIDs, typeIDs.length, new int[]{expectedCount}, false, 0);
 
-        classNames = new String[] { createTypeSignature(testClass1), createTypeSignature(testClass2) };
+        classNames = new String[]{createTypeSignature(testClass1), createTypeSignature(testClass2)};
 
         typeIDs = new long[classNames.length];
 
@@ -193,10 +197,10 @@ public class instanceCounts001 extends TestDebuggerType1 {
         for (int i = 0; i < classNames.length; i++)
             typeIDs[i] = debuggee.getReferenceTypeID(classNames[i]);
 
-        testCommand(typeIDs, typeIDs.length, new int[] { expectedCount, expectedCount }, false, 0);
+        testCommand(typeIDs, typeIDs.length, new int[]{expectedCount, expectedCount}, false, 0);
 
         // create command with refTypesCount < 0, expect ILLEGAL_ARGUMENT error
-        testCommand(typeIDs, -1, new int[] { expectedCount }, true, JDWP.Error.ILLEGAL_ARGUMENT);
+        testCommand(typeIDs, -1, new int[]{expectedCount}, true, JDWP.Error.ILLEGAL_ARGUMENT);
         resetStatusIfGC();
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/InstanceCounts/instanceCounts001/instanceCounts001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/InstanceCounts/instanceCounts001/instanceCounts001.java
@@ -67,7 +67,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.InstanceCounts.instanceCounts001.instanceCounts001
  *        nsk.jdwp.VirtualMachine.InstanceCounts.instanceCounts001.instanceCounts001a
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.jdwp.VirtualMachine.InstanceCounts.instanceCounts001.instanceCounts001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/InstanceCounts/instanceCounts001/instanceCounts001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/InstanceCounts/instanceCounts001/instanceCounts001.java
@@ -65,8 +65,7 @@
  * @requires !vm.graal.enabled
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.InstanceCounts.instanceCounts001.instanceCounts001
- *        nsk.jdwp.VirtualMachine.InstanceCounts.instanceCounts001.instanceCounts001a
+ * @build nsk.jdwp.VirtualMachine.InstanceCounts.instanceCounts001.instanceCounts001a
  * @run main/othervm/native
  *      nsk.jdwp.VirtualMachine.InstanceCounts.instanceCounts001.instanceCounts001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/RedefineClasses/redefinecls001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/RedefineClasses/redefinecls001/TestDescription.java
@@ -75,7 +75,7 @@
  *        nsk.jdwp.VirtualMachine.RedefineClasses.redefinecls001b
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.RedefineClasses.redefinecls001
  *      .
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/RedefineClasses/redefinecls001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/RedefineClasses/redefinecls001/TestDescription.java
@@ -70,8 +70,7 @@
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
  * @build ExecDriver
- * @build nsk.jdwp.VirtualMachine.RedefineClasses.redefinecls001
- *        nsk.jdwp.VirtualMachine.RedefineClasses.redefinecls001a
+ * @build nsk.jdwp.VirtualMachine.RedefineClasses.redefinecls001a
  *        nsk.jdwp.VirtualMachine.RedefineClasses.redefinecls001b
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ReleaseEvents/releaseevents001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ReleaseEvents/releaseevents001/TestDescription.java
@@ -57,7 +57,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents001
  *        nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ReleaseEvents/releaseevents001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ReleaseEvents/releaseevents001/TestDescription.java
@@ -55,8 +55,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents001
- *        nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents001a
+ * @build nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ReleaseEvents/releaseevents002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ReleaseEvents/releaseevents002/TestDescription.java
@@ -55,8 +55,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents002
- *        nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents002a
+ * @build nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents002a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents002
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ReleaseEvents/releaseevents002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/ReleaseEvents/releaseevents002/TestDescription.java
@@ -57,7 +57,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents002
  *        nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents002a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.ReleaseEvents.releaseevents002
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Resume/resume001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Resume/resume001/TestDescription.java
@@ -52,7 +52,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.Resume.resume001
  *        nsk.jdwp.VirtualMachine.Resume.resume001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.Resume.resume001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Resume/resume001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Resume/resume001/TestDescription.java
@@ -50,8 +50,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.Resume.resume001
- *        nsk.jdwp.VirtualMachine.Resume.resume001a
+ * @build nsk.jdwp.VirtualMachine.Resume.resume001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.Resume.resume001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/SetDefaultStratum/setdefstrat001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/SetDefaultStratum/setdefstrat001/TestDescription.java
@@ -53,8 +53,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.SetDefaultStratum.setdefstrat001
- *        nsk.jdwp.VirtualMachine.SetDefaultStratum.setdefstrat001a
+ * @build nsk.jdwp.VirtualMachine.SetDefaultStratum.setdefstrat001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.SetDefaultStratum.setdefstrat001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/SetDefaultStratum/setdefstrat001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/SetDefaultStratum/setdefstrat001/TestDescription.java
@@ -55,7 +55,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.SetDefaultStratum.setdefstrat001
  *        nsk.jdwp.VirtualMachine.SetDefaultStratum.setdefstrat001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.SetDefaultStratum.setdefstrat001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/TopLevelThreadGroups/threadgroups001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/TopLevelThreadGroups/threadgroups001/TestDescription.java
@@ -39,8 +39,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.TopLevelThreadGroups.threadgroups001
- *        nsk.jdwp.VirtualMachine.TopLevelThreadGroups.threadgroups001a
+ * @build nsk.jdwp.VirtualMachine.TopLevelThreadGroups.threadgroups001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.TopLevelThreadGroups.threadgroups001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/TopLevelThreadGroups/threadgroups001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/TopLevelThreadGroups/threadgroups001/TestDescription.java
@@ -41,7 +41,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.TopLevelThreadGroups.threadgroups001
  *        nsk.jdwp.VirtualMachine.TopLevelThreadGroups.threadgroups001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.TopLevelThreadGroups.threadgroups001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Version/version001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Version/version001/TestDescription.java
@@ -38,8 +38,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.Version.version001
- *        nsk.jdwp.VirtualMachine.Version.version001a
+ * @build nsk.jdwp.VirtualMachine.Version.version001a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.Version.version001
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Version/version001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Version/version001/TestDescription.java
@@ -40,7 +40,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.Version.version001
  *        nsk.jdwp.VirtualMachine.Version.version001a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.Version.version001
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Version/version002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Version/version002/TestDescription.java
@@ -39,8 +39,7 @@
  *
  * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
  *          /test/lib
- * @build nsk.jdwp.VirtualMachine.Version.version002
- *        nsk.jdwp.VirtualMachine.Version.version002a
+ * @build nsk.jdwp.VirtualMachine.Version.version002a
  * @run main/othervm
  *      nsk.jdwp.VirtualMachine.Version.version002
  *      -arch=${os.family}-${os.simpleArch}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Version/version002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/VirtualMachine/Version/version002/TestDescription.java
@@ -41,7 +41,7 @@
  *          /test/lib
  * @build nsk.jdwp.VirtualMachine.Version.version002
  *        nsk.jdwp.VirtualMachine.Version.version002a
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.jdwp.VirtualMachine.Version.version002
  *      -arch=${os.family}-${os.simpleArch}
  *      -verbose


### PR DESCRIPTION
the patch removes `PropertyResolvingWrapper` from `vmTestbase/nsk/jdwp` tests and cleans up/reformats the touched files.

testing:  ✅ `vmTestbase/nsk/jdwp` on `{linux,windows,macos}-x64`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252002](https://bugs.openjdk.java.net/browse/JDK-8252002): remove usage of PropertyResolvingWrapper in vmTestbase/nsk/jdwp


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/351/head:pull/351`
`$ git checkout pull/351`
