### PR TITLE
8253636: C2: Adjust NodeClasses::_max_classes

### DIFF
--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1039,7 +1039,7 @@ bool Node::verify_jvms(const JVMState* using_jvms) const {
 
 //------------------------------init_NodeProperty------------------------------
 void Node::init_NodeProperty() {
-  assert(_max_classes <= max_jushort, "too many NodeProperty classes");
+  assert(_max_classes <= max_juint, "too many NodeProperty classes");
   assert(max_flags() <= max_jushort, "too many NodeProperty flags");
 }
 

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -608,7 +608,7 @@ public:
   ClassMask_##cl = ((Bit_##cl << 1) - 1) ,
 
   // This enum is used only for C2 ideal and mach nodes with is_<node>() methods
-  // so that it's values fits into 16 bits.
+  // so that its values fit into 32 bits.
   enum NodeClasses {
     Bit_Node   = 0x00000000,
     Class_Node = 0x00000000,
@@ -719,7 +719,7 @@ public:
     DEFINE_CLASS_ID(Halt, Node, 15)
     DEFINE_CLASS_ID(Opaque1, Node, 16)
 
-    _max_classes  = ClassMask_Halt
+    _max_classes  = ClassMask_Opaque1
   };
   #undef DEFINE_CLASS_ID
 


### PR DESCRIPTION
Update `NodeClasses::_max_classes` to the max class id within the enumeration. Update comment and assertion to reflect that `NodeClasses` uses now 32 bits after the addition of `Opaque1` in JDK-8229495.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253636](https://bugs.openjdk.java.net/browse/JDK-8253636): C2: Adjust NodeClasses::_max_classes


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/397/head:pull/397`
`$ git checkout pull/397`
