### PR TITLE
8253761: Wrong URI syntax printed by jar --describe-module

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
@@ -1737,7 +1737,7 @@ public class Main {
         /** Returns an optional containing the effective URI. */
         @Override public Optional<String> uriString() {
             String uri = (Paths.get(zipFile.getName())).toUri().toString();
-            uri = "jar:" + uri + "/!" + entry.getName();
+            uri = "jar:" + uri + "!/" + entry.getName();
             return Optional.of(uri);
         }
     }

--- a/test/jdk/tools/jar/mmrjar/Basic.java
+++ b/test/jdk/tools/jar/mmrjar/Basic.java
@@ -269,7 +269,7 @@ public class Basic {
         jar("-d --file mr.jar");
 
         String uri = (Paths.get("mr.jar")).toUri().toString();
-        uri = "jar:" + uri + "/!module-info.class";
+        uri = "jar:" + uri + "!/module-info.class";
 
         actual = lines(outbytes);
         expected = Set.of(
@@ -423,7 +423,7 @@ public class Basic {
         actual = lines(outbytes);
         expected = Set.of(
                 "releases: 9 10",
-                "m1 " + uriPrefix + "/!META-INF/versions/9/module-info.class",
+                "m1 " + uriPrefix + "!/META-INF/versions/9/module-info.class",
                 "requires java.base mandated",
                 "exports p",
                 "main-class p.Main"
@@ -434,7 +434,7 @@ public class Basic {
         actual = lines(outbytes);
         expected = Set.of(
                 "releases: 9 10",
-                "m1 " + uriPrefix + "/!META-INF/versions/10/module-info.class",
+                "m1 " + uriPrefix + "!/META-INF/versions/10/module-info.class",
                 "requires java.base mandated",
                 "exports p",
                 "main-class p.Main"

--- a/test/jdk/tools/jar/modularJar/Basic.java
+++ b/test/jdk/tools/jar/modularJar/Basic.java
@@ -494,9 +494,9 @@ public class Basic {
             "--file=" + modularJar.toString())
             .assertSuccess()
             .resultChecker(r -> {
-                // Expect "bar jar:file:/.../!module-info.class"
+                // Expect "bar jar:file:/...!/module-info.class"
                 // conceals jdk.test.foo, conceals jdk.test.foo.internal"
-                String uri = "jar:" + modularJar.toUri().toString() + "/!module-info.class";
+                String uri = "jar:" + modularJar.toUri().toString() + "!/module-info.class";
                 assertTrue(r.output.contains("bar " + uri),
                            "Expecting to find \"bar " + uri + "\"",
                            "in output, but did not: [" + r.output + "]");
@@ -848,10 +848,14 @@ public class Basic {
             jar(option,
                 "--file=" + modularJar.toString())
                 .assertSuccess()
-                .resultChecker(r ->
+                .resultChecker(r -> {
                     assertTrue(r.output.contains(FOO.moduleName + "@" + FOO.version),
                                "Expected to find ", FOO.moduleName + "@" + FOO.version,
-                               " in [", r.output, "]")
+                               " in [", r.output, "]");
+                    assertTrue(r.output.contains(modularJar.toUri().toString()),
+                               "Expected to find ", modularJar.toUri().toString(),
+                               " in [", r.output, "]");
+                    }
                 );
 
             jar(option,


### PR DESCRIPTION
This commit replaces `"/!"` with `"!/"` in order to generate
valid URIs when printing a module description of a modular
JAR file. A valid URI is described here: [1]

https://bugs.openjdk.java.net/browse/JDK-8253761

[1] https://docs.oracle.com/en/java/javase/15/docs/api/java.base/java/net/JarURLConnection.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253761](https://bugs.openjdk.java.net/browse/JDK-8253761): Wrong URI syntax printed by jar --describe-module


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/393/head:pull/393`
`$ git checkout pull/393`
