### PR TITLE
8253748: StressIGV tests fail with release VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestStressIGVNOptions.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestStressIGVNOptions.java
@@ -27,9 +27,9 @@
  * @requires vm.compiler2.enabled
  * @summary Tests that different combinations of the options -XX:+StressIGVN and
  *          -XX:StressSeed=N are accepted.
- * @run main/othervm -XX:+StressIGVN
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN
  *      compiler.arguments.TestStressIGVNOptions
- * @run main/othervm -XX:+StressIGVN -XX:StressSeed=42
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=42
  *      compiler.arguments.TestStressIGVNOptions
  */
 

--- a/test/hotspot/jtreg/compiler/debug/TestGenerateStressSeed.java
+++ b/test/hotspot/jtreg/compiler/debug/TestGenerateStressSeed.java
@@ -51,7 +51,7 @@ public class TestGenerateStressSeed {
             String className = TestGenerateStressSeed.class.getName();
             String log = "test.log";
             String[] procArgs = {
-                "-Xcomp", "-XX:-TieredCompilation",
+                "-Xcomp", "-XX:-TieredCompilation", "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:CompileOnly=" + className + "::sum", "-XX:+StressIGVN",
                 "-XX:+LogCompilation", "-XX:LogFile=" + log, className, "10"};
             ProcessTools.createJavaProcessBuilder(procArgs).start().waitFor();

--- a/test/hotspot/jtreg/compiler/debug/TestStressIGVN.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressIGVN.java
@@ -30,7 +30,7 @@ import jdk.test.lib.Asserts;
 /*
  * @test
  * @bug 8252219
- * @requires vm.compiler2.enabled
+ * @requires vm.debug == true & vm.compiler2.enabled
  * @summary Tests that compilations with the same seed yield the same IGVN
  *          trace, and compilations with different seeds yield different IGVN
  *          traces.


### PR DESCRIPTION
The following StressIGV tests fails with release VMs
  - compiler/arguments/TestStressIGVNOptions.java
  - compiler/debug/TestGenerateStressSeed.java
  - compiler/debug/TestStressIGVN.java

The reason is that VM option 'StressIGVN' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.

The fix adds '-XX:+UnlockDiagnosticVMOptions' option.
And compiler/debug/TestStressIGVN.java should be only available for debug VMs since it depends on -XX:+TraceIterativeGVN.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253748](https://bugs.openjdk.java.net/browse/JDK-8253748): StressIGV tests fail with release VMs


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/390/head:pull/390`
`$ git checkout pull/390`
