### PR TITLE
8253728: tests fail with "assert(fr.is_compiled_frame()) failed: Wrong frame type"

### DIFF
--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1623,7 +1623,6 @@ void Deoptimization::deoptimize_frame_internal(JavaThread* thread, intptr_t* id,
   while (fr.id() != id) {
     fr = fr.sender(&reg_map);
   }
-  assert(fr.is_compiled_frame(), "Wrong frame type");
   deoptimize(thread, fr, reason);
 }
 


### PR DESCRIPTION
Spurious assert (valid for Aarch64 only).

The frame may already be deoptimized.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253728](https://bugs.openjdk.java.net/browse/JDK-8253728): tests fail with "assert(fr.is_compiled_frame()) failed: Wrong frame type"


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/388/head:pull/388`
`$ git checkout pull/388`
