### PR TITLE
8204256: improve jlink error message to report unsupported class file format

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
@@ -229,8 +229,8 @@ public class JlinkTask {
             List<String> remaining = optionsHelper.handleOptions(this, args);
             if (remaining.size() > 0 && !options.suggestProviders) {
                 throw taskHelper.newBadArgs("err.orphan.arguments",
-                        remaining.stream().collect(Collectors.joining(" ")))
-                        .showUsage(true);
+                                                 remaining.stream().collect(Collectors.joining(" ")))
+                                .showUsage(true);
             }
             if (options.help) {
                 optionsHelper.showHelp(PROGNAME);

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
@@ -229,8 +229,8 @@ public class JlinkTask {
             List<String> remaining = optionsHelper.handleOptions(this, args);
             if (remaining.size() > 0 && !options.suggestProviders) {
                 throw taskHelper.newBadArgs("err.orphan.arguments",
-                                            remaining.stream().collect(Collectors.joining(" ")))
-                                .showUsage(true);
+                        remaining.stream().collect(Collectors.joining(" ")))
+                        .showUsage(true);
             }
             if (options.help) {
                 optionsHelper.showHelp(PROGNAME);
@@ -259,8 +259,8 @@ public class JlinkTask {
                 }
 
                 if (options.modulePath.isEmpty()) {
-                     throw taskHelper.newBadArgs("err.modulepath.must.be.specified")
-                                 .showUsage(true);
+                    throw taskHelper.newBadArgs("err.modulepath.must.be.specified")
+                            .showUsage(true);
                 }
             }
 
@@ -275,8 +275,12 @@ public class JlinkTask {
             }
 
             return EXIT_OK;
+        } catch (FindException e) {
+            log.println(taskHelper.getMessage("err.prefix") + " " + e.getMessage());
+            e.printStackTrace(log);
+            return EXIT_ERROR;
         } catch (PluginException | IllegalArgumentException |
-                 UncheckedIOException |IOException | FindException | ResolutionException e) {
+                 UncheckedIOException |IOException | ResolutionException e) {
             log.println(taskHelper.getMessage("error.prefix") + " " + e.getMessage());
             if (DEBUG) {
                 e.printStackTrace(log);


### PR DESCRIPTION
This pull request contains a change to facilitate better error messages in jlink for when jlink creates an image from jmod files that are unsupported by the runtime by being _too new_. The existing behavior supports modules that are too old via an error about a mismatched version.

The solution to this problem is constrained by jlink's use of some specified behavior by java.lang.module.ModuleFinder. The solution in this PR is to subclass some existing exceptions internally as to signal to jlink more specific error conditions when attempting to find and open modules.

Bug here: https://bugs.openjdk.java.net/browse/JDK-8204256

New Error message example:

```Error reading module: /Users/igraves/dev/jdk-otro/build/macosx-x64/images/jmods/java.security.sasl.jmod
java.lang.module.FindException: Error reading module: /Users/igraves/dev/jdk-otro/build/macosx-x64/images/jmods/java.security.sasl.jmod
	at java.base/jdk.internal.module.ModulePath.readModule(ModulePath.java:350)
	at java.base/jdk.internal.module.ModulePath.scanDirectory(ModulePath.java:284)
	at java.base/jdk.internal.module.ModulePath.scan(ModulePath.java:232)
	at java.base/jdk.internal.module.ModulePath.scanNextEntry(ModulePath.java:190)
	at java.base/jdk.internal.module.ModulePath.find(ModulePath.java:154)
	at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.newModuleFinder(JlinkTask.java:443)
	at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.initJlinkConfig(JlinkTask.java:374)
	at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.run(JlinkTask.java:267)
	at jdk.jlink/jdk.tools.jlink.internal.Main.run(Main.java:54)
	at jdk.jlink/jdk.tools.jlink.internal.Main.main(Main.java:33)
Caused by: java.lang.module.InvalidModuleDescriptorException: Unsupported major.minor version 60.0
	at java.base/jdk.internal.module.ModuleInfo.invalidModuleDescriptor(ModuleInfo.java:1088)
	at java.base/jdk.internal.module.ModuleInfo.doRead(ModuleInfo.java:192)
	at java.base/jdk.internal.module.ModuleInfo.read(ModuleInfo.java:129)
	at java.base/jdk.internal.module.ModulePath.readJMod(ModulePath.java:395)
	at java.base/jdk.internal.module.ModulePath.readModule(ModulePath.java:343)
	... 9 more```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8204256](https://bugs.openjdk.java.net/browse/JDK-8204256): improve jlink error message to report unsupported class file format 


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to bee11534364eb8271dd2dfdc3e4ddea6ec1b86a7


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/409/head:pull/409`
`$ git checkout pull/409`
