### PR TITLE
8253747: tools/jpackage/share/AppImagePackageTest.java fails with InstalledPackageSize: 0

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
@@ -237,6 +237,7 @@ public class LinuxHelper {
                     if (getPackageFiles(cmd).count() > 01L) {
                         // there is something there so round up to 1 KB
                         estimate = 01L;
+                    }
                 }
                 return estimate;
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
@@ -229,8 +229,16 @@ public class LinuxHelper {
         final Path packageFile = cmd.outputBundle();
         switch (cmd.packageType()) {
             case LINUX_DEB:
-                return Long.parseLong(getDebBundleProperty(packageFile,
+                Long estimate = Long.parseLong(getDebBundleProperty(packageFile,
                         "Installed-Size"));
+                if (estimate == 0L) {
+                    // if the estimate in KB is 0, check if it is really empty
+                    // or just < 1KB as with AppImagePackageTest.testEmpty()
+                    if (getPackageFiles(cmd).count() > 01L) {
+                        // there is something there so round up to 1 KB
+                        estimate = 01L;
+                }
+                return estimate;
 
             case LINUX_RPM:
                 String size = getRpmBundleProperty(packageFile, "Size");


### PR DESCRIPTION
8253747: tools/jpackage/share/AppImagePackageTest.java fails with InstalledPackageSize: 0
Updated Debian code in test to get package size in BK, allowing for non-zero size less than 1KB

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253747](https://bugs.openjdk.java.net/browse/JDK-8253747): tools/jpackage/share/AppImagePackageTest.java fails with InstalledPackageSize: 0


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/404/head:pull/404`
`$ git checkout pull/404`
