### PR TITLE
8253689: [s390] Use flag kind "diagnostic" for platform specific flags

### DIFF
--- a/src/hotspot/cpu/s390/globals_s390.hpp
+++ b/src/hotspot/cpu/s390/globals_s390.hpp
@@ -83,37 +83,37 @@ define_pd_global(intx, InitArrayShortSize, 1*BytesPerLong);
                                                                               \
   /* Reoptimize code-sequences of calls at runtime, e.g. replace an */        \
   /* indirect call by a direct call.                                */        \
-  product(bool, ReoptimizeCallSequences, true,                                \
+  product(bool, ReoptimizeCallSequences, true, DIAGNOSTIC,                    \
           "Reoptimize code-sequences of calls at runtime.")                   \
                                                                               \
-  product(bool, UseByteReverseInstruction, true,                              \
+  product(bool, UseByteReverseInstruction, true, DIAGNOSTIC,                  \
           "Use byte reverse instruction.")                                    \
                                                                               \
-  product(bool, ExpandLoadingBaseDecode, true, "Expand the assembler "        \
-          "instruction required to load the base from DecodeN nodes during "  \
-          "matching.")                                                        \
-  product(bool, ExpandLoadingBaseDecode_NN, true, "Expand the assembler "     \
-          "instruction required to load the base from DecodeN_NN nodes "      \
-          "during matching.")                                                 \
-  product(bool, ExpandLoadingBaseEncode, true, "Expand the assembler "        \
-          "instruction required to load the base from EncodeP nodes during "  \
-          "matching.")                                                        \
-  product(bool, ExpandLoadingBaseEncode_NN, true, "Expand the assembler "     \
-          "instruction required to load the base from EncodeP_NN nodes "      \
-          "during matching.")                                                 \
+  product(bool, ExpandLoadingBaseDecode, true, DIAGNOSTIC,                    \
+          "Expand the assembler instruction required to load the base from "  \
+          "DecodeN nodes during matching.")                                   \
+  product(bool, ExpandLoadingBaseDecode_NN, true, DIAGNOSTIC,                 \
+          "Expand the assembler instruction required to load the base from "  \
+          "DecodeN_NN nodes during matching.")                                \
+  product(bool, ExpandLoadingBaseEncode, true, DIAGNOSTIC,                    \
+          "Expand the assembler instruction required to load the base from "  \
+          "EncodeP nodes during matching.")                                   \
+  product(bool, ExpandLoadingBaseEncode_NN, true, DIAGNOSTIC,                 \
+          "Expand the assembler instruction required to load the base from "  \
+          "EncodeP_NN nodes during matching.")                                \
                                                                               \
   /* Seems to pay off with 2 pages already. */                                \
-  product(size_t, MVCLEThreshold, +2*(4*K),                                   \
+  product(size_t, MVCLEThreshold, +2*(4*K), DIAGNOSTIC,                       \
           "Threshold above which page-aligned MVCLE copy/init is used.")      \
                                                                               \
-  product(bool, PreferLAoverADD, false,                                       \
+  product(bool, PreferLAoverADD, false, DIAGNOSTIC,                           \
           "Use LA/LAY instructions over ADD instructions (z/Architecture).")  \
                                                                               \
   develop(bool, ZapEmptyStackFields, false, "Write 0x0101... to empty stack"  \
           " fields. Use this to ease stack debugging.")                       \
                                                                               \
-  product(bool, TraceTraps, false, "Trace all traps the signal handler"       \
-          "handles.")
+  product(bool, TraceTraps, false, DIAGNOSTIC,                                \
+          "Trace all traps the signal handler handles.")
 
 // end of ARCH_FLAGS
 


### PR DESCRIPTION
Current platform implementation (globals_s390.hpp) uses regular product flags for everything.
These platform specific flags were never intended for official support. They are only there to diagnose issues and find workarounds.
So flag kind "diagnostic" fits better.

CSR: https://bugs.openjdk.java.net/browse/JDK-8253691

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253689](https://bugs.openjdk.java.net/browse/JDK-8253689): [s390] Use flag kind "diagnostic" for platform specific flags


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/414/head:pull/414`
`$ git checkout pull/414`
