### PR TITLE
8253792: javax.swing.text.GapContent documentation typos

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/GapContent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/GapContent.java
@@ -39,7 +39,7 @@ import java.lang.ref.ReferenceQueue;
 /**
  * An implementation of the AbstractDocument.Content interface
  * implemented using a gapped buffer similar to that used by emacs.
- * The underlying storage is a array of unicode characters with
+ * The underlying storage is an array of Unicode characters with
  * a gap somewhere.  The gap is moved to the location of changes
  * to take advantage of common behavior where most changes are
  * in the same location.  Changes that occur at a gap boundary are
@@ -49,8 +49,8 @@ import java.lang.ref.ReferenceQueue;
  * The positions tracking change are also generally cheap to
  * maintain.  The Position implementations (marks) store the array
  * index and can easily calculate the sequential position from
- * the current gap location.  Changes only require update to the
- * the marks between the old and new gap boundaries when the gap
+ * the current gap location.  Changes only require updating the
+ * marks between the old and new gap boundaries when the gap
  * is moved, so generally updating the marks is pretty cheap.
  * The marks are stored sorted so they can be located quickly
  * with a binary search.  This increases the cost of adding a
@@ -320,7 +320,7 @@ public class GapContent extends GapVector implements AbstractDocument.Content, S
 
     /**
      * Record used for searching for the place to
-     * start updating mark indexs when the gap
+     * start updating mark indexes when the gap
      * boundaries are moved.
      */
     private transient MarkData search;


### PR DESCRIPTION
Fixed some documentation typos

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253792](https://bugs.openjdk.java.net/browse/JDK-8253792):  javax.swing.text.GapContent documentation typos


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/421/head:pull/421`
`$ git checkout pull/421`
