### PR TITLE
8253829: Wrong length compared in SSPI bridge

### DIFF
--- a/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
+++ b/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -465,7 +465,7 @@ gss_compare_name(OM_uint32 *minor_status,
     }
 
     if (l1 < l2 && l1 != r2
-            || l2 < l1 && l2 != l1) {
+            || l2 < l1 && l2 != r1) {
         return GSS_S_COMPLETE; // different
     }
 


### PR DESCRIPTION
For two principals to be the same, they are either all "user@R", or one is "user" and the other is "user@R". The check here wants to fail early if the length are different. "l" is the whole length and "r" is the length of the name (without realm). The comparison should be reflective but there is a typo.

For example, for "user@R" and "user", l1 = 6, l2 = 4, r1 = 4, r2 = 4, the check will succeed and the names are treated as different. This is not the expected behavior.

No regression test because we don't support SSPI testing in the OpenJDK repo now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253829](https://bugs.openjdk.java.net/browse/JDK-8253829): Wrong length compared in SSPI bridge


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/419/head:pull/419`
`$ git checkout pull/419`
