### PR TITLE
8253647: Remove dead code in os::create_thread() on Linux/BSD

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -782,13 +782,6 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
 
   }
 
-  // Aborted due to thread limit being reached
-  if (state == ZOMBIE) {
-    thread->set_osthread(NULL);
-    delete osthread;
-    return false;
-  }
-
   // The thread is returned suspended (in state INITIALIZED),
   // and is started higher up in the call chain
   assert(state == INITIALIZED, "race condition");

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -978,13 +978,6 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
     }
   }
 
-  // Aborted due to thread limit being reached
-  if (state == ZOMBIE) {
-    thread->set_osthread(NULL);
-    delete osthread;
-    return false;
-  }
-
   // The thread is returned suspended (in state INITIALIZED),
   // and is started higher up in the call chain
   assert(state == INITIALIZED, "race condition");


### PR DESCRIPTION
Please review this small patch to remove dead code that is left behind by JDK-8078513.

Test:
- [x] tier1 on Linux 86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253647](https://bugs.openjdk.java.net/browse/JDK-8253647): Remove dead code in os::create_thread() on Linux/BSD


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/361/head:pull/361`
`$ git checkout pull/361`
