### PR TITLE
8253633: Remove unimplemented TieredThresholdPolicy::set_carry_if_neccessary

### DIFF
--- a/src/hotspot/share/compiler/tieredThresholdPolicy.hpp
+++ b/src/hotspot/share/compiler/tieredThresholdPolicy.hpp
@@ -166,8 +166,6 @@ class TieredThresholdPolicy : public CompilationPolicy {
   jlong _start_time;
   int _c1_count, _c2_count;
 
-  // Check if the counter is big enough and set carry (effectively infinity).
-  inline void set_carry_if_necessary(InvocationCounter *counter);
   // Set carry flags in the counters (in Method* and MDO).
   inline void handle_counter_overflow(Method* method);
   // Verify that a level is consistent with the compilation mode


### PR DESCRIPTION
The definition seems to be removed with JDK-8203883, but the declaration was left behind.

Testing:
 - [x] Linux x86_64 fastdebug build
 - [x] Text search for `set_carry_if_necessary` in `src/hotspot`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253633](https://bugs.openjdk.java.net/browse/JDK-8253633): Remove unimplemented TieredThresholdPolicy::set_carry_if_necessary ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/355/head:pull/355`
`$ git checkout pull/355`
