### PR TITLE
8253590: java/foreign tests are still failing on x86_32 after foreign-memaccess integration

### DIFF
--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @run testng TestArrays
+ * @run testng/othervm -Dforeign.restricted=permit TestArrays
  */
 
 import jdk.incubator.foreign.MemoryAddress;
@@ -105,10 +105,11 @@ public class TestArrays {
         }
     }
 
-    @Test(expectedExceptions = { UnsupportedOperationException.class,
-                                 IllegalArgumentException.class })
+    @Test(expectedExceptions = { UnsupportedOperationException.class })
     public void testTooBigForArray() {
-        MemorySegment.allocateNative((long) Integer.MAX_VALUE * 2).toByteArray();
+        try (MemorySegment segment = MemorySegment.ofNativeRestricted(MemoryAddress.NULL, (long)Integer.MAX_VALUE + 10L, null, null, null)) {
+            segment.toByteArray();
+        }
     }
 
     @Test(expectedExceptions = IllegalStateException.class)

--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -105,7 +105,7 @@ public class TestArrays {
         }
     }
 
-    @Test(expectedExceptions = { UnsupportedOperationException.class })
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testTooBigForArray() {
         try (MemorySegment segment = MemorySegment.ofNativeRestricted(MemoryAddress.NULL, (long)Integer.MAX_VALUE + 10L, null, null, null)) {
             segment.toByteArray();

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -27,7 +27,7 @@
  * @test
  * @modules java.base/sun.nio.ch
  *          jdk.incubator.foreign/jdk.internal.foreign
- * @run testng TestByteBuffer
+ * @run testng/othervm -Dforeign.restricted=permit TestByteBuffer
  */
 
 
@@ -461,7 +461,7 @@ public class TestByteBuffer {
     @Test(expectedExceptions = { UnsupportedOperationException.class,
                                  IllegalArgumentException.class })
     public void testTooBigForByteBuffer() {
-        try (MemorySegment segment = MemorySegment.allocateNative((long)Integer.MAX_VALUE + 10L)) {
+        try (MemorySegment segment = MemorySegment.ofNativeRestricted(MemoryAddress.NULL, (long)Integer.MAX_VALUE + 10L, null, null, null)) {
             segment.asByteBuffer();
         }
     }

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -458,8 +458,7 @@ public class TestByteBuffer {
         byteBuffer.get(); // should throw
     }
 
-    @Test(expectedExceptions = { UnsupportedOperationException.class,
-                                 IllegalArgumentException.class })
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testTooBigForByteBuffer() {
         try (MemorySegment segment = MemorySegment.ofNativeRestricted(MemoryAddress.NULL, (long)Integer.MAX_VALUE + 10L, null, null, null)) {
             segment.asByteBuffer();


### PR DESCRIPTION
This patch addresses a problem in a couple of tests for the foreign memory access API; we have two methods in the API, namely `MemorySegment::asByteBuffer` and `MemorySegment::toByteArray` which should throw an exception if invoked on a segment whose size is bigger than Integer.MAX_VALUE. The problem is that on 32-bits platform is not really possible to allocate a segment bigger than that; for that reason, at some point during 14 we "fixed" this by tweaking the test to allocate so much memory that the allocation itself would fail.

When we integrated the latest API changes, this dubious fix was reverted, and now the tests have started misbehaving again. A much better solution is not to rely on allocation; the two tests should just create a synthetic segment using `MemorySegment::ofNativeRestricted`; this way we can test that the API throws when it should, w/o being impacted by what Unsafe does, or does not support on 32-bits platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253590](https://bugs.openjdk.java.net/browse/JDK-8253590): java/foreign tests are still failing on x86_32 after foreign-memaccess integration


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/386/head:pull/386`
`$ git checkout pull/386`
