### PR TITLE
JDK-8253791: Issue with useAppleColor check in CSystemColors.m

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,7 +126,7 @@ static JNF_STATIC_MEMBER_CACHE(jm_systemColorsChanged, jc_LWCToolkit, "systemCol
 + (NSColor*)getColor:(NSUInteger)colorIndex useAppleColor:(BOOL)useAppleColor {
     NSColor* result = nil;
 
-    if (colorIndex < (useAppleColor) ? sun_lwawt_macosx_LWCToolkit_NUM_APPLE_COLORS : java_awt_SystemColor_NUM_COLORS) {
+    if (colorIndex < ((useAppleColor) ? sun_lwawt_macosx_LWCToolkit_NUM_APPLE_COLORS : java_awt_SystemColor_NUM_COLORS)) {
         result = (useAppleColor ? appleColors : sColors)[colorIndex];
     }
     else {


### PR DESCRIPTION
While looking into XCode 12 compilation issues, a problem in jdk/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
was found when checking the useAppleColor flag . Because this is a general issue and not really much related to XCode 12 (just shown when using the new compiler) a separate issue is filed for it.

See also
https://git.openjdk.java.net/jdk/pull/348 
(where Paul Hohensee created a change containing another XCode 12 issue;  but in the discussion it was seen as beneficial to separate the 2)

Best regards, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253791](https://bugs.openjdk.java.net/browse/JDK-8253791): Issue with useAppleColor check in CSystemColors.m


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/403/head:pull/403`
`$ git checkout pull/403`
