### PR TITLE
8253900: SA: wrong size computation when JVM was built without AOT

### DIFF
--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -229,6 +229,7 @@
   JVMTI_ONLY(nonstatic_field(MethodCounters,   _number_of_breakpoints,                        u2))                                   \
   nonstatic_field(MethodCounters,              _invocation_counter,                           InvocationCounter)                     \
   nonstatic_field(MethodCounters,              _backedge_counter,                             InvocationCounter)                     \
+  AOT_ONLY(nonstatic_field(MethodCounters,     _method,                                       Method*))                              \
                                                                                                                                      \
   nonstatic_field(MethodData,                  _size,                                         int)                                   \
   nonstatic_field(MethodData,                  _method,                                       Method*)                               \

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -296,6 +296,7 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   JVMTI_ONLY(nonstatic_field(MethodCounters,   _number_of_breakpoints,                        u2))                                   \
   nonstatic_field(MethodCounters,              _invocation_counter,                           InvocationCounter)                     \
   nonstatic_field(MethodCounters,              _backedge_counter,                             InvocationCounter)                     \
+  AOT_ONLY(nonstatic_field(MethodCounters,     _method,                                       Method*))                              \
   nonstatic_field(Method,                      _constMethod,                                  ConstMethod*)                          \
   nonstatic_field(Method,                      _method_data,                                  MethodData*)                           \
   nonstatic_field(Method,                      _method_counters,                              MethodCounters*)                       \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
@@ -316,6 +316,11 @@ public class InstanceKlass extends Klass {
   }
 
   public boolean hasStoredFingerprint() {
+    // has_stored_fingerprint() @ instanceKlass.cpp can return true only if INCLUDE_AOT is
+    // set during compilation.
+    if (!VM.getVM().hasAOT()) {
+      return false;
+    }
     return shouldStoreFingerprint() || isShared();
   }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -89,6 +89,8 @@ public class VM {
   private FileMapInfo  fileMapInfo;
   private Bytes        bytes;
 
+  /** Flag indicating if AOT is enabled in the build */
+  private boolean      hasAOT;
   /** Flag indicating if JVMTI support is included in the build */
   private boolean      isJvmtiSupported;
   /** Flags indicating whether we are attached to a core, C1, or C2 build */
@@ -443,6 +445,16 @@ public class VM {
     checkVMVersion(vmRelease);
 
     invocationEntryBCI = db.lookupIntConstant("InvocationEntryBci").intValue();
+
+    // We infer AOT if _method @ methodCounters is declared.
+    {
+      Type type = db.lookupType("MethodCounters");
+      if (type.getField("_method", false, false) == null) {
+        hasAOT = false;
+      } else {
+        hasAOT = true;
+      }
+    }
 
     // We infer the presence of JVMTI from the presence of the InstanceKlass::_breakpoints field.
     {
@@ -827,6 +839,11 @@ public class VM {
   /** Returns true if this is a isBigEndian, false otherwise */
   public boolean isBigEndian() {
     return isBigEndian;
+  }
+
+  /** Returns true if AOT is enabled, false otherwise */
+  public boolean hasAOT() {
+    return hasAOT;
   }
 
   /** Returns true if JVMTI is supported, false otherwise */

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -92,8 +92,6 @@ runtime/ReservedStack/ReservedStackTest.java 8231031 generic-all
 # :hotspot_serviceability
 
 serviceability/sa/sadebugd/DebugdConnectTest.java 8239062 macosx-x64
-serviceability/sa/TestInstanceKlassSize.java 8230664 linux-ppc64le,linux-ppc64
-serviceability/sa/TestInstanceKlassSizeForInterface.java 8230664 linux-ppc64le,linux-ppc64
 serviceability/sa/TestRevPtrsForInvokeDynamic.java 8241235 generic-all
 
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatIntervalTest.java 8214032 generic-all

--- a/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSize.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSize.java
@@ -107,7 +107,7 @@ public class TestInstanceKlassSize {
                 for (String s : output.asLines()) {
                     if (s.contains(instanceKlassName)) {
                        Asserts.assertTrue(
-                          s.contains(size), "The size computed by SA for" +
+                          s.contains(size), "The size computed by SA for " +
                           instanceKlassName + " does not match.");
                        match = true;
                     }


### PR DESCRIPTION
TestInstanceKlassSize was failing because, for PowerPC, the following code (instanceKlass.cpp) always compiles to `return false;`
```
bool InstanceKlass::has_stored_fingerprint() const {
#if INCLUDE_AOT
  return should_store_fingerprint() || is_shared();
#else
  return false;
#endif
}
```
However, in `hasStoredFingerprint()@InstanceKlass.java` the condition `shouldStoreFingerprint() || isShared();` is always evaluated and may return true (_AFAIK isShared() returns true_). Such condition adds 8 bytes in the `getSize()@InstanceKlass.java` causing the failure in TestInstanceKlassSize:
```
public long getSize() { // in number of bytes
  ...
  if (hasStoredFingerprint()) {
    size += 8; // uint64_t
  }
  return alignSize(size);
}
```
Considering these tests are failing for PowerPC only (_based on ProblemList.txt_), my solution checks if `hasStoredFingerprint()` is running on a PowerPC platform. I decided to go this way because there is no existing flag informing whether AOT is included or not and creating a new one just to handle the PowerPC case seems too much.

This patch is an attempt to fix https://bugs.openjdk.java.net/browse/JDK-8230664

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8253900](https://bugs.openjdk.java.net/browse/JDK-8253900): SA: wrong size computation when JVM was built without AOT


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/358/head:pull/358`
`$ git checkout pull/358`
