### PR TITLE
8252003: remove usage of PropertyResolvingWrapper in vmTestbase/nsk/jvmti

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddCapabilities/addcaps003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddCapabilities/addcaps003/TestDescription.java
@@ -49,7 +49,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.AddCapabilities.addcaps003
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -XX:+UnlockDiagnosticVMOptions
  *      -XX:+PrintInterpreter
  *      -XX:+IgnoreUnrecognizedVMOptions

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddCapabilities/addcaps003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddCapabilities/addcaps003/TestDescription.java
@@ -47,9 +47,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.AddCapabilities.addcaps003
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -XX:+UnlockDiagnosticVMOptions
  *      -XX:+PrintInterpreter
  *      -XX:+IgnoreUnrecognizedVMOptions

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch001/TestDescription.java
@@ -63,7 +63,7 @@
  *      newclass
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass"
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch001/TestDescription.java
@@ -62,7 +62,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass
  *
- * @build ExecDriver
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch001/TestDescription.java
@@ -64,7 +64,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass"
+ *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch002/TestDescription.java
@@ -88,7 +88,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass
  *
- * @build ExecDriver
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -Xbootclasspath/a:./bin/loadclass
  *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch002/TestDescription.java
@@ -91,7 +91,7 @@
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
  *      -Xbootclasspath/a:./bin/loadclass
- *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass"
+ *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch002/TestDescription.java
@@ -89,7 +89,7 @@
  *      newclass
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -Xbootclasspath/a:./bin/loadclass
  *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass"
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch002

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch003/TestDescription.java
@@ -73,7 +73,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass
  *
- * @build ExecDriver
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -Xbootclasspath/a:./bin/loadclass
  *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch003/TestDescription.java
@@ -76,7 +76,7 @@
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
  *      -Xbootclasspath/a:./bin/loadclass
- *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass"
+ *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch003/TestDescription.java
@@ -74,7 +74,7 @@
  *      newclass
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -Xbootclasspath/a:./bin/loadclass
  *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass"
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch003

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch004/TestDescription.java
@@ -71,7 +71,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass01 segment2=./bin/newclass02"
+ *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass01,segment2=./bin/newclass02
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch004
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch004/TestDescription.java
@@ -69,7 +69,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass02 newclass01
  *
- * @build ExecDriver
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass01,segment2=./bin/newclass02
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch004

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch004/TestDescription.java
@@ -70,7 +70,7 @@
  *      newclass02 newclass01
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass01 segment2=./bin/newclass02"
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch007/TestDescription.java
@@ -78,13 +78,13 @@
  *
  * @comment create bootclssearch003.jar in current directory
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf bootclssearch003.jar
  *      -C ./bin/newclass/
  *      nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch003.class
  *
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -Xbootclasspath/a:./bin/loadclass
  *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=live segment1=./bootclssearch003.jar"
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch003

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch007/TestDescription.java
@@ -77,13 +77,13 @@
  *      ../bootclssearch003/newclass
  *
  * @comment create bootclssearch003.jar in current directory
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf bootclssearch003.jar
  *      -C ./bin/newclass/
  *      nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch003.class
  *
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -Xbootclasspath/a:./bin/loadclass
  *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=live,segment1=./bootclssearch003.jar

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch007/TestDescription.java
@@ -86,7 +86,7 @@
  *
  * @run main/othervm/native ExecDriver --java
  *      -Xbootclasspath/a:./bin/loadclass
- *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=live segment1=./bootclssearch003.jar"
+ *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=live,segment1=./bootclssearch003.jar
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch008/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch008/TestDescription.java
@@ -77,7 +77,6 @@
  *      ../bootclssearch004/newclass02
  *
  * @comment create bootclssearch004.jar in ./bin/newclass01/
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf ./bin/newclass01/bootclssearch004.jar
@@ -85,13 +84,13 @@
  *      nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch004.class
  *
  * @comment create bootclssearch004.jar in ./bin/newclass02/
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf ./bin/newclass02/bootclssearch004.jar
  *      -C ./bin/newclass02/
  *      nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch004.class
  *
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=live,segment1=./bin/newclass01/bootclssearch004.jar,segment2=./bin/newclass02/bootclssearch004.jar
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch004

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch008/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch008/TestDescription.java
@@ -78,7 +78,7 @@
  *
  * @comment create bootclssearch004.jar in ./bin/newclass01/
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf ./bin/newclass01/bootclssearch004.jar
  *      -C ./bin/newclass01/
@@ -86,13 +86,13 @@
  *
  * @comment create bootclssearch004.jar in ./bin/newclass02/
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf ./bin/newclass02/bootclssearch004.jar
  *      -C ./bin/newclass02/
  *      nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch004.class
  *
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=live segment1=./bin/newclass01/bootclssearch004.jar segment2=./bin/newclass02/bootclssearch004.jar"
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch008/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch008/TestDescription.java
@@ -93,7 +93,7 @@
  *      nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch004.class
  *
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=live segment1=./bin/newclass01/bootclssearch004.jar segment2=./bin/newclass02/bootclssearch004.jar"
+ *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=live,segment1=./bin/newclass01/bootclssearch004.jar,segment2=./bin/newclass02/bootclssearch004.jar
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch004
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch009/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch009/TestDescription.java
@@ -65,13 +65,13 @@
  *      ../bootclssearch001/newclass
  *
  * @comment create bootclssearch001.jar in current directory
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf bootclssearch001.jar
  *      -C ./bin/newclass/
  *      nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch001.class
  *
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=live,segment1=./bootclssearch001.jar
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch009/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch009/TestDescription.java
@@ -73,7 +73,7 @@
  *      nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch001.class
  *
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=live segment1=./bootclssearch001.jar"
+ *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=live,segment1=./bootclssearch001.jar
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch009/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch009/TestDescription.java
@@ -66,13 +66,13 @@
  *
  * @comment create bootclssearch001.jar in current directory
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf bootclssearch001.jar
  *      -C ./bin/newclass/
  *      nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch001.class
  *
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=live segment1=./bootclssearch001.jar"
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch010/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch010/TestDescription.java
@@ -93,13 +93,13 @@
  *      ../bootclssearch002/newclass
  *
  * @comment create bootclssearch002.jar in current directory
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf bootclssearch002.jar
  *      -C ./bin/newclass/
  *      nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch002.class
  *
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -Xbootclasspath/a:./bin/loadclass
  *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=live,segment1=./bootclssearch002.jar

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch010/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch010/TestDescription.java
@@ -102,7 +102,7 @@
  *
  * @run main/othervm/native ExecDriver --java
  *      -Xbootclasspath/a:./bin/loadclass
- *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=live segment1=./bootclssearch002.jar"
+ *      -agentlib:bootclssearch_agent=-waittime=5,phasetocheck=live,segment1=./bootclssearch002.jar
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch010/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch010/TestDescription.java
@@ -94,13 +94,13 @@
  *
  * @comment create bootclssearch002.jar in current directory
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf bootclssearch002.jar
  *      -C ./bin/newclass/
  *      nsk/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch002.class
  *
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -Xbootclasspath/a:./bin/loadclass
  *      "-agentlib:bootclssearch_agent=-waittime=5 phasetocheck=live segment1=./bootclssearch002.jar"
  *      nsk.jvmti.AddToBootstrapClassLoaderSearch.bootclssearch002

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch001/TestDescription.java
@@ -63,7 +63,7 @@
  *      newclass
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -cp ${test.class.path}${path.separator}./bin/newclass
  *      "-agentlib:systemclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass"
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch001/TestDescription.java
@@ -65,7 +65,7 @@
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
  *      -cp ${test.class.path}${path.separator}./bin/newclass
- *      "-agentlib:systemclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass"
+ *      -agentlib:systemclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch001/TestDescription.java
@@ -62,7 +62,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass
  *
- * @build ExecDriver
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -cp ${test.class.path}${path.separator}./bin/newclass
  *      -agentlib:systemclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch002/TestDescription.java
@@ -64,7 +64,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:systemclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass"
+ *      -agentlib:systemclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch002/TestDescription.java
@@ -63,7 +63,7 @@
  *      newclass
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:systemclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass"
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch002/TestDescription.java
@@ -62,7 +62,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass
  *
- * @build ExecDriver
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:systemclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch002

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch003/TestDescription.java
@@ -70,7 +70,7 @@
  *      newclass02 newclass01
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:systemclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass01 segment2=./bin/newclass02"
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch003/TestDescription.java
@@ -71,7 +71,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:systemclssearch_agent=-waittime=5 phasetocheck=onload segment1=./bin/newclass01 segment2=./bin/newclass02"
+ *      -agentlib:systemclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass01,segment2=./bin/newclass02
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch003/TestDescription.java
@@ -69,7 +69,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass02 newclass01
  *
- * @build ExecDriver
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:systemclssearch_agent=-waittime=5,phasetocheck=onload,segment1=./bin/newclass01,segment2=./bin/newclass02
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch003

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch004/TestDescription.java
@@ -93,7 +93,7 @@
  *      nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch003.class
  *
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:systemclssearch_agent=-waittime=5 phasetocheck=live segment1=./bin/newclass01/systemclssearch003.jar segment2=./bin/newclass02/systemclssearch003.jar"
+ *      -agentlib:systemclssearch_agent=-waittime=5,phasetocheck=live,segment1=./bin/newclass01/systemclssearch003.jar,segment2=./bin/newclass02/systemclssearch003.jar
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch004/TestDescription.java
@@ -78,7 +78,7 @@
  *
  * @comment create systemclssearch003.jar in current directory
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf ./bin/newclass01/systemclssearch003.jar
  *      -C ./bin/newclass01/
@@ -86,13 +86,13 @@
  *
  * @comment create systemclssearch003.jar in current directory
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf ./bin/newclass02/systemclssearch003.jar
  *      -C ./bin/newclass02/
  *      nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch003.class
  *
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:systemclssearch_agent=-waittime=5 phasetocheck=live segment1=./bin/newclass01/systemclssearch003.jar segment2=./bin/newclass02/systemclssearch003.jar"
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch004/TestDescription.java
@@ -77,7 +77,6 @@
  *      ../systemclssearch003/newclass02
  *
  * @comment create systemclssearch003.jar in current directory
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf ./bin/newclass01/systemclssearch003.jar
@@ -85,13 +84,13 @@
  *      nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch003.class
  *
  * @comment create systemclssearch003.jar in current directory
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf ./bin/newclass02/systemclssearch003.jar
  *      -C ./bin/newclass02/
  *      nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch003.class
  *
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:systemclssearch_agent=-waittime=5,phasetocheck=live,segment1=./bin/newclass01/systemclssearch003.jar,segment2=./bin/newclass02/systemclssearch003.jar
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch003

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch005/TestDescription.java
@@ -74,7 +74,7 @@
  *      nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch001.class
  *
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:systemclssearch_agent=-waittime=5 phasetocheck=live segment1=systemclssearch001.jar"
+ *      -agentlib:systemclssearch_agent=-waittime=5,phasetocheck=live,segment1=systemclssearch001.jar
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch005/TestDescription.java
@@ -67,13 +67,13 @@
  *
  * @comment create systemclssearch001.jar in current directory
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf systemclssearch001.jar
  *      -C ./bin/newclass/
  *      nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch001.class
  *
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:systemclssearch_agent=-waittime=5 phasetocheck=live segment1=systemclssearch001.jar"
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch005/TestDescription.java
@@ -66,13 +66,13 @@
  *      ../systemclssearch001/newclass
  *
  * @comment create systemclssearch001.jar in current directory
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf systemclssearch001.jar
  *      -C ./bin/newclass/
  *      nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch001.class
  *
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:systemclssearch_agent=-waittime=5,phasetocheck=live,segment1=systemclssearch001.jar
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch006/TestDescription.java
@@ -66,13 +66,13 @@
  *      ../systemclssearch002/newclass
  *
  * @comment create systemclssearch002.jar in current directory
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf systemclssearch002.jar
  *      -C ./bin/newclass/
  *      nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch002.class
  *
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:systemclssearch_agent=-waittime=5,phasetocheck=live,segment1=systemclssearch002.jar
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch002

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch006/TestDescription.java
@@ -74,7 +74,7 @@
  *      nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch002.class
  *
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:systemclssearch_agent=-waittime=5 phasetocheck=live segment1=systemclssearch002.jar"
+ *      -agentlib:systemclssearch_agent=-waittime=5,phasetocheck=live,segment1=systemclssearch002.jar
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch006/TestDescription.java
@@ -67,13 +67,13 @@
  *
  * @comment create systemclssearch002.jar in current directory
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cf systemclssearch002.jar
  *      -C ./bin/newclass/
  *      nsk/jvmti/AddToSystemClassLoaderSearch/systemclssearch002.class
  *
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:systemclssearch_agent=-waittime=5 phasetocheck=live segment1=systemclssearch002.jar"
  *      nsk.jvmti.AddToSystemClassLoaderSearch.systemclssearch002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach001/attach001TestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach001/attach001TestRunner.java
@@ -44,7 +44,7 @@
  * @build nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm SimpleAgent00.jar ${test.src}/../sharedAgents/SimpleAgent00.mf
  *      nsk/jvmti/AttachOnDemand/sharedAgents/SimpleAgent00.class
@@ -52,7 +52,6 @@
  * @run main/othervm/native
  *      -XX:+UsePerfData
  *      -Djdk.attach.allowAttachSelf
- *      PropertyResolvingWrapper
  *      nsk.jvmti.AttachOnDemand.attach001.attach001TestRunner
  *      -jdk ${test.jdk}
  *      "-javaOpts=-XX:+UsePerfData -Djdk.attach.allowAttachSelf ${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach001/attach001TestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach001/attach001TestRunner.java
@@ -43,7 +43,6 @@
  * @comment create SimpleAgent00.jar in current directory
  * @build nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm SimpleAgent00.jar ${test.src}/../sharedAgents/SimpleAgent00.mf

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach001/attach001TestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach001/attach001TestRunner.java
@@ -54,7 +54,7 @@
  *      -Djdk.attach.allowAttachSelf
  *      nsk.jvmti.AttachOnDemand.attach001.attach001TestRunner
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData -Djdk.attach.allowAttachSelf ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData -Djdk.attach.allowAttachSelf ${test.vm.opts} ${test.java.opts}"
  *      -ja SimpleAgent00.jar
  *      -na simpleAgent00
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002/TestDescription.java
@@ -50,7 +50,7 @@
  *      newclass00
  *
  * @build nsk.jvmti.AttachOnDemand.attach002.attach002Target
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach002.attach002Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002/TestDescription.java
@@ -54,7 +54,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach002.attach002Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach002Agent00=-pathToNewByteCode=./bin/newclass00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java
@@ -53,14 +53,14 @@
  *
  * @comment compile newclassXX to bin/newclassXX
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/javac
  *      --patch-module java.base=${test.src}/newclass00/java.base
  *      -d bin/newclass00
  *      ${test.src}/newclass00/java.base/java/lang/InterruptedException.java
  *
  * @build nsk.jvmti.AttachOnDemand.attach002a.attach002aTarget
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach002a.attach002aTarget

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java
@@ -64,7 +64,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach002a.attach002aTarget
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach002aAgent00=-pathToNewByteCode=./bin/newclass00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java
@@ -52,7 +52,6 @@
  * @build nsk.share.aod.AODTestRunner
  *
  * @comment compile newclassXX to bin/newclassXX
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/javac
  *      --patch-module java.base=${test.src}/newclass00/java.base

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach003/TestDescription.java
@@ -56,7 +56,7 @@
  * @run main/othervm
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
  *      -ja SimpleAgent00.jar,SimpleAgent00.jar
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach003/TestDescription.java
@@ -47,7 +47,6 @@
  * @comment create SimpleAgent00.jar in current directory
  * @build nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm SimpleAgent00.jar ${test.src}/../sharedAgents/SimpleAgent00.mf

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach003/TestDescription.java
@@ -48,12 +48,12 @@
  * @build nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm SimpleAgent00.jar ${test.src}/../sharedAgents/SimpleAgent00.mf
  *      nsk/jvmti/AttachOnDemand/sharedAgents/SimpleAgent00.class
  *
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach004/TestDescription.java
@@ -56,7 +56,7 @@
  * @run main/othervm
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts} -Djava.security.manager -Djava.security.policy==${test.src}/attach004.policy"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts} -Djava.security.manager -Djava.security.policy==${test.src}/attach004.policy"
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
  *      -ja attach004Agent00.jar
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach004/TestDescription.java
@@ -48,12 +48,12 @@
  * @build nsk.jvmti.AttachOnDemand.attach004.attach004Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach004.attach004Agent00
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach004Agent00.jar ${test.src}/attach004Agent00.mf
  *      nsk/jvmti/AttachOnDemand/attach004/attach004Agent00.class
  *
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts} -Djava.security.manager -Djava.security.policy==${test.src}/attach004.policy"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach004/TestDescription.java
@@ -47,7 +47,6 @@
  * @comment create attach004Agent00.jar in current directory
  * @build nsk.jvmti.AttachOnDemand.attach004.attach004Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach004.attach004Agent00
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach004Agent00.jar ${test.src}/attach004Agent00.mf

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach008/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach008/TestDescription.java
@@ -42,7 +42,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.jvmti.AttachOnDemand.attach008.attach008Target
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach008.attach008Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach008/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach008/TestDescription.java
@@ -46,7 +46,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach008.attach008Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach008Agent00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach009/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach009/TestDescription.java
@@ -45,7 +45,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach009.attach009Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach009Agent00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach009/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach009/TestDescription.java
@@ -41,7 +41,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.jvmti.AttachOnDemand.attach009.attach009Target
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach009.attach009Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach010/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach010/TestDescription.java
@@ -53,7 +53,7 @@
  * @run main/othervm
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
  *      -ja attach010Agent00.jar
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach010/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach010/TestDescription.java
@@ -44,7 +44,6 @@
  * @comment create attach010Agent00.jar in current directory
  * @build nsk.jvmti.AttachOnDemand.attach010.attach010Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach010.attach010Agent00
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach010Agent00.jar ${test.src}/attach010Agent00.mf

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach010/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach010/TestDescription.java
@@ -45,12 +45,12 @@
  * @build nsk.jvmti.AttachOnDemand.attach010.attach010Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach010.attach010Agent00
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach010Agent00.jar ${test.src}/attach010Agent00.mf
  *      nsk/jvmti/AttachOnDemand/attach010/attach010Agent00.class
  *
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach011/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach011/TestDescription.java
@@ -53,7 +53,7 @@
  * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
  *      -na simpleAgent00
  *      -ja SimpleAgent00.jar

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach011/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach011/TestDescription.java
@@ -44,7 +44,6 @@
  * @comment create SimpleAgent00.jar in current directory
  * @build nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm SimpleAgent00.jar ${test.src}/../sharedAgents/SimpleAgent00.mf

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach011/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach011/TestDescription.java
@@ -45,12 +45,12 @@
  * @build nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm SimpleAgent00.jar ${test.src}/../sharedAgents/SimpleAgent00.mf
  *      nsk/jvmti/AttachOnDemand/sharedAgents/SimpleAgent00.class
  *
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach012/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach012/TestDescription.java
@@ -41,7 +41,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.share.aod.TargetApplicationWaitingAgents
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach012/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach012/TestDescription.java
@@ -44,7 +44,7 @@
  * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
  *      -na attach012Agent00
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach013/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach013/TestDescription.java
@@ -42,7 +42,7 @@
  * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
  *      -na simpleAgent00,simpleAgent00,simpleAgent00
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach013/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach013/TestDescription.java
@@ -39,7 +39,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.share.aod.TargetApplicationWaitingAgents
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach014/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach014/TestDescription.java
@@ -38,7 +38,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.jvmti.AttachOnDemand.attach014.attach014Target
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach014.attach014Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach014/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach014/TestDescription.java
@@ -42,7 +42,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach014.attach014Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach014Agent00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/TestDescription.java
@@ -50,7 +50,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach015.attach015Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach015Agent00,attach015Agent01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/TestDescription.java
@@ -46,7 +46,7 @@
  *        nsk.jvmti.AttachOnDemand.attach015.attach015Target
  *        nsk.jvmti.AttachOnDemand.attach015.ClassToLoad1
  *        nsk.jvmti.AttachOnDemand.attach015.ClassToLoad2
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach015.attach015Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java
@@ -52,7 +52,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach020.attach020Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach020Agent00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java
@@ -48,7 +48,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.jvmti.AttachOnDemand.attach020.attach020Target
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach020.attach020Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach021/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach021/TestDescription.java
@@ -44,7 +44,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.jvmti.AttachOnDemand.attach021.attach021Target
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach021.attach021Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach021/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach021/TestDescription.java
@@ -48,7 +48,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach021.attach021Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach021Agent00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java
@@ -47,7 +47,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.jvmti.AttachOnDemand.attach022.attach022Target
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach022.attach022Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java
@@ -51,7 +51,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach022.attach022Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach022Agent00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach024/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach024/TestDescription.java
@@ -46,7 +46,6 @@
  *        nsk.jvmti.AttachOnDemand.attach024.attach024Agent00
  *
  * @comment compile modified java.util.TooManyListenersException
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/javac
  *      -cp ${test.class.path}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach024/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach024/TestDescription.java
@@ -47,7 +47,7 @@
  *
  * @comment compile modified java.util.TooManyListenersException
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/javac
  *      -cp ${test.class.path}
  *      -d ./bin/classes
@@ -56,19 +56,19 @@
  *      ${test.src}/java.base/java/util/TooManyListenersException.java
  *
  * @comment create attach024Agent00.jar in current directory
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach024Agent00.jar ${test.src}/attach024Agent00.mf
  *      -C ./bin/classes
  *      java/util/TooManyListenersException.class
  * @run driver ClassFileInstaller
  *      nsk.jvmti.AttachOnDemand.attach024.attach024Agent00
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -uf attach024Agent00.jar
  *      nsk/jvmti/AttachOnDemand/attach024/attach024Agent00.class
  *
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      "-javaOpts=--add-reads java.base=ALL-UNNAMED -XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach024/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach024/TestDescription.java
@@ -71,7 +71,7 @@
  * @run main/othervm
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
- *      "-javaOpts=--add-reads java.base=ALL-UNNAMED -XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="--add-reads java.base=ALL-UNNAMED -XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
  *      -ja attach024Agent00.jar
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach030/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach030/TestDescription.java
@@ -52,12 +52,12 @@
  * @build nsk.jvmti.AttachOnDemand.attach030.attach030Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach030.attach030Agent00
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach030Agent00.jar ${test.src}/attach030Agent00.mf
  *      nsk/jvmti/AttachOnDemand/attach030/attach030Agent00.class
  *
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach030.attach030Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach030/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach030/TestDescription.java
@@ -51,7 +51,6 @@
  * @comment create attach030Agent00.jar in current directory
  * @build nsk.jvmti.AttachOnDemand.attach030.attach030Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach030.attach030Agent00
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach030Agent00.jar ${test.src}/attach030Agent00.mf

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach030/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach030/TestDescription.java
@@ -61,7 +61,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach030.attach030Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -ja attach030Agent00.jar=-pathToNewByteCode=./bin/newclass00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach031/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach031/TestDescription.java
@@ -45,7 +45,6 @@
  * @comment create attach031Agent00.jar in current directory
  * @build nsk.jvmti.AttachOnDemand.attach031.attach031Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach031.attach031Agent00
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach031Agent00.jar ${test.src}/attach031Agent00.mf

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach031/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach031/TestDescription.java
@@ -46,12 +46,12 @@
  * @build nsk.jvmti.AttachOnDemand.attach031.attach031Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach031.attach031Agent00
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach031Agent00.jar ${test.src}/attach031Agent00.mf
  *      nsk/jvmti/AttachOnDemand/attach031/attach031Agent00.class
  *
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach031/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach031/TestDescription.java
@@ -54,7 +54,7 @@
  * @run main/othervm
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
  *      -ja attach031Agent00.jar
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach034/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach034/TestDescription.java
@@ -47,7 +47,7 @@
  * @build nsk.jvmti.AttachOnDemand.attach034.attach034Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach034.attach034Agent00
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach034Agent00.jar ${test.src}/attach034Agent00.mf
  *      nsk/jvmti/AttachOnDemand/attach034/attach034Agent00.class
@@ -56,12 +56,12 @@
  * @build nsk.jvmti.AttachOnDemand.attach034.AgentParent
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach034.AgentParent
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm AgentParent.jar ${test.src}/AgentParent.mf
  *      nsk/jvmti/AttachOnDemand/attach034/AgentParent.class
  *
- * @run main/othervm PropertyResolvingWrapper
+ * @run main/othervm
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach034/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach034/TestDescription.java
@@ -64,7 +64,7 @@
  * @run main/othervm
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
  *      -ja AgentParent.jar,attach034Agent00.jar
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach034/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach034/TestDescription.java
@@ -46,7 +46,6 @@
  * @comment create attach034Agent00.jar in current directory
  * @build nsk.jvmti.AttachOnDemand.attach034.attach034Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach034.attach034Agent00
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach034Agent00.jar ${test.src}/attach034Agent00.mf
@@ -55,7 +54,6 @@
  * @comment create AgentParent.jar in current directory
  * @build nsk.jvmti.AttachOnDemand.attach034.AgentParent
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach034.AgentParent
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm AgentParent.jar ${test.src}/AgentParent.mf

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach036/attach036TestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach036/attach036TestRunner.java
@@ -40,7 +40,6 @@
  * @comment create attach036Agent00.jar in current directory
  * @build nsk.jvmti.AttachOnDemand.attach036.attach036Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach036.attach036Agent00
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach036Agent00.jar ${test.src}/attach036Agent00.mf

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach036/attach036TestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach036/attach036TestRunner.java
@@ -41,7 +41,7 @@
  * @build nsk.jvmti.AttachOnDemand.attach036.attach036Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach036.attach036Agent00
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach036Agent00.jar ${test.src}/attach036Agent00.mf
  *      nsk/jvmti/AttachOnDemand/attach036/attach036Agent00.class
@@ -49,7 +49,6 @@
  * @run main/othervm
  *      -XX:+UsePerfData
  *      -Djdk.attach.allowAttachSelf
- *      PropertyResolvingWrapper
  *      nsk.jvmti.AttachOnDemand.attach036.attach036TestRunner
  *      -jdk ${test.jdk}
  *      -ja attach036Agent00.jar

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach037/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach037/TestDescription.java
@@ -46,7 +46,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach037.attach037Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach037Agent00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach037/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach037/TestDescription.java
@@ -42,7 +42,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.jvmti.AttachOnDemand.attach037.attach037Target
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach037.attach037Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach038/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach038/TestDescription.java
@@ -44,7 +44,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach038.attach038Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach038Agent00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach038/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach038/TestDescription.java
@@ -40,7 +40,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.jvmti.AttachOnDemand.attach038.attach038Target
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach038.attach038Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach039/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach039/TestDescription.java
@@ -39,7 +39,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.share.aod.TargetApplicationWaitingAgents
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach039/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach039/TestDescription.java
@@ -42,7 +42,7 @@
  * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
  *      -na attach039Agent00
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach040/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach040/TestDescription.java
@@ -49,7 +49,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach040.attach040Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach040Agent00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach040/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach040/TestDescription.java
@@ -45,7 +45,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.jvmti.AttachOnDemand.attach040.attach040Target
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach040.attach040Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach041/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach041/TestDescription.java
@@ -46,7 +46,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.jvmti.AttachOnDemand.attach041.attach041Target
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach041.attach041Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach041/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach041/TestDescription.java
@@ -50,7 +50,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach041.attach041Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach041Agent00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach042/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach042/TestDescription.java
@@ -48,7 +48,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach042.attach042Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach042Agent00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach042/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach042/TestDescription.java
@@ -44,7 +44,7 @@
  *          /test/lib
  * @build nsk.share.aod.AODTestRunner
  *        nsk.jvmti.AttachOnDemand.attach042.attach042Target
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach042.attach042Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach043/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach043/TestDescription.java
@@ -66,7 +66,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach042.attach042Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach042Agent00
  *      -ja SimpleAgent00.jar,attach031Agent00.jar
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach043/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach043/TestDescription.java
@@ -47,7 +47,6 @@
  * @comment create SimpleAgent00.jar in current directory
  * @build nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm SimpleAgent00.jar ${test.src}/../sharedAgents/SimpleAgent00.mf
@@ -56,7 +55,6 @@
  * @comment create attach0031Agent00.jar in current directory
  * @build nsk.jvmti.AttachOnDemand.attach031.attach031Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach031.attach031Agent00
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach031Agent00.jar ${test.src}/../attach031/attach031Agent00.mf

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach043/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach043/TestDescription.java
@@ -48,7 +48,7 @@
  * @build nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.sharedAgents.SimpleAgent00
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm SimpleAgent00.jar ${test.src}/../sharedAgents/SimpleAgent00.mf
  *      nsk/jvmti/AttachOnDemand/sharedAgents/SimpleAgent00.class
@@ -57,12 +57,12 @@
  * @build nsk.jvmti.AttachOnDemand.attach031.attach031Agent00
  * @run driver ClassFileInstaller nsk.jvmti.AttachOnDemand.attach031.attach031Agent00
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/jar
  *      -cfm attach031Agent00.jar ${test.src}/../attach031/attach031Agent00.mf
  *      nsk/jvmti/AttachOnDemand/attach031/attach031Agent00.class
  *
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach042.attach042Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java
@@ -53,7 +53,7 @@
  * @build nsk.share.aod.AODTestRunner
  *        nsk.jvmti.AttachOnDemand.attach045.attach045Target
  *        nsk.jvmti.AttachOnDemand.attach045.ClassToLoad
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target "nsk.jvmti.AttachOnDemand.attach045.attach045Target -classPath ${test.class.path}"

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java
@@ -57,7 +57,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target "nsk.jvmti.AttachOnDemand.attach045.attach045Target -classPath ${test.class.path}"
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach045Agent00,attach045Agent01,attach045Agent02,attach045Agent03
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach046/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach046/TestDescription.java
@@ -49,7 +49,7 @@
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach046.attach046Target
- *      "-javaOpts=-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData ${test.vm.opts} ${test.java.opts}"
  *      -na attach046Agent00=-pathToNewByteCode=./bin/newclass00,attach046Agent00=-pathToNewByteCode=./bin/newclass01,attach046Agent00=-pathToNewByteCode=./bin/newclass02
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach046/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach046/TestDescription.java
@@ -45,7 +45,7 @@
  *      newclass02 newclass01 newclass00
  *
  * @build nsk.jvmti.AttachOnDemand.attach046.attach046Target
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.share.aod.AODTestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.jvmti.AttachOnDemand.attach046.attach046Target

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach050/attach050TestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach050/attach050TestRunner.java
@@ -35,7 +35,7 @@
  *      nsk.jvmti.AttachOnDemand.attach050.attach050TestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.share.aod.TargetApplicationWaitingAgents
- *      "-javaOpts=-XX:+UsePerfData -XX:+EnableDynamicAgentLoading ${test.vm.opts} ${test.java.opts}"
+ *      -javaOpts="-XX:+UsePerfData -XX:+EnableDynamicAgentLoading ${test.vm.opts} ${test.java.opts}"
  *      -na attach050Agent00
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach050/attach050TestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach050/attach050TestRunner.java
@@ -31,7 +31,7 @@
  *          /test/lib
  * @build nsk.jvmti.AttachOnDemand.attach050.attach050TestRunner
  *        nsk.share.aod.TargetApplicationWaitingAgents
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.jvmti.AttachOnDemand.attach050.attach050TestRunner
  *      -jdk ${test.jdk}
  *      -target nsk.share.aod.TargetApplicationWaitingAgents

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DataDumpRequest/datadumpreq001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DataDumpRequest/datadumpreq001/TestDescription.java
@@ -50,9 +50,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.DataDumpRequest.datadumpreq001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.DataDumpRequest.datadumpreq001
+ * @run main/othervm/native
  *      -agentlib:datadumpreq001=-waittime=5,-verbose=
  *      nsk.jvmti.DataDumpRequest.datadumpreq001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DataDumpRequest/datadumpreq001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DataDumpRequest/datadumpreq001/TestDescription.java
@@ -52,7 +52,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.DataDumpRequest.datadumpreq001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:datadumpreq001=-waittime=5 -verbose="
  *      nsk.jvmti.DataDumpRequest.datadumpreq001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DataDumpRequest/datadumpreq001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DataDumpRequest/datadumpreq001/TestDescription.java
@@ -53,7 +53,7 @@
  * @build ExecDriver
  *        nsk.jvmti.DataDumpRequest.datadumpreq001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:datadumpreq001=-waittime=5 -verbose="
+ *      -agentlib:datadumpreq001=-waittime=5,-verbose=
  *      nsk.jvmti.DataDumpRequest.datadumpreq001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc001/TestDescription.java
@@ -43,9 +43,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.ForceGarbageCollection.forcegc001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.ForceGarbageCollection.forcegc001
+ * @run main/othervm/native
  *      -agentlib:forcegc001=-waittime=5,objects=100
  *      nsk.jvmti.ForceGarbageCollection.forcegc001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc001/TestDescription.java
@@ -45,7 +45,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.ForceGarbageCollection.forcegc001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:forcegc001=-waittime=5 objects=100"
  *      nsk.jvmti.ForceGarbageCollection.forcegc001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc001/TestDescription.java
@@ -46,7 +46,7 @@
  * @build ExecDriver
  *        nsk.jvmti.ForceGarbageCollection.forcegc001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:forcegc001=-waittime=5 objects=100"
+ *      -agentlib:forcegc001=-waittime=5,objects=100
  *      nsk.jvmti.ForceGarbageCollection.forcegc001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc002/TestDescription.java
@@ -43,7 +43,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.ForceGarbageCollection.forcegc002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:forcegc002=-waittime=5 objects=100"
  *      nsk.jvmti.ForceGarbageCollection.forcegc002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc002/TestDescription.java
@@ -44,7 +44,7 @@
  * @build ExecDriver
  *        nsk.jvmti.ForceGarbageCollection.forcegc002
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:forcegc002=-waittime=5 objects=100"
+ *      -agentlib:forcegc002=-waittime=5,objects=100
  *      nsk.jvmti.ForceGarbageCollection.forcegc002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc002/TestDescription.java
@@ -41,9 +41,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.ForceGarbageCollection.forcegc002
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.ForceGarbageCollection.forcegc002
+ * @run main/othervm/native
  *      -agentlib:forcegc002=-waittime=5,objects=100
  *      nsk.jvmti.ForceGarbageCollection.forcegc002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/TestDescription.java
@@ -76,7 +76,7 @@
  * @build ExecDriver
  *        nsk.jvmti.GetCurrentThreadCpuTime.curthrcputime001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:curthrcputime001=-waittime=5 iterations=1000"
+ *      -agentlib:curthrcputime001=-waittime=5,iterations=1000
  *      nsk.jvmti.GetCurrentThreadCpuTime.curthrcputime001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/TestDescription.java
@@ -75,7 +75,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.GetCurrentThreadCpuTime.curthrcputime001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:curthrcputime001=-waittime=5 iterations=1000"
  *      nsk.jvmti.GetCurrentThreadCpuTime.curthrcputime001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/TestDescription.java
@@ -73,9 +73,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.GetCurrentThreadCpuTime.curthrcputime001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.GetCurrentThreadCpuTime.curthrcputime001
+ * @run main/othervm/native
  *      -agentlib:curthrcputime001=-waittime=5,iterations=1000
  *      nsk.jvmti.GetCurrentThreadCpuTime.curthrcputime001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectsWithTags/objwithtags001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectsWithTags/objwithtags001/TestDescription.java
@@ -43,7 +43,7 @@
  * @build ExecDriver
  *        nsk.jvmti.GetObjectsWithTags.objwithtags001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:objwithtags001=-waittime=5 tags=4 objects=5"
+ *      -agentlib:objwithtags001=-waittime=5,tags=4,objects=5
  *      nsk.jvmti.GetObjectsWithTags.objwithtags001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectsWithTags/objwithtags001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectsWithTags/objwithtags001/TestDescription.java
@@ -40,9 +40,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.GetObjectsWithTags.objwithtags001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.GetObjectsWithTags.objwithtags001
+ * @run main/othervm/native
  *      -agentlib:objwithtags001=-waittime=5,tags=4,objects=5
  *      nsk.jvmti.GetObjectsWithTags.objwithtags001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectsWithTags/objwithtags001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectsWithTags/objwithtags001/TestDescription.java
@@ -42,7 +42,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.GetObjectsWithTags.objwithtags001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:objwithtags001=-waittime=5 tags=4 objects=5"
  *      nsk.jvmti.GetObjectsWithTags.objwithtags001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops002/TestDescription.java
@@ -41,7 +41,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.GetSystemProperties.getsysprops002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -agentlib:getsysprops002=-waittime=5
  *      "-Dnsk.jvmti.test.property=value of nsk.jvmti.test.property"
  *      "-Dnsk.jvmti.test.property.empty="

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops002/TestDescription.java
@@ -43,8 +43,8 @@
  *        nsk.jvmti.GetSystemProperties.getsysprops002
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:getsysprops002=-waittime=5
- *      "-Dnsk.jvmti.test.property=value of nsk.jvmti.test.property"
- *      "-Dnsk.jvmti.test.property.empty="
+ *      -Dnsk.jvmti.test.property=value_of_nsk.jvmti.test.property
+ *      -Dnsk.jvmti.test.property.empty=
  *      nsk.jvmti.GetSystemProperties.getsysprops002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops002/TestDescription.java
@@ -39,9 +39,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.GetSystemProperties.getsysprops002
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.GetSystemProperties.getsysprops002
+ * @run main/othervm/native
  *      -agentlib:getsysprops002=-waittime=5
  *      -Dnsk.jvmti.test.property=value_of_nsk.jvmti.test.property
  *      -Dnsk.jvmti.test.property.empty=

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops002/getsysprops002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops002/getsysprops002.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops002/getsysprops002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops002/getsysprops002.cpp
@@ -42,7 +42,7 @@ typedef struct PropertyDescStruct {
 } PropertyDesc;
 
 static PropertyDesc propDescList[PROPERTIES_COUNT] = {
-    { "nsk.jvmti.test.property", "value of nsk.jvmti.test.property", 0 },
+    { "nsk.jvmti.test.property", "value_of_nsk.jvmti.test.property", 0 },
     { "nsk.jvmti.test.property.empty", "", 0 }
 };
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop002/TestDescription.java
@@ -39,9 +39,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.GetSystemProperty.getsysprop002
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.GetSystemProperty.getsysprop002
+ * @run main/othervm/native
  *      -agentlib:getsysprop002=-waittime=5
  *      -Dnsk.jvmti.test.property=value_of_nsk.jvmti.test.property
  *      -Dnsk.jvmti.test.property.empty=

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop002/TestDescription.java
@@ -41,7 +41,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.GetSystemProperty.getsysprop002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -agentlib:getsysprop002=-waittime=5
  *      "-Dnsk.jvmti.test.property=value of nsk.jvmti.test.property"
  *      "-Dnsk.jvmti.test.property.empty="

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop002/TestDescription.java
@@ -43,8 +43,8 @@
  *        nsk.jvmti.GetSystemProperty.getsysprop002
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:getsysprop002=-waittime=5
- *      "-Dnsk.jvmti.test.property=value of nsk.jvmti.test.property"
- *      "-Dnsk.jvmti.test.property.empty="
+ *      -Dnsk.jvmti.test.property=value_of_nsk.jvmti.test.property
+ *      -Dnsk.jvmti.test.property.empty=
  *      nsk.jvmti.GetSystemProperty.getsysprop002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop002/getsysprop002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop002/getsysprop002.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop002/getsysprop002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop002/getsysprop002.cpp
@@ -41,7 +41,7 @@ typedef struct PropertyDescStruct {
 } PropertyDesc;
 
 static PropertyDesc propDescList[PROPERTIES_COUNT] = {
-    { "nsk.jvmti.test.property", "value of nsk.jvmti.test.property" },
+    { "nsk.jvmti.test.property", "value_of_nsk.jvmti.test.property" },
     { "nsk.jvmti.test.property.empty", "" }
 };
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime001/TestDescription.java
@@ -76,7 +76,7 @@
  * @build ExecDriver
  *        nsk.jvmti.GetThreadCpuTime.thrcputime001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:thrcputime001=-waittime=5 iterations=1000"
+ *      -agentlib:thrcputime001=-waittime=5,iterations=1000
  *      nsk.jvmti.GetThreadCpuTime.thrcputime001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime001/TestDescription.java
@@ -75,7 +75,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.GetThreadCpuTime.thrcputime001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:thrcputime001=-waittime=5 iterations=1000"
  *      nsk.jvmti.GetThreadCpuTime.thrcputime001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime001/TestDescription.java
@@ -73,9 +73,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.GetThreadCpuTime.thrcputime001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.GetThreadCpuTime.thrcputime001
+ * @run main/othervm/native
  *      -agentlib:thrcputime001=-waittime=5,iterations=1000
  *      nsk.jvmti.GetThreadCpuTime.thrcputime001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/TestDescription.java
@@ -78,7 +78,7 @@
  * @build ExecDriver
  *        nsk.jvmti.GetThreadCpuTime.thrcputime002
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:thrcputime002=-waittime=5 iterations=1000"
+ *      -agentlib:thrcputime002=-waittime=5,iterations=1000
  *      nsk.jvmti.GetThreadCpuTime.thrcputime002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/TestDescription.java
@@ -75,9 +75,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.GetThreadCpuTime.thrcputime002
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.GetThreadCpuTime.thrcputime002
+ * @run main/othervm/native
  *      -agentlib:thrcputime002=-waittime=5,iterations=1000
  *      nsk.jvmti.GetThreadCpuTime.thrcputime002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/TestDescription.java
@@ -77,7 +77,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.GetThreadCpuTime.thrcputime002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:thrcputime002=-waittime=5 iterations=1000"
  *      nsk.jvmti.GetThreadCpuTime.thrcputime002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/TestDescription.java
@@ -43,9 +43,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.GetThreadGroupChildren.getthrdgrpchld001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.GetThreadGroupChildren.getthrdgrpchld001
+ * @run main/othervm/native
  *      -agentlib:getthrdgrpchld001=-waittime=5,threads=10
  *      nsk.jvmti.GetThreadGroupChildren.getthrdgrpchld001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/TestDescription.java
@@ -45,7 +45,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.GetThreadGroupChildren.getthrdgrpchld001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:getthrdgrpchld001=-waittime=5 threads=10"
  *      nsk.jvmti.GetThreadGroupChildren.getthrdgrpchld001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/TestDescription.java
@@ -46,7 +46,7 @@
  * @build ExecDriver
  *        nsk.jvmti.GetThreadGroupChildren.getthrdgrpchld001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:getthrdgrpchld001=-waittime=5 threads=10"
+ *      -agentlib:getthrdgrpchld001=-waittime=5,threads=10
  *      nsk.jvmti.GetThreadGroupChildren.getthrdgrpchld001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap001/TestDescription.java
@@ -60,7 +60,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterheap001=-waittime=5 objects=4"
  *      nsk.jvmti.IterateOverHeap.iterheap001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap001/TestDescription.java
@@ -61,7 +61,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterheap001=-waittime=5 objects=4"
+ *      -agentlib:iterheap001=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverHeap.iterheap001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap001/TestDescription.java
@@ -58,9 +58,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverHeap.iterheap001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverHeap.iterheap001
+ * @run main/othervm/native
  *      -agentlib:iterheap001=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverHeap.iterheap001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap002/TestDescription.java
@@ -61,7 +61,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap002
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterheap002=-waittime=5 objects=4"
+ *      -agentlib:iterheap002=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverHeap.iterheap002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap002/TestDescription.java
@@ -58,9 +58,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverHeap.iterheap002
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverHeap.iterheap002
+ * @run main/othervm/native
  *      -agentlib:iterheap002=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverHeap.iterheap002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap002/TestDescription.java
@@ -60,7 +60,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterheap002=-waittime=5 objects=4"
  *      nsk.jvmti.IterateOverHeap.iterheap002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap003/TestDescription.java
@@ -60,7 +60,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap003
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterheap003=-waittime=5 objects=4"
  *      nsk.jvmti.IterateOverHeap.iterheap003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap003/TestDescription.java
@@ -58,9 +58,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverHeap.iterheap003
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverHeap.iterheap003
+ * @run main/othervm/native
  *      -agentlib:iterheap003=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverHeap.iterheap003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap003/TestDescription.java
@@ -61,7 +61,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap003
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterheap003=-waittime=5 objects=4"
+ *      -agentlib:iterheap003=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverHeap.iterheap003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap004/TestDescription.java
@@ -51,7 +51,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap004
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterheap004=-waittime=5 -verbose"
+ *      -agentlib:iterheap004=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverHeap.iterheap004
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap004/TestDescription.java
@@ -48,9 +48,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverHeap.iterheap004
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverHeap.iterheap004
+ * @run main/othervm/native
  *      -agentlib:iterheap004=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverHeap.iterheap004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap004/TestDescription.java
@@ -50,7 +50,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap004
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterheap004=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverHeap.iterheap004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap005/TestDescription.java
@@ -55,7 +55,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap005
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterheap005=-waittime=5 -verbose"
+ *      -agentlib:iterheap005=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverHeap.iterheap005
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap005/TestDescription.java
@@ -54,7 +54,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap005
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterheap005=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverHeap.iterheap005
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap005/TestDescription.java
@@ -52,9 +52,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverHeap.iterheap005
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverHeap.iterheap005
+ * @run main/othervm/native
  *      -agentlib:iterheap005=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverHeap.iterheap005
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap006/TestDescription.java
@@ -48,7 +48,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap006
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterheap006=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverHeap.iterheap006
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap006/TestDescription.java
@@ -46,9 +46,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverHeap.iterheap006
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverHeap.iterheap006
+ * @run main/othervm/native
  *      -agentlib:iterheap006=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverHeap.iterheap006
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap006/TestDescription.java
@@ -49,7 +49,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap006
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterheap006=-waittime=5 -verbose"
+ *      -agentlib:iterheap006=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverHeap.iterheap006
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap007/TestDescription.java
@@ -53,7 +53,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap007
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterheap007=-waittime=5 -verbose"
+ *      -agentlib:iterheap007=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverHeap.iterheap007
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap007/TestDescription.java
@@ -50,9 +50,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverHeap.iterheap007
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverHeap.iterheap007
+ * @run main/othervm/native
  *      -agentlib:iterheap007=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverHeap.iterheap007
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap007/TestDescription.java
@@ -52,7 +52,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverHeap.iterheap007
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterheap007=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverHeap.iterheap007
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls001/TestDescription.java
@@ -61,7 +61,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterinstcls001=-waittime=5 objects=4"
+ *      -agentlib:iterinstcls001=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls001/TestDescription.java
@@ -60,7 +60,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterinstcls001=-waittime=5 objects=4"
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls001/TestDescription.java
@@ -58,9 +58,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverInstancesOfClass.iterinstcls001
+ * @run main/othervm/native
  *      -agentlib:iterinstcls001=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls002/TestDescription.java
@@ -61,7 +61,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls002
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterinstcls002=-waittime=5 objects=4"
+ *      -agentlib:iterinstcls002=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls002/TestDescription.java
@@ -58,9 +58,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls002
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverInstancesOfClass.iterinstcls002
+ * @run main/othervm/native
  *      -agentlib:iterinstcls002=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls002/TestDescription.java
@@ -60,7 +60,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterinstcls002=-waittime=5 objects=4"
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls003/TestDescription.java
@@ -58,9 +58,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls003
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverInstancesOfClass.iterinstcls003
+ * @run main/othervm/native
  *      -agentlib:iterinstcls003=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls003/TestDescription.java
@@ -60,7 +60,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls003
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterinstcls003=-waittime=5 objects=4"
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls003/TestDescription.java
@@ -61,7 +61,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls003
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterinstcls003=-waittime=5 objects=4"
+ *      -agentlib:iterinstcls003=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls004/TestDescription.java
@@ -48,7 +48,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls004
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterinstcls004=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls004/TestDescription.java
@@ -46,9 +46,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls004
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverInstancesOfClass.iterinstcls004
+ * @run main/othervm/native
  *      -agentlib:iterinstcls004=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls004/TestDescription.java
@@ -49,7 +49,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls004
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterinstcls004=-waittime=5 -verbose"
+ *      -agentlib:iterinstcls004=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls004
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls005/TestDescription.java
@@ -52,9 +52,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls005
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverInstancesOfClass.iterinstcls005
+ * @run main/othervm/native
  *      -agentlib:iterinstcls005=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls005
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls005/TestDescription.java
@@ -54,7 +54,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls005
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterinstcls005=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls005
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls005/TestDescription.java
@@ -55,7 +55,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls005
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterinstcls005=-waittime=5 -verbose"
+ *      -agentlib:iterinstcls005=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls005
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls006/TestDescription.java
@@ -46,9 +46,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls006
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverInstancesOfClass.iterinstcls006
+ * @run main/othervm/native
  *      -agentlib:iterinstcls006=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls006
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls006/TestDescription.java
@@ -48,7 +48,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls006
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterinstcls006=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls006
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls006/TestDescription.java
@@ -49,7 +49,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls006
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterinstcls006=-waittime=5 -verbose"
+ *      -agentlib:iterinstcls006=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls006
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls007/TestDescription.java
@@ -52,7 +52,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls007
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterinstcls007=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls007
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls007/TestDescription.java
@@ -50,9 +50,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls007
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverInstancesOfClass.iterinstcls007
+ * @run main/othervm/native
  *      -agentlib:iterinstcls007=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls007
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls007/TestDescription.java
@@ -53,7 +53,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverInstancesOfClass.iterinstcls007
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterinstcls007=-waittime=5 -verbose"
+ *      -agentlib:iterinstcls007=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverInstancesOfClass.iterinstcls007
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj001/TestDescription.java
@@ -54,9 +54,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj001
+ * @run main/othervm/native
  *      -agentlib:iterobjreachobj001=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj001/TestDescription.java
@@ -56,7 +56,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterobjreachobj001=-waittime=5 objects=4"
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj001/TestDescription.java
@@ -57,7 +57,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterobjreachobj001=-waittime=5 objects=4"
+ *      -agentlib:iterobjreachobj001=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj002/TestDescription.java
@@ -49,7 +49,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj002
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterobjreachobj002=-waittime=5 -verbose"
+ *      -agentlib:iterobjreachobj002=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj002/TestDescription.java
@@ -46,9 +46,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj002
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj002
+ * @run main/othervm/native
  *      -agentlib:iterobjreachobj002=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj002/TestDescription.java
@@ -48,7 +48,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterobjreachobj002=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj003/TestDescription.java
@@ -55,7 +55,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj003
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterobjreachobj003=-waittime=5 -verbose"
+ *      -agentlib:iterobjreachobj003=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj003/TestDescription.java
@@ -52,9 +52,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj003
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj003
+ * @run main/othervm/native
  *      -agentlib:iterobjreachobj003=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj003/TestDescription.java
@@ -54,7 +54,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj003
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterobjreachobj003=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj004/TestDescription.java
@@ -48,7 +48,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj004
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterobjreachobj004=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj004/TestDescription.java
@@ -49,7 +49,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj004
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterobjreachobj004=-waittime=5 -verbose"
+ *      -agentlib:iterobjreachobj004=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj004
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj004/TestDescription.java
@@ -46,9 +46,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj004
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj004
+ * @run main/othervm/native
  *      -agentlib:iterobjreachobj004=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj005/TestDescription.java
@@ -53,7 +53,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj005
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterobjreachobj005=-waittime=5 -verbose"
+ *      -agentlib:iterobjreachobj005=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj005
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj005/TestDescription.java
@@ -50,9 +50,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj005
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj005
+ * @run main/othervm/native
  *      -agentlib:iterobjreachobj005=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj005
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj005/TestDescription.java
@@ -52,7 +52,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj005
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterobjreachobj005=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverObjectsReachableFromObject.iterobjreachobj005
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj001/TestDescription.java
@@ -57,7 +57,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverReachableObjects.iterreachobj001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterreachobj001=-waittime=5 objects=4"
+ *      -agentlib:iterreachobj001=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj001/TestDescription.java
@@ -54,9 +54,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverReachableObjects.iterreachobj001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverReachableObjects.iterreachobj001
+ * @run main/othervm/native
  *      -agentlib:iterreachobj001=-waittime=5,objects=4
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj001/TestDescription.java
@@ -56,7 +56,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverReachableObjects.iterreachobj001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterreachobj001=-waittime=5 objects=4"
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java
@@ -49,9 +49,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverReachableObjects.iterreachobj002
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverReachableObjects.iterreachobj002
+ * @run main/othervm/native
  *      -agentlib:iterreachobj002=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java
@@ -52,7 +52,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverReachableObjects.iterreachobj002
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterreachobj002=-waittime=5 -verbose"
+ *      -agentlib:iterreachobj002=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/TestDescription.java
@@ -51,7 +51,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverReachableObjects.iterreachobj002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterreachobj002=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj003/TestDescription.java
@@ -53,9 +53,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverReachableObjects.iterreachobj003
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverReachableObjects.iterreachobj003
+ * @run main/othervm/native
  *      -agentlib:iterreachobj003=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj003/TestDescription.java
@@ -55,7 +55,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverReachableObjects.iterreachobj003
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterreachobj003=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj003/TestDescription.java
@@ -56,7 +56,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverReachableObjects.iterreachobj003
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterreachobj003=-waittime=5 -verbose"
+ *      -agentlib:iterreachobj003=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj004/TestDescription.java
@@ -49,7 +49,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverReachableObjects.iterreachobj004
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterreachobj004=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj004/TestDescription.java
@@ -47,9 +47,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverReachableObjects.iterreachobj004
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverReachableObjects.iterreachobj004
+ * @run main/othervm/native
  *      -agentlib:iterreachobj004=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj004/TestDescription.java
@@ -50,7 +50,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverReachableObjects.iterreachobj004
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterreachobj004=-waittime=5 -verbose"
+ *      -agentlib:iterreachobj004=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj004
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj005/TestDescription.java
@@ -50,9 +50,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateOverReachableObjects.iterreachobj005
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateOverReachableObjects.iterreachobj005
+ * @run main/othervm/native
  *      -agentlib:iterreachobj005=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj005
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj005/TestDescription.java
@@ -52,7 +52,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateOverReachableObjects.iterreachobj005
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:iterreachobj005=-waittime=5 -verbose"
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj005
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj005/TestDescription.java
@@ -53,7 +53,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateOverReachableObjects.iterreachobj005
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:iterreachobj005=-waittime=5 -verbose"
+ *      -agentlib:iterreachobj005=-waittime=5,-verbose
  *      nsk.jvmti.IterateOverReachableObjects.iterreachobj005
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-class-tagged/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-class-tagged/TestDescription.java
@@ -32,7 +32,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:HeapFilter=-waittime=5 filter=JVMTI_HEAP_FILTER_CLASS_TAGGED"
  *      nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-class-tagged/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-class-tagged/TestDescription.java
@@ -30,9 +30,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
+ * @run main/othervm/native
  *      -agentlib:HeapFilter=-waittime=5,filter=JVMTI_HEAP_FILTER_CLASS_TAGGED
  *      nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-class-tagged/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-class-tagged/TestDescription.java
@@ -33,7 +33,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:HeapFilter=-waittime=5 filter=JVMTI_HEAP_FILTER_CLASS_TAGGED"
+ *      -agentlib:HeapFilter=-waittime=5,filter=JVMTI_HEAP_FILTER_CLASS_TAGGED
  *      nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-class-untagged/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-class-untagged/TestDescription.java
@@ -32,7 +32,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:HeapFilter=-waittime=5 filter=JVMTI_HEAP_FILTER_CLASS_UNTAGGED"
  *      nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-class-untagged/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-class-untagged/TestDescription.java
@@ -33,7 +33,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:HeapFilter=-waittime=5 filter=JVMTI_HEAP_FILTER_CLASS_UNTAGGED"
+ *      -agentlib:HeapFilter=-waittime=5,filter=JVMTI_HEAP_FILTER_CLASS_UNTAGGED
  *      nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-class-untagged/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-class-untagged/TestDescription.java
@@ -30,9 +30,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
+ * @run main/othervm/native
  *      -agentlib:HeapFilter=-waittime=5,filter=JVMTI_HEAP_FILTER_CLASS_UNTAGGED
  *      nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-tagged/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-tagged/TestDescription.java
@@ -65,7 +65,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:HeapFilter=-waittime=5 filter=JVMTI_HEAP_FILTER_TAGGED"
+ *      -agentlib:HeapFilter=-waittime=5,filter=JVMTI_HEAP_FILTER_TAGGED
  *      nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-tagged/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-tagged/TestDescription.java
@@ -64,7 +64,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:HeapFilter=-waittime=5 filter=JVMTI_HEAP_FILTER_TAGGED"
  *      nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-tagged/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-tagged/TestDescription.java
@@ -62,9 +62,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
+ * @run main/othervm/native
  *      -agentlib:HeapFilter=-waittime=5,filter=JVMTI_HEAP_FILTER_TAGGED
  *      nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-untagged/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-untagged/TestDescription.java
@@ -30,9 +30,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
+ * @run main/othervm/native
  *      -agentlib:HeapFilter=-waittime=5,filter=JVMTI_HEAP_FILTER_UNTAGGED
  *      nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-untagged/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-untagged/TestDescription.java
@@ -32,7 +32,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:HeapFilter=-waittime=5 filter=JVMTI_HEAP_FILTER_UNTAGGED"
  *      nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-untagged/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter-untagged/TestDescription.java
@@ -33,7 +33,7 @@
  * @build ExecDriver
  *        nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:HeapFilter=-waittime=5 filter=JVMTI_HEAP_FILTER_UNTAGGED"
+ *      -agentlib:HeapFilter=-waittime=5,filter=JVMTI_HEAP_FILTER_UNTAGGED
  *      nsk.jvmti.IterateThroughHeap.filter_tagged.HeapFilter
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst001/TestDescription.java
@@ -41,7 +41,7 @@
  * @build ExecDriver
  *        nsk.jvmti.ResumeThreadList.resumethrdlst001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:resumethrdlst001=-waittime=5 threads=10"
+ *      -agentlib:resumethrdlst001=-waittime=5,threads=10
  *      nsk.jvmti.ResumeThreadList.resumethrdlst001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst001/TestDescription.java
@@ -40,7 +40,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.ResumeThreadList.resumethrdlst001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:resumethrdlst001=-waittime=5 threads=10"
  *      nsk.jvmti.ResumeThreadList.resumethrdlst001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst001/TestDescription.java
@@ -38,9 +38,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.ResumeThreadList.resumethrdlst001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.ResumeThreadList.resumethrdlst001
+ * @run main/othervm/native
  *      -agentlib:resumethrdlst001=-waittime=5,threads=10
  *      nsk.jvmti.ResumeThreadList.resumethrdlst001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst002/TestDescription.java
@@ -39,7 +39,7 @@
  * @build ExecDriver
  *        nsk.jvmti.ResumeThreadList.resumethrdlst002
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:resumethrdlst002=-waittime=5 threads=10"
+ *      -agentlib:resumethrdlst002=-waittime=5,threads=10
  *      nsk.jvmti.ResumeThreadList.resumethrdlst002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst002/TestDescription.java
@@ -38,7 +38,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.ResumeThreadList.resumethrdlst002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:resumethrdlst002=-waittime=5 threads=10"
  *      nsk.jvmti.ResumeThreadList.resumethrdlst002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst002/TestDescription.java
@@ -36,9 +36,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.ResumeThreadList.resumethrdlst002
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.ResumeThreadList.resumethrdlst002
+ * @run main/othervm/native
  *      -agentlib:resumethrdlst002=-waittime=5,threads=10
  *      nsk.jvmti.ResumeThreadList.resumethrdlst002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop002/TestDescription.java
@@ -46,9 +46,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.SetSystemProperty.setsysprop002
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:setsysprop002=-waittime=5
  *      -Dnsk.jvmti.test.property=initial_value_of_nsk.jvmti.test.property
  *      -Dnsk.jvmti.test.property.empty.old=

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop002/TestDescription.java
@@ -48,7 +48,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.SetSystemProperty.setsysprop002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -agentlib:setsysprop002=-waittime=5
  *      "-Dnsk.jvmti.test.property=initial value of nsk.jvmti.test.property"
  *      "-Dnsk.jvmti.test.property.empty.old="

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop002/TestDescription.java
@@ -50,9 +50,9 @@
  *        nsk.jvmti.SetSystemProperty.setsysprop002
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:setsysprop002=-waittime=5
- *      "-Dnsk.jvmti.test.property=initial value of nsk.jvmti.test.property"
- *      "-Dnsk.jvmti.test.property.empty.old="
- *      "-Dnsk.jvmti.test.property.empty.new=initial value of nsk.jvmti.test.property.empty.new"
+ *      -Dnsk.jvmti.test.property=initial_value_of_nsk.jvmti.test.property
+ *      -Dnsk.jvmti.test.property.empty.old=
+ *      -Dnsk.jvmti.test.property.empty.new=initial_value_of_nsk.jvmti.test.property.empty.new
  *      nsk.jvmti.SetSystemProperty.setsysprop002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop002/setsysprop002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop002/setsysprop002.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop002/setsysprop002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop002/setsysprop002.cpp
@@ -45,7 +45,7 @@ static PropertyDesc propDescList[PROPERTIES_COUNT] = {
     {
         "nsk.jvmti.test.property",
         {
-            "initial value of nsk.jvmti.test.property",
+            "initial_value_of_nsk.jvmti.test.property",
             "OnLoad phase value of nsk.jvmti.test.property",
             "live phase value of nsk.jvmti.test.property"
         }
@@ -61,7 +61,7 @@ static PropertyDesc propDescList[PROPERTIES_COUNT] = {
     {
         "nsk.jvmti.test.property.empty.new",
         {
-            "initial value of nsk.jvmti.test.property.empty.new",
+            "initial_value_of_nsk.jvmti.test.property.empty.new",
             "",
             "live phase value of nsk.jvmti.test.property.empty.new"
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop003/TestDescription.java
@@ -50,9 +50,9 @@
  *        nsk.jvmti.SetSystemProperty.setsysprop003
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:setsysprop003=-waittime=5
- *      "-Dnsk.jvmti.test.property=initial value of nsk.jvmti.test.property"
- *      "-Dnsk.jvmti.test.property.empty.old="
- *      "-Dnsk.jvmti.test.property.empty.new=initial value of nsk.jvmti.test.property.empty.new"
+ *      -Dnsk.jvmti.test.property=initial_value_of_nsk.jvmti.test.property
+ *      -Dnsk.jvmti.test.property.empty.old=
+ *      -Dnsk.jvmti.test.property.empty.new=initial_value_of_nsk.jvmti.test.property.empty.new
  *      nsk.jvmti.SetSystemProperty.setsysprop003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop003/TestDescription.java
@@ -48,7 +48,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.SetSystemProperty.setsysprop003
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -agentlib:setsysprop003=-waittime=5
  *      "-Dnsk.jvmti.test.property=initial value of nsk.jvmti.test.property"
  *      "-Dnsk.jvmti.test.property.empty.old="

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop003/TestDescription.java
@@ -46,9 +46,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.SetSystemProperty.setsysprop003
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:setsysprop003=-waittime=5
  *      -Dnsk.jvmti.test.property=initial_value_of_nsk.jvmti.test.property
  *      -Dnsk.jvmti.test.property.empty.old=

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst001/TestDescription.java
@@ -40,7 +40,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.SuspendThreadList.suspendthrdlst001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:suspendthrdlst001=-waittime=5 threads=10"
  *      nsk.jvmti.SuspendThreadList.suspendthrdlst001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst001/TestDescription.java
@@ -41,7 +41,7 @@
  * @build ExecDriver
  *        nsk.jvmti.SuspendThreadList.suspendthrdlst001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:suspendthrdlst001=-waittime=5 threads=10"
+ *      -agentlib:suspendthrdlst001=-waittime=5,threads=10
  *      nsk.jvmti.SuspendThreadList.suspendthrdlst001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst001/TestDescription.java
@@ -38,9 +38,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.SuspendThreadList.suspendthrdlst001
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:suspendthrdlst001=-waittime=5,threads=10
  *      nsk.jvmti.SuspendThreadList.suspendthrdlst001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst002/TestDescription.java
@@ -36,9 +36,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.SuspendThreadList.suspendthrdlst002
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:suspendthrdlst002=-waittime=5,threads=10
  *      nsk.jvmti.SuspendThreadList.suspendthrdlst002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst002/TestDescription.java
@@ -39,7 +39,7 @@
  * @build ExecDriver
  *        nsk.jvmti.SuspendThreadList.suspendthrdlst002
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:suspendthrdlst002=-waittime=5 threads=10"
+ *      -agentlib:suspendthrdlst002=-waittime=5,threads=10
  *      nsk.jvmti.SuspendThreadList.suspendthrdlst002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst002/TestDescription.java
@@ -38,7 +38,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.SuspendThreadList.suspendthrdlst002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:suspendthrdlst002=-waittime=5 threads=10"
  *      nsk.jvmti.SuspendThreadList.suspendthrdlst002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8252003 is fixed
-allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP02/ap02t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP02/ap02t001/TestDescription.java
@@ -40,9 +40,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.allocation.AP02.ap02t001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.scenarios.allocation.AP02.ap02t001
+ * @run main/othervm/native
  *      -agentlib:ap02t001=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP02.ap02t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP02/ap02t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP02/ap02t001/TestDescription.java
@@ -42,7 +42,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP02.ap02t001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:ap02t001=-waittime=5 -verbose"
  *      nsk.jvmti.scenarios.allocation.AP02.ap02t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP02/ap02t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP02/ap02t001/TestDescription.java
@@ -43,7 +43,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP02.ap02t001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:ap02t001=-waittime=5 -verbose"
+ *      -agentlib:ap02t001=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP02.ap02t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001/TestDescription.java
@@ -49,9 +49,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.allocation.AP03.ap03t001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.scenarios.allocation.AP03.ap03t001
+ * @run main/othervm/native
  *      -agentlib:ap03t001=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP03.ap03t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001/TestDescription.java
@@ -52,7 +52,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP03.ap03t001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:ap03t001=-waittime=5 -verbose"
+ *      -agentlib:ap03t001=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP03.ap03t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001/TestDescription.java
@@ -51,7 +51,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP03.ap03t001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:ap03t001=-waittime=5 -verbose"
  *      nsk.jvmti.scenarios.allocation.AP03.ap03t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t001/TestDescription.java
@@ -57,9 +57,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.allocation.AP04.ap04t001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.scenarios.allocation.AP04.ap04t001
+ * @run main/othervm/native
  *      -agentlib:ap04t001=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP04.ap04t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t001/TestDescription.java
@@ -59,7 +59,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP04.ap04t001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:ap04t001=-waittime=5 -verbose"
  *      nsk.jvmti.scenarios.allocation.AP04.ap04t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t001/TestDescription.java
@@ -60,7 +60,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP04.ap04t001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:ap04t001=-waittime=5 -verbose"
+ *      -agentlib:ap04t001=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP04.ap04t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t002/TestDescription.java
@@ -57,9 +57,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.allocation.AP04.ap04t002
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.scenarios.allocation.AP04.ap04t002
+ * @run main/othervm/native
  *      -agentlib:ap04t002=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP04.ap04t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t002/TestDescription.java
@@ -59,7 +59,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP04.ap04t002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:ap04t002=-waittime=5 -verbose"
  *      nsk.jvmti.scenarios.allocation.AP04.ap04t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t002/TestDescription.java
@@ -60,7 +60,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP04.ap04t002
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:ap04t002=-waittime=5 -verbose"
+ *      -agentlib:ap04t002=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP04.ap04t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t003/TestDescription.java
@@ -58,7 +58,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP04.ap04t003
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:ap04t003=-waittime=5 -verbose"
+ *      -agentlib:ap04t003=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP04.ap04t003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t003/TestDescription.java
@@ -57,7 +57,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP04.ap04t003
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:ap04t003=-waittime=5 -verbose"
  *      nsk.jvmti.scenarios.allocation.AP04.ap04t003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t003/TestDescription.java
@@ -55,9 +55,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.allocation.AP04.ap04t003
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.scenarios.allocation.AP04.ap04t003
+ * @run main/othervm/native
  *      -agentlib:ap04t003=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP04.ap04t003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP07/ap07t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP07/ap07t002/TestDescription.java
@@ -46,7 +46,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP07.ap07t002
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:ap07t002=-waittime=5 -verbose"
+ *      -agentlib:ap07t002=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP07.ap07t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP07/ap07t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP07/ap07t002/TestDescription.java
@@ -43,9 +43,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.allocation.AP07.ap07t002
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.scenarios.allocation.AP07.ap07t002
+ * @run main/othervm/native
  *      -agentlib:ap07t002=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP07.ap07t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP07/ap07t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP07/ap07t002/TestDescription.java
@@ -45,7 +45,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP07.ap07t002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:ap07t002=-waittime=5 -verbose"
  *      nsk.jvmti.scenarios.allocation.AP07.ap07t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP09/ap09t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP09/ap09t001/TestDescription.java
@@ -51,7 +51,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP09.ap09t001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:ap09t001=-waittime=5 -verbose"
  *      nsk.jvmti.scenarios.allocation.AP09.ap09t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP09/ap09t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP09/ap09t001/TestDescription.java
@@ -49,9 +49,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.allocation.AP09.ap09t001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.scenarios.allocation.AP09.ap09t001
+ * @run main/othervm/native
  *      -agentlib:ap09t001=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP09.ap09t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP09/ap09t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP09/ap09t001/TestDescription.java
@@ -52,7 +52,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP09.ap09t001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:ap09t001=-waittime=5 -verbose"
+ *      -agentlib:ap09t001=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.allocation.AP09.ap09t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP12/ap12t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP12/ap12t001/TestDescription.java
@@ -41,7 +41,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP12.ap12t001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:ap12t001=-waittime=5 -verbose"
+ *      -agentlib:ap12t001=-waittime=5,-verbose
  *      -XX:-UseGCOverheadLimit
  *      nsk.jvmti.scenarios.allocation.AP12.ap12t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP12/ap12t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP12/ap12t001/TestDescription.java
@@ -40,7 +40,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.allocation.AP12.ap12t001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:ap12t001=-waittime=5 -verbose"
  *      -XX:-UseGCOverheadLimit
  *      nsk.jvmti.scenarios.allocation.AP12.ap12t001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP12/ap12t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP12/ap12t001/TestDescription.java
@@ -38,9 +38,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.allocation.AP12.ap12t001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.scenarios.allocation.AP12.ap12t001
+ * @run main/othervm/native
  *      -agentlib:ap12t001=-waittime=5,-verbose
  *      -XX:-UseGCOverheadLimit
  *      nsk.jvmti.scenarios.allocation.AP12.ap12t001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI04/bi04t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI04/bi04t002/TestDescription.java
@@ -55,7 +55,6 @@
  *        nsk.jvmti.scenarios.bcinstr.BI04.bi04t002a
  *
  * @comment compile newclassXX to bin/newclassXX
- * @build ExecDriver
  * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/javac
  *      --patch-module java.base=${test.src}/newclass02/java.base
@@ -64,7 +63,7 @@
  *      --add-reads=java.base=ALL-UNNAMED
  *      ${test.src}/newclass02/java.base/java/lang/Object.java
  *
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      --add-reads=java.base=ALL-UNNAMED
  *      -XX:+UnlockDiagnosticVMOptions
  *      -XX:-CheckIntrinsics

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI04/bi04t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI04/bi04t002/TestDescription.java
@@ -56,7 +56,7 @@
  *
  * @comment compile newclassXX to bin/newclassXX
  * @build ExecDriver
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/javac
  *      --patch-module java.base=${test.src}/newclass02/java.base
  *      -d bin/newclass02
@@ -64,7 +64,7 @@
  *      --add-reads=java.base=ALL-UNNAMED
  *      ${test.src}/newclass02/java.base/java/lang/Object.java
  *
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      --add-reads=java.base=ALL-UNNAMED
  *      -XX:+UnlockDiagnosticVMOptions
  *      -XX:-CheckIntrinsics

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI04/bi04t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI04/bi04t002/TestDescription.java
@@ -69,7 +69,7 @@
  *      -XX:+UnlockDiagnosticVMOptions
  *      -XX:-CheckIntrinsics
  *      -Xbootclasspath/a:${test.class.path}
- *      "-agentlib:bi04t002=pathToNewByteCode=./bin -waittime=5"
+ *      -agentlib:bi04t002=pathToNewByteCode=./bin,-waittime=5
  *      nsk.jvmti.scenarios.bcinstr.BI04.bi04t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t001/TestDescription.java
@@ -55,8 +55,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      loadclass
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:em01t001=classLoaderCount=100,-waittime=5
  *      nsk.jvmti.scenarios.events.EM01.em01t001
  *      ./bin/loadclass

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t001/TestDescription.java
@@ -57,7 +57,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:em01t001=classLoaderCount=100 -waittime=5"
+ *      -agentlib:em01t001=classLoaderCount=100,-waittime=5
  *      nsk.jvmti.scenarios.events.EM01.em01t001
  *      ./bin/loadclass
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t001/TestDescription.java
@@ -56,7 +56,7 @@
  *      loadclass
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:em01t001=classLoaderCount=100 -waittime=5"
  *      nsk.jvmti.scenarios.events.EM01.em01t001
  *      ./bin/loadclass

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t002/TestDescription.java
@@ -56,7 +56,7 @@
  *      loadclass
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:em01t002=classLoaderCount=100 -waittime=5"
  *      nsk.jvmti.scenarios.events.EM01.em01t002
  *      ./bin/loadclass

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t002/TestDescription.java
@@ -57,7 +57,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:em01t002=classLoaderCount=100 -waittime=5"
+ *      -agentlib:em01t002=classLoaderCount=100,-waittime=5
  *      nsk.jvmti.scenarios.events.EM01.em01t002
  *      ./bin/loadclass
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t002/TestDescription.java
@@ -55,8 +55,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      loadclass
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:em01t002=classLoaderCount=100,-waittime=5
  *      nsk.jvmti.scenarios.events.EM01.em01t002
  *      ./bin/loadclass

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM06/em06t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM06/em06t001/TestDescription.java
@@ -52,7 +52,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:em06t001=classLoaderCount=500 -waittime=5"
+ *      -agentlib:em06t001=classLoaderCount=500,-waittime=5
  *      nsk.jvmti.scenarios.events.EM06.em06t001
  *      ./bin/loadclass
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM06/em06t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM06/em06t001/TestDescription.java
@@ -50,8 +50,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      loadclass
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:em06t001=classLoaderCount=500,-waittime=5
  *      nsk.jvmti.scenarios.events.EM06.em06t001
  *      ./bin/loadclass

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM06/em06t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM06/em06t001/TestDescription.java
@@ -51,7 +51,7 @@
  *      loadclass
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:em06t001=classLoaderCount=500 -waittime=5"
  *      nsk.jvmti.scenarios.events.EM06.em06t001
  *      ./bin/loadclass

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/TestDescription.java
@@ -60,8 +60,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      loadclass
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:em07t002=attempts=2,-waittime=5
  *      -XX:-UseGCOverheadLimit
  *      nsk.jvmti.scenarios.events.EM07.em07t002

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/TestDescription.java
@@ -61,7 +61,7 @@
  *      loadclass
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:em07t002=attempts=2 -waittime=5"
  *      -XX:-UseGCOverheadLimit
  *      nsk.jvmti.scenarios.events.EM07.em07t002

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/TestDescription.java
@@ -62,7 +62,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:em07t002=attempts=2 -waittime=5"
+ *      -agentlib:em07t002=attempts=2,-waittime=5
  *      -XX:-UseGCOverheadLimit
  *      nsk.jvmti.scenarios.events.EM07.em07t002
  *      ./bin/loadclass

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF04/gf04t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF04/gf04t001/TestDescription.java
@@ -54,7 +54,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass
  *
- * @build ExecDriver
+ * @comment ExecDriver is used b/c main class isn't on source/class path
  * @run main/othervm/native ExecDriver --java
  *      -agentlib:gf04t001=-waittime=5,segment=./bin/newclass
  *      nsk.jvmti.scenarios.general_functions.GF04.gf04t001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF04/gf04t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF04/gf04t001/TestDescription.java
@@ -56,7 +56,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:gf04t001=-waittime=5 segment=./bin/newclass"
+ *      -agentlib:gf04t001=-waittime=5,segment=./bin/newclass
  *      nsk.jvmti.scenarios.general_functions.GF04.gf04t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF04/gf04t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF04/gf04t001/TestDescription.java
@@ -55,7 +55,7 @@
  *      newclass
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:gf04t001=-waittime=5 segment=./bin/newclass"
  *      nsk.jvmti.scenarios.general_functions.GF04.gf04t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF06/gf06t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF06/gf06t001/TestDescription.java
@@ -53,7 +53,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.general_functions.GF06.gf06t001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:gf06t001=-waittime=5 -verbose"
+ *      -agentlib:gf06t001=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.general_functions.GF06.gf06t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF06/gf06t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF06/gf06t001/TestDescription.java
@@ -50,9 +50,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.general_functions.GF06.gf06t001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.scenarios.general_functions.GF06.gf06t001
+ * @run main/othervm/native
  *      -agentlib:gf06t001=-waittime=5,-verbose
  *      nsk.jvmti.scenarios.general_functions.GF06.gf06t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF06/gf06t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF06/gf06t001/TestDescription.java
@@ -52,7 +52,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.general_functions.GF06.gf06t001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:gf06t001=-waittime=5 -verbose"
  *      nsk.jvmti.scenarios.general_functions.GF06.gf06t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t.java
@@ -26,12 +26,17 @@ package nsk.jvmti.scenarios.general_functions.GF08;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 public class gf08t {
     public static void main(String[] args) throws Exception {
         String libName = args[0];
         String className = args[1];
-        String phrase = args[2];
-        String verboseType = args[3];
+        String verboseType = args[2];
+        String phrase = Arrays.stream(args)
+                             .skip(3)
+                             .collect(Collectors.joining(" "));
 
         OutputAnalyzer oa = ProcessTools.executeTestJvm(
                 "-agentlib:" + libName + "=-waittime=5 setVerboseMode=yes",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java
@@ -87,8 +87,8 @@ public class TestDriver {
         nsk.jvmti.scenarios.general_functions.GF08.gf08t.main(new String[] {
                 "gf08t001",
                 nsk.jvmti.scenarios.general_functions.GF08.gf08t001.class.getName(),
-                keyPhrase,
-                "gc"});
+                "gc",
+                keyPhrase});
     }
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t002/TestDescription.java
@@ -51,8 +51,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.general_functions.GF08.gf08t002
+ * @build nsk.jvmti.scenarios.general_functions.GF08.gf08t002
  *        nsk.jvmti.scenarios.general_functions.GF08.gf08t
  * @run main/othervm/native
  *      nsk.jvmti.scenarios.general_functions.GF08.gf08t

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t002/TestDescription.java
@@ -54,7 +54,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.general_functions.GF08.gf08t002
  *        nsk.jvmti.scenarios.general_functions.GF08.gf08t
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.jvmti.scenarios.general_functions.GF08.gf08t
  *      gf08t002
  *      nsk.jvmti.scenarios.general_functions.GF08.gf08t002

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t002/TestDescription.java
@@ -58,7 +58,7 @@
  *      nsk.jvmti.scenarios.general_functions.GF08.gf08t
  *      gf08t002
  *      nsk.jvmti.scenarios.general_functions.GF08.gf08t002
- *      "class,load"
  *      class
+ *      class,load
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t003/TestDescription.java
@@ -51,8 +51,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.general_functions.GF08.gf08t003
+ * @build nsk.jvmti.scenarios.general_functions.GF08.gf08t003
  *        nsk.jvmti.scenarios.general_functions.GF08.gf08t
  * @run main/othervm/native
  *      nsk.jvmti.scenarios.general_functions.GF08.gf08t

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t003/TestDescription.java
@@ -58,7 +58,7 @@
  *      nsk.jvmti.scenarios.general_functions.GF08.gf08t
  *      gf08t003
  *      nsk.jvmti.scenarios.general_functions.GF08.gf08t003
- *      "Registering JNI native method"
  *      jni
+ *      Registering JNI native method
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t003/TestDescription.java
@@ -54,7 +54,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.general_functions.GF08.gf08t003
  *        nsk.jvmti.scenarios.general_functions.GF08.gf08t
- * @run main/othervm/native PropertyResolvingWrapper
+ * @run main/othervm/native
  *      nsk.jvmti.scenarios.general_functions.GF08.gf08t
  *      gf08t003
  *      nsk.jvmti.scenarios.general_functions.GF08.gf08t003

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t001/TestDescription.java
@@ -42,7 +42,7 @@
  *        nsk.jvmti.scenarios.hotswap.HS101.hs101t001
  *        nsk.share.jvmti.ProfileCollector
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:HotSwap=-waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:HotSwap=-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t001/TestDescription.java
@@ -38,10 +38,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.hotswap.HS101.hs101t001
+ * @build nsk.jvmti.scenarios.hotswap.HS101.hs101t001
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:HotSwap=-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t001/TestDescription.java
@@ -41,7 +41,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.hotswap.HS101.hs101t001
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:HotSwap=-waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t002/TestDescription.java
@@ -38,10 +38,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.hotswap.HS101.hs101t002
+ * @build nsk.jvmti.scenarios.hotswap.HS101.hs101t002
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:HotSwap=-waittime=5,package=nsk,samples=100,mode=interpreted
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t002/TestDescription.java
@@ -41,7 +41,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.hotswap.HS101.hs101t002
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:HotSwap=-waittime=5 package=nsk samples=100 mode=interpreted"
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t002/TestDescription.java
@@ -42,7 +42,7 @@
  *        nsk.jvmti.scenarios.hotswap.HS101.hs101t002
  *        nsk.share.jvmti.ProfileCollector
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:HotSwap=-waittime=5 package=nsk samples=100 mode=interpreted"
+ *      -agentlib:HotSwap=-waittime=5,package=nsk,samples=100,mode=interpreted
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t003/TestDescription.java
@@ -43,7 +43,7 @@
  *        nsk.jvmti.scenarios.hotswap.HS101.hs101t003
  *        nsk.share.jvmti.ProfileCollector
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:HotSwap=-waittime=5 package=nsk samples=100 mode=mixed"
+ *      -agentlib:HotSwap=-waittime=5,package=nsk,samples=100,mode=mixed
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t003/TestDescription.java
@@ -39,10 +39,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.hotswap.HS101.hs101t003
+ * @build nsk.jvmti.scenarios.hotswap.HS101.hs101t003
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:HotSwap=-waittime=5,package=nsk,samples=100,mode=mixed
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t003/TestDescription.java
@@ -42,7 +42,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.hotswap.HS101.hs101t003
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:HotSwap=-waittime=5 package=nsk samples=100 mode=mixed"
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t004/TestDescription.java
@@ -38,10 +38,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.hotswap.HS101.hs101t004
+ * @build nsk.jvmti.scenarios.hotswap.HS101.hs101t004
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -Xss2m
  *      -agentlib:HotSwap=-waittime=5,package=nsk,samples=100,mode=compiled,bci=call
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t004

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t004/TestDescription.java
@@ -41,7 +41,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.hotswap.HS101.hs101t004
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -Xss2m
  *      "-agentlib:HotSwap=-waittime=5 package=nsk samples=100 mode=compiled bci=call"
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t004

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t004/TestDescription.java
@@ -43,7 +43,7 @@
  *        nsk.share.jvmti.ProfileCollector
  * @run main/othervm/native ExecDriver --java
  *      -Xss2m
- *      "-agentlib:HotSwap=-waittime=5 package=nsk samples=100 mode=compiled bci=call"
+ *      -agentlib:HotSwap=-waittime=5,package=nsk,samples=100,mode=compiled,bci=call
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t004
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t005/TestDescription.java
@@ -43,7 +43,7 @@
  *        nsk.share.jvmti.ProfileCollector
  * @run main/othervm/native ExecDriver --java
  *      -Xss2m
- *      "-agentlib:HotSwap=-waittime=5 package=nsk samples=100 mode=interpreted bci=call"
+ *      -agentlib:HotSwap=-waittime=5,package=nsk,samples=100,mode=interpreted,bci=call
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t005
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t005/TestDescription.java
@@ -38,10 +38,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.hotswap.HS101.hs101t005
+ * @build nsk.jvmti.scenarios.hotswap.HS101.hs101t005
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -Xss2m
  *      -agentlib:HotSwap=-waittime=5,package=nsk,samples=100,mode=interpreted,bci=call
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t005

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t005/TestDescription.java
@@ -41,7 +41,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.hotswap.HS101.hs101t005
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -Xss2m
  *      "-agentlib:HotSwap=-waittime=5 package=nsk samples=100 mode=interpreted bci=call"
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t005

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t006/TestDescription.java
@@ -44,7 +44,7 @@
  *        nsk.share.jvmti.ProfileCollector
  * @run main/othervm/native ExecDriver --java
  *      -Xss2m
- *      "-agentlib:HotSwap=-waittime=5 package=nsk samples=100 mode=mixed bci=call"
+ *      -agentlib:HotSwap=-waittime=5,package=nsk,samples=100,mode=mixed,bci=call
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t006
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t006/TestDescription.java
@@ -39,10 +39,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.hotswap.HS101.hs101t006
+ * @build nsk.jvmti.scenarios.hotswap.HS101.hs101t006
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -Xss2m
  *      -agentlib:HotSwap=-waittime=5,package=nsk,samples=100,mode=mixed,bci=call
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t006

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t006/TestDescription.java
@@ -42,7 +42,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.hotswap.HS101.hs101t006
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -Xss2m
  *      "-agentlib:HotSwap=-waittime=5 package=nsk samples=100 mode=mixed bci=call"
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t006

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t007/TestDescription.java
@@ -41,7 +41,7 @@
  *        nsk.jvmti.scenarios.hotswap.HS101.hs101t007
  *        nsk.share.jvmti.ProfileCollector
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:HotSwap=-waittime=5 package=nsk sync=1000 mode=compiled bci=alloc"
+ *      -agentlib:HotSwap=-waittime=5,package=nsk,sync=1000,mode=compiled,bci=alloc
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t007
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t007/TestDescription.java
@@ -37,10 +37,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.hotswap.HS101.hs101t007
+ * @build nsk.jvmti.scenarios.hotswap.HS101.hs101t007
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:HotSwap=-waittime=5,package=nsk,sync=1000,mode=compiled,bci=alloc
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t007
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t007/TestDescription.java
@@ -40,7 +40,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.hotswap.HS101.hs101t007
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:HotSwap=-waittime=5 package=nsk sync=1000 mode=compiled bci=alloc"
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t007
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t008/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t008/TestDescription.java
@@ -40,7 +40,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.hotswap.HS101.hs101t008
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:HotSwap=-waittime=5 package=nsk sync=100 mode=interpreted bci=alloc"
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t008
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t008/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t008/TestDescription.java
@@ -41,7 +41,7 @@
  *        nsk.jvmti.scenarios.hotswap.HS101.hs101t008
  *        nsk.share.jvmti.ProfileCollector
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:HotSwap=-waittime=5 package=nsk sync=100 mode=interpreted bci=alloc"
+ *      -agentlib:HotSwap=-waittime=5,package=nsk,sync=100,mode=interpreted,bci=alloc
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t008
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t008/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS101/hs101t008/TestDescription.java
@@ -37,10 +37,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.hotswap.HS101.hs101t008
+ * @build nsk.jvmti.scenarios.hotswap.HS101.hs101t008
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:HotSwap=-waittime=5,package=nsk,sync=100,mode=interpreted,bci=alloc
  *      nsk.jvmti.scenarios.hotswap.HS101.hs101t008
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t001/TestDescription.java
@@ -42,7 +42,7 @@
  *        nsk.jvmti.scenarios.hotswap.HS102.hs102t001
  *        nsk.share.jvmti.ProfileCollector
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:HotSwap=-waittime=5 package=java/lang samples=10 mode=compiled"
+ *      -agentlib:HotSwap=-waittime=5,package=java/lang,samples=10,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS102.hs102t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t001/TestDescription.java
@@ -38,10 +38,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.hotswap.HS102.hs102t001
+ * @build nsk.jvmti.scenarios.hotswap.HS102.hs102t001
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:HotSwap=-waittime=5,package=java/lang,samples=10,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS102.hs102t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t001/TestDescription.java
@@ -41,7 +41,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.hotswap.HS102.hs102t001
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:HotSwap=-waittime=5 package=java/lang samples=10 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS102.hs102t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t002/TestDescription.java
@@ -40,10 +40,9 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.hotswap.HS102.hs102t002
+ * @build nsk.jvmti.scenarios.hotswap.HS102.hs102t002
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:HotSwap=-waittime=5,package=java/lang,samples=10,mode=mixed
  *      nsk.jvmti.scenarios.hotswap.HS102.hs102t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t002/TestDescription.java
@@ -43,7 +43,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.hotswap.HS102.hs102t002
  *        nsk.share.jvmti.ProfileCollector
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:HotSwap=-waittime=5 package=java/lang samples=10 mode=mixed"
  *      nsk.jvmti.scenarios.hotswap.HS102.hs102t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t002/TestDescription.java
@@ -44,7 +44,7 @@
  *        nsk.jvmti.scenarios.hotswap.HS102.hs102t002
  *        nsk.share.jvmti.ProfileCollector
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:HotSwap=-waittime=5 package=java/lang samples=10 mode=mixed"
+ *      -agentlib:HotSwap=-waittime=5,package=java/lang,samples=10,mode=mixed
  *      nsk.jvmti.scenarios.hotswap.HS102.hs102t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS103/hs103t002/hs103t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS103/hs103t002/hs103t002.java
@@ -40,7 +40,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs103t002=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS103.hs103t002.hs103t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS103/hs103t002/hs103t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS103/hs103t002/hs103t002.java
@@ -39,8 +39,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs103t002=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS103.hs103t002.hs103t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS103/hs103t002/hs103t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS103/hs103t002/hs103t002.java
@@ -41,7 +41,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs103t002=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs103t002=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS103.hs103t002.hs103t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS104/hs104t001/hs104t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS104/hs104t001/hs104t001.java
@@ -41,7 +41,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs104t001=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs104t001=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS104.hs104t001.hs104t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS104/hs104t001/hs104t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS104/hs104t001/hs104t001.java
@@ -39,8 +39,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs104t001=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS104.hs104t001.hs104t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS104/hs104t001/hs104t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS104/hs104t001/hs104t001.java
@@ -40,7 +40,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs104t001=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS104.hs104t001.hs104t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t001/TestDescription.java
@@ -70,8 +70,7 @@
  *      -g:lines,source,vars
  *      newclass02 newclass03 newclass newclass01
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs201t001=pathToNewByteCode=./bin,-waittime=5
  *      nsk.jvmti.scenarios.hotswap.HS201.hs201t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t001/TestDescription.java
@@ -71,7 +71,7 @@
  *      newclass02 newclass03 newclass newclass01
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs201t001=pathToNewByteCode=./bin -waittime=5"
  *      nsk.jvmti.scenarios.hotswap.HS201.hs201t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t001/TestDescription.java
@@ -72,7 +72,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs201t001=pathToNewByteCode=./bin -waittime=5"
+ *      -agentlib:hs201t001=pathToNewByteCode=./bin,-waittime=5
  *      nsk.jvmti.scenarios.hotswap.HS201.hs201t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/TestDescription.java
@@ -72,7 +72,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs201t002=pathToNewByteCode=./bin -waittime=5"
+ *      -agentlib:hs201t002=pathToNewByteCode=./bin,-waittime=5
  *      nsk.jvmti.scenarios.hotswap.HS201.hs201t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/TestDescription.java
@@ -70,8 +70,7 @@
  *      -g:lines,source,vars
  *      newclass
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs201t002=pathToNewByteCode=./bin,-waittime=5
  *      nsk.jvmti.scenarios.hotswap.HS201.hs201t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/TestDescription.java
@@ -71,7 +71,7 @@
  *      newclass
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs201t002=pathToNewByteCode=./bin -waittime=5"
  *      nsk.jvmti.scenarios.hotswap.HS201.hs201t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS202/hs202t001/hs202t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS202/hs202t001/hs202t001.java
@@ -43,8 +43,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs202t001=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS202.hs202t001.hs202t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS202/hs202t001/hs202t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS202/hs202t001/hs202t001.java
@@ -44,7 +44,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs202t001=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS202.hs202t001.hs202t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS202/hs202t001/hs202t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS202/hs202t001/hs202t001.java
@@ -45,7 +45,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs202t001=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs202t001=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS202.hs202t001.hs202t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS202/hs202t002/hs202t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS202/hs202t002/hs202t002.java
@@ -45,7 +45,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs202t002=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs202t002=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS202.hs202t002.hs202t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS202/hs202t002/hs202t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS202/hs202t002/hs202t002.java
@@ -44,7 +44,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs202t002=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS202.hs202t002.hs202t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS202/hs202t002/hs202t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS202/hs202t002/hs202t002.java
@@ -43,8 +43,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs202t002=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS202.hs202t002.hs202t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t001/hs203t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t001/hs203t001.java
@@ -46,7 +46,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs203t001=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs203t001=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS203.hs203t001.hs203t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t001/hs203t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t001/hs203t001.java
@@ -45,7 +45,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs203t001=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS203.hs203t001.hs203t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t001/hs203t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t001/hs203t001.java
@@ -44,8 +44,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs203t001=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS203.hs203t001.hs203t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t002/hs203t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t002/hs203t002.java
@@ -48,8 +48,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs203t002=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS203.hs203t002.hs203t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t002/hs203t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t002/hs203t002.java
@@ -49,7 +49,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs203t002=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS203.hs203t002.hs203t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t002/hs203t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t002/hs203t002.java
@@ -50,7 +50,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs203t002=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs203t002=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS203.hs203t002.hs203t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t003/hs203t003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t003/hs203t003.java
@@ -48,7 +48,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs203t003=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS203.hs203t003.hs203t003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t003/hs203t003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t003/hs203t003.java
@@ -47,8 +47,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs203t003=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS203.hs203t003.hs203t003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t003/hs203t003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t003/hs203t003.java
@@ -49,7 +49,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs203t003=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs203t003=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS203.hs203t003.hs203t003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t004/hs203t004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t004/hs203t004.java
@@ -45,8 +45,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -XX:-Inline
  *      -XX:CompileThreshold=900
  *      -Xbatch

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t004/hs203t004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t004/hs203t004.java
@@ -51,7 +51,7 @@
  *      -XX:CompileThreshold=900
  *      -Xbatch
  *      -XX:-TieredCompilation
- *      "-agentlib:hs203t004=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs203t004=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS203.hs203t004.hs203t004
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t004/hs203t004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t004/hs203t004.java
@@ -46,7 +46,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -XX:-Inline
  *      -XX:CompileThreshold=900
  *      -Xbatch

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t001/hs204t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t001/hs204t001.java
@@ -52,7 +52,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass02 newclass03 newclass01 newclass00
  *
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs204t001=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS204.hs204t001.hs204t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t001/hs204t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t001/hs204t001.java
@@ -45,14 +45,13 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *      nsk.jvmti.scenarios.hotswap.HS204.hs204t001.hs204t001
+ * @build nsk.jvmti.scenarios.hotswap.HS204.hs204t001.hs204t001
  *
  * @comment compile newclassXX to bin/newclassXX
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass02 newclass03 newclass01 newclass00
  *
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs204t001=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS204.hs204t001.hs204t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t001/hs204t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t001/hs204t001.java
@@ -53,7 +53,7 @@
  *      newclass02 newclass03 newclass01 newclass00
  *
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs204t001=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs204t001=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS204.hs204t001.hs204t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t002/hs204t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t002/hs204t002.java
@@ -44,7 +44,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs204t002=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs204t002=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS204.hs204t002.hs204t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t002/hs204t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t002/hs204t002.java
@@ -42,8 +42,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs204t002=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS204.hs204t002.hs204t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t002/hs204t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t002/hs204t002.java
@@ -43,7 +43,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs204t002=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS204.hs204t002.hs204t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t003/hs204t003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t003/hs204t003.java
@@ -53,8 +53,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs204t003=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS204.hs204t003.hs204t003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t003/hs204t003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t003/hs204t003.java
@@ -54,7 +54,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs204t003=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS204.hs204t003.hs204t003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t003/hs204t003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t003/hs204t003.java
@@ -55,7 +55,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs204t003=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs204t003=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS204.hs204t003.hs204t003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t004/hs204t004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t004/hs204t004.java
@@ -46,7 +46,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs204t004=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs204t004=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS204.hs204t004.hs204t004
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t004/hs204t004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t004/hs204t004.java
@@ -45,7 +45,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs204t004=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS204.hs204t004.hs204t004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t004/hs204t004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t004/hs204t004.java
@@ -44,8 +44,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs204t004=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS204.hs204t004.hs204t004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t001/hs301t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t001/hs301t001.java
@@ -56,7 +56,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs301t001=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t001.hs301t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t001/hs301t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t001/hs301t001.java
@@ -57,7 +57,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs301t001=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs301t001=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t001.hs301t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t001/hs301t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t001/hs301t001.java
@@ -55,8 +55,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs301t001=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t001.hs301t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t002/hs301t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t002/hs301t002.java
@@ -45,7 +45,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs301t002=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t002.hs301t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t002/hs301t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t002/hs301t002.java
@@ -44,8 +44,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs301t002=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t002.hs301t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t002/hs301t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t002/hs301t002.java
@@ -46,7 +46,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs301t002=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs301t002=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t002.hs301t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t003/hs301t003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t003/hs301t003.java
@@ -47,7 +47,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs301t003=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs301t003=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t003.hs301t003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t003/hs301t003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t003/hs301t003.java
@@ -46,7 +46,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs301t003=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t003.hs301t003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t003/hs301t003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t003/hs301t003.java
@@ -45,8 +45,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs301t003=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t003.hs301t003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t004/hs301t004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t004/hs301t004.java
@@ -42,8 +42,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs301t004=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t004.hs301t004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t004/hs301t004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t004/hs301t004.java
@@ -44,7 +44,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs301t004=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs301t004=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t004.hs301t004
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t004/hs301t004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t004/hs301t004.java
@@ -43,7 +43,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs301t004=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t004.hs301t004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t005/hs301t005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t005/hs301t005.java
@@ -36,7 +36,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      -DLocation=./bin/loadclass
  *      "-agentlib:hs301t005=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t005.hs301t005

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t005/hs301t005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t005/hs301t005.java
@@ -38,7 +38,7 @@
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
  *      -DLocation=./bin/loadclass
- *      "-agentlib:hs301t005=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs301t005=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t005.hs301t005
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t005/hs301t005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t005/hs301t005.java
@@ -35,8 +35,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -DLocation=./bin/loadclass
  *      -agentlib:hs301t005=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS301.hs301t005.hs301t005

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t001/hs302t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t001/hs302t001.java
@@ -37,7 +37,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs302t001=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs302t001=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t001.hs302t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t001/hs302t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t001/hs302t001.java
@@ -35,8 +35,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs302t001=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t001.hs302t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t001/hs302t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t001/hs302t001.java
@@ -36,7 +36,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs302t001=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t001.hs302t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t002/hs302t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t002/hs302t002.java
@@ -36,7 +36,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs302t002=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t002.hs302t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t002/hs302t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t002/hs302t002.java
@@ -37,7 +37,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs302t002=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs302t002=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t002.hs302t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t002/hs302t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t002/hs302t002.java
@@ -35,8 +35,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs302t002=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t002.hs302t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t003/hs302t003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t003/hs302t003.java
@@ -36,7 +36,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs302t003=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t003.hs302t003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t003/hs302t003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t003/hs302t003.java
@@ -35,8 +35,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs302t003=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t003.hs302t003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t003/hs302t003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t003/hs302t003.java
@@ -37,7 +37,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs302t003=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs302t003=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t003.hs302t003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t004/hs302t004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t004/hs302t004.java
@@ -37,7 +37,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs302t004=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs302t004=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t004.hs302t004
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t004/hs302t004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t004/hs302t004.java
@@ -35,8 +35,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs302t004=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t004.hs302t004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t004/hs302t004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t004/hs302t004.java
@@ -36,7 +36,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs302t004=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t004.hs302t004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t005/hs302t005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t005/hs302t005.java
@@ -35,8 +35,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs302t005=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t005.hs302t005
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t005/hs302t005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t005/hs302t005.java
@@ -37,7 +37,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs302t005=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs302t005=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t005.hs302t005
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t005/hs302t005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t005/hs302t005.java
@@ -36,7 +36,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs302t005=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t005.hs302t005
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t006/hs302t006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t006/hs302t006.java
@@ -37,7 +37,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs302t006=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs302t006=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t006.hs302t006
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t006/hs302t006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t006/hs302t006.java
@@ -35,8 +35,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs302t006=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t006.hs302t006
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t006/hs302t006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t006/hs302t006.java
@@ -36,7 +36,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs302t006=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t006.hs302t006
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t007/hs302t007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t007/hs302t007.java
@@ -36,7 +36,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs302t007=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t007.hs302t007
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t007/hs302t007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t007/hs302t007.java
@@ -35,8 +35,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs302t007=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t007.hs302t007
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t007/hs302t007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t007/hs302t007.java
@@ -37,7 +37,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs302t007=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs302t007=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t007.hs302t007
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t008/hs302t008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t008/hs302t008.java
@@ -37,7 +37,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs302t008=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs302t008=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t008.hs302t008
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t008/hs302t008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t008/hs302t008.java
@@ -35,8 +35,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs302t008=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t008.hs302t008
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t008/hs302t008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t008/hs302t008.java
@@ -36,7 +36,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs302t008=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t008.hs302t008
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t009/hs302t009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t009/hs302t009.java
@@ -37,7 +37,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs302t009=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs302t009=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t009.hs302t009
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t009/hs302t009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t009/hs302t009.java
@@ -36,7 +36,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs302t009=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t009.hs302t009
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t009/hs302t009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t009/hs302t009.java
@@ -35,8 +35,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs302t009=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t009.hs302t009
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t010/hs302t010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t010/hs302t010.java
@@ -36,7 +36,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs302t010=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t010.hs302t010
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t010/hs302t010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t010/hs302t010.java
@@ -37,7 +37,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs302t010=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs302t010=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t010.hs302t010
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t010/hs302t010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t010/hs302t010.java
@@ -35,8 +35,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs302t010=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t010.hs302t010
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t011/hs302t011.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t011/hs302t011.java
@@ -35,8 +35,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs302t011=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t011.hs302t011
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t011/hs302t011.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t011/hs302t011.java
@@ -36,7 +36,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs302t011=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t011.hs302t011
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t011/hs302t011.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t011/hs302t011.java
@@ -37,7 +37,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs302t011=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs302t011=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t011.hs302t011
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t012/hs302t012.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t012/hs302t012.java
@@ -36,7 +36,7 @@
  *      newclass00
  *
  * @build ExecDriver
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:hs302t012=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t012.hs302t012
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t012/hs302t012.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t012/hs302t012.java
@@ -37,7 +37,7 @@
  *
  * @build ExecDriver
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:hs302t012=pathToNewByteCode=./bin -waittime=5 package=nsk samples=100 mode=compiled"
+ *      -agentlib:hs302t012=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t012.hs302t012
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t012/hs302t012.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS302/hs302t012/hs302t012.java
@@ -35,8 +35,7 @@
  * @run driver nsk.share.ExtraClassesBuilder
  *      newclass00
  *
- * @build ExecDriver
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:hs302t012=pathToNewByteCode=./bin,-waittime=5,package=nsk,samples=100,mode=compiled
  *      nsk.jvmti.scenarios.hotswap.HS302.hs302t012.hs302t012
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA01/ma01t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA01/ma01t001/TestDescription.java
@@ -42,8 +42,8 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.multienv.MA01.ma01t001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:ma01t001=opt1=opt1 -waittime=5"
- *      "-agentlib:ma01t001a=opt2=opt2 -waittime=5"
+ *      -agentlib:ma01t001=opt1=opt1,-waittime=5
+ *      -agentlib:ma01t001a=opt2=opt2,-waittime=5
  *      nsk.jvmti.scenarios.multienv.MA01.ma01t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA01/ma01t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA01/ma01t001/TestDescription.java
@@ -41,7 +41,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.multienv.MA01.ma01t001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:ma01t001=opt1=opt1 -waittime=5"
  *      "-agentlib:ma01t001a=opt2=opt2 -waittime=5"
  *      nsk.jvmti.scenarios.multienv.MA01.ma01t001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA01/ma01t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA01/ma01t001/TestDescription.java
@@ -39,9 +39,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.multienv.MA01.ma01t001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.scenarios.multienv.MA01.ma01t001
+ * @run main/othervm/native
  *      -agentlib:ma01t001=opt1=opt1,-waittime=5
  *      -agentlib:ma01t001a=opt2=opt2,-waittime=5
  *      nsk.jvmti.scenarios.multienv.MA01.ma01t001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t001/TestDescription.java
@@ -59,7 +59,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.sampling.SP03.sp03t001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:sp03t001=-waittime=5 threads=10"
+ *      -agentlib:sp03t001=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP03.sp03t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t001/TestDescription.java
@@ -56,9 +56,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.sampling.SP03.sp03t001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.scenarios.sampling.SP03.sp03t001
+ * @run main/othervm/native
  *      -agentlib:sp03t001=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP03.sp03t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t001/TestDescription.java
@@ -58,7 +58,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.sampling.SP03.sp03t001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:sp03t001=-waittime=5 threads=10"
  *      nsk.jvmti.scenarios.sampling.SP03.sp03t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t002/TestDescription.java
@@ -58,7 +58,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.sampling.SP03.sp03t002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:sp03t002=-waittime=5 threads=10"
  *      nsk.jvmti.scenarios.sampling.SP03.sp03t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t002/TestDescription.java
@@ -56,9 +56,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.sampling.SP03.sp03t002
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.scenarios.sampling.SP03.sp03t002
+ * @run main/othervm/native
  *      -agentlib:sp03t002=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP03.sp03t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t002/TestDescription.java
@@ -59,7 +59,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.sampling.SP03.sp03t002
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:sp03t002=-waittime=5 threads=10"
+ *      -agentlib:sp03t002=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP03.sp03t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t001/TestDescription.java
@@ -56,9 +56,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.sampling.SP04.sp04t001
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:sp04t001=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP04.sp04t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t001/TestDescription.java
@@ -59,7 +59,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.sampling.SP04.sp04t001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:sp04t001=-waittime=5 threads=10"
+ *      -agentlib:sp04t001=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP04.sp04t001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t001/TestDescription.java
@@ -58,7 +58,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.sampling.SP04.sp04t001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:sp04t001=-waittime=5 threads=10"
  *      nsk.jvmti.scenarios.sampling.SP04.sp04t001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t002/TestDescription.java
@@ -56,9 +56,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.scenarios.sampling.SP04.sp04t002
- * @run main/othervm/native ExecDriver --java
+ * @run main/othervm/native
  *      -agentlib:sp04t002=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP04.sp04t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t002/TestDescription.java
@@ -58,7 +58,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.scenarios.sampling.SP04.sp04t002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:sp04t002=-waittime=5 threads=10"
  *      nsk.jvmti.scenarios.sampling.SP04.sp04t002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t002/TestDescription.java
@@ -59,7 +59,7 @@
  * @build ExecDriver
  *        nsk.jvmti.scenarios.sampling.SP04.sp04t002
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:sp04t002=-waittime=5 threads=10"
+ *      -agentlib:sp04t002=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP04.sp04t002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref001/TestDescription.java
@@ -54,9 +54,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.unit.FollowReferences.followref001
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.unit.FollowReferences.followref001
+ * @run main/othervm/native
  *      -agentlib:followref001=-waittime=5,-verbose,objects=3
  *      nsk.jvmti.unit.FollowReferences.followref001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref001/TestDescription.java
@@ -56,7 +56,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.unit.FollowReferences.followref001
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:followref001=-waittime=5 -verbose objects=3"
  *      nsk.jvmti.unit.FollowReferences.followref001
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref001/TestDescription.java
@@ -57,7 +57,7 @@
  * @build ExecDriver
  *        nsk.jvmti.unit.FollowReferences.followref001
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:followref001=-waittime=5 -verbose objects=3"
+ *      -agentlib:followref001=-waittime=5,-verbose,objects=3
  *      nsk.jvmti.unit.FollowReferences.followref001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref002/TestDescription.java
@@ -55,9 +55,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.unit.FollowReferences.followref002
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.unit.FollowReferences.followref002
+ * @run main/othervm/native
  *      -agentlib:followref002=-waittime=5,-verbose,objects=3
  *      nsk.jvmti.unit.FollowReferences.followref002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref002/TestDescription.java
@@ -58,7 +58,7 @@
  * @build ExecDriver
  *        nsk.jvmti.unit.FollowReferences.followref002
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:followref002=-waittime=5 -verbose objects=3"
+ *      -agentlib:followref002=-waittime=5,-verbose,objects=3
  *      nsk.jvmti.unit.FollowReferences.followref002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref002/TestDescription.java
@@ -57,7 +57,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.unit.FollowReferences.followref002
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:followref002=-waittime=5 -verbose objects=3"
  *      nsk.jvmti.unit.FollowReferences.followref002
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/TestDescription.java
@@ -59,7 +59,7 @@
  * @build ExecDriver
  *        nsk.jvmti.unit.FollowReferences.followref003
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:followref003=-waittime=5 -verbose objects=3"
+ *      -agentlib:followref003=-waittime=5,-verbose,objects=3
  *      nsk.jvmti.unit.FollowReferences.followref003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/TestDescription.java
@@ -58,7 +58,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.unit.FollowReferences.followref003
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:followref003=-waittime=5 -verbose objects=3"
  *      nsk.jvmti.unit.FollowReferences.followref003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/TestDescription.java
@@ -56,9 +56,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.unit.FollowReferences.followref003
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.unit.FollowReferences.followref003
+ * @run main/othervm/native
  *      -agentlib:followref003=-waittime=5,-verbose,objects=3
  *      nsk.jvmti.unit.FollowReferences.followref003
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref004/TestDescription.java
@@ -44,7 +44,7 @@
  * @build ExecDriver
  *      nsk.jvmti.unit.FollowReferences.followref004
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:followref004=-waittime=5 -verbose"
+ *      -agentlib:followref004=-waittime=5,-verbose
  *      nsk.jvmti.unit.FollowReferences.followref004
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref004/TestDescription.java
@@ -43,7 +43,7 @@
  *          /test/lib
  * @build ExecDriver
  *      nsk.jvmti.unit.FollowReferences.followref004
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:followref004=-waittime=5 -verbose"
  *      nsk.jvmti.unit.FollowReferences.followref004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref004/TestDescription.java
@@ -41,9 +41,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *      nsk.jvmti.unit.FollowReferences.followref004
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.unit.FollowReferences.followref004
+ * @run main/othervm/native
  *      -agentlib:followref004=-waittime=5,-verbose
  *      nsk.jvmti.unit.FollowReferences.followref004
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref005/TestDescription.java
@@ -39,7 +39,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.unit.FollowReferences.followref005
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:followref005=-waittime=5 -verbose"
  *      nsk.jvmti.unit.FollowReferences.followref005
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref005/TestDescription.java
@@ -37,9 +37,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.unit.FollowReferences.followref005
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.unit.FollowReferences.followref005
+ * @run main/othervm/native
  *      -agentlib:followref005=-waittime=5,-verbose
  *      nsk.jvmti.unit.FollowReferences.followref005
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref005/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref005/TestDescription.java
@@ -40,7 +40,7 @@
  * @build ExecDriver
  *        nsk.jvmti.unit.FollowReferences.followref005
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:followref005=-waittime=5 -verbose"
+ *      -agentlib:followref005=-waittime=5,-verbose
  *      nsk.jvmti.unit.FollowReferences.followref005
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref006/TestDescription.java
@@ -44,9 +44,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build ExecDriver
- *        nsk.jvmti.unit.FollowReferences.followref006
- * @run main/othervm/native ExecDriver --java
+ * @build nsk.jvmti.unit.FollowReferences.followref006
+ * @run main/othervm/native
  *      -agentlib:followref006=-waittime=5,-verbose
  *      nsk.jvmti.unit.FollowReferences.followref006
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref006/TestDescription.java
@@ -46,7 +46,7 @@
  *          /test/lib
  * @build ExecDriver
  *        nsk.jvmti.unit.FollowReferences.followref006
- * @run main/othervm/native PropertyResolvingWrapper ExecDriver --java
+ * @run main/othervm/native ExecDriver --java
  *      "-agentlib:followref006=-waittime=5 -verbose"
  *      nsk.jvmti.unit.FollowReferences.followref006
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref006/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref006/TestDescription.java
@@ -47,7 +47,7 @@
  * @build ExecDriver
  *        nsk.jvmti.unit.FollowReferences.followref006
  * @run main/othervm/native ExecDriver --java
- *      "-agentlib:followref006=-waittime=5 -verbose"
+ *      -agentlib:followref006=-waittime=5,-verbose
  *      nsk.jvmti.unit.FollowReferences.followref006
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/ArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/ArgumentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/ArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/ArgumentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,7 +154,7 @@ public class ArgumentHandler extends ArgumentParser {
         if (optionString == null)
             return;
 
-        StringTokenizer st = new StringTokenizer(optionString, " ~,");
+        StringTokenizer st = new StringTokenizer(optionString);
         while (st.hasMoreTokens()) {
             String token = st.nextToken();
             int start = token.startsWith("-")? 1 : 0;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/ArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/ArgumentHandler.java
@@ -154,7 +154,7 @@ public class ArgumentHandler extends ArgumentParser {
         if (optionString == null)
             return;
 
-        StringTokenizer st = new StringTokenizer(optionString);
+        StringTokenizer st = new StringTokenizer(optionString, " ~,");
         while (st.hasMoreTokens()) {
             String token = st.nextToken();
             int start = token.startsWith("-")? 1 : 0;


### PR DESCRIPTION
Hi all,

could you please review the patch which removes `PropertyResolvingWrapper` from `vmTestbase/nsk/jvmti` tests? as `jtreg` doesn't support spaces in the arguments and doesn't handle `"` in any special ways, the patch also:
 - `s/"-javaOpts=/-javaOpts="/`
 - makes `nsk.jvmti.scenarios.general_functions.GF08` to use 2nd arg as `verboseType` and 3rd and the rest args concatenated as `phrase` and updates the tests accordingly
 - removes spaces and surrounding `"` from `nsk.jvmti.test.property*`
 - removes `"` surrounding `-agentlib:`, replaces spaces in `-agentlib` with `,` and updates `ArgumentHandler` to treat `,` (as well as ` ` and `~`) as options delimiters, so it's consistent w/ `jvmti_tools.cpp`

testing: ✅  `vmTestbase/nsk/jvmti` on {linux,windows,macos}-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252003](https://bugs.openjdk.java.net/browse/JDK-8252003): remove usage of PropertyResolvingWrapper in vmTestbase/nsk/jvmti


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to 6190e55b1d51e024bce14622ba510c75dc35fcb6
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/370/head:pull/370`
`$ git checkout pull/370`
