### PR TITLE
8241151: Incorrect lint warning for no definition of serialVersionUID in a record

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5348,8 +5348,8 @@ public class Attr extends JCTree.Visitor {
             }
 
             if (svuid == null) {
-                log.warning(LintCategory.SERIAL,
-                        tree.pos(), Warnings.MissingSVUID(c));
+                if (!c.isRecord())
+                    log.warning(LintCategory.SERIAL, tree.pos(), Warnings.MissingSVUID(c));
                 return;
             }
 

--- a/test/langtools/tools/javac/records/RecordCompilationTests.java
+++ b/test/langtools/tools/javac/records/RecordCompilationTests.java
@@ -145,8 +145,10 @@ public class RecordCompilationTests extends CompilationTestCase {
         }
     }
 
+    boolean useAP;
+
     public RecordCompilationTests() {
-        boolean useAP = System.getProperty("useAP") == null ? false : System.getProperty("useAP").equals("true");
+        useAP = System.getProperty("useAP") == null ? false : System.getProperty("useAP").equals("true");
         setDefaultFilename("R.java");
         setCompileOptions(useAP ? PREVIEW_OPTIONS_WITH_AP : PREVIEW_OPTIONS);
         System.out.println(useAP ? "running all tests using an annotation processor" : "running all tests without annotation processor");
@@ -1663,5 +1665,21 @@ public class RecordCompilationTests extends CompilationTestCase {
                 record R<T>(T t[]) {}
                 """
         );
+    }
+
+    public void testNoWarningForSerializableRecords() {
+        if (!useAP) {
+            /* dont execute this test when the default annotation processor is on as it will fail due to
+             * spurious warnings
+             */
+            appendCompileOptions("-Werror", "-Xlint:serial");
+            assertOK(
+                    """
+                    import java.io.*;
+                    record R() implements java.io.Serializable {}
+                    """
+            );
+            removeLastCompileOptions(2);
+        }
     }
 }

--- a/test/langtools/tools/javac/records/RecordCompilationTests.java
+++ b/test/langtools/tools/javac/records/RecordCompilationTests.java
@@ -26,7 +26,7 @@
 /**
  * RecordCompilationTests
  *
- * @test 8250629 8252307 8247352
+ * @test 8250629 8252307 8247352 8241151
  * @summary Negative compilation tests, and positive compilation (smoke) tests for records
  * @library /lib/combo /tools/lib /tools/javac/lib
  * @modules
@@ -148,7 +148,7 @@ public class RecordCompilationTests extends CompilationTestCase {
     boolean useAP;
 
     public RecordCompilationTests() {
-        useAP = System.getProperty("useAP") == null ? false : System.getProperty("useAP").equals("true");
+        useAP = System.getProperty("useAP", "false").equals("true");
         setDefaultFilename("R.java");
         setCompileOptions(useAP ? PREVIEW_OPTIONS_WITH_AP : PREVIEW_OPTIONS);
         System.out.println(useAP ? "running all tests using an annotation processor" : "running all tests without annotation processor");


### PR DESCRIPTION
Co-authored-by: Bernard Blaser <bsrbnd@gmail.com>
Co-authored-by: Vicente Romero <vicente.romero@oracle.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241151](https://bugs.openjdk.java.net/browse/JDK-8241151): Incorrect lint warning for no definition of serialVersionUID in a record


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Contributors
 * Bernard Blaser `<bsrbnd@gmail.com>`
 * Vicente Romero `<vicente.romero@oracle.com>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/363/head:pull/363`
`$ git checkout pull/363`
