### PR TITLE
8253624: gtest fails when run from make with read-only source directory

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -609,6 +609,7 @@ define SetupRunGtestTestBody
 	$$(call LogWarn, Running test '$$($1_TEST)')
 	$$(call MakeDir, $$($1_TEST_RESULTS_DIR) $$($1_TEST_SUPPORT_DIR))
 	$$(call ExecuteWithLog, $$($1_TEST_SUPPORT_DIR)/gtest, ( \
+	    $$(CD) $$($1_TEST_SUPPORT_DIR) && \
 	    $$(FIXPATH) $$(TEST_IMAGE_DIR)/hotspot/gtest/$$($1_VARIANT)/gtestLauncher \
 	        -jdk $(JDK_UNDER_TEST) $$($1_GTEST_FILTER) \
 	        --gtest_output=xml:$$($1_TEST_RESULTS_DIR)/gtest.xml \


### PR DESCRIPTION
In an out-of-tree build where the source code is in a read-only location
several gtests such as LogFileOutput.invalid_file_test_vm will fail
because they write files to the current working directory.

```
  [ RUN ] LogFileOutput.invalid_file_test_vm
  # To suppress the following error report, specify this argument
  # after -XX: or in .hotspotrc: SuppressErrorAt=/logTestUtils.inline.hpp:65
  assert failed: failed to create directory tmplogdir
  #
  # A fatal error has been detected by the Java Runtime Environment:
  #
  # Internal Error (/mnt/nicgas01-pc/jdk/test/hotspot/gtest/logging/logTestUtils.inline.hpp:65), pid=51470, tid=51470
  # assert(!failed) failed: failed to create directory tmplogdir
```

Run the gtest launcher with the working directory set to the test
support directory which we know is writable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253624](https://bugs.openjdk.java.net/browse/JDK-8253624): gtest fails when run from make with read-only source directory


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/354/head:pull/354`
`$ git checkout pull/354`
