### PR TITLE
8253548: jvmFlagAccess.cpp: clang 9.0.0 format specifier error

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
@@ -247,7 +247,7 @@ public:
     st->print("[ " SIZE_FORMAT_W(-25) " ... " SIZE_FORMAT_W(25) " ]", min, max);
   }
   void print_default_range(outputStream* st) const {
-    st->print("[ " SIZE_FORMAT_W(-25) " ... " SIZE_FORMAT_W(25) " ]", size_t(0), SIZE_MAX);
+    st->print("[ " SIZE_FORMAT_W(-25) " ... " SIZE_FORMAT_W(25) " ]", size_t(0), size_t(SIZE_MAX));
   }
 };
 


### PR DESCRIPTION
Please review this trivial fix for older clang compiler printf format warning. As mentioned on [JDK-8253548](https://bugs.openjdk.java.net/browse/JDK-8253548), these's an existing typecast in [logFileOutput.cpp](
https://github.com/openjdk/jdk/blame/efd10546865998028aa6d34cf939ca0de67a90fc/hotspot/src/share/vm/logging/logFileOutput.cpp#L194) for the same reason that SIZE_MAX is not actually of the size_t type for older clang compilers.

Testing with mach5 tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253548](https://bugs.openjdk.java.net/browse/JDK-8253548): jvmFlagAccess.cpp: clang 9.0.0 format specifier error


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/365/head:pull/365`
`$ git checkout pull/365`
