### PR TITLE
8253763: ParallelObjectIterator should have virtual destructor

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -90,6 +90,7 @@ class GCHeapLog : public EventLogBase<GCMessage> {
 class ParallelObjectIterator : public CHeapObj<mtGC> {
 public:
   virtual void object_iterate(ObjectClosure* cl, uint worker_id) = 0;
+  virtual ~ParallelObjectIterator() {}
 };
 
 //


### PR DESCRIPTION
The ParallelObjectIterator should have virtual destructor, since implementations of CollectedHeap::parallel_object_iterator() returns the base type, which is later passed to the delete operator.

Today both G1 and Shenandoah leaks memory here. I noticed this bug when when implementing ZCollectedHeap::parallel_object_iterator(). Bug was introduced in JDK-8215624.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253763](https://bugs.openjdk.java.net/browse/JDK-8253763): ParallelObjectIterator should have virtual destructor


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/395/head:pull/395`
`$ git checkout pull/395`
