### PR TITLE
8238737: remove DeoptimizeAllClassesRate from CTW library

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,11 +83,6 @@ public class Compiler {
             executor.execute(new CompileMethodCommand(id, e));
         }
         METHOD_COUNT.addAndGet(methodCount);
-
-        if (Utils.DEOPTIMIZE_ALL_CLASSES_RATE > 0
-                && (id % Utils.DEOPTIMIZE_ALL_CLASSES_RATE == 0)) {
-            WHITE_BOX.deoptimizeAll();
-        }
     }
 
     private static void preloadClasses(String className, long id,

--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Utils.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,13 +62,6 @@ public class Utils {
      */
     public static final Pattern PATH_SEPARATOR = Pattern.compile(
             File.pathSeparator, Pattern.LITERAL);
-    /**
-     * Value of {@code -DDeoptimizeAllClassesRate}. Frequency of
-     * {@code WB.deoptimizeAll()} invocation If it less that {@code 0},
-     * {@code WB.deoptimizeAll()} will not be invoked.
-     */
-    public static final int DEOPTIMIZE_ALL_CLASSES_RATE
-            = Integer.getInteger("DeoptimizeAllClassesRate", -1);
     /**
      * Value of {@code -DCompileTheWorldStopAt}. Last class to consider.
      */


### PR DESCRIPTION
Hi all,

after [8238247 ](https://bugs.openjdk.java.net/browse/JDK-8238247), `DeoptimizeAllClassesRate` property became completely useless, and as I mentioned in the [review](https://mail.openjdk.java.net/pipermail/hotspot-compiler-dev/2020-February/036927.html), I didn't (and still don't) have any idea why we added this at the first place. 

I have looked into the old implementation of CTW (one in `/src/share/vm/classfile/classLoader.cpp`) both at the time Java impl. was added by [8012447](https://bugs.openjdk.java.net/browse/JDK-8012447) and the old impl. was removed by [8214917](https://bugs.openjdk.java.net/browse/JDK-8214917), and there is nothing that would suggest that we had/needed `DeoptimizeAllClassesRate`, it's not and has never been used by any of our tests, so I'm going to remove it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8238737](https://bugs.openjdk.java.net/browse/JDK-8238737): remove DeoptimizeAllClassesRate from CTW library


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/418/head:pull/418`
`$ git checkout pull/418`
