### PR TITLE
8253750: use build-stable default seed for Utils.RANDOM_GENERATOR

### DIFF
--- a/test/lib-test/jdk/test/lib/RandomGeneratorTest.java
+++ b/test/lib-test/jdk/test/lib/RandomGeneratorTest.java
@@ -86,10 +86,6 @@ public class RandomGeneratorTest {
                 return SEED_VM_OPTION + Utils.SEED;
             }
 
-            @Override
-            protected boolean isOutputExpected(String orig, String output) {
-                return output.equals(orig);
-            }
         },
         DIFFERENT_SEED {
             @Override
@@ -101,6 +97,11 @@ public class RandomGeneratorTest {
             public void verify(String orig, String[] cmdLine) {
                 cmdLine[0] = getSeedOption();
                 super.verify(orig, cmdLine);
+            }
+
+            @Override
+            protected boolean isOutputExpected(String orig, String output) {
+                return !super.isOutputExpected(orig, output);
             }
         },
         NO_SEED {
@@ -119,7 +120,7 @@ public class RandomGeneratorTest {
         public abstract String getSeedOption();
 
         protected boolean isOutputExpected(String orig, String output) {
-            return !output.equals(orig);
+            return output.equals(orig);
         }
 
         /**

--- a/test/lib-test/jdk/test/lib/RandomGeneratorTest.java
+++ b/test/lib-test/jdk/test/lib/RandomGeneratorTest.java
@@ -46,9 +46,10 @@ import jdk.test.lib.Utils;
 /**
  * The test verifies correctness of work {@link jdk.test.lib.Utils#getRandomInstance()}.
  * Test works in three modes: same seed provided, no seed provided and
- * different seed provided. In the first case the test expects that all random numbers
- * will be repeated in all next iterations. For other two modes test expects that
- * randomly generated numbers differ from original.
+ * different seed provided.
+ * In the first case, the test expects that all random numbers will be repeated in all next iterations.
+ * In the second case, the numbers are expected to be the same for promotable builds and different for other builds.
+ * In the last case, the test expects the randomly generated numbers differ from original.
  */
 public class RandomGeneratorTest {
     private static final String SEED_VM_OPTION = "-D" + Utils.SEED_PROPERTY_NAME + "=";
@@ -86,6 +87,10 @@ public class RandomGeneratorTest {
                 return SEED_VM_OPTION + Utils.SEED;
             }
 
+            @Override
+            protected boolean isOutputExpected(String orig, String output) {
+                return output.equals(orig);
+            }
         },
         DIFFERENT_SEED {
             @Override
@@ -101,13 +106,18 @@ public class RandomGeneratorTest {
 
             @Override
             protected boolean isOutputExpected(String orig, String output) {
-                return !super.isOutputExpected(orig, output);
+                return !output.equals(orig);
             }
         },
         NO_SEED {
             @Override
             public String getSeedOption() {
                 return null;
+            }
+
+            @Override
+            protected boolean isOutputExpected(String orig, String output) {
+                return Runtime.version().build().orElse(0) > 0 ^ !output.equals(orig);
             }
         };
 
@@ -119,9 +129,7 @@ public class RandomGeneratorTest {
          */
         public abstract String getSeedOption();
 
-        protected boolean isOutputExpected(String orig, String output) {
-            return output.equals(orig);
-        }
+        protected abstract boolean isOutputExpected(String orig, String output);
 
         /**
          * Verifies that the original output meets expectations

--- a/test/lib/jdk/test/lib/Utils.java
+++ b/test/lib/jdk/test/lib/Utils.java
@@ -129,9 +129,10 @@ public final class Utils {
      */
     public static final String SEED_PROPERTY_NAME = "jdk.test.lib.random.seed";
 
-    /* (non-javadoc)
-     * Random generator with (or without) predefined seed. Depends on
-     * "jdk.test.lib.random.seed" property value.
+    /**
+     * Random generator with predefined seed. If "jdk.test.lib.random.seed" is
+     * specified, its value is used as seed, otherwise, seed based on string
+     * representation of {@link Runtime#version()} is used.
      */
     private static volatile Random RANDOM_GENERATOR;
 
@@ -153,7 +154,9 @@ public final class Utils {
            // use 1st 8 bytes of md5($version)
            try {
                var md = MessageDigest.getInstance("MD5");
-               var bytes = System.getProperty("java.vm.version").getBytes(StandardCharsets.UTF_8);
+               var bytes = Runtime.version()
+                                  .toString()
+                                  .getBytes(StandardCharsets.UTF_8);
                bytes = md.digest(bytes);
                SEED = ByteBuffer.wrap(bytes).getLong();
            } catch (NoSuchAlgorithmException e) {
@@ -550,8 +553,9 @@ public final class Utils {
 
     /**
      * Returns {@link java.util.Random} generator initialized with particular seed.
-     * The seed could be provided via system property {@link Utils#SEED_PROPERTY_NAME}
-     * In case no seed is provided, the method uses a random number.
+     * The seed could be provided via system property {@link Utils#SEED_PROPERTY_NAME}.
+     * In case no seed is provided, the seed based on string representation of
+     * {@link Runtime#version()}, which is different from build to build, is used.
      * The used seed printed to stdout.
      * @return {@link java.util.Random} generator with particular seed.
      */


### PR DESCRIPTION
Hi all,

could you please review the patch which updates `jdk.test.lib.Utils` to use md5 hash-sum of `java.vm.version` property as default seed for `Utils.RANDOM_GENERATOR`?

from JBS:
> using the same seed for all runs of a build will make it possible (easier) to compare results from different test runs (e.g. on different platforms, w/ different flags) and consequently will make test results analysis easier. the proposed solution is to use the seed based on Runtime.version() / "java.vm.version", which are different from build to build, if there is no seed specified by "jdk.test.lib.random.seed" property.

the patch also updates `RandomGeneratorTest` test, so it expects now that the same values are generated if no seed is provided. 

testing: 
✅ tier1
✅ `test/lib-test/jdk/test/lib/` against personal build on linux,windows,macos-x64
✅ `test/lib-test/jdk/test/lib/` against CI build on linux,windows,macos-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253750](https://bugs.openjdk.java.net/browse/JDK-8253750): use build-stable default seed for Utils.RANDOM_GENERATOR


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/391/head:pull/391`
`$ git checkout pull/391`
