### PR TITLE
6514600: AbstractAction can throw NullPointerException when clone()d

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/ArrayTable.java
+++ b/src/java.desktop/share/classes/javax/swing/ArrayTable.java
@@ -255,17 +255,19 @@ class ArrayTable implements Cloneable {
      */
     public Object clone() {
         ArrayTable newArrayTable = new ArrayTable();
-        if (isArray()) {
-            Object[] array = (Object[])table;
-            for (int i = 0 ;i < array.length-1 ; i+=2) {
-                newArrayTable.put(array[i], array[i+1]);
-            }
-        } else {
-            Hashtable<?,?> tmp = (Hashtable)table;
-            Enumeration<?> keys = tmp.keys();
-            while (keys.hasMoreElements()) {
-                Object o = keys.nextElement();
-                newArrayTable.put(o,tmp.get(o));
+        if (table != null) {
+            if (isArray()) {
+                Object[] array = (Object[]) table;
+                for (int i = 0; i < array.length - 1; i += 2) {
+                    newArrayTable.put(array[i], array[i + 1]);
+                }
+            } else {
+                Hashtable<?, ?> tmp = (Hashtable) table;
+                Enumeration<?> keys = tmp.keys();
+                while (keys.hasMoreElements()) {
+                    Object o = keys.nextElement();
+                    newArrayTable.put(o, tmp.get(o));
+                }
             }
         }
         return newArrayTable;

--- a/test/jdk/javax/swing/Action/AbstractActionBug.java
+++ b/test/jdk/javax/swing/Action/AbstractActionBug.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 6514600
+   @summary Verifies if AbstractAction throws NullPointerException when cloned
+   @run main AbstractActionBug
+ */
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+
+public final class AbstractActionBug extends AbstractAction implements Cloneable
+{
+    public static final void main(String[] args) throws Exception
+    {
+        AbstractActionBug a1 = new AbstractActionBug("a1");
+        a1 = (AbstractActionBug) a1.clone();
+        System.out.println("a1 cloned ok");
+
+        AbstractActionBug a2 = new AbstractActionBug("a2");
+        a2.putValue(NAME, "null");
+        a2 = (AbstractActionBug) a2.clone();
+        System.out.println("a2 cloned ok");
+
+        AbstractActionBug a3 = new AbstractActionBug(null);
+        a3 = (AbstractActionBug) a3.clone();
+        System.out.println("a3 cloned ok");
+    }
+
+    private AbstractActionBug(String name) {
+        putValue(NAME, name);
+    }
+
+    public void actionPerformed(ActionEvent e)
+    {
+    }
+}


### PR DESCRIPTION
Please review a fix for an issue whereby it is seen that AbstractAction which has had its values clear()ed or nulled fails to clone and throws NPE.
This is because AbstractAction contains an inner class ArrayTable, whose 'table' field is lazily instantiated, and nulled on clear(), and thus can be null. The clone() method assumes it is not null.
Proposed fix is to add a check for null for "table" field in clone().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6514600](https://bugs.openjdk.java.net/browse/JDK-6514600): AbstractAction can throw NullPointerException when clone()d


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/377/head:pull/377`
`$ git checkout pull/377`
