### PR TITLE
8253822: Remove unused exception_address_is_unpack_entry

### DIFF
--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -601,10 +601,6 @@ class DeoptimizationBlob: public SingletonBlob {
 
   // Typing
   bool is_deoptimization_stub() const { return true; }
-  bool exception_address_is_unpack_entry(address pc) const {
-    address unpack_pc = unpack();
-    return (pc == unpack_pc || (pc + frame::pc_return_offset) == unpack_pc);
-  }
 
   // GC for args
   void preserve_callee_argument_oops(frame fr, const RegisterMap *reg_map, OopClosure* f) { /* Nothing to do */ }


### PR DESCRIPTION
I have searched the code base without finding any use.

Please review,

Best regards,
Nils

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253822](https://bugs.openjdk.java.net/browse/JDK-8253822): Remove unused exception_address_is_unpack_entry


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/410/head:pull/410`
`$ git checkout pull/410`
