### PR TITLE
8253660: Need better error report when artifact resolution fails in AotCompiler.java

### DIFF
--- a/test/hotspot/jtreg/compiler/aot/AotCompiler.java
+++ b/test/hotspot/jtreg/compiler/aot/AotCompiler.java
@@ -268,6 +268,7 @@ public class AotCompiler {
             }
         } catch (ArtifactResolverException e) {
             System.err.println("artifact resolution error: " + e);
+            e.printStackTrace(System.err);
             // let jaotc try to find linker
             return null;
         }

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -853,7 +853,7 @@ public abstract class PKCS11Test {
                         + "please check if JIB jar is present in classpath.");
             } else {
                 throw new RuntimeException("Fetch artifact failed: " + clazz
-                        + "\nPlease make sure the artifact is available.");
+                        + "\nPlease make sure the artifact is available.", e);
             }
         }
         Policy.setPolicy(null); // Clear the policy created by JIB if any

--- a/test/lib/jdk/test/lib/artifacts/ArtifactResolverException.java
+++ b/test/lib/jdk/test/lib/artifacts/ArtifactResolverException.java
@@ -12,4 +12,16 @@ public class ArtifactResolverException extends Exception {
     public ArtifactResolverException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    public String toString() {
+        return super.toString() + ": " + getRootCause().toString();
+    }
+
+    public Throwable getRootCause() {
+        Throwable rootCause = getCause();
+        while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+            rootCause = rootCause.getCause();
+        }
+        return rootCause;
+    }
 }


### PR DESCRIPTION
In AotCompiler.java, if artifact resolution fails, we have no way of diagnosing the error. This patch improves the default toString() of ArtifactResolverException to automatically include the toString() method of the root cause. It also adds stack trace printing specifically in AotCompiler.java. 

I also found a similar issue in PKCS11Test, and fixed it by adding the ArtifactResolverException there as cause for the RuntimeException being thrown. This causes the stack trace to be printed on failure.

I looked through all other uses of ArtifactResolver, but they are handling the exception in a way that already prints the stack trace.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253660](https://bugs.openjdk.java.net/browse/JDK-8253660): Need better error report when artifact resolution fails in AotCompiler.java


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/368/head:pull/368`
`$ git checkout pull/368`
