### PR TITLE
JDK-8253733: Cleanup internal taglet API

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -274,7 +274,7 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
      * @param contentTree the content tree to which the deprecated information will be added.
      */
     protected void addDeprecatedInfo(Element member, Content contentTree) {
-        Content output = (new DeprecatedTaglet()).getTagletOutput(member,
+        Content output = (new DeprecatedTaglet()).getAllBlockTagOutput(member,
             writer.getTagletWriterInstance(false));
         if (!output.isEmpty()) {
             Content deprecatedContent = output;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
@@ -376,7 +376,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
     @Override
     public void addParamInfo(Content classInfoTree) {
         if (utils.hasBlockTag(typeElement, DocTree.Kind.PARAM)) {
-            Content paramInfo = (new ParamTaglet()).getTagletOutput(typeElement,
+            Content paramInfo = (new ParamTaglet()).getAllBlockTagOutput(typeElement,
                     getTagletWriterInstance(false));
             if (!paramInfo.isEmpty()) {
                 classInfoTree.add(HtmlTree.DL(HtmlStyle.notes, paramInfo));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriterImpl.java
@@ -258,7 +258,7 @@ public class ConstantsSummaryWriterImpl extends HtmlDocletWriter implements Cons
      * @return the value column of the constant table row
      */
     private Content getValue(VariableElement member) {
-        String value = utils.constantValueExpresion(member);
+        String value = utils.constantValueExpression(member);
         Content valueContent = new StringContent(value);
         return HtmlTree.CODE(valueContent);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -94,6 +94,7 @@ import jdk.javadoc.internal.doclets.toolkit.Messages;
 import jdk.javadoc.internal.doclets.toolkit.PackageSummaryWriter;
 import jdk.javadoc.internal.doclets.toolkit.Resources;
 import jdk.javadoc.internal.doclets.toolkit.taglets.DocRootTaglet;
+import jdk.javadoc.internal.doclets.toolkit.taglets.Taglet;
 import jdk.javadoc.internal.doclets.toolkit.taglets.TagletWriter;
 import jdk.javadoc.internal.doclets.toolkit.util.Comparators;
 import jdk.javadoc.internal.doclets.toolkit.util.CommentHelper;
@@ -332,27 +333,52 @@ public class HtmlDocletWriter {
         if (utils.isExecutableElement(e) && !utils.isConstructor(e)) {
             addMethodInfo((ExecutableElement)e, dl);
         }
-        Content output = new ContentBuilder();
-        TagletWriter.genTagOutput(configuration.tagletManager, e,
-            configuration.tagletManager.getBlockTaglets(e),
-                getTagletWriterInstance(false), output);
+        Content output = getBlockTagOutput(e);
         dl.add(output);
         htmlTree.add(dl);
     }
 
     /**
-     * Check whether there are any tags for Serialization Overview
-     * section to be printed.
+     * Returns the content generated from the default supported set of block tags
+     * for this element.
      *
-     * @param field the VariableElement object to check for tags.
-     * @return true if there are tags to be printed else return false.
+     * @param element the element
+     *
+     * @return the content
+     */
+    protected Content getBlockTagOutput(Element element) {
+        return getBlockTagOutput(element, configuration.tagletManager.getBlockTaglets(element));
+    }
+
+    /**
+     * Returns the content generated from a specified set of block tags
+     * for this element.
+     *
+     * @param element the element
+     * @param taglets the taglets to handle the required set of tags
+     *
+     * @return the content
+     */
+    protected Content getBlockTagOutput(Element element, List<Taglet> taglets) {
+        return getTagletWriterInstance(false)
+                .getBlockTagOutput(configuration.tagletManager, element, taglets);
+    }
+
+    /**
+     * Returns whether there are any tags in a field for the Serialization Overview
+     * section to be generated.
+     *
+     * @param field the field to check
+     * @return {@code true} if and only if there are tags to be included
      */
     protected boolean hasSerializationOverviewTags(VariableElement field) {
-        Content output = new ContentBuilder();
-        TagletWriter.genTagOutput(configuration.tagletManager, field,
-                configuration.tagletManager.getBlockTaglets(field),
-                getTagletWriterInstance(false), output);
+        Content output = getBlockTagOutput(field);
         return !output.isEmpty();
+    }
+
+    private Content getInlineTagOutput(Element element, DocTree holder, DocTree tree, boolean isFirstSentence, boolean inSummary) {
+        return getTagletWriterInstance(isFirstSentence, inSummary)
+                .getInlineTagOutput(element, configuration.tagletManager, holder, tree);
     }
 
     /**
@@ -1440,11 +1466,8 @@ public class HtmlDocletWriter {
 
                 @Override
                 public Boolean visitDocRoot(DocRootTree node, Content c) {
-                    Content docRootContent = TagletWriter.getInlineTagOutput(element,
-                            configuration.tagletManager,
-                            holderTag,
-                            node,
-                            getTagletWriterInstance(isFirstSentence));
+                    Content docRootContent = getInlineTagOutput(element, holderTag, node,
+                            isFirstSentence, false);
                     if (c != null) {
                         c.add(docRootContent);
                     } else {
@@ -1476,9 +1499,8 @@ public class HtmlDocletWriter {
 
                 @Override
                 public Boolean visitInheritDoc(InheritDocTree node, Content c) {
-                    Content output = TagletWriter.getInlineTagOutput(element,
-                            configuration.tagletManager, holderTag,
-                            tag, getTagletWriterInstance(isFirstSentence));
+                    Content output = getInlineTagOutput(element, holderTag, node,
+                            isFirstSentence, false);
                     result.add(output);
                     // if we obtained the first sentence successfully, nothing more to do
                     return (isFirstSentence && !output.isEmpty());
@@ -1486,9 +1508,7 @@ public class HtmlDocletWriter {
 
                 @Override
                 public Boolean visitIndex(IndexTree node, Content p) {
-                    Content output = TagletWriter.getInlineTagOutput(element,
-                            configuration.tagletManager, holderTag, tag,
-                            getTagletWriterInstance(isFirstSentence, inSummary));
+                    Content output = getInlineTagOutput(element, holderTag, node, isFirstSentence, inSummary);
                     if (output != null) {
                         result.add(output);
                     }
@@ -1535,18 +1555,14 @@ public class HtmlDocletWriter {
 
                 @Override
                 public Boolean visitSummary(SummaryTree node, Content c) {
-                    Content output = TagletWriter.getInlineTagOutput(element,
-                            configuration.tagletManager, holderTag, tag,
-                            getTagletWriterInstance(isFirstSentence));
+                    Content output = getInlineTagOutput(element, holderTag, node, isFirstSentence, false);
                     result.add(output);
                     return false;
                 }
 
                 @Override
                 public Boolean visitSystemProperty(SystemPropertyTree node, Content p) {
-                    Content output = TagletWriter.getInlineTagOutput(element,
-                            configuration.tagletManager, holderTag, tag,
-                            getTagletWriterInstance(isFirstSentence, inSummary));
+                    Content output = getInlineTagOutput(element, holderTag, node, isFirstSentence, inSummary);
                     if (output != null) {
                         result.add(output);
                     }
@@ -1579,9 +1595,7 @@ public class HtmlDocletWriter {
 
                 @Override
                 protected Boolean defaultAction(DocTree node, Content c) {
-                    Content output = TagletWriter.getInlineTagOutput(element,
-                            configuration.tagletManager, holderTag, tag,
-                            getTagletWriterInstance(isFirstSentence));
+                    Content output = getInlineTagOutput(element, holderTag, node, isFirstSentence, false);
                     if (output != null) {
                         result.add(output);
                     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
@@ -196,13 +196,12 @@ public class HtmlSerialFieldWriter extends FieldWriterImpl
      */
     @Override
     public void addMemberTags(VariableElement field, Content contentTree) {
-        Content tagContent = new ContentBuilder();
-        TagletWriter.genTagOutput(configuration.tagletManager, field,
-                configuration.tagletManager.getBlockTaglets(field),
-                writer.getTagletWriterInstance(false), tagContent);
-        HtmlTree dl = HtmlTree.DL(HtmlStyle.notes);
-        dl.add(tagContent);
-        contentTree.add(dl);  // TODO: what if empty?
+        Content tagContent = writer.getBlockTagOutput(field);
+        if (!tagContent.isEmpty()) {
+            HtmlTree dl = HtmlTree.DL(HtmlStyle.notes);
+            dl.add(tagContent);
+            contentTree.add(dl);
+        }
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialMethodWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialMethodWriter.java
@@ -153,16 +153,12 @@ public class HtmlSerialMethodWriter extends MethodWriterImpl implements
      */
     @Override
     public void addMemberTags(ExecutableElement member, Content methodsContentTree) {
-        Content tagContent = new ContentBuilder();
-        TagletManager tagletManager =
-            configuration.tagletManager;
-        TagletWriter.genTagOutput(tagletManager, member,
-            tagletManager.getSerializedFormTaglets(),
-            writer.getTagletWriterInstance(false), tagContent);
+        TagletManager tagletManager = configuration.tagletManager;
+        Content tagContent = writer.getBlockTagOutput(member, tagletManager.getSerializedFormTaglets());
         HtmlTree dl = HtmlTree.DL(HtmlStyle.notes);
         dl.add(tagContent);
         methodsContentTree.add(dl);
-        if (name(member).compareTo("writeExternal") == 0
+        if (name(member).equals("writeExternal")
                 && utils.getSerialDataTrees(member).isEmpty()) {
             serialWarning(member, "doclet.MissingSerialDataTag",
                 utils.getFullyQualifiedName(member.getEnclosingElement()), name(member));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -143,9 +143,9 @@ public class TagletWriterImpl extends TagletWriter {
                 result.add(HtmlTree.SPAN(HtmlStyle.deprecatedLabel,
                         htmlWriter.getDeprecatedPhrase(element)));
                 if (!deprs.isEmpty()) {
-                    List<? extends DocTree> commentTags = ch.getDescription(deprs.get(0));
-                    if (!commentTags.isEmpty()) {
-                        result.add(commentTagsToOutput(null, element, commentTags, false));
+                    List<? extends DocTree> commentTrees = ch.getDescription(deprs.get(0));
+                    if (!commentTrees.isEmpty()) {
+                        result.add(commentTagsToOutput(element, null, commentTrees, false));
                     }
                 }
             }
@@ -154,8 +154,8 @@ public class TagletWriterImpl extends TagletWriter {
                 result.add(HtmlTree.SPAN(HtmlStyle.deprecatedLabel,
                         htmlWriter.getDeprecatedPhrase(element)));
                 if (!deprs.isEmpty()) {
-                    List<? extends DocTree> bodyTags = ch.getBody(deprs.get(0));
-                    Content body = commentTagsToOutput(null, element, bodyTags, false);
+                    List<? extends DocTree> bodyTrees = ch.getBody(deprs.get(0));
+                    Content body = commentTagsToOutput(element, null, bodyTrees, false);
                     if (!body.isEmpty())
                         result.add(HtmlTree.DIV(HtmlStyle.deprecationComment, body));
                 }
@@ -203,18 +203,6 @@ public class TagletWriterImpl extends TagletWriter {
         List<? extends DocTree> description = ch.getDescription(paramTag);
         body.add(htmlWriter.commentTagsToContent(paramTag, element, description, false, inSummary));
         return HtmlTree.DD(body);
-    }
-
-    @Override
-    public Content propertyTagOutput(Element element, DocTree tag, String prefix) {
-        Content body = new ContentBuilder();
-        CommentHelper ch = utils.getCommentHelper(element);
-        body.add(new RawHtml(prefix));
-        body.add(" ");
-        body.add(HtmlTree.CODE(new RawHtml(ch.getText(tag))));
-        body.add(".");
-        Content result = HtmlTree.P(body);
-        return result;
     }
 
     @Override
@@ -273,7 +261,7 @@ public class TagletWriterImpl extends TagletWriter {
     }
 
     @Override
-    public Content simpleTagOutput(Element element, List<? extends DocTree> simpleTags, String header) {
+    public Content simpleBlockTagOutput(Element element, List<? extends DocTree> simpleTags, String header) {
         CommentHelper ch = utils.getCommentHelper(element);
         ContentBuilder body = new ContentBuilder();
         boolean many = false;
@@ -285,16 +273,6 @@ public class TagletWriterImpl extends TagletWriter {
             body.add(htmlWriter.commentTagsToContent(simpleTag, element, bodyTags, false, inSummary));
             many = true;
         }
-        return new ContentBuilder(
-                HtmlTree.DT(new RawHtml(header)),
-                HtmlTree.DD(body));
-    }
-
-    @Override
-    public Content simpleTagOutput(Element element, DocTree simpleTag, String header) {
-        CommentHelper ch = utils.getCommentHelper(element);
-        List<? extends DocTree> description = ch.getDescription(simpleTag);
-        Content body = htmlWriter.commentTagsToContent(simpleTag, element, description, false, inSummary);
         return new ContentBuilder(
                 HtmlTree.DT(new RawHtml(header)),
                 HtmlTree.DD(body));
@@ -358,18 +336,18 @@ public class TagletWriterImpl extends TagletWriter {
     }
 
     @Override
-    public Content commentTagsToOutput(DocTree holderTag, List<? extends DocTree> tags) {
-        return commentTagsToOutput(holderTag, null, tags, false);
-    }
-
-    @Override
-    public Content commentTagsToOutput(Element holder, List<? extends DocTree> tags) {
+    public Content commentTagsToOutput(DocTree holder, List<? extends DocTree> tags) {
         return commentTagsToOutput(null, holder, tags, false);
     }
 
     @Override
-    public Content commentTagsToOutput(DocTree holderTag,
-                                       Element holder,
+    public Content commentTagsToOutput(Element element, List<? extends DocTree> tags) {
+        return commentTagsToOutput(element, null, tags, false);
+    }
+
+    @Override
+    public Content commentTagsToOutput(Element holder,
+                                       DocTree holderTag,
                                        List<? extends DocTree> tags,
                                        boolean isFirstSentence)
     {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
@@ -238,7 +238,7 @@ public class SerializedFormBuilder extends AbstractBuilder {
             if (field.getSimpleName().toString().compareTo(SERIAL_VERSION_UID) == 0 &&
                 field.getConstantValue() != null) {
                 writer.addSerialUIDInfo(SERIAL_VERSION_UID_HEADER,
-                                        utils.constantValueExpresion(field), serialUidTree);
+                                        utils.constantValueExpression(field), serialUidTree);
                 break;
             }
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/BaseTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/BaseTaglet.java
@@ -143,7 +143,7 @@ public class BaseTaglet implements Taglet {
      * @implSpec This implementation throws {@link UnsupportedTagletOperationException}.
      */
     @Override
-    public Content getTagletOutput(Element element, DocTree tag, TagletWriter writer) {
+    public Content getInlineTagOutput(Element element, DocTree tag, TagletWriter writer) {
         throw new UnsupportedTagletOperationException("Method not supported in taglet " + getName() + ".");
     }
 
@@ -153,7 +153,7 @@ public class BaseTaglet implements Taglet {
      * @implSpec This implementation throws {@link UnsupportedTagletOperationException}
      */
     @Override
-    public Content getTagletOutput(Element holder, TagletWriter writer) {
+    public Content getAllBlockTagOutput(Element holder, TagletWriter writer) {
         throw new UnsupportedTagletOperationException("Method not supported in taglet " + getName() + ".");
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/CodeTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/CodeTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/CodeTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/CodeTaglet.java
@@ -58,7 +58,7 @@ public class CodeTaglet extends BaseTaglet {
     }
 
     @Override
-    public Content getTagletOutput(Element element, DocTree tag, TagletWriter writer) {
+    public Content getInlineTagOutput(Element element, DocTree tag, TagletWriter writer) {
         return writer.codeTagOutput(element, tag);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/DeprecatedTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/DeprecatedTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/DeprecatedTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/DeprecatedTaglet.java
@@ -49,7 +49,7 @@ public class DeprecatedTaglet extends BaseTaglet {
     }
 
     @Override
-    public Content getTagletOutput(Element holder, TagletWriter writer) {
+    public Content getAllBlockTagOutput(Element holder, TagletWriter writer) {
         return writer.deprecatedTagOutput(holder);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/DocRootTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/DocRootTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/DocRootTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/DocRootTaglet.java
@@ -53,7 +53,7 @@ public class DocRootTaglet extends BaseTaglet {
     }
 
     @Override
-    public Content getTagletOutput(Element holder, DocTree tag, TagletWriter writer) {
+    public Content getInlineTagOutput(Element holder, DocTree tag, TagletWriter writer) {
         return writer.getDocRootOutput();
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/IndexTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/IndexTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/IndexTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/IndexTaglet.java
@@ -45,7 +45,7 @@ public class IndexTaglet extends BaseTaglet {
     }
 
     @Override
-    public Content getTagletOutput(Element element, DocTree tag, TagletWriter writer) {
+    public Content getInlineTagOutput(Element element, DocTree tag, TagletWriter writer) {
         return writer.indexTagOutput(element, tag);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/InheritDocTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/InheritDocTaglet.java
@@ -95,8 +95,8 @@ public class InheritDocTaglet extends BaseTaglet {
         DocFinder.Output inheritedDoc = DocFinder.search(configuration, input);
         if (inheritedDoc.isValidInheritDocTag) {
             if (!inheritedDoc.inlineTags.isEmpty()) {
-                replacement = writer.commentTagsToOutput(inheritedDoc.holderTag,
-                    inheritedDoc.holder, inheritedDoc.inlineTags, isFirstSentence);
+                replacement = writer.commentTagsToOutput(inheritedDoc.holder, inheritedDoc.holderTag,
+                    inheritedDoc.inlineTags, isFirstSentence);
                 ch.setOverrideElement(inheritedDoc.holder);
             }
 
@@ -111,7 +111,7 @@ public class InheritDocTaglet extends BaseTaglet {
     }
 
     @Override
-    public Content getTagletOutput(Element e, DocTree tag, TagletWriter tagletWriter) {
+    public Content getInlineTagOutput(Element e, DocTree tag, TagletWriter tagletWriter) {
         DocTree inheritTag = (tag.getKind() == DocTree.Kind.INHERIT_DOC) ? null : tag;
         return retrieveInheritedDocumentation(tagletWriter, e,
                 inheritTag, tagletWriter.isFirstSentence);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/LiteralTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/LiteralTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/LiteralTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/LiteralTaglet.java
@@ -51,7 +51,7 @@ public class LiteralTaglet extends BaseTaglet {
     }
 
     @Override
-    public Content getTagletOutput(Element e, DocTree tag, TagletWriter writer) {
+    public Content getInlineTagOutput(Element e, DocTree tag, TagletWriter writer) {
         return writer.literalTagOutput(e, tag);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -134,7 +134,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
 
     @Override
     @SuppressWarnings("preview")
-    public Content getTagletOutput(Element holder, TagletWriter writer) {
+    public Content getAllBlockTagOutput(Element holder, TagletWriter writer) {
         Utils utils = writer.configuration().utils;
         if (utils.isExecutableElement(holder)) {
             ExecutableElement member = (ExecutableElement) holder;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ReturnTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ReturnTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ReturnTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ReturnTaglet.java
@@ -70,7 +70,7 @@ public class ReturnTaglet extends BaseTaglet implements InheritableTaglet {
     }
 
     @Override
-    public Content getTagletOutput(Element holder, TagletWriter writer) {
+    public Content getAllBlockTagOutput(Element holder, TagletWriter writer) {
         Messages messages = writer.configuration().getMessages();
         Utils utils = writer.configuration().utils;
         TypeMirror returnType = utils.getReturnType(writer.getCurrentPageElement(), (ExecutableElement)holder);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SeeTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SeeTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SeeTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SeeTaglet.java
@@ -66,7 +66,7 @@ public class SeeTaglet extends BaseTaglet implements InheritableTaglet {
     }
 
     @Override
-    public Content getTagletOutput(Element holder, TagletWriter writer) {
+    public Content getAllBlockTagOutput(Element holder, TagletWriter writer) {
         Utils utils = writer.configuration().utils;
         List<? extends DocTree> tags = utils.getSeeTrees(holder);
         Element e = holder;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SimpleTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SimpleTaglet.java
@@ -40,7 +40,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocFinder;
 import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 
 /**
- * A custom single-argument tag.
+ * A custom single-argument block tag.
  *
  *  <p><b>This is NOT part of any supported API.
  *  If you write code that depends on this, you do so at your own risk.
@@ -178,17 +178,17 @@ public class SimpleTaglet extends BaseTaglet implements InheritableTaglet {
     }
 
     @Override
-    public Content getTagletOutput(Element element, DocTree tag, TagletWriter writer) {
-        return header == null || tag == null ? null : writer.simpleTagOutput(element, tag, header);
+    public Content getInlineTagOutput(Element element, DocTree tag, TagletWriter writer) {
+        return null;
     }
 
     @Override
-    public Content getTagletOutput(Element holder, TagletWriter writer) {
+    public Content getAllBlockTagOutput(Element holder, TagletWriter writer) {
         Utils utils = writer.configuration().utils;
         List<? extends DocTree> tags = utils.getBlockTags(holder, this);
         if (header == null || tags.isEmpty()) {
             return null;
         }
-        return writer.simpleTagOutput(holder, tags, header);
+        return writer.simpleBlockTagOutput(holder, tags, header);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SimpleTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SimpleTaglet.java
@@ -178,11 +178,6 @@ public class SimpleTaglet extends BaseTaglet implements InheritableTaglet {
     }
 
     @Override
-    public Content getInlineTagOutput(Element element, DocTree tag, TagletWriter writer) {
-        return null;
-    }
-
-    @Override
     public Content getAllBlockTagOutput(Element holder, TagletWriter writer) {
         Utils utils = writer.configuration().utils;
         List<? extends DocTree> tags = utils.getBlockTags(holder, this);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SummaryTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SummaryTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SummaryTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SummaryTaglet.java
@@ -49,7 +49,7 @@ public class SummaryTaglet extends BaseTaglet {
     }
 
     @Override
-    public Content getTagletOutput(Element holder, DocTree tag, TagletWriter writer) {
+    public Content getInlineTagOutput(Element holder, DocTree tag, TagletWriter writer) {
         return writer.commentTagsToOutput(holder, ((SummaryTree)tag).getSummary());
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SystemPropertyTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SystemPropertyTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SystemPropertyTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SystemPropertyTaglet.java
@@ -49,7 +49,7 @@ public class SystemPropertyTaglet extends BaseTaglet {
     }
 
     @Override
-    public Content getTagletOutput(Element element, DocTree tag, TagletWriter writer) {
+    public Content getInlineTagOutput(Element element, DocTree tag, TagletWriter writer) {
         return writer.systemPropertyTagOutput(element, tag);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/Taglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/Taglet.java
@@ -127,27 +127,29 @@ public interface Taglet {
 
     /**
      * Returns the content to be included in the generated output for an
-     * instance of a tag handled by this taglet.
+     * instance of an inline tag handled by this taglet.
      *
-     * @param element the element for the enclosing doc comment
-     * @param tag     the tag
-     * @param writer  the taglet-writer used in this doclet
+     * @param owner  the element for the enclosing doc comment
+     * @param tag    the tag
+     * @param writer the taglet-writer used in this doclet
+     *
      * @return the output for this tag
-     * @throws UnsupportedTagletOperationException thrown when the method is not supported by the taglet
+     * @throws UnsupportedTagletOperationException if the method is not supported by the taglet
      */
-    Content getTagletOutput(Element element, DocTree tag, TagletWriter writer) throws
+    Content getInlineTagOutput(Element owner, DocTree tag, TagletWriter writer) throws
             UnsupportedTagletOperationException;
 
     /**
      * Returns the content to be included in the generated output for
-     * instances of a tag handled by this taglet.
+     * all instances of block tags handled by this taglet.
      *
-     * @param element the element for the enclosing doc comment
-     * @param writer  the taglet-writer used in this doclet
+     * @param owner  the element for the enclosing doc comment
+     * @param writer the taglet-writer used in this doclet
+     *
      * @return the output for this tag
-     * @throws UnsupportedTagletOperationException thrown when the method is not supported by the taglet
+     * @throws UnsupportedTagletOperationException if the method is not supported by the taglet
      */
-    Content getTagletOutput(Element element, TagletWriter writer) throws
+    Content getAllBlockTagOutput(Element owner, TagletWriter writer) throws
             UnsupportedTagletOperationException;
 
     class UnsupportedTagletOperationException extends UnsupportedOperationException {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletManager.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletManager.java
@@ -110,7 +110,7 @@ public class TagletManager {
     /**
      * The taglets that can appear inline in descriptive text.
      */
-    private List<Taglet> inlineTags;
+    private Map<String, Taglet> inlineTags;
 
     /**
      * The taglets that can appear in the serialized form.
@@ -288,7 +288,7 @@ public class TagletManager {
     }
 
     /**
-     * Add a new {@code SimpleTaglet}.
+     * Adds a new {@code SimpleTaglet}.
      *
      * If this tag already exists and the header passed as an argument is {@code null},
      * move tag to the back of the list. If this tag already exists and the
@@ -332,11 +332,12 @@ public class TagletManager {
     }
 
     /**
-     * Given a name of a seen custom tag, remove it from the set of unseen
-     * custom tags.
-     * @param name the name of the seen custom tag
+     * Reports that a tag was seen in a doc comment.
+     * It is removed from the list of custom tags that have not yet been seen.
+     *
+     * @param name the name of the tag
      */
-    void seenCustomTag(String name) {
+    void seenTag(String name) {
         unseenCustomTags.remove(name);
     }
 
@@ -497,9 +498,9 @@ public class TagletManager {
      * Returns the taglets that can appear inline, in descriptive text.
      * @return the taglets that can appear inline
      */
-    List<Taglet> getInlineTaglets() {
+    Map<String, Taglet> getInlineTaglets() {
         if (inlineTags == null) {
-            initBlockTaglets();
+            initTaglets();
         }
         return inlineTags;
     }
@@ -510,7 +511,7 @@ public class TagletManager {
      */
     public List<Taglet> getSerializedFormTaglets() {
         if (serializedFormTags == null) {
-            initBlockTaglets();
+            initTaglets();
         }
         return serializedFormTags;
     }
@@ -525,7 +526,7 @@ public class TagletManager {
     @SuppressWarnings("fallthrough")
     public List<Taglet> getBlockTaglets(Element e) {
         if (blockTagletsByLocation == null) {
-            initBlockTaglets();
+            initTaglets();
         }
 
         switch (e.getKind()) {
@@ -565,30 +566,30 @@ public class TagletManager {
     }
 
     /**
-     * Initialize the custom tag Lists.
+     * Initialize the tag collections.
      */
-    private void initBlockTaglets() {
+    private void initTaglets() {
 
         blockTagletsByLocation = new EnumMap<>(Location.class);
         for (Location site : Location.values()) {
             blockTagletsByLocation.put(site, new ArrayList<>());
         }
 
-        inlineTags = new ArrayList<>();
+        inlineTags = new LinkedHashMap<>();
 
-        for (Taglet current : allTaglets.values()) {
-            if (current.isInlineTag()) {
-                inlineTags.add(current);
+        for (Taglet t : allTaglets.values()) {
+            if (t.isInlineTag()) {
+                inlineTags.put(t.getName(), t);
             }
 
-            if (current.isBlockTag()) {
-                for (Location l : current.getAllowedLocations()) {
-                    blockTagletsByLocation.get(l).add(current);
+            if (t.isBlockTag()) {
+                for (Location l : t.getAllowedLocations()) {
+                    blockTagletsByLocation.get(l).add(t);
                 }
             }
         }
 
-        //Init the serialized form tags
+        // init the serialized form tags for the serialized form page
         serializedFormTags = new ArrayList<>();
         serializedFormTags.add(allTaglets.get(SERIAL_DATA.tagName));
         serializedFormTags.add(allTaglets.get(THROWS.tagName));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
@@ -26,6 +26,7 @@
 package jdk.javadoc.internal.doclets.toolkit.taglets;
 
 import java.util.List;
+import java.util.Map;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
@@ -60,186 +61,185 @@ public abstract class TagletWriter {
     }
 
     /**
-     * @return an instance of an output object.
+     * Returns an instance of an output object.
+     *
+     * @return an instance of an output object
      */
     public abstract Content getOutputInstance();
 
     /**
-     * Return the output for a {@code {@code ...}} tag.
+     * Returns the output for a {@code {@code ...}} tag.
      *
-     * @param element
-     * @param tag the tag.
-     * @return the output of the taglet.
+     * @param element The element that owns the doc comment
+     * @param tag     the tag
+     *
+     * @return the output
      */
     protected abstract Content codeTagOutput(Element element, DocTree tag);
 
     /**
-     * Return the output for a {@code {@index...}} tag.
+     * Returns the output for a {@code {@index...}} tag.
      *
-     * @param tag the tag.
-     * @return the output of the taglet.
+     * @param element The element that owns the doc comment
+     * @param tag     the tag
+     *
+     * @return the output
      */
     protected abstract Content indexTagOutput(Element element, DocTree tag);
 
     /**
-     * Returns the output for the DocRoot inline tag.
-     * @return the output for the DocRoot inline tag.
+     * Returns the output for a {@code {@docRoot}} tag.
+     *
+     * @return the output
      */
     protected abstract Content getDocRootOutput();
 
     /**
-     * Return the deprecated tag output.
+     * Returns the output for a {@code @deprecated ...} tag.
      *
-     * @param element the element to write deprecated documentation for.
-     * @return the output of the deprecated tag.
+     * @param element The element that owns the doc comment
+     *
+     * @return the output
      */
     protected abstract Content deprecatedTagOutput(Element element);
 
     /**
      * Return the output for a {@code {@literal ...}} tag.
      *
-     * @param element
-     * @param tag the tag.
-     * @return the output of the taglet.
+     * @param element The element that owns the doc comment
+     * @param tag     the tag
+     *
+     * @return the output
      */
     protected abstract Content literalTagOutput(Element element, DocTree tag);
 
     /**
-     * Return the header for the param tags.
+     * Returns the header for the {@code @param} tags.
      *
      * @param kind the kind of header that is required
-     * @return the header for the param tags
+     *
+     * @return the header
      */
     protected abstract Content getParamHeader(ParamTaglet.ParamKind kind);
 
     /**
-     * Return the output for param tags.
+     * Returns the output for a {@code @param} tag.
+     * Note we cannot rely on the name in the tag, because we might be
+     * inheriting the tag.
      *
-     * @param element
-     * @param paramTag the parameter to document.
-     * @param paramName the name of the parameter.
-     * @return the output of the param tag.
+     * @param element   The element that owns the doc comment
+     * @param paramTag  the parameter to document
+     * @param paramName the name of the parameter
+     *
+     * @return the output
      */
     protected abstract Content paramTagOutput(Element element, DocTree paramTag, String paramName);
 
     /**
-     * Return the output for property tags.
+     * Returns the output for a {@code @return} tag.
      *
-     * @param element
-     * @param propertyTag the parameter to document.
-     * @param prefix the text with which to prefix the property name.
-     * @return the output of the param tag.
-     */
-    protected abstract Content propertyTagOutput(Element element, DocTree propertyTag, String prefix);
-
-    /**
-     * Return the return tag output.
+     * @param element   The element that owns the doc comment
+     * @param returnTag the return tag to document
      *
-     * @param element
-     * @param returnTag the return tag to output.
-     * @return the output of the return tag.
+     * @return the output
      */
     protected abstract Content returnTagOutput(Element element, DocTree returnTag);
 
     /**
-     * Return the see tag output.
+     * Returns the output for {@code @see} tags.
      *
-     * @param holder
-     * @param seeTags the array of See tags.
-     * @return the output of the see tags.
+     * @param element The element that owns the doc comment
+     * @param seeTags the list of tags
+     *
+     * @return the output
      */
-    protected abstract Content seeTagOutput(Element holder, List<? extends DocTree> seeTags);
+    protected abstract Content seeTagOutput(Element element, List<? extends DocTree> seeTags);
 
     /**
-     * Return the output for a simple tag.
+     * Returns the output for a series of simple tags.
      *
-     * @param element
-     * @param simpleTags the array of simple tags.
-     * @param header
-     * @return the output of the simple tags.
+     * @param element    The element that owns the doc comment
+     * @param simpleTags the list of simple tags
+     * @param header     the header for the series of tags
+     *
+     * @return the output
      */
-    protected abstract Content simpleTagOutput(Element element, List<? extends DocTree> simpleTags, String header);
+    protected abstract Content simpleBlockTagOutput(Element element, List<? extends DocTree> simpleTags, String header);
 
     /**
-     * Return the output for a simple tag.
+     * Returns the output for a {@code {@systemProperty...}} tag.
      *
-     * @param element
-     * @param simpleTag the simple tag.
-     * @param header
-     * @return the output of the simple tag.
-     */
-    protected abstract Content simpleTagOutput(Element element, DocTree simpleTag, String header);
-
-    /**
-     * Return the system property tag output.
-     *
-     * @param element
+     * @param element           The element that owns the doc comment
      * @param systemPropertyTag the system property tag
-     * @return the output of system property tag
+     *
+     * @return the output
      */
     protected abstract Content systemPropertyTagOutput(Element element, DocTree systemPropertyTag);
 
     /**
-     * Return the header for the throws tag.
+     * Returns the header for the {@code @throws} tag.
      *
-     * @return the header for the throws tag.
+     * @return the header for the throws tag
      */
     protected abstract Content getThrowsHeader();
 
     /**
-     * Return the header for the throws tag.
+     * Returns the output for a {@code @throws} tag.
      *
-     * @param element
-     * @param throwsTag the throws tag.
-     * @param substituteType instantiated type of a generic type-variable, or null.
-     * @return the output of the throws tag.
+     * @param element        The element that owns the doc comment
+     * @param throwsTag      the throws tag
+     * @param substituteType instantiated type of a generic type-variable, or null
+     *
+     * @return the output
      */
     protected abstract Content throwsTagOutput(Element element, DocTree throwsTag, TypeMirror substituteType);
 
     /**
-     * Return the output for the throws tag.
+     * Returns the output for a default {@code @throws} tag.
      *
-     * @param throwsType the throws type.
-     * @return the output of the throws type.
+     * @param throwsType the type that is thrown
+     *
+     * @return the output
      */
     protected abstract Content throwsTagOutput(TypeMirror throwsType);
 
     /**
-     * Return the output for the value tag.
+     * Returns the output for a {@code {@value}} tag.
      *
-     * @param field       the constant field that holds the value tag.
-     * @param constantVal the constant value to document.
+     * @param field       the constant field that holds the value tag
+     * @param constantVal the constant value to document
      * @param includeLink true if we should link the constant text to the
-     *                    constant field itself.
-     * @return the output of the value tag.
+     *                    constant field itself
+     *
+     * @return the output
      */
     protected abstract Content valueTagOutput(VariableElement field,
         String constantVal, boolean includeLink);
 
     /**
-     * Return the main type element of the current page or null for pages that don't have one.
+     * Returns the main type element of the current page or null for pages that don't have one.
      *
      * @return the type element of the current page or null.
      */
     protected abstract TypeElement getCurrentPageElement();
 
     /**
-     * Given an output object, append to it the tag documentation for
-     * the given member.
+     * Returns the content generated from the block tags for a given element.
+     * The content is generated according to the order of the list of taglets.
+     * The result is a possibly-empty list of the output generated by each
+     * of the given taglets for all of the tags they individually support.
      *
-     * @param tagletManager the manager that manages the taglets.
-     * @param element the element that we are print tags for.
-     * @param taglets the taglets to print.
-     * @param writer the writer that will generate the output strings.
-     * @param output the output buffer to store the output in.
+     * @param tagletManager the manager that manages the taglets
+     * @param element       the element that we are to write tags for
+     * @param taglets       the taglets for the tags to write
+     *
+     * @return the content
      */
-    public static void genTagOutput(TagletManager tagletManager,
+    public Content getBlockTagOutput(TagletManager tagletManager,
                                     Element element,
-                                    List<Taglet> taglets,
-                                    TagletWriter writer,
-                                    Content output)
-    {
-        Utils utils = writer.configuration().utils;
+                                    List<Taglet> taglets) {
+        Content output = getOutputInstance();
+        Utils utils = configuration().utils;
         tagletManager.checkTags(element, utils.getBlockTags(element), false);
         tagletManager.checkTags(element, utils.getFullBody(element), true);
         for (Taglet taglet : taglets) {
@@ -248,6 +248,7 @@ public abstract class TagletWriter {
                 // section away from the tag info, so skip here.
                 continue;
             }
+
             if (element.getKind() == ElementKind.MODULE && taglet instanceof BaseTaglet) {
                 BaseTaglet t = (BaseTaglet) taglet;
                 switch (t.getTagKind()) {
@@ -258,111 +259,119 @@ public abstract class TagletWriter {
                         continue;
                 }
             }
+
             if (taglet instanceof DeprecatedTaglet) {
                 //Deprecated information is documented "inline", not in tag info
                 //section.
                 continue;
             }
+
             if (taglet instanceof SimpleTaglet && !((SimpleTaglet) taglet).enabled) {
                 // taglet has been disabled
                 continue;
             }
-            Content currentOutput = null;
+
             try {
-                currentOutput = taglet.getTagletOutput(element, writer);
-            } catch (UnsupportedTagletOperationException utoe) {
-                //The taglet does not take a member as an argument.  Let's try
-                //a single tag.
-                List<? extends DocTree> tags = utils.getBlockTags(element, taglet);
-                if (!tags.isEmpty()) {
-                    currentOutput = taglet.getTagletOutput(element, tags.get(0), writer);
+                Content tagletOutput = taglet.getAllBlockTagOutput(element, this);
+                if (tagletOutput != null) {
+                    tagletManager.seenTag(taglet.getName());
+                    output.add(tagletOutput);
                 }
-            }
-            if (currentOutput != null) {
-                tagletManager.seenCustomTag(taglet.getName());
-                output.add(currentOutput);
+            } catch (UnsupportedTagletOperationException e) {
+                // malformed taglet:
+                // claims to support block tags but does not provide the appropriate method.
             }
         }
+        return output;
     }
+
     /**
-     * Given an inline tag, return its output.
-     * @param holder
-     * @param tagletManager The taglet manager for the current doclet.
-     * @param holderTag The tag that holds this inline tag, or {@code null} if
-     *                  there is no tag that holds it.
-     * @param inlineTag The inline tag to be documented.
-     * @param tagletWriter The taglet writer to write the output.
-     * @return The output of the inline tag.
+     * Returns the content generated from an inline tag in the doc comment for a given element,
+     * or {@code null} if the tag is not supported or does not return any output.
+     *
+     * @param holder        the element associated with the doc comment
+     * @param tagletManager the taglet manager for the current doclet
+     * @param holderTag     the tag that holds this inline tag, or {@code null} if
+     *                      there is no tag that holds it
+     * @param inlineTag     the inline tag to be documented
+     *
+     * @return the content, or {@code null}
      */
-    public static Content getInlineTagOutput(Element holder,
-                                             TagletManager tagletManager,
-                                             DocTree holderTag,
-                                             DocTree inlineTag,
-                                             TagletWriter tagletWriter)
-    {
-        List<Taglet> definedTags = tagletManager.getInlineTaglets();
-        CommentHelper ch = tagletWriter.configuration().utils.getCommentHelper(holder);
+    public Content getInlineTagOutput(Element holder,
+                                      TagletManager tagletManager,
+                                      DocTree holderTag,
+                                      DocTree inlineTag) {
+
+        Map<String, Taglet> inlineTags = tagletManager.getInlineTaglets();
+        CommentHelper ch = configuration().utils.getCommentHelper(holder);
         final String inlineTagName = ch.getTagName(inlineTag);
-        //This is a custom inline tag.
-        for (Taglet definedTag : definedTags) {
-            if ((definedTag.getName()).equals(inlineTagName)) {
-                // Given a name of a seen custom tag, remove it from the
-                // set of unseen custom tags.
-                tagletManager.seenCustomTag(definedTag.getName());
-                Content output = definedTag.getTagletOutput(holder,
-                        holderTag != null &&
-                        definedTag.getName().equals("inheritDoc") ?
-                        holderTag : inlineTag, tagletWriter);
-                return output;
-            }
+        Taglet t = inlineTags.get(inlineTagName);
+        if (t == null) {
+            return null;
         }
-        return null;
+
+        try {
+            Content tagletOutput = t.getInlineTagOutput(holder,
+                    holderTag != null && t.getName().equals("inheritDoc") ? holderTag : inlineTag,
+                    this);
+            tagletManager.seenTag(t.getName());
+            return tagletOutput;
+        } catch (UnsupportedTagletOperationException e) {
+            // malformed taglet:
+            // claims to support inline tags but does not provide the appropriate method.
+            return null;
+        }
     }
 
     /**
-     * Converts inline tags and text to TagOutput, expanding the
+     * Converts inline tags and text to content, expanding the
+     * inline tags along the way.  Called wherever text can contain
+     * an inline tag, such as in comments or in free-form text arguments
+     * to block tags.
+     *
+     * @param holderTree the tree that holds the documentation
+     * @param trees      list of {@code DocTree} nodes containing text and inline tags (often alternating)
+     *                   present in the text of interest for this doc
+     *
+     * @return the generated content
+     */
+    public abstract Content commentTagsToOutput(DocTree holderTree, List<? extends DocTree> trees);
+
+    /**
+     * Converts inline tags and text to content, expanding the
+     * inline tags along the way.  Called wherever text can contain
+     * an inline tag, such as in comments or in free-form text arguments
+     * to block tags.
+     *
+     * @param element The element that owns the documentation
+     * @param trees  list of {@code DocTree} nodes containing text and inline tags (often alternating)
+     *               present in the text of interest for this doc
+     *
+     * @return the generated content
+     */
+    public abstract Content commentTagsToOutput(Element element, List<? extends DocTree> trees);
+
+    /**
+     * Converts inline tags and text to content, expanding the
      * inline tags along the way.  Called wherever text can contain
      * an inline tag, such as in comments or in free-form text arguments
      * to non-inline tags.
      *
-     * @param holderTag the tag that holds the documentation.
-     * @param tags   array of text tags and inline tags (often alternating)
-     *               present in the text of interest for this doc.
-     * @return the {@link Content} representing the comments.
-     */
-    public abstract Content commentTagsToOutput(DocTree holderTag, List<? extends DocTree> tags);
-
-    /**
-     * Converts inline tags and text to TagOutput, expanding the
-     * inline tags along the way.  Called wherever text can contain
-     * an inline tag, such as in comments or in free-form text arguments
-     * to non-inline tags.
+     * @param element         the element where comment resides
+     * @param holder          the tag that holds the documentation
+     * @param trees           array of text tags and inline tags (often alternating)
+     *                        present in the text of interest for this doc
+     * @param isFirstSentence true if this is the first sentence
      *
-     * @param holder the element where comment resides.
-     * @param tags   array of text tags and inline tags (often alternating)
-     *               present in the text of interest for this doc.
-     * @return the {@link Content} representing the comments.
+     * @return the generated content
      */
-    public abstract Content commentTagsToOutput(Element holder, List<? extends DocTree> tags);
+    public abstract Content commentTagsToOutput(Element element, DocTree holder,
+                                                List<? extends DocTree> trees, boolean isFirstSentence);
 
     /**
-     * Converts inline tags and text to TagOutput, expanding the
-     * inline tags along the way.  Called wherever text can contain
-     * an inline tag, such as in comments or in free-form text arguments
-     * to non-inline tags.
+     * Returns  an instance of the configuration used for this doclet.
      *
-     * @param holderTag the tag that holds the documentation.
-     * @param holder the element where comment resides.
-     * @param tags   array of text tags and inline tags (often alternating)
-     *               present in the text of interest for this doc.
-     * @param isFirstSentence true if this is the first sentence.
-     * @return the {@link Content} representing the comments.
-     */
-    public abstract Content commentTagsToOutput(DocTree holderTag,
-        Element holder, List<? extends DocTree> tags, boolean isFirstSentence);
-
-    /**
-     * @return an instance of the configuration used for this doclet.
+     * @return an instance of the configuration used for this doclet
      */
     public abstract BaseConfiguration configuration();
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
@@ -238,6 +238,12 @@ public abstract class TagletWriter {
     public Content getBlockTagOutput(TagletManager tagletManager,
                                     Element element,
                                     List<Taglet> taglets) {
+        for (Taglet t : taglets) {
+            if (!t.isBlockTag()) {
+                throw new IllegalArgumentException(t.getName());
+            }
+        }
+
         Content output = getOutputInstance();
         Utils utils = configuration().utils;
         tagletManager.checkTags(element, utils.getBlockTags(element), false);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
@@ -95,7 +95,7 @@ public abstract class TagletWriter {
     protected abstract Content getDocRootOutput();
 
     /**
-     * Returns the output for a {@code @deprecated ...} tag.
+     * Returns the output for a {@code @deprecated} tag.
      *
      * @param element The element that owns the doc comment
      *
@@ -104,7 +104,7 @@ public abstract class TagletWriter {
     protected abstract Content deprecatedTagOutput(Element element);
 
     /**
-     * Return the output for a {@code {@literal ...}} tag.
+     * Returns the output for a {@code {@literal ...}} tag.
      *
      * @param element The element that owns the doc comment
      * @param tag     the tag
@@ -279,7 +279,8 @@ public abstract class TagletWriter {
                 }
             } catch (UnsupportedTagletOperationException e) {
                 // malformed taglet:
-                // claims to support block tags but does not provide the appropriate method.
+                // claims to support block tags (see Taglet.isBlockTag) but does not provide the
+                // appropriate method, Taglet.getAllBlockTagOutput.
             }
         }
         return output;
@@ -318,7 +319,8 @@ public abstract class TagletWriter {
             return tagletOutput;
         } catch (UnsupportedTagletOperationException e) {
             // malformed taglet:
-            // claims to support inline tags but does not provide the appropriate method.
+            // claims to support inline tags (see Taglet.isInlineTag) but does not provide the
+            // appropriate method, Taglet.getInlineTagOutput.
             return null;
         }
     }
@@ -369,7 +371,7 @@ public abstract class TagletWriter {
                                                 List<? extends DocTree> trees, boolean isFirstSentence);
 
     /**
-     * Returns  an instance of the configuration used for this doclet.
+     * Returns an instance of the configuration used for this doclet.
      *
      * @return an instance of the configuration used for this doclet
      */

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -153,7 +153,7 @@ public class ThrowsTaglet extends BaseTaglet
     }
 
     @Override
-    public Content getTagletOutput(Element holder, TagletWriter writer) {
+    public Content getAllBlockTagOutput(Element holder, TagletWriter writer) {
         Utils utils = writer.configuration().utils;
         ExecutableElement execHolder = (ExecutableElement) holder;
         ExecutableType instantiatedType = utils.asInstantiatedMethodType(

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/UserTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/UserTaglet.java
@@ -25,7 +25,6 @@
 
 package jdk.javadoc.internal.doclets.toolkit.taglets;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -111,14 +110,14 @@ public final class UserTaglet implements Taglet {
     }
 
     @Override
-    public Content getTagletOutput(Element element, DocTree tag, TagletWriter writer) {
+    public Content getInlineTagOutput(Element element, DocTree tag, TagletWriter writer) {
         Content output = writer.getOutputInstance();
-        output.add(new RawHtml(userTaglet.toString(Collections.singletonList(tag), element)));
+        output.add(new RawHtml(userTaglet.toString(List.of(tag), element)));
         return output;
     }
 
     @Override
-    public Content getTagletOutput(Element holder, TagletWriter writer) {
+    public Content getAllBlockTagOutput(Element holder, TagletWriter writer) {
         Content output = writer.getOutputInstance();
         Utils utils = writer.configuration().utils;
         List<? extends DocTree> tags = utils.getBlockTags(holder, this);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ValueTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ValueTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ValueTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ValueTaglet.java
@@ -85,10 +85,11 @@ public class ValueTaglet extends BaseTaglet {
     }
 
     @Override
-    public Content getTagletOutput(Element holder, DocTree tag, TagletWriter writer) {
-        Utils utils = writer.configuration().utils;
-        Messages messages = writer.configuration().getMessages();
-        VariableElement field = getVariableElement(holder, writer.configuration(), tag);
+    public Content getInlineTagOutput(Element holder, DocTree tag, TagletWriter writer) {
+        BaseConfiguration configuration = writer.configuration();
+        Utils utils = configuration.utils;
+        Messages messages = configuration.getMessages();
+        VariableElement field = getVariableElement(holder, configuration, tag);
         if (field == null) {
             if (tag.toString().isEmpty()) {
                 //Invalid use of @value
@@ -101,7 +102,7 @@ public class ValueTaglet extends BaseTaglet {
             }
         } else if (field.getConstantValue() != null) {
             return writer.valueTagOutput(field,
-                utils.constantValueExpresion(field),
+                utils.constantValueExpression(field),
                 // TODO: investigate and cleanup
                 // in the j.l.m world, equals will not be accurate
                 // !field.equals(tag.holder())

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -2268,7 +2268,7 @@ public class Utils {
 
     private ConstantValueExpression cve = null;
 
-    public String constantValueExpresion(VariableElement ve) {
+    public String constantValueExpression(VariableElement ve) {
         if (cve == null)
             cve = new ConstantValueExpression();
         return cve.constantValueExpression(configuration.workArounds, ve);


### PR DESCRIPTION
This is a general cleanup of various classes related to the handling of tags and taglets in the standard doclet.

The initial motivation was to clean up static methods on `TagletWriter` that took a `TagletWriter` as a parameter. These methods are converted into instance methods, and the call sites simplified as well.

Another area of cleanup is to make clear which methods are used for inline tags and which are used for block tags.

Some dead code is removed, and the doc comments are generally cleaned up as well.  More details are given in the JBS issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253733](https://bugs.openjdk.java.net/browse/JDK-8253733): Cleanup internal taglet API


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/406/head:pull/406`
`$ git checkout pull/406`
