### PR TITLE
8253611: AArch64: Concurrency problems in JavaFrameAnchor

### DIFF
--- a/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
@@ -66,8 +66,8 @@ public:
 
   // last_Java_sp is acting, among other things, as the acquire/release target:
   // when last_Java_sp is not NULL, has_last_frame() is true, and the rest of
-  // the frame has to be valid. This means the reads of last_Java_sp should be
-  // first and acquiring, and last_Java_sp stores should be last and releasing.
+  // the frame has to be valid. This means last_Java_sp loads should be first
+  // and acquiring, and last_Java_sp stores should be last and releasing.
   // Additionally, resets of the frame should be as prompt as possible, therefore
   // we got to "flush" it with trailing fences.
 

--- a/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
@@ -72,16 +72,14 @@ public:
   // we got to "flush" it with trailing fences.
 
   intptr_t* last_Java_sp(void) const {
-    intptr_t* sp = _last_Java_sp;
-    OrderAccess::acquire();
-    return sp;
+    return Atomic::load_acquire(&_last_Java_sp);
   }
 
   void set_last_Java_sp(intptr_t* sp) {
-    OrderAccess::release();
-    _last_Java_sp = sp;
-    if (sp == NULL) {
-      OrderAccess::fence();
+    if (sp != NULL) {
+      Atomic::release_store(&_last_Java_sp, sp);
+    } else {
+      Atomic::release_store_fence(&_last_Java_sp, sp);
     }
   }
 

--- a/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
@@ -36,8 +36,7 @@ private:
 
 public:
   void clear(void) {
-    // clearing _last_Java_sp must be first
-    reset_last_Java_sp();
+    set_last_Java_sp(NULL);
     _last_Java_fp = NULL;
     _last_Java_pc = NULL;
   }
@@ -51,7 +50,7 @@ public:
     // unless the value is changing
     //
     if (last_Java_fp() != src->_last_Java_sp) {
-      reset_last_Java_sp();
+      set_last_Java_sp(NULL);
     }
     _last_Java_fp = src->_last_Java_fp;
     _last_Java_pc = src->_last_Java_pc;
@@ -79,18 +78,11 @@ public:
   }
 
   void set_last_Java_sp(intptr_t* sp) {
-    if (sp != NULL) {
-      OrderAccess::release();
-      _last_Java_sp = sp;
-    } else {
-      reset_last_Java_sp();
-    }
-  }
-
-  void reset_last_Java_sp() {
     OrderAccess::release();
-    _last_Java_sp = NULL;
-    OrderAccess::fence();
+    _last_Java_sp = sp;
+    if (sp == NULL) {
+      OrderAccess::fence();
+    }
   }
 
   intptr_t* last_Java_fp(void) { return _last_Java_fp; }

--- a/src/hotspot/share/runtime/javaFrameAnchor.hpp
+++ b/src/hotspot/share/runtime/javaFrameAnchor.hpp
@@ -73,11 +73,11 @@ friend class JavaCallWrapper;
   // It is important that when last_Java_sp != NULL that the rest of the frame
   // anchor (including platform specific) all be valid.
 
-  bool has_last_Java_frame() const                   { return _last_Java_sp != NULL; }
+  bool has_last_Java_frame() const                   { return last_Java_sp() != NULL; }
   // This is very dangerous unless sp == NULL
   // Invalidate the anchor so that has_last_frame is false
   // and no one should look at the other fields.
-  void zap(void)                                     { _last_Java_sp = NULL; }
+  void zap(void)                                     { set_last_Java_sp(NULL); }
 
 #include CPU_HEADER(javaFrameAnchor)
 

--- a/src/hotspot/share/runtime/javaFrameAnchor.hpp
+++ b/src/hotspot/share/runtime/javaFrameAnchor.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_RUNTIME_JAVAFRAMEANCHOR_HPP
 #define SHARE_RUNTIME_JAVAFRAMEANCHOR_HPP
 
+#include "runtime/atomic.hpp"
 #include "runtime/orderAccess.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"


### PR DESCRIPTION
It looks that `_last_Java_sp` is additionally used as acquire/release flag that guards the rest of the state. Yet, the coding in `javaFrameAnchor_aarch64.hpp` is incorrect at least in one place:

```
    _last_Java_fp = src->_last_Java_fp;
    _last_Java_pc = src->_last_Java_pc;
    // Must be last so profiler will always see valid frame if has_last_frame() is true
    _last_Java_sp = src->_last_Java_sp;
```

There should be `OrderAccess::release()` where the comment suggesting the ordering constraint actually is -- I believe that is a copy-paste error from x86. Other platforms have `release` thre. Additionally, it has to be matched with `OrderAccess::acquire()` before `_last_Java_sp` reads, which requires the shared code to use the platform-specific getter.

Testing:
  - [x] Linux x86_64 tier1
  - [x] Linux AArch64 tier1
  - [x] Linux AArch64 tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253611](https://bugs.openjdk.java.net/browse/JDK-8253611): AArch64: Concurrency problems in JavaFrameAnchor


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)
 * aph - **Reviewer** ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/352/head:pull/352`
`$ git checkout pull/352`
