### PR TITLE
8253637: Update EC removal

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -207,9 +207,20 @@ public class AlgorithmId implements Serializable, DerEncoder {
                 bytes.putNull();
             }*/
             if (algid.equals(RSASSA_PSS_oid) || algid.equals(ed448_oid)
-                    || algid.equals(ed25519_oid)) {
+                    || algid.equals(ed25519_oid)
+                    || algid.equals(x448_oid)
+                    || algid.equals(x25519_oid)
+                    || algid.equals(SHA224withECDSA_oid)
+                    || algid.equals(SHA256withECDSA_oid)
+                    || algid.equals(SHA384withECDSA_oid)
+                    || algid.equals(SHA512withECDSA_oid)) {
                 // RFC 4055 3.3: when an RSASSA-PSS key does not require
                 // parameter validation, field is absent.
+                // RFC 8410 3: for id-X25519, id-X448, id-Ed25519, and
+                // id-Ed448, the parameters must be absent.
+                // RFC 5758 3.2: the encoding must omit the parameters field
+                // for ecdsa-with-SHA224, ecdsa-with-SHA256, ecdsa-with-SHA384
+                // and ecdsa-with-SHA512.
             } else {
                 bytes.putNull();
             }
@@ -643,6 +654,20 @@ public class AlgorithmId implements Serializable, DerEncoder {
             ObjectIdentifier.of(KnownOIDs.Ed25519);
     public static final ObjectIdentifier ed448_oid =
             ObjectIdentifier.of(KnownOIDs.Ed448);
+
+    public static final ObjectIdentifier x25519_oid =
+            ObjectIdentifier.of(KnownOIDs.X25519);
+    public static final ObjectIdentifier x448_oid =
+            ObjectIdentifier.of(KnownOIDs.X448);
+
+    public static final ObjectIdentifier SHA224withECDSA_oid =
+            ObjectIdentifier.of(KnownOIDs.SHA224withECDSA);
+    public static final ObjectIdentifier SHA256withECDSA_oid =
+            ObjectIdentifier.of(KnownOIDs.SHA256withECDSA);
+    public static final ObjectIdentifier SHA384withECDSA_oid =
+            ObjectIdentifier.of(KnownOIDs.SHA384withECDSA);
+    public static final ObjectIdentifier SHA512withECDSA_oid =
+            ObjectIdentifier.of(KnownOIDs.SHA512withECDSA);
 
     /**
      * Creates a signature algorithm name from a digest algorithm

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
@@ -170,9 +170,10 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
         byte[] result;
         Optional<byte[]> resultOpt = deriveKeyImpl(privateKey, publicKey);
         if (resultOpt.isEmpty()) {
+            NamedCurve nc = CurveDB.lookup(publicKey.getParams());
             throw new IllegalStateException(
                 new InvalidAlgorithmParameterException("Curve not supported: " +
-                    publicKey.getParams().toString()));
+                    (nc != null ? nc.toString() : "unknown")));
         }
         result = resultOpt.get();
         publicKey = null;

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -704,7 +704,6 @@ javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
-sun/security/ec/TestEC.java                                     8253637 linux-aarch64
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -42,7 +42,7 @@
 # List items are testnames followed by labels, all MUST BE commented
 #   as to why they are here and use a label:
 #     generic-all   Problems on all platforms
-#     generic-ARCH  Where ARCH is one of: x64, i586, ppc64, ppc64le, s390x etc.
+#     generic-ARCH  Where ARCH is one of: x64, i586, ppc64, ppc64le, s390x, aarch64 etc.
 #     OSNAME-all    Where OSNAME is one of: linux, windows, macosx, aix
 #     OSNAME-ARCH   Specific on to one OSNAME and ARCH, e.g. macosx-x64
 #     OSNAME-REV    Specific on to one OSNAME and REV, e.g. macosx-10.7.4
@@ -704,6 +704,7 @@ javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
+sun/security/ec/TestEC.java                                     8253637 linux-aarch64
 
 ############################################################################
 

--- a/test/jdk/sun/security/ec/TestEC.java
+++ b/test/jdk/sun/security/ec/TestEC.java
@@ -37,8 +37,9 @@
  * @library ../../../java/security/testlibrary
  * @library ../../../javax/net/ssl/TLSCommon
  * @modules jdk.crypto.cryptoki/sun.security.pkcs11.wrapper
- * @run main/othervm -Djdk.tls.namedGroups="secp256r1,sect193r1" -Djdk.sunec.disableNative=false TestEC
- * @run main/othervm -Djava.security.policy=TestEC.policy -Djdk.tls.namedGroups="secp256r1,sect193r1" -Djdk.sunec.disableNative=false TestEC
+ * @run main/othervm -Djdk.tls.namedGroups="secp256r1" TestEC
+ * @run main/othervm -Djava.security.policy=TestEC.policy
+ *    -Djdk.tls.namedGroups="secp256r1" TestEC
  */
 
 import java.security.NoSuchProviderException;

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -96,7 +96,7 @@ public abstract class PKCS11Test {
     // NSS version info
     public static enum ECCState { None, Basic, Extended };
     static double nss_version = -1;
-    static ECCState nss_ecc_status = ECCState.Extended;
+    static ECCState nss_ecc_status = ECCState.Basic;
 
     // The NSS library we need to search for in getNSSLibDir()
     // Default is "libsoftokn3.so", listed as "softokn3"

--- a/test/jdk/sun/security/x509/AlgorithmId/OmitAlgIdParam.java
+++ b/test/jdk/sun/security/x509/AlgorithmId/OmitAlgIdParam.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8252377
+ * @library /test/lib
+ * @modules java.base/sun.security.util
+ *          java.base/sun.security.x509
+ * @summary The AlgorithmIdentifier for ECDSA should omit the parameters field
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.SecurityTools;
+import jdk.test.lib.process.OutputAnalyzer;
+import static jdk.test.lib.security.DerUtils.*;
+
+import java.io.File;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import sun.security.util.*;
+
+public class OmitAlgIdParam {
+
+    public static void main(String[] args) throws Exception {
+        keytool("-genkeypair -keyalg ec -dname CN=EC1 -alias ecsha224 "
+                + "-sigalg SHA224withECDSA -keystore ks -storepass changeit");
+
+        keytool("-genkeypair -keyalg ec -dname CN=EC2 -alias ecsha256 "
+                + "-sigalg SHA256withECDSA -keystore ks -storepass changeit");
+
+        keytool("-genkeypair -keyalg ec -dname CN=EC3 -alias ecsha384 "
+                + "-sigalg SHA384withECDSA -keystore ks -storepass changeit");
+
+        keytool("-genkeypair -keyalg ec -dname CN=EC4 -alias ecsha512 "
+                + "-sigalg SHA512withECDSA -keystore ks -storepass changeit");
+
+        KeyStore kstore = KeyStore.getInstance(
+                new File("ks"), "changeit".toCharArray());
+
+        // SHA224withECDSA
+        checkAlgId(kstore, "ecsha224", "SHA224withECDSA",
+                ObjectIdentifier.of(KnownOIDs.SHA224withECDSA));
+
+        // SHA256withECDSA
+        checkAlgId(kstore, "ecsha256", "SHA256withECDSA",
+                ObjectIdentifier.of(KnownOIDs.SHA256withECDSA));
+
+        // SHA384withECDSA
+        checkAlgId(kstore, "ecsha384", "SHA384withECDSA",
+                ObjectIdentifier.of(KnownOIDs.SHA384withECDSA));
+
+        // SHA512withECDSA
+        checkAlgId(kstore, "ecsha512", "SHA512withECDSA",
+                ObjectIdentifier.of(KnownOIDs.SHA512withECDSA));
+    }
+
+    private static void checkAlgId(KeyStore ks, String alias, String alg,
+            ObjectIdentifier oid) throws Exception {
+        X509Certificate cert = (X509Certificate)ks.getCertificate(alias);
+        System.out.println("SigAlgName = " + cert.getSigAlgName());
+
+        Asserts.assertEQ(cert.getPublicKey().getAlgorithm(), "EC");
+        Asserts.assertEQ(cert.getSigAlgName(), alg);
+
+        byte[] data = cert.getEncoded();
+        // Parameters field in the specified AlgorithmIdentifier should be omitted
+        // Checking the first signature AlgorithmIdentifier in the cert
+        checkAlg(data, "020", oid);
+        shouldNotExist(data, "021");
+        // Checking the second signature AlgorithmIdentifier in the cert
+        checkAlg(data, "10", oid);
+        shouldNotExist(data, "11");
+    }
+
+    static OutputAnalyzer keytool(String cmd) throws Exception {
+        return SecurityTools.keytool(cmd).shouldHaveExitValue(0);
+    }
+}


### PR DESCRIPTION
Hi,

I need a quick review for two changes.  The primary is a failure that shows up on linux-aarch64 because the systems do not have NSS.  The default was to allow all curves tested, which before the native library removal was ok.  The second was a missed changeset that got left in the local repo that helped find the curve name on an exception message.

Thanks

Tony

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253637](https://bugs.openjdk.java.net/browse/JDK-8253637): Update EC removal


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/366/head:pull/366`
`$ git checkout pull/366`
