### PR TITLE
8253631: Remove unimplemented CompileBroker methods after JEP-165

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -271,10 +271,6 @@ class CompileBroker: AllStatic {
   static void shutdown_compiler_runtime(AbstractCompiler* comp, CompilerThread* thread);
 
 public:
-
-  static DirectivesStack* dirstack();
-  static void set_dirstack(DirectivesStack* stack);
-
   enum {
     // The entry bci used for non-OSR compilations.
     standard_entry_bci = InvocationEntryBci
@@ -289,7 +285,6 @@ public:
   static bool compilation_is_complete(const methodHandle& method, int osr_bci, int comp_level);
   static bool compilation_is_in_queue(const methodHandle& method);
   static void print_compile_queues(outputStream* st);
-  static void print_directives(outputStream* st);
   static int queue_size(int comp_level) {
     CompileQueue *q = compile_queue(comp_level);
     return q != NULL ? q->size() : 0;


### PR DESCRIPTION
It would seem that JEP-175 implementation task (JDK-8137167) introduced declarations without any implementations in CompilerBroker:

```
  static DirectivesStack* dirstack();
  static void set_dirstack(DirectivesStack* stack);
  static void print_directives(outputStream* st);
```

This can be cleaned up.

Testing:
  - [x] Linux x86_64 fastdebug build
  - [x] Text searches for `dirstack` and `print_directives` in `src/hotspot`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253631](https://bugs.openjdk.java.net/browse/JDK-8253631): Remove unimplemented CompileBroker methods after JEP-165


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/353/head:pull/353`
`$ git checkout pull/353`
