### PR TITLE
8252881: [JVMCI] ResolvedJavaType.resolveMethod fails in fastdebug when invoked with a constructor

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
@@ -479,6 +479,11 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
         if (!method.getDeclaringClass().isAssignableFrom(this)) {
             return null;
         }
+        if (method.isConstructor()) {
+            // Constructor calls should have be checked in the verifier and the declaring class
+            // isAssignableFrom this so treat it as resolved.
+            return method;
+        }
         HotSpotResolvedJavaMethodImpl hotSpotMethod = (HotSpotResolvedJavaMethodImpl) method;
         HotSpotResolvedObjectTypeImpl hotSpotCallerType = (HotSpotResolvedObjectTypeImpl) callerType;
         return compilerToVM().resolveMethod(this, hotSpotMethod, hotSpotCallerType);

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
@@ -480,8 +480,8 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
             return null;
         }
         if (method.isConstructor()) {
-            // Constructor calls should have be checked in the verifier and the declaring class
-            // isAssignableFrom this so treat it as resolved.
+            // Constructor calls should have been checked in the verifier and method's
+            // declaring class is assignable from this (see above) so treat it as resolved.
             return method;
         }
         HotSpotResolvedJavaMethodImpl hotSpotMethod = (HotSpotResolvedJavaMethodImpl) method;


### PR DESCRIPTION
This change prevents a call to `CompilerToVM.resolveMethod` with an argument representing a constructor. Such a call triggers an assertion in a fastdebug VM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252881](https://bugs.openjdk.java.net/browse/JDK-8252881): [JVMCI] ResolvedJavaType.resolveMethod fails in fastdebug when invoked with a constructor


### Reviewers
 * [Tom Rodriguez](https://openjdk.java.net/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to 7726f71cba74b8f0c0c08d8807bdb504c6cdefce


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/407/head:pull/407`
`$ git checkout pull/407`
