### PR TITLE
8251464: make Node::dump(int depth) support indent

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -105,6 +105,10 @@
   notproduct(bool, PrintIdeal, false,                                       \
           "Print ideal graph before code generation")                       \
                                                                             \
+  notproduct(uintx, PrintIdealIndentThreshold, 0,                           \
+          "A depth threshold of ideal graph. Indentation is disabled "      \
+          "when users attempt to dump an ideal graph deeper than it.")      \
+                                                                            \
   notproduct(bool, PrintOpto, false,                                        \
           "Print compiler2 attempts")                                       \
                                                                             \

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -329,6 +329,7 @@ Node::Node(uint req)
   : _idx(Init(req))
 #ifdef ASSERT
   , _parse_idx(_idx)
+  , _indent(0)
 #endif
 {
   assert( req < Compile::current()->max_node_limit() - NodeLimitFudgeFactor, "Input limit exceeded" );
@@ -349,6 +350,7 @@ Node::Node(Node *n0)
   : _idx(Init(1))
 #ifdef ASSERT
   , _parse_idx(_idx)
+  , _indent(0)
 #endif
 {
   debug_only( verify_construction() );
@@ -362,6 +364,7 @@ Node::Node(Node *n0, Node *n1)
   : _idx(Init(2))
 #ifdef ASSERT
   , _parse_idx(_idx)
+  , _indent(0)
 #endif
 {
   debug_only( verify_construction() );
@@ -377,6 +380,7 @@ Node::Node(Node *n0, Node *n1, Node *n2)
   : _idx(Init(3))
 #ifdef ASSERT
   , _parse_idx(_idx)
+  , _indent(0)
 #endif
 {
   debug_only( verify_construction() );
@@ -394,6 +398,7 @@ Node::Node(Node *n0, Node *n1, Node *n2, Node *n3)
   : _idx(Init(4))
 #ifdef ASSERT
   , _parse_idx(_idx)
+  , _indent(0)
 #endif
 {
   debug_only( verify_construction() );
@@ -413,6 +418,7 @@ Node::Node(Node *n0, Node *n1, Node *n2, Node *n3, Node *n4)
   : _idx(Init(5))
 #ifdef ASSERT
   , _parse_idx(_idx)
+  , _indent(0)
 #endif
 {
   debug_only( verify_construction() );
@@ -435,6 +441,7 @@ Node::Node(Node *n0, Node *n1, Node *n2, Node *n3,
   : _idx(Init(6))
 #ifdef ASSERT
   , _parse_idx(_idx)
+  , _indent(0)
 #endif
 {
   debug_only( verify_construction() );
@@ -459,6 +466,7 @@ Node::Node(Node *n0, Node *n1, Node *n2, Node *n3,
   : _idx(Init(7))
 #ifdef ASSERT
   , _parse_idx(_idx)
+  , _indent(0)
 #endif
 {
   debug_only( verify_construction() );
@@ -1718,7 +1726,12 @@ void Node::dump(const char* suffix, bool mark, outputStream *st) const {
   Compile* C = Compile::current();
   bool is_new = C->node_arena()->contains(this);
   C->_in_dump_cnt++;
-  st->print("%c%d%s\t%s\t=== ", is_new ? ' ' : 'o', _idx, mark ? " >" : "", Name());
+
+  if (_indent > 0) {
+    st->print("%*s", (_indent << 1), "  ");
+  }
+
+  st->print("%c%d%s%s  === ", is_new ? ' ' : 'o', _idx, mark ? " >" : "  ", Name());
 
   // Dump the required and precedence inputs
   dump_req(st);
@@ -1843,7 +1856,7 @@ void Node::dump_out(outputStream *st) const {
 // moving in a given direction until a certain depth (distance from the start
 // node) is reached. Duplicates are ignored.
 // Arguments:
-//   nstack:        the nodes are collected into this array.
+//   queue:         the nodes are collected into this array.
 //   start:         the node at which to start collecting.
 //   direction:     if this is a positive number, collect input nodes; if it is
 //                  a negative number, collect output nodes.
@@ -1851,15 +1864,18 @@ void Node::dump_out(outputStream *st) const {
 //   include_start: whether to include the start node in the result collection.
 //   only_ctrl:     whether to regard control edges only during traversal.
 //   only_data:     whether to regard data edges only during traversal.
-static void collect_nodes_i(GrowableArray<Node*> *nstack, const Node* start, int direction, uint depth, bool include_start, bool only_ctrl, bool only_data) {
+static void collect_nodes_i(GrowableArray<Node*>* queue, const Node* start, int direction, uint depth, bool include_start, bool only_ctrl, bool only_data) {
+  bool indent = depth <= PrintIdealIndentThreshold;
   Node* s = (Node*) start; // remove const
-  nstack->append(s);
+  queue->append(s);
   int begin = 0;
   int end = 0;
+
+  s->set_indent(0);
   for(uint i = 0; i < depth; i++) {
-    end = nstack->length();
+    end = queue->length();
     for(int j = begin; j < end; j++) {
-      Node* tp  = nstack->at(j);
+      Node* tp  = queue->at(j);
       uint limit = direction > 0 ? tp->len() : tp->outcnt();
       for(uint k = 0; k < limit; k++) {
         Node* n = direction > 0 ? tp->in(k) : tp->raw_out(k);
@@ -1869,17 +1885,17 @@ static void collect_nodes_i(GrowableArray<Node*> *nstack, const Node* start, int
         if (n->is_Root() || n->is_top()) continue;
         if (only_ctrl && !n->is_CFG()) continue;
         if (only_data && n->is_CFG()) continue;
-
-        bool on_stack = nstack->contains(n);
-        if (!on_stack) {
-          nstack->append(n);
+        bool in_queue = queue->contains(n);
+        if (!in_queue) {
+          queue->append(n);
+          n->set_indent(indent ? (i + 1) : 0);
         }
       }
     }
     begin = end;
   }
   if (!include_start) {
-    nstack->remove(s);
+    queue->remove(s);
   }
 }
 
@@ -1887,17 +1903,17 @@ static void collect_nodes_i(GrowableArray<Node*> *nstack, const Node* start, int
 static void dump_nodes(const Node* start, int d, bool only_ctrl) {
   if (NotANode(start)) return;
 
-  GrowableArray <Node *> nstack(Compile::current()->live_nodes());
-  collect_nodes_i(&nstack, start, d, (uint) ABS(d), true, only_ctrl, false);
+  GrowableArray <Node *> queue(Compile::current()->live_nodes());
+  collect_nodes_i(&queue, start, d, (uint) ABS(d), true, only_ctrl, false);
 
-  int end = nstack.length();
+  int end = queue.length();
   if (d > 0) {
     for(int j = end-1; j >= 0; j--) {
-      nstack.at(j)->dump();
+      queue.at(j)->dump();
     }
   } else {
     for(int j = 0; j < end; j++) {
-      nstack.at(j)->dump();
+      queue.at(j)->dump();
     }
   }
 }

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1119,6 +1119,12 @@ private:
 
 //----------------- Printing, etc
 #ifndef PRODUCT
+  int _indent;
+
+ public:
+  void set_indent(int indent) { _indent = indent; }
+
+ private:
   static bool add_to_worklist(Node* n, Node_List* worklist, Arena* old_arena, VectorSet* old_space, VectorSet* new_space);
 public:
   Node* find(int idx, bool only_ctrl = false); // Search the graph for the given idx.

--- a/test/hotspot/jtreg/compiler/c2/cr7200264/TestDriver.java
+++ b/test/hotspot/jtreg/compiler/c2/cr7200264/TestDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class TestDriver {
 
     private void verifyVectorizationNumber(List<String> vectorizationLog) {
         for (Map.Entry<String, Long> entry : expectedVectorizationNumbers.entrySet()) {
-            String v = "\t" + entry.getKey();
+            String v = entry.getKey();
             long actualNum = vectorizationLog.stream()
                     .filter(s -> s.contains(v)).count();
             long expectedNum = entry.getValue();

--- a/test/hotspot/jtreg/compiler/loopopts/UseCountedLoopSafepointsTest.java
+++ b/test/hotspot/jtreg/compiler/loopopts/UseCountedLoopSafepointsTest.java
@@ -73,12 +73,12 @@ public class UseCountedLoopSafepointsTest {
         List<Node> safePoints = new ArrayList<>();
         List<Node> loopEnds = new ArrayList<>();
         for (String line : oa.getOutput().split("\\n")) {
-            int separatorIndex = line.indexOf("\t===");
+            int separatorIndex = line.indexOf("  ===");
             if (separatorIndex > -1) {
                 String header = line.substring(0, separatorIndex);
-                if (header.endsWith("\tSafePoint")) {
+                if (header.endsWith("SafePoint")) {
                     safePoints.add(new Node("SafePoint", line));
-                } else if (header.endsWith("\tCountedLoopEnd")) {
+                } else if (header.endsWith("CountedLoopEnd")) {
                     loopEnds.add(new Node("CountedLoopEnd", line));
                 }
             }
@@ -110,7 +110,7 @@ public class UseCountedLoopSafepointsTest {
             List<Integer> tmpFrom = new ArrayList<>();
             List<Integer> tmpTo = new ArrayList<>();
             // parse string like: " $id    $name       ===  $to1 $to2 ...   [[ $from1 $from2 ... ]] $anything"
-            // example:  318    SafePoint       ===  317  1  304  1  1  10  308  [[ 97  74 ]]  ...
+            // example:  318    SafePoint  ===  317  1  304  1  1  10  308  [[ 97  74 ]]  ...
             id = Integer.parseInt(str.substring(1, str.indexOf(name)).trim());
             Arrays.stream(str.substring(str.indexOf("===") + 4, str.indexOf("[[")).trim().split("\\s+"))
                   .map(Integer::parseInt)


### PR DESCRIPTION
Node::dump(depth) indents 2 whitespaces for each level.
The function isnot on until the depth of the ideal graph isnot greater
than PrintIdealIndentThreshold (0 by default).

/cc hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251464](https://bugs.openjdk.java.net/browse/JDK-8251464): make Node::dump(int depth) support indent


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 2c5376f092f50a6e918f6730a472de9a64cca6ee


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/371/head:pull/371`
`$ git checkout pull/371`
