### PR TITLE
8253770: Test tools/javac/parser/JavacParserTest.java fails on Windows after JDK-8253584

### DIFF
--- a/test/langtools/tools/javac/parser/JavacParserTest.java
+++ b/test/langtools/tools/javac/parser/JavacParserTest.java
@@ -1604,7 +1604,7 @@ public class JavacParserTest extends TestCase {
                           } """;
         assertEquals("Unexpected AST, got:\n" + ast, expected, ast);
         assertEquals("Unexpected errors, got:\n" + out.toString(),
-                     out.toString(),
+                     out.toString().replaceAll("\\R", "\n"),
                      """
                      Test.java:5:17: compiler.err.expected: token.identifier
                      Test.java:5:16: compiler.err.not.stmt


### PR DESCRIPTION
…s after JDK-8253584

The issue is (again) not normalized line endings for the test output - fixed in by normalizing the line endings in the actual output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253770](https://bugs.openjdk.java.net/browse/JDK-8253770): Test tools/javac/parser/JavacParserTest.java fails on Windows after JDK-8253584


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/399/head:pull/399`
`$ git checkout pull/399`
