### PR TITLE
8225329: -XX:+PrintBiasedLockingStatistics causes crash during initia…

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1156,7 +1156,7 @@ void MacroAssembler::biased_locking_enter(Register lock_reg,
   // the prototype header is no longer biased and we have to revoke
   // the bias on this object.
   testptr(header_reg, markWord::biased_lock_mask_in_place);
-  jccb(Assembler::notZero, try_revoke_bias);
+  jcc(Assembler::notZero, try_revoke_bias);
 
   // Biasing is still enabled for this data type. See whether the
   // epoch of the current bias is still valid, meaning that the epoch


### PR DESCRIPTION
…lization on Windows platforms

This bug was fixed in 11.0.3-oracle, but also exists in 16:
https://bugs.openjdk.java.net/browse/JDK-8225329

VM crashes when built with VS2017, but passes with this trivial fix.

jdk16\bin\java -XX:+UnlockDiagnosticVMOptions -XX:+UseBiasedLocking -XX:+PrintBiasedLockingStatistics -version
OpenJDK 64-Bit Server VM warning: Temporarily processing option UseBiasedLocking; support is scheduled for removal in 16.0

Seems like we won't need this fix for a long time, but fixes should be done upstream for other backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8225329](https://bugs.openjdk.java.net/browse/JDK-8225329): -XX:+PrintBiasedLockingStatistics causes crash during initialization on Windows platforms ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/372/head:pull/372`
`$ git checkout pull/372`
