### PR TITLE
8253543: sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java failed with "AssertionError: All pixels are not black"

### DIFF
--- a/test/jdk/sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java
+++ b/test/jdk/sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 
 import com.sun.swingset3.demos.button.ButtonDemo;
+import org.jemmy2ext.JemmyExt;
 import org.jtregext.GuiTestListener;
 import org.netbeans.jemmy.ClassReference;
 import org.netbeans.jemmy.ComponentChooser;
@@ -33,7 +34,11 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 
 import javax.swing.UIManager;
@@ -72,10 +77,24 @@ public class ButtonDemoScreenshotTest {
         UIManager.setLookAndFeel(lookAndFeel);
         Robot rob = new Robot();
 
+        //capture some of the background
+        Dimension screeSize = Toolkit.getDefaultToolkit().getScreenSize();
+        Point screenCenter = new Point(screeSize.width / 2, screeSize.height / 2);
+        Rectangle center = new Rectangle(
+                screenCenter.x - 50, screenCenter.y - 50,
+                screenCenter.x + 50, screenCenter.y + 50);
+        BufferedImage background = rob.createScreenCapture(center);
+
         new ClassReference(ButtonDemo.class.getCanonicalName()).startApplication();
 
         JFrameOperator mainFrame = new JFrameOperator(DEMO_TITLE);
-        waitImageIsStill(rob, mainFrame);
+        mainFrame.waitComponentShowing(true);
+
+        //make sure the frame is already painted
+        waitChangedImage(rob, () -> rob.createScreenCapture(center),
+                background, mainFrame.getTimeouts(), "background.png");
+        //make sure the frame is painted completely
+        waitStillImage(rob, mainFrame, "frame.png");
 
         // Check all the buttons
         for (int i : BUTTONS) {
@@ -83,7 +102,7 @@ public class ButtonDemoScreenshotTest {
         }
     }
 
-    private void checkButton(JFrameOperator jfo, int i, Robot rob) {
+    private void checkButton(JFrameOperator jfo, int i, Robot rob) throws InterruptedException {
         JButtonOperator button = new JButtonOperator(jfo, i);
 
         //additional instrumentation for JDK-8198920. To be removed after the bug is fixed
@@ -93,9 +112,8 @@ public class ButtonDemoScreenshotTest {
 
         button.moveMouse(button.getCenterX(), button.getCenterY());
 
-        BufferedImage initialButtonImage = capture(rob, button);
-        assertNotBlack(initialButtonImage);
-        save(initialButtonImage, "button" + i + ".png");
+        BufferedImage notPressed, pressed = null;
+        notPressed = waitStillImage(rob, button, "not-pressed-" + i + ".png");
 
         BufferedImage[] pressedImage = new BufferedImage[1];
 
@@ -108,22 +126,15 @@ public class ButtonDemoScreenshotTest {
             //additional instrumentation for JDK-8198920. To be removed after the bug is fixed
             button.getOutput().printTrace("JDK-8198920: Button press confirmed by " + System.currentTimeMillis());
             //end of instrumentation for JDK-8198920
-            button.waitState(new ComponentChooser() {
-                public boolean checkComponent(Component c) {
-                    pressedImage[0] = capture(rob, button);
-                    assertNotBlack(pressedImage[0]);
-                    return !sComparator.compare(initialButtonImage, pressedImage[0]);
-                }
-
-                public String getDescription() {
-                    return "Button with new image";
-                }
-            });
+            waitChangedImage(rob, () -> capture(rob, button), notPressed,
+                    button.getTimeouts(), "pressed-" + i + ".png");
+            pressed = waitStillImage(rob, button, "pressed.png");
         } finally {
-            if (pressedImage[0] != null) {
-                save(pressedImage[0], "button" + i + "_pressed.png");
-            }
             button.releaseMouse();
+            if(pressed != null) {
+                waitChangedImage(rob, () -> capture(rob, button), pressed,
+                        button.getTimeouts(), "released-" + i + ".png");
+            }
             //additional instrumentation for JDK-8198920. To be removed after the bug is fixed
             button.getOutput().printTrace("JDK-8198920: Button released at " + System.currentTimeMillis());
             try {

--- a/test/jdk/sanity/client/SwingSet/src/ButtonDemoTest.java
+++ b/test/jdk/sanity/client/SwingSet/src/ButtonDemoTest.java
@@ -24,8 +24,6 @@
 import org.jtregext.GuiTestListener;
 import com.sun.swingset3.demos.JHyperlink;
 import com.sun.swingset3.demos.button.ButtonDemo;
-
-import java.awt.image.BufferedImage;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import javax.swing.ButtonModel;
@@ -35,7 +33,7 @@ import javax.swing.event.ChangeEvent;
 import static org.testng.AssertJUnit.*;
 import org.testng.annotations.Test;
 import org.jemmy2ext.JemmyExt.ByToolTipChooser;
-import static org.jemmy2ext.JemmyExt.*;
+import static org.jemmy2ext.JemmyExt.EXACT_STRING_COMPARATOR;
 import org.netbeans.jemmy.ClassReference;
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;

--- a/test/jdk/sanity/client/SwingSet/src/ButtonDemoTest.java
+++ b/test/jdk/sanity/client/SwingSet/src/ButtonDemoTest.java
@@ -24,6 +24,8 @@
 import org.jtregext.GuiTestListener;
 import com.sun.swingset3.demos.JHyperlink;
 import com.sun.swingset3.demos.button.ButtonDemo;
+
+import java.awt.image.BufferedImage;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import javax.swing.ButtonModel;
@@ -33,7 +35,7 @@ import javax.swing.event.ChangeEvent;
 import static org.testng.AssertJUnit.*;
 import org.testng.annotations.Test;
 import org.jemmy2ext.JemmyExt.ByToolTipChooser;
-import static org.jemmy2ext.JemmyExt.EXACT_STRING_COMPARATOR;
+import static org.jemmy2ext.JemmyExt.*;
 import org.netbeans.jemmy.ClassReference;
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;

--- a/test/jdk/sanity/client/SwingSet/src/EditorPaneDemoTest.java
+++ b/test/jdk/sanity/client/SwingSet/src/EditorPaneDemoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,8 @@
 
 import static com.sun.swingset3.demos.editorpane.EditorPaneDemo.DEMO_TITLE;
 import static com.sun.swingset3.demos.editorpane.EditorPaneDemo.SOURCE_FILES;
-import static org.jemmy2ext.JemmyExt.EXACT_STRING_COMPARATOR;
-import static org.jemmy2ext.JemmyExt.assertNotBlack;
+import static org.jemmy2ext.JemmyExt.*;
+import static org.testng.Assert.assertFalse;
 
 import java.awt.Color;
 import java.awt.Dimension;
@@ -149,7 +149,8 @@ public class EditorPaneDemoTest {
         final int xGap = 100, yGap = 40, columns = 2, rows = 5;
         editorPaneOperator.waitState(comp -> {
             BufferedImage capturedImage = ImageTool.getImage(imageRect);
-            assertNotBlack(capturedImage);
+            save(capturedImage, "editor.png");
+            assertFalse(isBlack(capturedImage), "image blackness");
             int x = 0, y = 0, i = 0, j;
             for (; i < columns; i++) {
                 x += xGap;

--- a/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/button/ButtonDemo.java
+++ b/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/button/ButtonDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -218,6 +218,7 @@ public final class ButtonDemo extends JPanel {
             JFrame frame = new JFrame(DEMO_TITLE);
             frame.add(buttonDemo);
             frame.pack();
+            frame.setLocationRelativeTo(null);
             frame.setVisible(true);
         });
     }


### PR DESCRIPTION
Added a few synchronization points to the test:
	1	wait for the screen to change where the test window is displayed
	2	wait for the image to get still (i.e. painted complete)
	3	wait for the image to change after the mouse move
	4	wait for the image change and then to get still after the mouse press
	5	wait for the image to change after the mouse release

@mrserb Can you take a look?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253543](https://bugs.openjdk.java.net/browse/JDK-8253543): sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java failed with "AssertionError: All pixels are not black"


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/389/head:pull/389`
`$ git checkout pull/389`
