### PR TITLE
5078989: Null Pointer exception in SpinnerListMode

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/SpinnerListModel.java
+++ b/src/java.desktop/share/classes/javax/swing/SpinnerListModel.java
@@ -236,10 +236,12 @@ public class SpinnerListModel extends AbstractSpinnerModel implements Serializab
 
         do {
             Object value = list.get(counter);
-            String string = value.toString();
+            if (value != null) {
+                String string = value.toString();
 
-            if (string != null && string.startsWith(substring)) {
-                return value;
+                if (string != null && string.startsWith(substring)) {
+                    return value;
+                }
             }
             counter = (counter + 1) % max;
         } while (counter != index);

--- a/test/jdk/javax/swing/JSpinner/SpinnerTest.java
+++ b/test/jdk/javax/swing/JSpinner/SpinnerTest.java
@@ -72,7 +72,7 @@ public class SpinnerTest
                 frame.setLocationRelativeTo(null);
             });
             robot.waitForIdle();
-	    robot.delay(1000);
+            robot.delay(1000);
             Point loc = spinner.getLocationOnScreen();
 
             robot.mouseMove(loc.x, loc.y);

--- a/test/jdk/javax/swing/JSpinner/SpinnerTest.java
+++ b/test/jdk/javax/swing/JSpinner/SpinnerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 5078989
+   @key headful
+   @summary Verifies Null Pointer exception is not thrown in SpinnerListMode
+   @run main SpinnerTest
+ */
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerListModel;
+import javax.swing.SwingUtilities;
+import java.awt.event.KeyEvent;
+import java.awt.Point;
+import java.awt.Robot;
+
+public class SpinnerTest
+{
+    private static JFrame frame;
+    private static JSpinner spinner;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                //Create and set up the window.
+                frame = new JFrame("SpinnerDemo");
+                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+                JPanel panel = new JPanel();
+                String[] values = {"Month: ", "Year: ", null, "Date", "Sent"};
+
+                SpinnerListModel listModel = new SpinnerListModel(values);
+
+                JLabel l = new JLabel("Spinner");
+                panel.add(l);
+
+                spinner = new JSpinner(listModel);
+                l.setLabelFor(spinner);
+                panel.add(spinner);
+
+                panel.setOpaque(true); //content panes must be opaque
+                frame.setContentPane(panel);
+
+                //Display the window.
+                frame.pack();
+                frame.setVisible(true);
+                frame.setLocationRelativeTo(null);
+            });
+            robot.waitForIdle();
+	    robot.delay(1000);
+            Point loc = spinner.getLocationOnScreen();
+
+            robot.mouseMove(loc.x, loc.y);
+            robot.keyPress(KeyEvent.VK_SPACE);
+            robot.keyRelease(KeyEvent.VK_SPACE);
+
+        } finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(() -> frame.dispose());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Please review a fix for an issue where it is seen that when the data in SpinnerListModel has a null value, pressing any key after deleting the current value throws null pointer exception.
This is because findNextMatch() calls list.get but dont check for null value and tries to call toString() on the value resulting in NPE.
The spec is not clear about SpinnerListModel having null values in List so user can have null values in List passed to SpinnerListModel constructor so we need to guard against it for NPE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-5078989](https://bugs.openjdk.java.net/browse/JDK-5078989): Null Pointer exception in SpinnerListMode


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/423/head:pull/423`
`$ git checkout pull/423`
