### PR TITLE
8251123: doclint warnings about missing javadoc tags and comments

### DIFF
--- a/src/java.desktop/share/classes/java/applet/Applet.java
+++ b/src/java.desktop/share/classes/java/applet/Applet.java
@@ -99,7 +99,10 @@ public class Applet extends Panel {
     /**
      * Read an applet from an object input stream.
      *
-     * @param  s an object input stream
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
      *         returns {@code true}
      * @serial

--- a/src/java.desktop/share/classes/java/awt/AWTEvent.java
+++ b/src/java.desktop/share/classes/java/awt/AWTEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,6 +87,9 @@ import sun.awt.AWTAccessor;
  */
 public abstract class AWTEvent extends EventObject {
 
+    /**
+     * The private data.
+     */
     private byte[] bdata;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/AWTKeyStroke.java
+++ b/src/java.desktop/share/classes/java/awt/AWTKeyStroke.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +22,20 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
-import java.awt.event.KeyEvent;
-import sun.awt.AppContext;
 import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
-import java.io.Serializable;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Field;
+
+import sun.awt.AppContext;
 import sun.swing.SwingAccessor;
 
 /**
@@ -77,9 +79,25 @@ public class AWTKeyStroke implements Serializable {
     //A key withing the cache
     private static AWTKeyStroke APP_CONTEXT_KEYSTROKE_KEY = new AWTKeyStroke();
 
+    /**
+     * The character value for a keyboard key.
+     */
     private char keyChar = KeyEvent.CHAR_UNDEFINED;
+
+    /**
+     * The key code for this {@code AWTKeyStroke}.
+     */
     private int keyCode = KeyEvent.VK_UNDEFINED;
+
+    /**
+     * The bitwise-ored combination of any modifiers.
+     */
     private int modifiers;
+
+    /**
+     * {@code true} if this {@code AWTKeyStroke} corresponds to a key release;
+     * {@code false} otherwise.
+     */
     private boolean onKeyRelease;
 
     static {

--- a/src/java.desktop/share/classes/java/awt/Button.java
+++ b/src/java.desktop/share/classes/java/awt/Button.java
@@ -25,14 +25,20 @@
 
 package java.awt;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.peer.ButtonPeer;
 import java.beans.BeanProperty;
-import java.util.EventListener;
-import java.awt.event.*;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
 import java.io.IOException;
-import javax.accessibility.*;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.EventListener;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleAction;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleValue;
 
 /**
  * This class creates a labeled button. The application can cause
@@ -428,9 +434,8 @@ public class Button extends Component implements Accessible {
 
     /* Serialization support.
      */
-
-    /*
-     * Button Serial Data Version.
+    /**
+     * Serialized data version.
      * @serial
      */
     private int buttonSerializedDataVersion = 1;
@@ -449,7 +454,8 @@ public class Button extends Component implements Accessible {
      *   {@code actionListenerK} indicating an
      *     {@code ActionListener} object
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @see AWTEventMulticaster#save(ObjectOutputStream, String, EventListener)
      * @see java.awt.Component#actionListenerK
      * @see #readObject(ObjectInputStream)
@@ -469,10 +475,12 @@ public class Button extends Component implements Accessible {
      * receive action events fired by the button.
      * Unrecognized keys or values will be ignored.
      *
-     * @param s the {@code ObjectInputStream} to read
-     * @exception HeadlessException if
-     *   {@code GraphicsEnvironment.isHeadless} returns
-     *   {@code true}
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @serial
      * @see #removeActionListener(ActionListener)
      * @see #addActionListener(ActionListener)

--- a/src/java.desktop/share/classes/java/awt/CardLayout.java
+++ b/src/java.desktop/share/classes/java/awt/CardLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,14 @@
 
 package java.awt;
 
-import java.util.Hashtable;
-import java.util.Vector;
-import java.util.Enumeration;
-
-import java.io.Serializable;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamField;
-import java.io.IOException;
+import java.io.Serializable;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Vector;
 
 /**
  * A {@code CardLayout} object is a layout manager for a
@@ -68,8 +67,8 @@ public class CardLayout implements LayoutManager2,
      */
     Vector<Card> vector = new Vector<>();
 
-    /*
-     * A pair of Component and String that represents its name.
+    /**
+     * A pair of component and string that represents its name.
      */
     class Card implements Serializable {
         static final long serialVersionUID = 6640330810709497518L;
@@ -110,10 +109,10 @@ public class CardLayout implements LayoutManager2,
     /**
      * @serialField tab         Hashtable
      *      deprecated, for forward compatibility only
-     * @serialField hgap        int
-     * @serialField vgap        int
-     * @serialField vector      Vector
-     * @serialField currentCard int
+     * @serialField hgap        int the horizontal Layout gap
+     * @serialField vgap        int the vertical Layout gap
+     * @serialField vector      Vector the pairs of components and their names
+     * @serialField currentCard int the index of Component currently displayed
      */
     private static final ObjectStreamField[] serialPersistentFields = {
         new ObjectStreamField("tab", Hashtable.class),
@@ -559,6 +558,11 @@ public class CardLayout implements LayoutManager2,
 
     /**
      * Reads serializable fields from stream.
+     *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      */
     @SuppressWarnings("unchecked")
     private void readObject(ObjectInputStream s)
@@ -591,6 +595,9 @@ public class CardLayout implements LayoutManager2,
 
     /**
      * Writes serializable fields to stream.
+     *
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      */
     private void writeObject(ObjectOutputStream s)
         throws IOException

--- a/src/java.desktop/share/classes/java/awt/Checkbox.java
+++ b/src/java.desktop/share/classes/java/awt/Checkbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,16 +22,24 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.awt.peer.CheckboxPeer;
-import java.awt.event.*;
-import java.util.EventListener;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
 import java.io.IOException;
-import javax.accessibility.*;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.EventListener;
 
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleAction;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleValue;
 
 /**
  * A check box is a graphical component that can be in either an
@@ -602,8 +610,8 @@ public class Checkbox extends Component implements ItemSelectable, Accessible {
     /* Serialization support.
      */
 
-    /*
-     * Serialized data version
+    /**
+     * Serialized data version.
      * @serial
      */
     private int checkboxSerializedDataVersion = 1;
@@ -615,7 +623,8 @@ public class Checkbox extends Component implements ItemSelectable, Accessible {
      * {@code ItemListeners} are detected and
      * no attempt is made to serialize them.
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData {@code null} terminated sequence of 0
      *   or more pairs; the pair consists of a {@code String}
      *   and an {@code Object}; the {@code String} indicates
@@ -642,10 +651,12 @@ public class Checkbox extends Component implements ItemSelectable, Accessible {
      * item events fired by the {@code Checkbox}.
      * Unrecognized keys or values will be ignored.
      *
-     * @param s the {@code ObjectInputStream} to read
-     * @exception HeadlessException if
-     *   {@code GraphicsEnvironment.isHeadless} returns
-     *   {@code true}
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @serial
      * @see #removeItemListener(ItemListener)
      * @see #addItemListener(ItemListener)

--- a/src/java.desktop/share/classes/java/awt/CheckboxMenuItem.java
+++ b/src/java.desktop/share/classes/java/awt/CheckboxMenuItem.java
@@ -25,6 +25,7 @@
 
 package java.awt;
 
+import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.peer.CheckboxMenuItemPeer;
@@ -426,8 +427,8 @@ public class CheckboxMenuItem extends MenuItem implements ItemSelectable, Access
     /* Serialization support.
      */
 
-    /*
-     * Serial Data Version
+    /**
+     * Serialized data version.
      * @serial
      */
     private int checkboxMenuItemSerializedDataVersion = 1;
@@ -439,7 +440,8 @@ public class CheckboxMenuItem extends MenuItem implements ItemSelectable, Access
      * {@code ItemListeners} are detected and
      * no attempt is made to serialize them.
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData {@code null} terminated sequence of
      *  0 or more pairs; the pair consists of a {@code String}
      *  and an {@code Object}; the {@code String} indicates
@@ -460,17 +462,20 @@ public class CheckboxMenuItem extends MenuItem implements ItemSelectable, Access
       s.writeObject(null);
     }
 
-    /*
+    /**
      * Reads the {@code ObjectInputStream} and if it
      * isn't {@code null} adds a listener to receive
      * item events fired by the {@code Checkbox} menu item.
      * Unrecognized keys or values will be ignored.
      *
-     * @param s the {@code ObjectInputStream} to read
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      * @serial
-     * @see removeActionListener()
-     * @see addActionListener()
-     * @see #writeObject
+     * @see #removeActionListener(ActionListener)
+     * @see #addActionListener(ActionListener)
+     * @see #writeObject(ObjectOutputStream)
      */
     private void readObject(ObjectInputStream s)
       throws ClassNotFoundException, IOException

--- a/src/java.desktop/share/classes/java/awt/Choice.java
+++ b/src/java.desktop/share/classes/java/awt/Choice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +22,22 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
-import java.util.*;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.awt.peer.ChoicePeer;
-import java.awt.event.*;
-import java.util.EventListener;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.EventListener;
+import java.util.Vector;
 
-import javax.accessibility.*;
-
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleAction;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
 
 /**
  * The {@code Choice} class presents a pop-up menu of choices.
@@ -654,8 +658,8 @@ public class Choice extends Component implements ItemSelectable, Accessible {
     /* Serialization support.
      */
 
-    /*
-     * Choice Serial Data Version.
+    /**
+     * Serialized data version.
      * @serial
      */
     private int choiceSerializedDataVersion = 1;
@@ -667,7 +671,8 @@ public class Choice extends Component implements ItemSelectable, Accessible {
      * {@code ItemListeners} are detected and
      * no attempt is made to serialize them.
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData {@code null} terminated sequence of 0
      *   or more pairs; the pair consists of a {@code String}
      *   and an {@code Object}; the {@code String} indicates
@@ -694,10 +699,12 @@ public class Choice extends Component implements ItemSelectable, Accessible {
      * item events fired by the {@code Choice} item.
      * Unrecognized keys or values will be ignored.
      *
-     * @param s the {@code ObjectInputStream} to read
-     * @exception HeadlessException if
-     *   {@code GraphicsEnvironment.isHeadless} returns
-     *   {@code true}
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @serial
      * @see #removeItemListener(ItemListener)
      * @see #addItemListener(ItemListener)

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -716,6 +716,9 @@ public abstract class Component implements ImageObserver, MenuContainer,
         return acc;
     }
 
+    /**
+     * Whether the component is packed or not;
+     */
     boolean isPacked = false;
 
     /**
@@ -8328,7 +8331,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
         return hasFocus();
     }
 
-    /*
+    /**
      * Used to disallow auto-focus-transfer on disposal of the focus owner
      * in the process of disposing its parent container.
      */
@@ -8903,7 +8906,8 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * The non-serializable listeners are detected and
      * no attempt is made to serialize them.
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData {@code null} terminated sequence of
      *   0 or more pairs; the pair consists of a {@code String}
      *   and an {@code Object}; the {@code String} indicates
@@ -8974,7 +8978,10 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * of events fired by the component.
      * Unrecognized keys or values will be ignored.
      *
-     * @param s the {@code ObjectInputStream} to read
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      * @see #writeObject(ObjectOutputStream)
      */
     private void readObject(ObjectInputStream s)

--- a/src/java.desktop/share/classes/java/awt/ComponentOrientation.java
+++ b/src/java.desktop/share/classes/java/awt/ComponentOrientation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -201,6 +201,9 @@ public final class ComponentOrientation implements java.io.Serializable
         return result;
     }
 
+    /**
+     * The bitwise-ored combination of flags.
+     */
     private int orientation;
 
     private ComponentOrientation(int value)

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -26,15 +26,20 @@
 package java.awt;
 
 import java.awt.dnd.DropTarget;
-
-import java.awt.event.*;
-
-import java.awt.peer.ContainerPeer;
+import java.awt.event.AWTEventListener;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ContainerEvent;
+import java.awt.event.ContainerListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.HierarchyEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseWheelEvent;
 import java.awt.peer.ComponentPeer;
+import java.awt.peer.ContainerPeer;
 import java.awt.peer.LightweightPeer;
-
 import java.beans.PropertyChangeListener;
-
 import java.io.IOException;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
@@ -43,30 +48,26 @@ import java.io.ObjectStreamField;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.Serializable;
-
 import java.lang.ref.WeakReference;
 import java.security.AccessController;
-
 import java.util.ArrayList;
 import java.util.EventListener;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.accessibility.*;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleComponent;
+import javax.accessibility.AccessibleContext;
 
-import sun.util.logging.PlatformLogger;
-
-import sun.awt.AppContext;
 import sun.awt.AWTAccessor;
 import sun.awt.AWTAccessor.MouseEventAccessor;
+import sun.awt.AppContext;
 import sun.awt.PeerEvent;
 import sun.awt.SunToolkit;
-
 import sun.awt.dnd.SunDropTargetEvent;
-
 import sun.java2d.pipe.Region;
-
 import sun.security.action.GetBooleanAction;
+import sun.util.logging.PlatformLogger;
 
 /**
  * A generic Abstract Window Toolkit(AWT) container object is a component
@@ -3666,7 +3667,8 @@ public class Container extends Component {
      *        is Serializable; otherwise, {@code null} is written.</li>
      * </ul>
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData {@code null} terminated sequence of 0 or more pairs;
      *   the pair consists of a {@code String} and {@code Object};
      *   the {@code String} indicates the type of object and
@@ -3713,7 +3715,10 @@ public class Container extends Component {
      *        as optional data.</li>
      * </ul>
      *
-     * @param s the {@code ObjectInputStream} to read
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      * @serial
      * @see #addContainerListener
      * @see #writeObject(ObjectOutputStream)

--- a/src/java.desktop/share/classes/java/awt/ContainerOrderFocusTraversalPolicy.java
+++ b/src/java.desktop/share/classes/java/awt/ContainerOrderFocusTraversalPolicy.java
@@ -22,10 +22,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
+
 import sun.util.logging.PlatformLogger;
 
 /**
@@ -62,7 +64,14 @@ public class ContainerOrderFocusTraversalPolicy extends FocusTraversalPolicy
 {
     private static final PlatformLogger log = PlatformLogger.getLogger("java.awt.ContainerOrderFocusTraversalPolicy");
 
+    /**
+     * This constant is used when the forward focus traversal order is active.
+     */
     private final int FORWARD_TRAVERSAL = 0;
+
+    /**
+     * This constant is used when the backward focus traversal order is active.
+     */
     private final int BACKWARD_TRAVERSAL = 1;
 
     /*
@@ -70,6 +79,10 @@ public class ContainerOrderFocusTraversalPolicy extends FocusTraversalPolicy
      */
     private static final long serialVersionUID = 486933713763926351L;
 
+    /**
+     * Whether this {@code ContainerOrderFocusTraversalPolicy} transfers focus
+     * down-cycle implicitly.
+     */
     private boolean implicitDownCycleTraversal = true;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/Dialog.java
+++ b/src/java.desktop/share/classes/java/awt/Dialog.java
@@ -22,23 +22,32 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
+import java.awt.event.ComponentEvent;
+import java.awt.event.HierarchyEvent;
+import java.awt.event.InvocationEvent;
+import java.awt.event.WindowEvent;
 import java.awt.peer.DialogPeer;
-import java.awt.event.*;
-import java.io.ObjectInputStream;
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.concurrent.atomic.AtomicLong;
+import java.io.ObjectInputStream;
+import java.security.AccessControlException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import javax.accessibility.*;
-import sun.awt.AppContext;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+
 import sun.awt.AWTPermissions;
+import sun.awt.AppContext;
 import sun.awt.SunToolkit;
 import sun.awt.util.IdentityArrayList;
 import sun.awt.util.IdentityLinkedList;
-import java.security.AccessControlException;
 
 /**
  * A Dialog is a top-level window with a title and a border
@@ -1587,6 +1596,16 @@ public class Dialog extends Window {
         }
     }
 
+    /**
+     * Reads serializable fields from stream.
+     *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
+     */
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException, HeadlessException
     {

--- a/src/java.desktop/share/classes/java/awt/FileDialog.java
+++ b/src/java.desktop/share/classes/java/awt/FileDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
 import java.awt.peer.FileDialogPeer;
+import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.io.File;
+
 import sun.awt.AWTAccessor;
 
 /**
@@ -60,38 +62,38 @@ public class FileDialog extends Dialog {
      */
     public static final int SAVE = 1;
 
-    /*
+    /**
      * There are two {@code FileDialog} modes: {@code LOAD} and
      * {@code SAVE}.
      * This integer will represent one or the other.
      * If the mode is not specified it will default to {@code LOAD}.
      *
      * @serial
-     * @see getMode()
-     * @see setMode()
+     * @see #getMode
+     * @see #setMode
      * @see java.awt.FileDialog#LOAD
      * @see java.awt.FileDialog#SAVE
      */
     int mode;
 
-    /*
+    /**
      * The string specifying the directory to display
      * in the file dialog.  This variable may be {@code null}.
      *
      * @serial
-     * @see getDirectory()
-     * @see setDirectory()
+     * @see #getDirectory
+     * @see #setDirectory
      */
     String dir;
 
-    /*
+    /**
      * The string specifying the initial value of the
      * filename text field in the file dialog.
      * This variable may be {@code null}.
      *
      * @serial
-     * @see getFile()
-     * @see setFile()
+     * @see #getFile
+     * @see #setFile
      */
     String file;
 
@@ -114,16 +116,16 @@ public class FileDialog extends Dialog {
      */
     private boolean multipleMode = false;
 
-    /*
+    /**
      * The filter used as the file dialog's filename filter.
      * The file dialog will only be displaying files whose
      * names are accepted by this filter.
      * This variable may be {@code null}.
      *
      * @serial
-     * @see #getFilenameFilter()
-     * @see #setFilenameFilter()
-     * @see FileNameFilter
+     * @see #getFilenameFilter
+     * @see #setFilenameFilter
+     * @see FilenameFilter
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     FilenameFilter filter;
@@ -598,7 +600,10 @@ public class FileDialog extends Dialog {
      * either a {@code dir} or a {@code file}
      * equal to an empty string to {@code null}.
      *
-     * @param s the {@code ObjectInputStream} to read
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      */
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException

--- a/src/java.desktop/share/classes/java/awt/FlowLayout.java
+++ b/src/java.desktop/share/classes/java/awt/FlowLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
-import java.io.ObjectInputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
 
 /**
  * A flow layout arranges components in a directional flow, much
@@ -662,6 +663,11 @@ public class FlowLayout implements LayoutManager, java.io.Serializable {
      * Reads this object out of a serialization stream, handling
      * objects written by older versions of the class that didn't contain all
      * of the fields we use now..
+     *
+     * @param  stream the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      */
     private void readObject(ObjectInputStream stream)
          throws IOException, ClassNotFoundException

--- a/src/java.desktop/share/classes/java/awt/Font.java
+++ b/src/java.desktop/share/classes/java/awt/Font.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,13 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.peer.FontPeer;
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FilePermission;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
 import java.lang.ref.SoftReference;
 import java.nio.file.Files;
 import java.security.AccessController;
@@ -47,24 +53,45 @@ import java.util.Locale;
 import java.util.Map;
 
 import sun.awt.ComponentFactory;
-import sun.font.StandardGlyphVector;
-
 import sun.font.AttributeMap;
 import sun.font.AttributeValues;
 import sun.font.CompositeFont;
+import sun.font.CoreMetrics;
 import sun.font.CreatedFontTracker;
 import sun.font.Font2D;
 import sun.font.Font2DHandle;
 import sun.font.FontAccess;
 import sun.font.FontDesignMetrics;
+import sun.font.FontLineMetrics;
 import sun.font.FontManager;
 import sun.font.FontManagerFactory;
 import sun.font.FontUtilities;
 import sun.font.GlyphLayout;
-import sun.font.FontLineMetrics;
-import sun.font.CoreMetrics;
+import sun.font.StandardGlyphVector;
 
-import static sun.font.EAttribute.*;
+import static sun.font.EAttribute.EBACKGROUND;
+import static sun.font.EAttribute.EBIDI_EMBEDDING;
+import static sun.font.EAttribute.ECHAR_REPLACEMENT;
+import static sun.font.EAttribute.EFAMILY;
+import static sun.font.EAttribute.EFONT;
+import static sun.font.EAttribute.EFOREGROUND;
+import static sun.font.EAttribute.EINPUT_METHOD_HIGHLIGHT;
+import static sun.font.EAttribute.EINPUT_METHOD_UNDERLINE;
+import static sun.font.EAttribute.EJUSTIFICATION;
+import static sun.font.EAttribute.EKERNING;
+import static sun.font.EAttribute.ELIGATURES;
+import static sun.font.EAttribute.ENUMERIC_SHAPING;
+import static sun.font.EAttribute.EPOSTURE;
+import static sun.font.EAttribute.ERUN_DIRECTION;
+import static sun.font.EAttribute.ESIZE;
+import static sun.font.EAttribute.ESTRIKETHROUGH;
+import static sun.font.EAttribute.ESUPERSCRIPT;
+import static sun.font.EAttribute.ESWAP_COLORS;
+import static sun.font.EAttribute.ETRACKING;
+import static sun.font.EAttribute.ETRANSFORM;
+import static sun.font.EAttribute.EUNDERLINE;
+import static sun.font.EAttribute.EWEIGHT;
+import static sun.font.EAttribute.EWIDTH;
 
 /**
  * The {@code Font} class represents fonts, which are used to
@@ -1884,7 +1911,8 @@ public class Font implements java.io.Serializable
     /**
      * Writes default serializable fields to a stream.
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @see AWTEventMulticaster#save(ObjectOutputStream, String, EventListener)
      * @see #readObject(java.io.ObjectInputStream)
      */
@@ -1907,7 +1935,10 @@ public class Font implements java.io.Serializable
      * Reads the {@code ObjectInputStream}.
      * Unrecognized keys or values will be ignored.
      *
-     * @param s the {@code ObjectInputStream} to read
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      * @serial
      * @see #writeObject(java.io.ObjectOutputStream)
      */

--- a/src/java.desktop/share/classes/java/awt/Frame.java
+++ b/src/java.desktop/share/classes/java/awt/Frame.java
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
 import java.awt.event.KeyEvent;
@@ -38,7 +39,6 @@ import javax.accessibility.AccessibleContext;
 import javax.accessibility.AccessibleRole;
 import javax.accessibility.AccessibleState;
 import javax.accessibility.AccessibleStateSet;
-import javax.swing.WindowConstants;
 
 import sun.awt.AWTAccessor;
 import sun.awt.SunToolkit;
@@ -345,11 +345,14 @@ public class Frame extends Window implements MenuContainer {
      */
     boolean     mbManagement = false;   /* used only by the Motif impl. */
 
+    /**
+     * The bitwise mask of frame state constants.
+     */
     // XXX: uwe: abuse old field for now
     // will need to take care of serialization
     private int state = NORMAL;
 
-    /*
+    /**
      * The Windows owned by the Frame.
      * Note: in 1.2 this has been superseded by Window.ownedWindowList
      *
@@ -1176,7 +1179,8 @@ public class Frame extends Window implements MenuContainer {
      * an optional serializable icon {@code Image}, which is
      * available as of 1.4.
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData an optional icon {@code Image}
      * @see java.awt.Image
      * @see #getIconImage
@@ -1206,13 +1210,13 @@ public class Frame extends Window implements MenuContainer {
      * will be thrown.
      * Unrecognized keys or values will be ignored.
      *
-     * @param s the {@code ObjectInputStream} to read
-     * @exception java.io.OptionalDataException if an icon {@code Image}
-     *   is not available, but anything other than an EOF
-     *   is detected
-     * @exception HeadlessException if
-     *   {@code GraphicsEnvironment.isHeadless} returns
-     *   {@code true}
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws java.io.OptionalDataException if an icon {@code Image} is not
+     *         available, but anything other than an EOF is detected
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless()
      * @see java.awt.Image
      * @see #getIconImage

--- a/src/java.desktop/share/classes/java/awt/GridBagLayoutInfo.java
+++ b/src/java.desktop/share/classes/java/awt/GridBagLayoutInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,27 +35,65 @@ package java.awt;
  * @since 1.6
  */
 public class GridBagLayoutInfo implements java.io.Serializable {
+
     /*
      * serialVersionUID
      */
     private static final long serialVersionUID = -4899416460737170217L;
 
-    int width, height;          /* number of  cells: horizontal and vertical */
-    int startx, starty;         /* starting point for layout */
-    int[] minWidth;             /* largest minWidth in each column */
-    int[] minHeight;            /* largest minHeight in each row */
-    double[] weightX;           /* largest weight in each column */
-    double[] weightY;           /* largest weight in each row */
-    boolean hasBaseline;        /* Whether or not baseline layout has been
-                                 * requested and one of the components
-                                 * has a valid baseline. */
+    /**
+     * The number of cells: horizontal and vertical.
+     */
+    int width, height;
+
+    /**
+     * The starting point for layout.
+     */
+    int startx, starty;
+
+    /**
+     * The largest minWidth in each column.
+     */
+    int[] minWidth;
+
+    /**
+     * The largest minHeight in each row.
+     */
+    int[] minHeight;
+
+    /**
+     * The largest weight in each column.
+     */
+    double[] weightX;
+
+    /**
+     * The largest weight in each row.
+     */
+    double[] weightY;
+
+    /**
+     * Whether or not baseline layout has been requested and one of the
+     * components has a valid baseline.
+     */
+    boolean hasBaseline;
+
     // These are only valid if hasBaseline is true and are indexed by
     // row.
-    short[] baselineType;       /* The type of baseline for a particular
-                                 * row.  A mix of the BaselineResizeBehavior
-                                 * constants (1 << ordinal()) */
-    int[] maxAscent;            /* Max ascent (baseline). */
-    int[] maxDescent;           /* Max descent (height - baseline) */
+    /**
+     * The type of baseline for a particular row. A mix of the
+     * BaselineResizeBehavior constants {@code (1 << ordinal())}
+     */
+    short[] baselineType;
+
+    /**
+     * Max ascent (baseline).
+     */
+    int[] maxAscent;
+
+    /**
+     * Max descent (height - baseline)
+     */
+    int[] maxDescent;
 
     /**
      * Creates an instance of GridBagLayoutInfo representing {@code GridBagLayout}

--- a/src/java.desktop/share/classes/java/awt/Label.java
+++ b/src/java.desktop/share/classes/java/awt/Label.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,16 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
 import java.awt.peer.LabelPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import javax.accessibility.*;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
 
 /**
  * A {@code Label} object is a component for placing text in a
@@ -153,12 +157,16 @@ public class Label extends Component implements Accessible {
 
     /**
      * Read a label from an object input stream.
-     * @exception HeadlessException if
-     * {@code GraphicsEnvironment.isHeadless()} returns
-     * {@code true}
+     *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @serial
-     * @since 1.4
      * @see java.awt.GraphicsEnvironment#isHeadless
+     * @since 1.4
      */
     private void readObject(ObjectInputStream s)
         throws ClassNotFoundException, IOException, HeadlessException {

--- a/src/java.desktop/share/classes/java/awt/List.java
+++ b/src/java.desktop/share/classes/java/awt/List.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +22,28 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
-import java.util.Vector;
-import java.util.Locale;
-import java.util.EventListener;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.awt.peer.ListPeer;
-import java.awt.event.*;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
 import java.io.IOException;
-import javax.accessibility.*;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.EventListener;
+import java.util.Locale;
+import java.util.Vector;
 
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleSelection;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
 
 /**
  * The {@code List} component presents the user with a
@@ -1234,7 +1244,8 @@ public class List extends Component implements ItemSelectable, Accessible {
      *  {@code actionListenerK} indicating an
      *    {@code ActionListener} object
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @see AWTEventMulticaster#save(ObjectOutputStream, String, EventListener)
      * @see java.awt.Component#itemListenerK
      * @see java.awt.Component#actionListenerK
@@ -1264,10 +1275,12 @@ public class List extends Component implements ItemSelectable, Accessible {
      * {@code List}.
      * Unrecognized keys or values will be ignored.
      *
-     * @param s the {@code ObjectInputStream} to write
-     * @exception HeadlessException if
-     *   {@code GraphicsEnvironment.isHeadless} returns
-     *   {@code true}
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @see #removeItemListener(ItemListener)
      * @see #addItemListener(ItemListener)
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -1532,8 +1545,15 @@ public class List extends Component implements ItemSelectable, Accessible {
 
         // [[[FIXME]]] need to finish implementing this!!!
 
-            private List parent;
-            private int  indexInParent;
+           /**
+            * The parent {@code List}.
+            */
+           private List parent;
+
+           /**
+            * The index in the parent.
+            */
+           private int indexInParent;
 
             /**
              * Constructs new {@code AccessibleAWTListChild} with the given

--- a/src/java.desktop/share/classes/java/awt/MediaTracker.java
+++ b/src/java.desktop/share/classes/java/awt/MediaTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,8 @@
 
 package java.awt;
 
-import java.awt.Component;
-import java.awt.Image;
 import java.awt.image.ImageObserver;
+
 import sun.awt.image.MultiResolutionToolkitImage;
 
 /**
@@ -923,6 +922,10 @@ abstract class MediaEntry {
     }
 }
 
+/**
+ * The entry of the list of {@code Images} that is being tracked by the
+ * {@code MediaTracker}.
+ */
 @SuppressWarnings("serial") // MediaEntry does not have a no-arg ctor
 class ImageMediaEntry extends MediaEntry implements ImageObserver,
 java.io.Serializable {

--- a/src/java.desktop/share/classes/java/awt/Menu.java
+++ b/src/java.desktop/share/classes/java/awt/Menu.java
@@ -526,7 +526,8 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
     /**
      * Writes default serializable fields to stream.
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @see AWTEventMulticaster#save(ObjectOutputStream, String, EventListener)
      * @see #readObject(ObjectInputStream)
      */
@@ -540,10 +541,12 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
      * Reads the {@code ObjectInputStream}.
      * Unrecognized keys or values will be ignored.
      *
-     * @param s the {@code ObjectInputStream} to read
-     * @exception HeadlessException if
-     *   {@code GraphicsEnvironment.isHeadless} returns
-     *   {@code true}
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #writeObject(ObjectOutputStream)
      */

--- a/src/java.desktop/share/classes/java/awt/MenuBar.java
+++ b/src/java.desktop/share/classes/java/awt/MenuBar.java
@@ -427,7 +427,8 @@ public class MenuBar extends MenuComponent implements MenuContainer, Accessible 
     /**
      * Writes default serializable fields to stream.
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @see AWTEventMulticaster#save(ObjectOutputStream, String, EventListener)
      * @see #readObject(java.io.ObjectInputStream)
      */
@@ -441,10 +442,12 @@ public class MenuBar extends MenuComponent implements MenuContainer, Accessible 
      * Reads the {@code ObjectInputStream}.
      * Unrecognized keys or values will be ignored.
      *
-     * @param s the {@code ObjectInputStream} to read
-     * @exception HeadlessException if
-     *   {@code GraphicsEnvironment.isHeadless} returns
-     *   {@code true}
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #writeObject(java.io.ObjectOutputStream)
      */

--- a/src/java.desktop/share/classes/java/awt/MenuComponent.java
+++ b/src/java.desktop/share/classes/java/awt/MenuComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -438,10 +438,12 @@ public abstract class MenuComponent implements java.io.Serializable {
     /**
      * Reads the menu component from an object input stream.
      *
-     * @param s the {@code ObjectInputStream} to read
-     * @exception HeadlessException if
-     *   {@code GraphicsEnvironment.isHeadless} returns
-     *   {@code true}
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @serial
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -465,10 +467,11 @@ public abstract class MenuComponent implements java.io.Serializable {
 
     /*
      * --- Accessibility Support ---
-     *
-     *  MenuComponent will contain all of the methods in interface Accessible,
-     *  though it won't actually implement the interface - that will be up
-     *  to the individual objects which extend MenuComponent.
+     */
+    /**
+     * MenuComponent will contain all of the methods in interface Accessible,
+     * though it won't actually implement the interface - that will be up
+     * to the individual objects which extend MenuComponent.
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     AccessibleContext accessibleContext = null;

--- a/src/java.desktop/share/classes/java/awt/MenuItem.java
+++ b/src/java.desktop/share/classes/java/awt/MenuItem.java
@@ -725,7 +725,8 @@ public class MenuItem extends MenuComponent implements Accessible {
      * as optional data. The non-serializable listeners are
      * detected and no attempt is made to serialize them.
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData {@code null} terminated sequence of 0
      *   or more pairs; the pair consists of a {@code String}
      *   and an {@code Object}; the {@code String}
@@ -751,10 +752,12 @@ public class MenuItem extends MenuComponent implements Accessible {
      * action events fired by the {@code Menu} Item.
      * Unrecognized keys or values will be ignored.
      *
-     * @param s the {@code ObjectInputStream} to read
-     * @exception HeadlessException if
-     *   {@code GraphicsEnvironment.isHeadless} returns
-     *   {@code true}
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @see #removeActionListener(ActionListener)
      * @see #addActionListener(ActionListener)
      * @see #writeObject(ObjectOutputStream)

--- a/src/java.desktop/share/classes/java/awt/ScrollPane.java
+++ b/src/java.desktop/share/classes/java/awt/ScrollPane.java
@@ -22,19 +22,26 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
+import java.awt.event.AdjustmentEvent;
+import java.awt.event.AdjustmentListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseWheelEvent;
 import java.awt.peer.ScrollPanePeer;
-import java.awt.event.*;
-import javax.accessibility.*;
-import sun.awt.ScrollPaneWheelScroller;
-import sun.awt.SunToolkit;
-
 import java.beans.ConstructorProperties;
 import java.beans.Transient;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.IOException;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+
+import sun.awt.ScrollPaneWheelScroller;
+import sun.awt.SunToolkit;
 
 /**
  * A container class which implements automatic horizontal and/or
@@ -672,6 +679,9 @@ public class ScrollPane extends Container implements Accessible {
 
     /**
      * Writes default serializable fields to stream.
+     *
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      */
     private void writeObject(ObjectOutputStream s) throws IOException {
         // 4352819: We only need this degenerate writeObject to make
@@ -682,9 +692,13 @@ public class ScrollPane extends Container implements Accessible {
 
     /**
      * Reads default serializable fields to stream.
-     * @exception HeadlessException if
-     * {@code GraphicsEnvironment.isHeadless()} returns
-     * {@code true}
+     *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
     private void readObject(ObjectInputStream s)
@@ -719,6 +733,9 @@ public class ScrollPane extends Container implements Accessible {
 //      }
     }
 
+    /**
+     * Invoked when the value of the adjustable has changed.
+     */
     class PeerFixer implements AdjustmentListener, java.io.Serializable
     {
         private static final long serialVersionUID = 1043664721353696630L;
@@ -809,53 +826,4 @@ public class ScrollPane extends Container implements Accessible {
 
     } // class AccessibleAWTScrollPane
 
-}
-
-/*
- * In JDK 1.1.1, the pkg private class java.awt.PeerFixer was moved to
- * become an inner class of ScrollPane, which broke serialization
- * for ScrollPane objects using JDK 1.1.
- * Instead of moving it back out here, which would break all JDK 1.1.x
- * releases, we keep PeerFixer in both places. Because of the scoping rules,
- * the PeerFixer that is used in ScrollPane will be the one that is the
- * inner class. This pkg private PeerFixer class below will only be used
- * if the Java 2 platform is used to deserialize ScrollPane objects that were serialized
- * using JDK1.1
- */
-class PeerFixer implements AdjustmentListener, java.io.Serializable {
-    /*
-     * serialVersionUID
-     */
-    private static final long serialVersionUID = 7051237413532574756L;
-
-    PeerFixer(ScrollPane scroller) {
-        this.scroller = scroller;
-    }
-
-    /**
-     * Invoked when the value of the adjustable has changed.
-     */
-    @SuppressWarnings("deprecation")
-    public void adjustmentValueChanged(AdjustmentEvent e) {
-        Adjustable adj = e.getAdjustable();
-        int value = e.getValue();
-        ScrollPanePeer peer = (ScrollPanePeer) scroller.peer;
-        if (peer != null) {
-            peer.setValue(adj, value);
-        }
-
-        Component c = scroller.getComponent(0);
-        switch(adj.getOrientation()) {
-        case Adjustable.VERTICAL:
-            c.move(c.getLocation().x, -(value));
-            break;
-        case Adjustable.HORIZONTAL:
-            c.move(-(value), c.getLocation().y);
-            break;
-        default:
-            throw new IllegalArgumentException("Illegal adjustable orientation");
-        }
-    }
-
-    private ScrollPane scroller;
 }

--- a/src/java.desktop/share/classes/java/awt/ScrollPane.java
+++ b/src/java.desktop/share/classes/java/awt/ScrollPane.java
@@ -863,14 +863,14 @@ class PeerFixer implements AdjustmentListener, java.io.Serializable {
 
         Component c = scroller.getComponent(0);
         switch(adj.getOrientation()) {
-            case Adjustable.VERTICAL:
-                c.move(c.getLocation().x, -(value));
-                break;
-            case Adjustable.HORIZONTAL:
-                c.move(-(value), c.getLocation().y);
-                break;
-            default:
-                throw new IllegalArgumentException("Illegal adjustable orientation");
+        case Adjustable.VERTICAL:
+            c.move(c.getLocation().x, -(value));
+            break;
+        case Adjustable.HORIZONTAL:
+            c.move(-(value), c.getLocation().y);
+            break;
+        default:
+            throw new IllegalArgumentException("Illegal adjustable orientation");
         }
     }
 

--- a/src/java.desktop/share/classes/java/awt/ScrollPane.java
+++ b/src/java.desktop/share/classes/java/awt/ScrollPane.java
@@ -827,3 +827,52 @@ public class ScrollPane extends Container implements Accessible {
     } // class AccessibleAWTScrollPane
 
 }
+
+/*
+ * In JDK 1.1.1, the pkg private class java.awt.PeerFixer was moved to
+ * become an inner class of ScrollPane, which broke serialization
+ * for ScrollPane objects using JDK 1.1.
+ * Instead of moving it back out here, which would break all JDK 1.1.x
+ * releases, we keep PeerFixer in both places. Because of the scoping rules,
+ * the PeerFixer that is used in ScrollPane will be the one that is the
+ * inner class. This pkg private PeerFixer class below will only be used
+ * if the Java 2 platform is used to deserialize ScrollPane objects that were serialized
+ * using JDK1.1
+ */
+class PeerFixer implements AdjustmentListener, java.io.Serializable {
+    /*
+     * serialVersionUID
+     */
+    private static final long serialVersionUID = 7051237413532574756L;
+
+    PeerFixer(ScrollPane scroller) {
+        this.scroller = scroller;
+    }
+
+    /**
+     * Invoked when the value of the adjustable has changed.
+     */
+    @SuppressWarnings("deprecation")
+    public void adjustmentValueChanged(AdjustmentEvent e) {
+        Adjustable adj = e.getAdjustable();
+        int value = e.getValue();
+        ScrollPanePeer peer = (ScrollPanePeer) scroller.peer;
+        if (peer != null) {
+            peer.setValue(adj, value);
+        }
+
+        Component c = scroller.getComponent(0);
+        switch(adj.getOrientation()) {
+            case Adjustable.VERTICAL:
+                c.move(c.getLocation().x, -(value));
+                break;
+            case Adjustable.HORIZONTAL:
+                c.move(-(value), c.getLocation().y);
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal adjustable orientation");
+        }
+    }
+
+    private ScrollPane scroller;
+}

--- a/src/java.desktop/share/classes/java/awt/ScrollPaneAdjustable.java
+++ b/src/java.desktop/share/classes/java/awt/ScrollPaneAdjustable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package java.awt;
 
-import sun.awt.AWTAccessor;
+package java.awt;
 
 import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
 import java.awt.peer.ScrollPanePeer;
 import java.io.Serializable;
 
+import sun.awt.AWTAccessor;
 
 /**
  * This class represents the state of a horizontal or vertical
@@ -138,6 +138,10 @@ public class ScrollPaneAdjustable implements Adjustable, Serializable {
      */
     private int blockIncrement = 1;
 
+    /**
+     * Specified adjustment listener to receive adjustment events from this
+     * {@code ScrollPaneAdjustable}.
+     */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     private AdjustmentListener adjustmentListener;
 

--- a/src/java.desktop/share/classes/java/awt/Scrollbar.java
+++ b/src/java.desktop/share/classes/java/awt/Scrollbar.java
@@ -22,16 +22,23 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
+import java.awt.event.AdjustmentEvent;
+import java.awt.event.AdjustmentListener;
 import java.awt.peer.ScrollbarPeer;
-import java.awt.event.*;
-import java.util.EventListener;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
 import java.io.IOException;
-import javax.accessibility.*;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.EventListener;
 
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleValue;
 
 /**
  * The {@code Scrollbar} class embodies a scroll bar, a
@@ -1171,7 +1178,8 @@ public class Scrollbar extends Component implements Adjustable, Accessible {
      * as optional data. The non-serializable listeners are
      * detected and no attempt is made to serialize them.
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData {@code null} terminated sequence of 0
      *   or more pairs; the pair consists of a {@code String}
      *   and an {@code Object}; the {@code String} indicates
@@ -1199,10 +1207,12 @@ public class Scrollbar extends Component implements Adjustable, Accessible {
      * {@code Scrollbar}.
      * Unrecognized keys or values will be ignored.
      *
-     * @param s the {@code ObjectInputStream} to read
-     * @exception HeadlessException if
-     *   {@code GraphicsEnvironment.isHeadless} returns
-     *   {@code true}
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #writeObject(ObjectOutputStream)
      */

--- a/src/java.desktop/share/classes/java/awt/SystemColor.java
+++ b/src/java.desktop/share/classes/java/awt/SystemColor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
-import sun.awt.AWTAccessor;
-
 import java.io.ObjectStreamException;
-
 import java.lang.annotation.Native;
+
+import sun.awt.AWTAccessor;
 
 /**
  * A class to encapsulate symbolic colors representing the color of
@@ -536,6 +536,8 @@ public final class SystemColor extends Color implements java.io.Serializable {
      * each {@code SystemColor} object.
      * @return a proxy {@code SystemColor} object with its value
      *         replaced by the corresponding system color index.
+     * @throws ObjectStreamException if a new object replacing this object could
+     *         not be created
      */
     private Object writeReplace() throws ObjectStreamException
     {

--- a/src/java.desktop/share/classes/java/awt/TextArea.java
+++ b/src/java.desktop/share/classes/java/awt/TextArea.java
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
 import java.awt.peer.TextAreaPeer;
@@ -649,9 +650,13 @@ public class TextArea extends TextComponent {
 
     /**
      * Read the ObjectInputStream.
-     * @exception HeadlessException if
-     * {@code GraphicsEnvironment.isHeadless()} returns
-     * {@code true}
+     *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
     private void readObject(ObjectInputStream s)

--- a/src/java.desktop/share/classes/java/awt/TextComponent.java
+++ b/src/java.desktop/share/classes/java/awt/TextComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +22,27 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
-import java.awt.peer.TextComponentPeer;
-import java.awt.event.*;
-import java.util.EventListener;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
-import java.io.IOException;
-import java.text.BreakIterator;
-import javax.swing.text.AttributeSet;
-import javax.accessibility.*;
+import java.awt.event.TextEvent;
+import java.awt.event.TextListener;
 import java.awt.im.InputMethodRequests;
+import java.awt.peer.TextComponentPeer;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.text.BreakIterator;
+import java.util.EventListener;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleText;
+import javax.swing.text.AttributeSet;
+
 import sun.awt.AWTPermissions;
 import sun.awt.InputMethodSupport;
 
@@ -102,9 +111,11 @@ public class TextComponent extends Component implements Accessible {
      */
     int selectionEnd;
 
-    // A flag used to tell whether the background has been set by
-    // developer code (as opposed to AWT code).  Used to determine
-    // the background color of non-editable TextComponents.
+    /**
+     * A flag used to tell whether the background has been set by
+     * developer code (as opposed to AWT code).  Used to determine
+     * the background color of non-editable TextComponents.
+     */
     boolean backgroundSetByClientCode = false;
 
     /**
@@ -766,6 +777,8 @@ public class TextComponent extends Component implements Accessible {
      *             is one of the following :
      *             textListenerK indicating and TextListener object.
      *
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @see AWTEventMulticaster#save(ObjectOutputStream, String, EventListener)
      * @see java.awt.Component#textListenerK
      */
@@ -794,9 +807,12 @@ public class TextComponent extends Component implements Accessible {
      * TextComponent.  Unrecognized keys or values will be
      * ignored.
      *
-     * @exception HeadlessException if
-     * {@code GraphicsEnvironment.isHeadless()} returns
-     * {@code true}
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @see #removeTextListener
      * @see #addTextListener
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -1199,5 +1215,8 @@ public class TextComponent extends Component implements Accessible {
         }
     }  // end of AccessibleAWTTextComponent
 
+    /**
+     * Whether support of input methods should be checked or not.
+     */
     private boolean checkForEnableIM = true;
 }

--- a/src/java.desktop/share/classes/java/awt/TextField.java
+++ b/src/java.desktop/share/classes/java/awt/TextField.java
@@ -22,16 +22,20 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.awt;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.peer.TextFieldPeer;
-import java.awt.event.*;
-import java.util.EventListener;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
 import java.io.IOException;
-import javax.accessibility.*;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.EventListener;
 
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
 
 /**
  * A {@code TextField} object is a text component
@@ -701,6 +705,8 @@ public class TextField extends TextComponent {
      *             is one of the following :
      *             ActionListenerK indicating and ActionListener object.
      *
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @see AWTEventMulticaster#save(ObjectOutputStream, String, EventListener)
      * @see java.awt.Component#actionListenerK
      */
@@ -719,9 +725,12 @@ public class TextField extends TextComponent {
      * TextField.  Unrecognized keys or values will be
      * ignored.
      *
-     * @exception HeadlessException if
-     * {@code GraphicsEnvironment.isHeadless()} returns
-     * {@code true}
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @see #removeActionListener(ActionListener)
      * @see #addActionListener(ActionListener)
      * @see java.awt.GraphicsEnvironment#isHeadless

--- a/src/java.desktop/share/classes/java/awt/Toolkit.java
+++ b/src/java.desktop/share/classes/java/awt/Toolkit.java
@@ -2211,6 +2211,9 @@ public abstract class Toolkit {
         }
     }
 
+    /**
+     * This is a utility class to support desktop properties.
+     */
     @SuppressWarnings("serial")
     private static class DesktopPropertyChangeSupport extends PropertyChangeSupport {
 

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -241,7 +241,12 @@ public class Window extends Container implements Accessible {
     private transient Component temporaryLostComponent;
 
     static boolean systemSyncLWRequests = false;
-    boolean     syncLWRequests = false;
+
+    /**
+     * Focus transfers for the lightweight components request should be made
+     * synchronously.
+     */
+    boolean syncLWRequests = false;
     transient boolean beforeFirstShow = true;
     private transient boolean disposing = false;
     transient WindowDisposerRecord disposerRecord = null;
@@ -2936,7 +2941,8 @@ public class Window extends Container implements Accessible {
      * Writes a list of child windows as optional data.
      * Writes a list of icon images as optional data
      *
-     * @param s the {@code ObjectOutputStream} to write
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData {@code null} terminated sequence of
      *    0 or more pairs; the pair consists of a {@code String}
      *    and {@code Object}; the {@code String}
@@ -3091,10 +3097,12 @@ public class Window extends Container implements Accessible {
      * (possibly {@code null}) child windows.
      * Unrecognized keys or values will be ignored.
      *
-     * @param s the {@code ObjectInputStream} to read
-     * @exception HeadlessException if
-     *   {@code GraphicsEnvironment.isHeadless} returns
-     *   {@code true}
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless()}
+     *         returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #writeObject
      */
@@ -3427,6 +3435,10 @@ public class Window extends Container implements Accessible {
         return super.canContainFocusOwner(focusOwnerCandidate) && isFocusableWindow();
     }
 
+    /**
+     * {@code true} if this Window should appear at the default location,
+     * {@code false} if at the current location.
+     */
     private volatile boolean locationByPlatform = locationByPlatformProp;
 
 

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -243,8 +243,7 @@ public class Window extends Container implements Accessible {
     static boolean systemSyncLWRequests = false;
 
     /**
-     * Focus transfers for the lightweight components request should be made
-     * synchronously.
+     * Focus transfers should be synchronous for lightweight component requests.
      */
     boolean syncLWRequests = false;
     transient boolean beforeFirstShow = true;

--- a/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
@@ -99,7 +99,14 @@ public abstract class ColorSpace implements Serializable {
      */
     private static final long serialVersionUID = -409452704308689724L;
 
+    /**
+     * One of the {@code ColorSpace} type constants.
+     */
     private int type;
+
+    /**
+     * The number of components in the color space.
+     */
     private int numComponents;
     private transient String [] compName = null;
 

--- a/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -35,6 +35,8 @@
 
 package java.awt.color;
 
+import java.io.IOException;
+
 import sun.java2d.cmm.CMSManager;
 import sun.java2d.cmm.ColorTransform;
 import sun.java2d.cmm.PCMM;
@@ -82,11 +84,34 @@ public class ICC_ColorSpace extends ColorSpace {
      */
     private static final long serialVersionUID = 3455889114070431483L;
 
-    private ICC_Profile    thisProfile;
+    /**
+     * The specified {@code ICC_Profile} object.
+     */
+    private ICC_Profile thisProfile;
+
+    /**
+     * The maximum normalized component values.
+     */
     private float[] minVal;
+
+    /**
+     * The minimum normalized component values.
+     */
     private float[] maxVal;
+
+    /**
+     * Difference between min and max values.
+     */
     private float[] diffMinMax;
+
+    /**
+     * Inverted value of the difference between min and max values.
+     */
     private float[] invDiffMinMax;
+
+    /**
+     * Whether the values should be scaled or not.
+     */
     private boolean needScaleInit = true;
 
     // {to,from}{RGB,CIEXYZ} methods create and cache these when needed
@@ -123,7 +148,12 @@ public class ICC_ColorSpace extends ColorSpace {
     }
 
     /**
-     * Validate an ICC_ColorSpace read from an object input stream
+     * Validate an ICC_ColorSpace read from an object input stream.
+     *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      */
     private void readObject(java.io.ObjectInputStream s)
         throws ClassNotFoundException, java.io.IOException {

--- a/src/java.desktop/share/classes/java/awt/dnd/DragGestureEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragGestureEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,30 +23,22 @@
  * questions.
  */
 
-
 package java.awt.dnd;
 
 import java.awt.Component;
 import java.awt.Cursor;
-
 import java.awt.Image;
 import java.awt.Point;
-
-import java.awt.event.InputEvent;
-
 import java.awt.datatransfer.Transferable;
-
-import java.io.InvalidObjectException;
-import java.util.EventObject;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Iterator;
-
+import java.awt.event.InputEvent;
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-
+import java.util.Collections;
+import java.util.EventObject;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * A {@code DragGestureEvent} is passed
@@ -300,6 +292,8 @@ public class DragGestureEvent extends EventObject {
      * {@code DragGestureEvent} created from the resulting deserialized
      * stream will contain an empty {@code List} of gesture events.
      *
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData The default serializable fields, in alphabetical order,
      *             followed by either a {@code List} instance, or
      *             {@code null}.
@@ -323,6 +317,10 @@ public class DragGestureEvent extends EventObject {
      * {@code null}, this object's {@code List} of gesture events
      * is set to an empty {@code List}.
      *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      * @since 1.4
      */
     private void readObject(ObjectInputStream s)

--- a/src/java.desktop/share/classes/java/awt/dnd/DragGestureRecognizer.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragGestureRecognizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,19 +25,16 @@
 
 package java.awt.dnd;
 
-import java.awt.event.InputEvent;
 import java.awt.Component;
 import java.awt.Point;
-
-import java.io.InvalidObjectException;
-import java.util.Collections;
-import java.util.TooManyListenersException;
-import java.util.ArrayList;
-
+import java.awt.event.InputEvent;
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.TooManyListenersException;
 
 /**
  * The {@code DragGestureRecognizer} is an
@@ -393,6 +390,8 @@ public abstract class DragGestureRecognizer implements Serializable {
      * {@code DragGestureListener} is written out if and only if it can be
      * serialized. If not, {@code null} is written instead.
      *
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData The default serializable fields, in alphabetical order,
      *             followed by either a {@code DragGestureListener}, or
      *             {@code null}.
@@ -411,6 +410,10 @@ public abstract class DragGestureRecognizer implements Serializable {
      * fields. This object's {@code DragGestureListener} is then
      * deserialized as well by using the next object in the stream.
      *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      * @since 1.4
      */
     @SuppressWarnings("unchecked")

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,6 @@ import sun.awt.AWTAccessor;
 import sun.awt.AWTAccessor.DragSourceContextAccessor;
 import sun.awt.dnd.SunDragSourceContextPeer;
 import sun.security.action.GetIntegerAction;
-
 
 /**
  * The {@code DragSource} is the entity responsible
@@ -803,6 +802,8 @@ public class DragSource implements Serializable {
      *     {@code DragSourceMotionListener} object.
      * </ul>
      *
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData Either a {@code FlavorMap} instance, or
      *      {@code null}, followed by a {@code null}-terminated
      *      sequence of 0 or more pairs; the pair consists of a
@@ -849,6 +850,10 @@ public class DragSource implements Serializable {
      * <li>Otherwise, the key/value pair is skipped.
      * </ul>
      *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      * @see java.awt.datatransfer.SystemFlavorMap#getDefaultFlavorMap
      * @since 1.4
      */

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSourceContext.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSourceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -544,6 +544,8 @@ public class DragSourceContext
      * {@code DragSourceListener} is written out if and only if it can be
      * serialized. If not, {@code null} is written instead.
      *
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData The default serializable fields, in alphabetical order,
      *             followed by either a {@code Transferable} instance, or
      *             {@code null}, followed by either a
@@ -570,6 +572,10 @@ public class DragSourceContext
      * {@code Transferable} is set to a dummy {@code Transferable}
      * which supports no {@code DataFlavor}s.
      *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      * @since 1.4
      */
     private void readObject(ObjectInputStream s)

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTarget.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,6 @@
 
 package java.awt.dnd;
 
-import java.util.TooManyListenersException;
-
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
-
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.GraphicsEnvironment;
@@ -40,18 +33,23 @@ import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.datatransfer.FlavorMap;
 import java.awt.datatransfer.SystemFlavorMap;
-import javax.swing.Timer;
+import java.awt.dnd.peer.DropTargetPeer;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.peer.ComponentPeer;
 import java.awt.peer.LightweightPeer;
-import java.awt.dnd.peer.DropTargetPeer;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.TooManyListenersException;
+
+import javax.swing.Timer;
 
 import sun.awt.AWTAccessor;
 import sun.awt.AWTAccessor.ComponentAccessor;
-
 
 /**
  * The {@code DropTarget} is associated
@@ -576,6 +574,8 @@ public class DropTarget implements DropTargetListener, Serializable {
      * only if it can be serialized. If not, {@code null} is written
      * instead.
      *
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData The default serializable fields, in alphabetical order,
      *             followed by either a {@code DropTargetListener}
      *             instance, or {@code null}.
@@ -598,6 +598,10 @@ public class DropTarget implements DropTargetListener, Serializable {
      * {@code DropTargetListener}. If this fails, the next object in the
      * stream is used instead.
      *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      * @since 1.4
      */
     private void readObject(ObjectInputStream s)

--- a/src/java.desktop/share/classes/java/awt/event/FocusEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/FocusEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,6 +381,9 @@ public class FocusEvent extends ComponentEvent {
      * {@link Cause#UNKNOWN} and its other fields have the same values as in
      * this {@code FocusEvent} instance.
      *
+     * @return a newly created object from deserialized data
+     * @throws ObjectStreamException if a new object replacing this object could
+     *         not be created
      * @serial
      * @see #cause
      * @since 9

--- a/src/java.desktop/share/classes/java/awt/event/HierarchyEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/HierarchyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -162,9 +162,23 @@ public class HierarchyEvent extends AWTEvent {
      */
     public static final int SHOWING_CHANGED = 0x4;
 
+    /**
+     * The {@code Component} at the top of the hierarchy which was changed.
+     */
     Component changed;
+
+    /**
+     * The parent of the {@code changed} component. This may be the parent
+     * before or after the change, depending on the type of change.
+     */
     Container changedParent;
-    long      changeFlags;
+
+    /**
+     * A bitmask which indicates the type(s) of the {@code HIERARCHY_CHANGED}
+     * events represented in this event object. For information on allowable
+     * values, see the class description for {@link HierarchyEvent}
+     */
+    long changeFlags;
 
     /**
      * Constructs an {@code HierarchyEvent} object to identify a

--- a/src/java.desktop/share/classes/java/awt/event/InputMethodEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/InputMethodEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,19 +25,19 @@
 
 package java.awt.event;
 
-import sun.awt.AWTAccessor;
-import sun.awt.AppContext;
-import sun.awt.SunToolkit;
-
 import java.awt.AWTEvent;
 import java.awt.Component;
 import java.awt.EventQueue;
 import java.awt.font.TextHitInfo;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.lang.annotation.Native;
 import java.text.AttributedCharacterIterator;
 import java.text.CharacterIterator;
-import java.lang.annotation.Native;
+
+import sun.awt.AWTAccessor;
+import sun.awt.AppContext;
+import sun.awt.SunToolkit;
 
 /**
  * Input method events contain information about text that is being
@@ -414,6 +414,11 @@ public class InputMethodEvent extends AWTEvent {
      * Initializes the {@code when} field if it is not present in the
      * object input stream. In that case, the field will be initialized by
      * invoking {@link java.awt.EventQueue#getMostRecentEventTime()}.
+     *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      */
     private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
         s.defaultReadObject();

--- a/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+
 import sun.awt.AWTAccessor;
 
 /**
@@ -1878,6 +1879,11 @@ public class KeyEvent extends InputEvent {
     /**
      * Sets new modifiers by the old ones. The key modifiers
      * override overlapping mouse modifiers.
+     *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      * @serial
      */
     @SuppressWarnings("deprecation")

--- a/src/java.desktop/share/classes/java/awt/event/MouseEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/MouseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,11 @@ package java.awt.event;
 
 import java.awt.Component;
 import java.awt.GraphicsEnvironment;
+import java.awt.IllegalComponentStateException;
 import java.awt.Point;
 import java.awt.Toolkit;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.awt.IllegalComponentStateException;
-import java.awt.MouseInfo;
 
 import sun.awt.AWTAccessor;
 import sun.awt.SunToolkit;
@@ -1188,6 +1187,11 @@ public class MouseEvent extends InputEvent {
 
     /**
      * Sets new modifiers by the old ones.
+     *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      * @serial
      */
     @SuppressWarnings("deprecation")

--- a/src/java.desktop/share/classes/java/awt/event/WindowEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/WindowEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.awt.event;
 
 import java.awt.Window;
 import java.lang.annotation.Native;
+
 import sun.awt.AppContext;
 import sun.awt.SunToolkit;
 
@@ -163,11 +164,14 @@ public class WindowEvent extends ComponentEvent {
     transient Window opposite;
 
     /**
-     * TBS
+     * Previous state of the window for window state change event.
      */
     int oldState;
-    int newState;
 
+    /**
+     * New state of the window for window state change event.
+     */
+    int newState;
 
     /*
      * JDK 1.1 serialVersionUID

--- a/src/java.desktop/share/classes/java/awt/font/TransformAttribute.java
+++ b/src/java.desktop/share/classes/java/awt/font/TransformAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,9 @@
 package java.awt.font;
 
 import java.awt.geom.AffineTransform;
-import java.io.Serializable;
+import java.io.IOException;
 import java.io.ObjectStreamException;
+import java.io.Serializable;
 
 /**
  * The {@code TransformAttribute} class provides an immutable
@@ -99,6 +100,12 @@ public final class TransformAttribute implements Serializable {
      */
     public static final TransformAttribute IDENTITY = new TransformAttribute(null);
 
+    /**
+     * Writes default serializable fields to stream.
+     *
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
+     */
     private void writeObject(java.io.ObjectOutputStream s)
       throws java.io.IOException
     {
@@ -109,7 +116,12 @@ public final class TransformAttribute implements Serializable {
         s.defaultWriteObject();
     }
 
-    /*
+    /**
+     * Resolves a {@code TransformAttribute} object after serialization.
+     *
+     * @return a newly created object from deserialized data
+     * @throws ObjectStreamException if a new object replacing this object could
+     *         not be created
      * @since 1.6
      */
     private Object readResolve() throws ObjectStreamException {

--- a/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
+++ b/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.awt.geom;
 
 import java.awt.Shape;
 import java.beans.ConstructorProperties;
+import java.io.IOException;
 
 /**
  * The {@code AffineTransform} class represents a 2D affine transform
@@ -3942,12 +3943,26 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      */
     private static final long serialVersionUID = 1330973210523860834L;
 
+    /**
+     * Writes default serializable fields to stream.
+     *
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
+     */
     private void writeObject(java.io.ObjectOutputStream s)
         throws java.io.IOException
     {
         s.defaultWriteObject();
     }
 
+    /**
+     * Reads the {@code ObjectInputStream}.
+     *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     */
     private void readObject(java.io.ObjectInputStream s)
         throws java.lang.ClassNotFoundException, java.io.IOException
     {

--- a/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package java.awt.geom;
 
+import java.io.IOException;
 import java.io.Serializable;
 
 /**
@@ -330,6 +331,8 @@ public abstract class Arc2D extends RectangularShape {
          * indicating the arc type of this {@code Arc2D}
          * instance.
          *
+         * @param  s the {@code ObjectOutputStream} to write
+         * @throws IOException if an I/O error occurs
          * @serialData
          * <ol>
          * <li>The default serializable fields.
@@ -352,6 +355,10 @@ public abstract class Arc2D extends RectangularShape {
          * indicating the arc type of this {@code Arc2D}
          * instance.
          *
+         * @param  s the {@code ObjectInputStream} to read
+         * @throws ClassNotFoundException if the class of a serialized object
+         *         could not be found
+         * @throws IOException if an I/O error occurs
          * @serialData
          * <ol>
          * <li>The default serializable fields.
@@ -622,6 +629,8 @@ public abstract class Arc2D extends RectangularShape {
          * indicating the arc type of this {@code Arc2D}
          * instance.
          *
+         * @param  s the {@code ObjectOutputStream} to write
+         * @throws IOException if an I/O error occurs
          * @serialData
          * <ol>
          * <li>The default serializable fields.
@@ -644,6 +653,10 @@ public abstract class Arc2D extends RectangularShape {
          * indicating the arc type of this {@code Arc2D}
          * instance.
          *
+         * @param  s the {@code ObjectInputStream} to read
+         * @throws ClassNotFoundException if the class of a serialized object
+         *         could not be found
+         * @throws IOException if an I/O error occurs
          * @serialData
          * <ol>
          * <li>The default serializable fields.

--- a/src/java.desktop/share/classes/java/awt/geom/Path2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Path2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.awt.geom;
 
 import java.awt.Rectangle;
 import java.awt.Shape;
+import java.io.IOException;
 import java.io.Serializable;
 import java.io.StreamCorruptedException;
 import java.util.Arrays;
@@ -857,6 +858,8 @@ public abstract class Path2D implements Shape, Cloneable {
          * serialization of the path segments stored in this
          * path.
          *
+         * @param  s the {@code ObjectOutputStream} to write
+         * @throws IOException if an I/O error occurs
          * @serialData
          * <ol>
          * <li>The default serializable fields.
@@ -994,6 +997,10 @@ public abstract class Path2D implements Shape, Cloneable {
          * The serial data for this object is described in the
          * writeObject method.
          *
+         * @param  s the {@code ObjectInputStream} to read
+         * @throws ClassNotFoundException if the class of a serialized object
+         *         could not be found
+         * @throws IOException if an I/O error occurs
          * @since 1.6
          */
         private void readObject(java.io.ObjectInputStream s)
@@ -1632,6 +1639,8 @@ public abstract class Path2D implements Shape, Cloneable {
          * serialization of the path segments stored in this
          * path.
          *
+         * @param  s the {@code ObjectOutputStream} to write
+         * @throws IOException if an I/O error occurs
          * @serialData
          * <ol>
          * <li>The default serializable fields.
@@ -1768,6 +1777,10 @@ public abstract class Path2D implements Shape, Cloneable {
          * The serial data for this object is described in the
          * writeObject method.
          *
+         * @param  s the {@code ObjectInputStream} to read
+         * @throws ClassNotFoundException if the class of a serialized object
+         *         could not be found
+         * @throws IOException if an I/O error occurs         *
          * @since 1.6
          */
         private void readObject(java.io.ObjectInputStream s)

--- a/src/java.desktop/share/classes/java/beans/IndexedPropertyChangeEvent.java
+++ b/src/java.desktop/share/classes/java/beans/IndexedPropertyChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.beans;
 
 /**
@@ -41,8 +42,12 @@ package java.beans;
  * @author Mark Davidson
  */
 public class IndexedPropertyChangeEvent extends PropertyChangeEvent {
+
     private static final long serialVersionUID = -320227448495806870L;
 
+    /**
+     * The index of the property element that was changed.
+     */
     private int index;
 
     /**

--- a/src/java.desktop/share/classes/java/beans/PropertyChangeSupport.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyChangeSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.beans;
 
-import java.io.Serializable;
-import java.io.ObjectStreamField;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamField;
+import java.io.Serializable;
 import java.util.Hashtable;
 import java.util.Map.Entry;
 
@@ -423,6 +424,10 @@ public class PropertyChangeSupport implements Serializable {
     }
 
     /**
+     * Writes serializable fields to stream.
+     *
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData Null terminated list of {@code PropertyChangeListeners}.
      * <p>
      * At serialization time we skip non-serializable listeners and
@@ -462,6 +467,14 @@ public class PropertyChangeSupport implements Serializable {
         s.writeObject(null);
     }
 
+    /**
+     * Reads the {@code ObjectInputStream}.
+     *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     */
     private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
         this.map = new PropertyChangeListenerMap();
 
@@ -491,9 +504,13 @@ public class PropertyChangeSupport implements Serializable {
     private Object source;
 
     /**
-     * @serialField children                                   Hashtable
-     * @serialField source                                     Object
+     * @serialField children Hashtable
+     *              The list of {@code PropertyChangeListeners}
+     * @serialField source Object
+     *              The object to be provided as the "source" for any generated
+     *              events
      * @serialField propertyChangeSupportSerializedDataVersion int
+     *              The version
      */
     private static final ObjectStreamField[] serialPersistentFields = {
             new ObjectStreamField("children", Hashtable.class),

--- a/src/java.desktop/share/classes/java/beans/VetoableChangeSupport.java
+++ b/src/java.desktop/share/classes/java/beans/VetoableChangeSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.beans;
 
-import java.io.Serializable;
-import java.io.ObjectStreamField;
-import java.io.ObjectOutputStream;
-import java.io.ObjectInputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamField;
+import java.io.Serializable;
 import java.util.Hashtable;
 import java.util.Map.Entry;
 
@@ -412,6 +413,10 @@ public class VetoableChangeSupport implements Serializable {
     }
 
     /**
+     * Writes serializable fields to stream.
+     *
+     * @param  s the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      * @serialData Null terminated list of {@code VetoableChangeListeners}.
      * <p>
      * At serialization time we skip non-serializable listeners and
@@ -451,6 +456,14 @@ public class VetoableChangeSupport implements Serializable {
         s.writeObject(null);
     }
 
+    /**
+     * Reads the {@code ObjectInputStream}.
+     *
+     * @param  s the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
+     */
     private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
         this.map = new VetoableChangeListenerMap();
 
@@ -480,9 +493,13 @@ public class VetoableChangeSupport implements Serializable {
     private Object source;
 
     /**
-     * @serialField children                                   Hashtable
-     * @serialField source                                     Object
+     * @serialField children Hashtable
+     *              The list of {@code PropertyChangeListeners}
+     * @serialField source Object
+     *              The object to be provided as the "source" for any generated
+     *              events
      * @serialField vetoableChangeSupportSerializedDataVersion int
+     *              The version
      */
     private static final ObjectStreamField[] serialPersistentFields = {
             new ObjectStreamField("children", Hashtable.class),

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,12 +28,9 @@ package java.beans.beancontext;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
-
+import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
 import java.beans.VetoableChangeSupport;
-
-import java.beans.PropertyVetoException;
-
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -312,8 +309,10 @@ public class BeanContextChildSupport implements BeanContextChild, BeanContextSer
 
     /**
      * Write the persistence state of the object.
+     *
+     * @param  oos the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      */
-
     private void writeObject(ObjectOutputStream oos) throws IOException {
 
         /*
@@ -332,10 +331,13 @@ public class BeanContextChildSupport implements BeanContextChild, BeanContextSer
 
     /**
      * Restore a persistent object, must wait for subsequent setBeanContext()
-     * to fully restore any resources obtained from the new nesting
-     * BeanContext
+     * to fully restore any resources obtained from the new nesting BeanContext.
+     *
+     * @param  ois the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      */
-
     private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
         ois.defaultReadObject();
     }

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceRevokedEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceRevokedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,6 @@
  */
 
 package java.beans.beancontext;
-
-import java.beans.beancontext.BeanContextEvent;
-
-import java.beans.beancontext.BeanContextServices;
 
 /**
  * <p>
@@ -94,6 +90,10 @@ public class BeanContextServiceRevokedEvent extends BeanContextEvent {
     /**
      * A {@code Class} reference to the service that is being revoked.
      */
-    protected Class<?>                   serviceClass;
-    private   boolean                    invalidateRefs;
+    protected Class<?> serviceClass;
+
+    /**
+     * {@code true} if current service is being forcibly revoked.
+     */
+    private boolean invalidateRefs;
 }

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,22 +25,18 @@
 
 package java.beans.beancontext;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
-
-import java.util.TooManyListenersException;
-
 import java.util.Locale;
+import java.util.Map;
+import java.util.TooManyListenersException;
 
 /**
  * <p>
@@ -1209,9 +1205,11 @@ public class      BeanContextServicesSupport extends BeanContextSupport
     }
 
     /**
-     * serialize the instance
+     * Serialize the instance.
+     *
+     * @param  oos the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      */
-
     private synchronized void writeObject(ObjectOutputStream oos) throws IOException {
         oos.defaultWriteObject();
 
@@ -1219,9 +1217,13 @@ public class      BeanContextServicesSupport extends BeanContextSupport
     }
 
     /**
-     * deserialize the instance
+     * Deserialize the instance.
+     *
+     * @param  ois the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      */
-
     private synchronized void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
 
         ois.defaultReadObject();

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,37 +27,24 @@ package java.beans.beancontext;
 
 import java.awt.Component;
 import java.awt.Container;
-
 import java.beans.Beans;
-import java.beans.AppletInitializer;
-
-import java.beans.DesignMode;
-
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
-
-import java.beans.VetoableChangeListener;
-import java.beans.VetoableChangeSupport;
 import java.beans.PropertyVetoException;
-
+import java.beans.VetoableChangeListener;
 import java.beans.Visibility;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-
 import java.net.URL;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
-
 
 /**
  * This helper class provides a utility implementation of the
@@ -338,8 +325,16 @@ public class      BeanContextSupport extends BeanContextChildSupport
          */
 
 
+        /**
+         * The child.
+         */
         @SuppressWarnings("serial") // Not statically typed as Serializable
-        private           Object   child;
+        private Object child;
+
+        /**
+         * The peer if the child and the peer are related by an implementation
+         * of BeanContextProxy
+         */
         @SuppressWarnings("serial") // Not statically typed as Serializable
         private           Object   proxyPeer;
 
@@ -997,9 +992,9 @@ public class      BeanContextSupport extends BeanContextChildSupport
      * it should always call writeObject() followed by writeChildren() and
      * readObject() followed by readChildren().
      *
-     * @param oos the ObjectOutputStream
+     * @param  oos the {@code ObjectOutputStream} to write
+     * @throws IOException if an I/O error occurs
      */
-
     private synchronized void writeObject(ObjectOutputStream oos) throws IOException {
         serializing = true;
 
@@ -1065,8 +1060,12 @@ public class      BeanContextSupport extends BeanContextChildSupport
      * deserialize contents ... if this instance has a distinct peer the
      * children are *not* serialized here, the peer's readObject() must call
      * readChildren() after deserializing this instance.
+     *
+     * @param  ois the {@code ObjectInputStream} to read
+     * @throws ClassNotFoundException if the class of a serialized object could
+     *         not be found
+     * @throws IOException if an I/O error occurs
      */
-
     private synchronized void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
 
         synchronized(BeanContext.globalHierarchyLock) {
@@ -1372,7 +1371,10 @@ public class      BeanContextSupport extends BeanContextChildSupport
      */
     protected transient HashMap<Object, BCSChild>         children;
 
-    private             int             serializable  = 0; // children serializable
+    /**
+     * Currently serializable children.
+     */
+    private int serializable = 0; // children serializable
 
     /**
      * all accesses to the {@code protected ArrayList bcmListeners} field

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataNode.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,16 +30,19 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.w3c.dom.Attr;
+import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.DOMException;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.TypeInfo;
 import org.w3c.dom.UserDataHandler;
 
-
+/**
+ * A {@code IIODOMException} is thrown by the {@code IIOMetadataNode} in
+ * "exceptional" circumstances.
+ */
 class IIODOMException extends DOMException {
     private static final long serialVersionUID = -4369510142067447468L;
 

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataNode.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataNode.java
@@ -40,7 +40,7 @@ import org.w3c.dom.TypeInfo;
 import org.w3c.dom.UserDataHandler;
 
 /**
- * A {@code IIODOMException} is thrown by the {@code IIOMetadataNode} in
+ * An {@code IIODOMException} is thrown by the {@code IIOMetadataNode} in
  * "exceptional" circumstances.
  */
 class IIODOMException extends DOMException {

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/DialogOwner.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/DialogOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,10 @@
 package javax.print.attribute.standard;
 
 import java.awt.Window;
+
 import javax.print.attribute.Attribute;
 import javax.print.attribute.PrintRequestAttribute;
+
 import sun.print.DialogOwnerAccessor;
 
 /**
@@ -59,6 +61,9 @@ public final class DialogOwner implements PrintRequestAttribute {
 
     private static final long serialVersionUID = -1901909867156076547L;
 
+    /**
+     * The owner of the dialog.
+     */
     private Window owner;
     private transient long id;
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthDesktopPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthDesktopPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,34 @@
 
 package javax.swing.plaf.synth;
 
-import javax.swing.*;
-import javax.swing.border.*;
-import javax.swing.plaf.*;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+import java.awt.event.ContainerEvent;
+import java.awt.event.ContainerListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyVetoException;
+
+import javax.swing.DefaultDesktopManager;
+import javax.swing.DesktopManager;
+import javax.swing.JComponent;
+import javax.swing.JDesktopPane;
+import javax.swing.JInternalFrame;
+import javax.swing.JLayeredPane;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+import javax.swing.border.BevelBorder;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.UIResource;
 import javax.swing.plaf.basic.BasicDesktopPaneUI;
-import java.beans.*;
-import java.awt.event.*;
-import java.awt.*;
 
 /**
  * Provides the Synth L&amp;F UI delegate for
@@ -198,6 +219,9 @@ public class SynthDesktopPaneUI extends BasicDesktopPaneUI implements
         super.uninstallDesktopManager();
     }
 
+    /**
+     * The {@code TaskBar} installed by the UI.
+     */
     @SuppressWarnings("serial") // Same-version serialization only and
                                 // internal anonymous classes
     static class TaskBar extends JPanel implements ComponentListener, ContainerListener {
@@ -327,6 +351,9 @@ public class SynthDesktopPaneUI extends BasicDesktopPaneUI implements
         }
     }
 
+    /**
+     * The default {@code DesktopManager} installed by the UI.
+     */
     @SuppressWarnings("serial") // Same-version serialization only
     class SynthDesktopManager extends DefaultDesktopManager implements UIResource {
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthInternalFrameTitlePane.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthInternalFrameTitlePane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,33 @@
 
 package javax.swing.plaf.synth;
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
-import javax.swing.plaf.*;
-import javax.swing.plaf.basic.BasicInternalFrameTitlePane;
-import java.beans.PropertyChangeListener;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Image;
+import java.awt.Insets;
+import java.awt.LayoutManager;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
+
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JInternalFrame;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.JSeparator;
+import javax.swing.SwingConstants;
+import javax.swing.UIManager;
+import javax.swing.plaf.UIResource;
+import javax.swing.plaf.basic.BasicInternalFrameTitlePane;
+
 import sun.swing.SwingUtilities2;
 
 /**
@@ -157,6 +176,9 @@ class SynthInternalFrameTitlePane extends BasicInternalFrameTitlePane
         super.uninstallDefaults();
     }
 
+    /**
+     * A subclass of {@code JPopupMenu} that implements {@code UIResource}.
+     */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     private static class JPopupMenuUIResource extends JPopupMenu implements
         UIResource { }

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthListUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthListUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,19 @@
 
 package javax.swing.plaf.synth;
 
-import javax.swing.*;
-import javax.swing.border.*;
-import javax.swing.plaf.*;
-import javax.swing.plaf.basic.*;
-import java.awt.*;
-import java.beans.PropertyChangeListener;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Graphics;
 import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JComponent;
+import javax.swing.JList;
+import javax.swing.border.Border;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.UIResource;
+import javax.swing.plaf.basic.BasicListUI;
 
 /**
  * Provides the Synth L&amp;F UI delegate for
@@ -198,6 +204,9 @@ public class SynthListUI extends BasicListUI
         return SynthLookAndFeel.getComponentState(c);
     }
 
+    /**
+     * The {@code DefaultListCellRenderer} installed by the UI.
+     */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     private class SynthListCellRenderer extends DefaultListCellRenderer.UIResource {
         @Override public String getName() {

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthScrollPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthScrollPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,20 +25,27 @@
 
 package javax.swing.plaf.synth;
 
-import javax.swing.*;
-import javax.swing.text.JTextComponent;
-import javax.swing.border.*;
-import javax.swing.plaf.*;
-import javax.swing.plaf.basic.*;
-
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeEvent;
-
-import java.awt.*;
-import java.awt.event.ContainerListener;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.Rectangle;
 import java.awt.event.ContainerEvent;
-import java.awt.event.FocusListener;
+import java.awt.event.ContainerListener;
 import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import javax.swing.JComponent;
+import javax.swing.JScrollPane;
+import javax.swing.JViewport;
+import javax.swing.UIManager;
+import javax.swing.border.AbstractBorder;
+import javax.swing.border.Border;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.UIResource;
+import javax.swing.plaf.basic.BasicScrollPaneUI;
+import javax.swing.text.JTextComponent;
 
 /**
  * Provides the Synth L&amp;F UI delegate for
@@ -230,7 +237,9 @@ public class SynthScrollPaneUI extends BasicScrollPaneUI
         }
     }
 
-
+    /**
+     * A subclass of {@code AbstractBorder} that implements {@code UIResource}.
+     */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     private class ViewportBorder extends AbstractBorder implements UIResource {
         private Insets insets;

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTabbedPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTabbedPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,31 @@
 
 package javax.swing.plaf.synth;
 
-import javax.swing.*;
-import javax.swing.plaf.*;
-import javax.swing.plaf.basic.*;
+import java.awt.Component;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.LayoutManager;
+import java.awt.Rectangle;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import javax.swing.BorderFactory;
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.UIResource;
+import javax.swing.plaf.basic.BasicTabbedPaneUI;
 import javax.swing.text.View;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeEvent;
 import sun.swing.SwingUtilities2;
 
 /**
@@ -912,6 +928,10 @@ public class SynthTabbedPaneUI extends BasicTabbedPaneUI
         }
     }
 
+    /**
+     * A subclass of {@code SynthArrowButton} that implements
+     * {@code UIResource}.
+     */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     private class SynthScrollableTabButton extends SynthArrowButton implements
             UIResource {

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTableHeaderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTableHeaderUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,23 @@
 
 package javax.swing.plaf.synth;
 
-import java.awt.*;
-import java.beans.*;
-import javax.swing.*;
-import javax.swing.border.*;
-import javax.swing.plaf.*;
-import javax.swing.plaf.basic.*;
-import javax.swing.table.*;
-import sun.swing.table.*;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import javax.swing.RowSorter;
+import javax.swing.border.Border;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.UIResource;
+import javax.swing.plaf.basic.BasicTableHeaderUI;
+import javax.swing.table.JTableHeader;
+import javax.swing.table.TableCellRenderer;
+
+import sun.swing.table.DefaultTableCellHeaderRenderer;
 
 /**
  * Provides the Synth L&amp;F UI delegate for
@@ -217,6 +226,9 @@ public class SynthTableHeaderUI extends BasicTableHeaderUI
         }
     }
 
+    /**
+     * The {@code DefaultTableCellHeaderRenderer} installed by the UI.
+     */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     private class HeaderRenderer extends DefaultTableCellHeaderRenderer {
         HeaderRenderer() {

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTableUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTableUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.text.DateFormat;
 import java.text.Format;
 import java.text.NumberFormat;
 import java.util.Date;
+
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JCheckBox;
@@ -45,7 +46,9 @@ import javax.swing.JLabel;
 import javax.swing.JTable;
 import javax.swing.LookAndFeel;
 import javax.swing.border.Border;
-import javax.swing.plaf.*;
+import javax.swing.plaf.ColorUIResource;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.UIResource;
 import javax.swing.plaf.basic.BasicTableUI;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.JTableHeader;
@@ -706,6 +709,9 @@ public class SynthTableUI extends BasicTableUI
         }
     }
 
+    /**
+     * The renderer installed by the UI to render the boolean data.
+     */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     private class SynthBooleanTableCellRenderer extends JCheckBox implements
                       TableCellRenderer {
@@ -745,6 +751,9 @@ public class SynthTableUI extends BasicTableUI
         }
     }
 
+    /**
+     * The {@code DefaultTableCellRenderer} installed by the UI.
+     */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     private class SynthTableCellRenderer extends DefaultTableCellRenderer {
         private Object numberFormat;

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTreeUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTreeUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing.plaf.synth;
 
 import java.awt.Color;
@@ -32,6 +33,7 @@ import java.awt.Rectangle;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Enumeration;
+
 import javax.swing.DefaultCellEditor;
 import javax.swing.Icon;
 import javax.swing.JComponent;
@@ -680,6 +682,10 @@ public class SynthTreeUI extends BasicTreeUI
         return super.getRowX(row, depth) + padding;
     }
 
+    /**
+     * A subclass of {@code DefaultTreeCellRenderer} that implements
+     * {@code UIResource}.
+     */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     private class SynthTreeCellRenderer extends DefaultTreeCellRenderer
                                implements UIResource {

--- a/src/java.desktop/share/classes/javax/swing/text/GapVector.java
+++ b/src/java.desktop/share/classes/javax/swing/text/GapVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package javax.swing.text;
 
-import java.util.Vector;
 import java.io.Serializable;
-import javax.swing.undo.UndoableEdit;
 
 /**
  * An implementation of a gapped buffer similar to that used by
@@ -67,17 +66,24 @@ abstract class GapVector implements Serializable {
     /**
      * Allocate an array to store items of the type
      * appropriate (which is determined by the subclass).
+     *
+     * @param  len the length of the array
+     * @return the java array of some type
      */
     protected abstract Object allocateArray(int len);
 
     /**
-     * Get the length of the allocated array
+     * Get the length of the allocated array.
+     *
+     * @return the length of the array
      */
     protected abstract int getArrayLength();
 
     /**
      * Access to the array.  The actual type
      * of the array is known only by the subclass.
+     *
+     * @return the java array of some type
      */
     protected final Object getArray() {
         return array;
@@ -85,6 +91,8 @@ abstract class GapVector implements Serializable {
 
     /**
      * Access to the start of the gap.
+     *
+     * @return the start of the gap
      */
     protected final int getGapStart() {
         return g0;
@@ -92,6 +100,8 @@ abstract class GapVector implements Serializable {
 
     /**
      * Access to the end of the gap.
+     *
+     * @return the end of the gap
      */
     protected final int getGapEnd() {
         return g1;
@@ -128,6 +138,7 @@ abstract class GapVector implements Serializable {
      *  the location in the contiguous space being modeled.
      * @param rmSize the number of items to remove
      * @param addItems the new items to place in storage.
+     * @param addSize the number of items to add
      */
     protected void replace(int position, int rmSize, Object addItems, int addSize) {
         int addOffset = 0;
@@ -219,7 +230,9 @@ abstract class GapVector implements Serializable {
 
     /**
      * Make the gap bigger, moving any necessary data and updating
-     * the appropriate marks
+     * the appropriate marks.
+     *
+     * @param  newSize the new capacity
      */
     protected void shiftEnd(int newSize) {
         int oldSize = getArrayLength();
@@ -251,6 +264,8 @@ abstract class GapVector implements Serializable {
      * without changing the size of the gap.  This
      * moves the data in the array and updates the
      * marks accordingly.
+     *
+     * @param  newGapStart the new start of the gap
      */
     protected void shiftGap(int newGapStart) {
         if (newGapStart == g0) {
@@ -280,6 +295,8 @@ abstract class GapVector implements Serializable {
      * gap start down to the new gap start are squeezed
      * to the end of the gap (their location has been
      * removed).
+     *
+     * @param  newGapStart the new start of the gap
      */
     protected void shiftGapStartDown(int newGapStart) {
         g0 = newGapStart;
@@ -292,6 +309,8 @@ abstract class GapVector implements Serializable {
      * gap end up to the new gap end are squeezed
      * to the end of the gap (their location has been
      * removed).
+     *
+     * @param  newGapEnd the new end of the gap
      */
     protected void shiftGapEndUp(int newGapEnd) {
         g1 = newGapEnd;


### PR DESCRIPTION
We have a number of missing javadoc tags and comments in the desktop module.
Most of the missing comments are related to the serialized form.

The fix:
  - Adds missing comments to the non-static/non-transient fields(even private) of the "serializable" classes
  - Adds comments to the "serializable" classes even if those classes are non-public
  - Fixes references/adds missing tags to the special methods(like readObject/writeObject)
  - Delete the java.awt.PeerFixer class.

I need advice about what exact change should be reviewed in  the CSR(except PeerFixer removal)

Note that in some cases I added the comments to the "implementation details", so I did not specify it fully.

The old review request:
https://mail.openjdk.java.net/pipermail/beans-dev/2020-August/000423.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251123](https://bugs.openjdk.java.net/browse/JDK-8251123): doclint warnings about missing javadoc tags and comments


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**) ⚠️ Review applies to cfc1df5d40d7c67719e97e93c41f31bb46d6b700
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/369/head:pull/369`
`$ git checkout pull/369`
