### PR TITLE
checkToArray() only checks the first array.

### DIFF
--- a/test/jdk/java/util/concurrent/tck/ArrayDequeTest.java
+++ b/test/jdk/java/util/concurrent/tck/ArrayDequeTest.java
@@ -738,7 +738,7 @@ public class ArrayDequeTest extends JSR166TestCase {
             Integer x = (Integer) it.next();
             assertEquals(s + i, (int) x);
             for (Object[] a : as)
-                assertSame(a1[i], x);
+                assertSame(a[i], x);
         }
     }
 


### PR DESCRIPTION
Probably a small typo during refactoring from only calling one toArray() method to a whole array of toArray()s.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/401/head:pull/401`
`$ git checkout pull/401`
