### PR TITLE
JDK-8253700: spurious "extends Throwable" at end of Optional.orElseThrow method declaration

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
@@ -51,6 +51,7 @@ import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.EXECUT
 import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.MEMBER;
 import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.MEMBER_TYPE_PARAMS;
 import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.RECEIVER_TYPE;
+import static jdk.javadoc.internal.doclets.formats.html.LinkInfoImpl.Kind.THROWS_TYPE;
 
 /**
  * Print method and constructor info.
@@ -254,19 +255,16 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
      */
     protected Content getExceptions(ExecutableElement member) {
         List<? extends TypeMirror> exceptions = utils.asInstantiatedMethodType(typeElement, member).getThrownTypes();
-        Content htmltree = new ContentBuilder();
-        if (!exceptions.isEmpty()) {
-            Content link = writer.getLink(new LinkInfoImpl(configuration, MEMBER, exceptions.get(0)));
-            htmltree.add(link);
-            for (int i = 1; i < exceptions.size(); i++) {
-                htmltree.add(",");
-                htmltree.add(DocletConstants.NL);
-                Content exceptionLink = writer.getLink(new LinkInfoImpl(configuration, MEMBER,
-                        exceptions.get(i)));
-                htmltree.add(exceptionLink);
+        Content htmlTree = new ContentBuilder();
+        for (TypeMirror t : exceptions) {
+            if (!htmlTree.isEmpty()) {
+                htmlTree.add(",");
+                htmlTree.add(DocletConstants.NL);
             }
+            Content link = writer.getLink(new LinkInfoImpl(configuration, THROWS_TYPE, t));
+            htmlTree.add(link);
         }
-        return htmltree;
+        return htmlTree;
     }
 
     protected TypeElement implementsMethodInIntfac(ExecutableElement method,
@@ -303,7 +301,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
                 buf.append(",");
             }
             TypeMirror t = parameters.get(i).asType();
-            SimpleTypeVisitor9<Boolean, Void> stv = new SimpleTypeVisitor9<Boolean, Void>() {
+            SimpleTypeVisitor9<Boolean, Void> stv = new SimpleTypeVisitor9<>() {
                 boolean foundTypeVariable = false;
 
                 @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
@@ -208,14 +208,19 @@ public class LinkInfoImpl extends LinkInfo {
         PROPERTY_COPY,
 
         /**
-         * A receiver type
+         * A receiver type.
          */
         RECEIVER_TYPE,
 
         /**
-         * A record component within a class signature
+         * A record component within a class signature.
          */
-        RECORD_COMPONENT
+        RECORD_COMPONENT,
+
+        /**
+         * A type thrown from a method.
+         */
+        THROWS_TYPE
     }
 
     public final HtmlConfiguration configuration;
@@ -389,9 +394,8 @@ public class LinkInfoImpl extends LinkInfo {
 
             case RETURN_TYPE:
             case SUMMARY_RETURN_TYPE:
-                excludeTypeBounds = true;
-                break;
             case EXECUTABLE_MEMBER_PARAM:
+            case THROWS_TYPE:
                 excludeTypeBounds = true;
                 break;
         }

--- a/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+  * @test
+  * @bug 8253700
+  * @summary spurious "extends Throwable" at end of method declaration
+  * throws section.  Make sure that the link is below a Throws heading.
+  * @library /tools/lib ../../lib
+  * @modules jdk.javadoc/jdk.javadoc.internal.tool
+  * @build javadoc.tester.* toolbox.ToolBox
+  * @run main TestThrows
+  */
+
+ import java.io.IOException;
+ import java.nio.file.Path;
+
+ import toolbox.ToolBox;
+
+ import javadoc.tester.JavadocTester;
+
+ public class TestThrows extends JavadocTester {
+
+     public static void main(String... args) throws Exception {
+         TestThrows tester = new TestThrows();
+         tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+     }
+
+     private final ToolBox tb = new ToolBox();
+
+     @Test
+     public void testThrowsWithBound(Path base) throws IOException {
+         Path src = base.resolve("src");
+         tb.writeJavaFiles(src,
+                 """
+                     /**
+                      * This is interface C.
+                      */
+                     public interface C {
+                         /**
+                          * Method m.
+                          * @param <T> the throwable
+                          * @throws T if a specific error occurs
+                          * @throws Exception if an exception occurs
+                          */
+                         <T extends Throwable> void m() throws T, Exception;
+                     }
+                     """);
+
+         javadoc("-d", base.resolve("out").toString(),
+                 src.resolve("C.java").toString());
+         checkExit(Exit.OK);
+
+         checkOutput("C.html", true,
+                 """
+                     <div class="member-signature"><span class="type-parameters">&lt;T extends java\
+                     .lang.Throwable&gt;</span>&nbsp;<span class="return-type">void</span>&nbsp;<sp\
+                     an class="member-name">m</span>()
+                                                     throws <span class="exceptions">T,
+                     java.lang.Exception</span></div>
+                     """,
+                 """
+                     <dl class="notes">
+                     <dt>Type Parameters:</dt>
+                     <dd><code>T</code> - the throwable</dd>
+                     <dt>Throws:</dt>
+                     <dd><code>T</code> - if a specific error occurs</dd>
+                     <dd><code>java.lang.Exception</code> - if an exception occurs</dd>
+                     </dl>
+                     """);
+     }
+}


### PR DESCRIPTION
The link for the `throws` type was not filtering out the bounds. A new `LinkInfoImpl.Kind` is added for `THROWS_TYPE`.

The loop to generate the list of exceptions is simplified.

A new test is provided. The generated API for `Optional.orElseThrow` has also been verified as correct.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253700](https://bugs.openjdk.java.net/browse/JDK-8253700): spurious "extends Throwable" at end of Optional.orElseThrow method declaration


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/417/head:pull/417`
`$ git checkout pull/417`
