### PR TITLE
8253588: C1: assert(false) failed: unknown register on x86_32 only with -XX:+TraceLinearScanLevel=4

### DIFF
--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -5436,7 +5436,7 @@ bool LinearScanWalker::alloc_free_reg(Interval* cur) {
     hint_reg = register_hint->assigned_reg();
     hint_regHi = register_hint->assigned_regHi();
 
-    if (allocator()->is_precolored_cpu_interval(register_hint)) {
+    if (_num_phys_regs == 2 && allocator()->is_precolored_cpu_interval(register_hint)) {
       assert(hint_reg != any_reg && hint_regHi == any_reg, "must be for fixed intervals");
       hint_regHi = hint_reg + 1;  // connect e.g. eax-edx
     }


### PR DESCRIPTION
[JDK-8251093](https://bugs.openjdk.java.net/browse/JDK-8251093) introduced some additional logging of intervals and its registers in various places. On 32-bit only, we could have two registers for an interval. A hi-register is only used when the interval has `_num_phys_regs` set to 2. In one such place ([L5448](https://github.com/chhagedorn/jdk/blob/29ed779487bad3c359fb13dfad3f41832637a470/src/hotspot/share/c1/c1_LinearScan.cpp#L5448)), we log the hi-register `hint_regHi`. On [L5441](https://github.com/chhagedorn/jdk/blob/29ed779487bad3c359fb13dfad3f41832637a470/src/hotspot/share/c1/c1_LinearScan.cpp#L5441), however, we can assign it an invalid register number when `_num_phys_regs` is 1. That was not a problem before JDK-8251093 as we only used `hint_regHi` later after a `_num_phys_regs == 2` check on [L5484](https://github.com/chhagedorn/jdk/blob/29ed779487bad3c359fb13dfad3f41832637a470/src/hotspot/share/c1/c1_LinearScan.cpp#L5484). But the additional logging is performed earlier resulting in this assertion failure when trying to log the invalid `hint_regHi` register.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253588](https://bugs.openjdk.java.net/browse/JDK-8253588): C1: assert(false) failed: unknown register on x86_32 only with -XX:+TraceLinearScanLevel=4


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/356/head:pull/356`
`$ git checkout pull/356`
