### PR TITLE
8253815: Remove unused HeapRegionManager::_num_committed from SA

### DIFF
--- a/src/hotspot/share/gc/g1/vmStructs_g1.hpp
+++ b/src/hotspot/share/gc/g1/vmStructs_g1.hpp
@@ -53,7 +53,6 @@
   nonstatic_field(G1HeapRegionTable, _shift_by,         uint)                 \
                                                                               \
   nonstatic_field(HeapRegionManager, _regions,          G1HeapRegionTable)    \
-  nonstatic_field(HeapRegionManager, _num_committed,    uint)                 \
                                                                               \
   volatile_nonstatic_field(G1CollectedHeap, _summary_bytes_used, size_t)      \
   nonstatic_field(G1CollectedHeap, _hrm,                HeapRegionManager*)   \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/HeapRegionManager.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/HeapRegionManager.java
@@ -42,8 +42,6 @@ import sun.jvm.hotspot.types.TypeDataBase;
 public class HeapRegionManager extends VMObject {
     // G1HeapRegionTable _regions
     static private long regionsFieldOffset;
-    // uint _committed_length
-    static private CIntegerField numCommittedField;
 
     static {
         VM.registerVMInitializedObserver(new Observer() {
@@ -57,7 +55,6 @@ public class HeapRegionManager extends VMObject {
         Type type = db.lookupType("HeapRegionManager");
 
         regionsFieldOffset = type.getField("_regions").getOffset();
-        numCommittedField = type.getCIntegerField("_num_committed");
     }
 
     private G1HeapRegionTable regions() {
@@ -72,10 +69,6 @@ public class HeapRegionManager extends VMObject {
 
     public long length() {
         return regions().length();
-    }
-
-    public long committedLength() {
-        return numCommittedField.getValue(addr);
     }
 
     public Iterator<HeapRegion> heapRegionIterator() {


### PR DESCRIPTION
While doing some refactoring I wanted to move HeapRegionManager::_num_committed and realized that I needed to update the SA. After some looking around it turns out that it is unused and I can remove the numCommittedField from the HeapRegionManager class in the SA. 

Local build and test looks good and running tier1 and some svc-testing to ensure I haven't missed anything.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253815](https://bugs.openjdk.java.net/browse/JDK-8253815): Remove unused HeapRegionManager::_num_committed from SA 


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/408/head:pull/408`
`$ git checkout pull/408`
