### PR TITLE
8253778: ShenandoahSafepoint::is_at_shenandoah_safepoint should not access VMThread state from other threads

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -403,7 +403,7 @@ void ShenandoahAsserts::assert_heaplocked_or_safepoint(const char* file, int lin
     return;
   }
 
-  if (ShenandoahSafepoint::is_at_shenandoah_safepoint()) {
+  if (ShenandoahSafepoint::is_at_shenandoah_safepoint() && Thread::current()->is_VM_thread()) {
     return;
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -403,7 +403,7 @@ void ShenandoahAsserts::assert_heaplocked_or_safepoint(const char* file, int lin
     return;
   }
 
-  if (ShenandoahSafepoint::is_at_shenandoah_safepoint() && Thread::current()->is_VM_thread()) {
+  if (ShenandoahSafepoint::is_at_shenandoah_safepoint()) {
     return;
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -145,6 +145,11 @@ public:
   static inline bool is_at_shenandoah_safepoint() {
     if (!SafepointSynchronize::is_at_safepoint()) return false;
 
+    // This is not VM thread, cannot see what VM thread is doing,
+    // so pretend this is a proper Shenandoah safepoint
+    if (!Thread::current()->is_VM_thread()) return true;
+
+    // Otherwise check we are at proper safepoint type
     VM_Operation* vm_op = VMThread::vm_operation();
     if (vm_op == NULL) return false;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -141,7 +141,9 @@ public:
 
 class ShenandoahSafepoint : public AllStatic {
 public:
-  // check if Shenandoah GC safepoint is in progress
+  // Check if Shenandoah GC safepoint is in progress. This is nominally
+  // equivalent to calling SafepointSynchronize::is_at_safepoint(), but
+  // it also checks the Shenandoah specifics, when it can.
   static inline bool is_at_shenandoah_safepoint() {
     if (!SafepointSynchronize::is_at_safepoint()) return false;
 
@@ -149,7 +151,7 @@ public:
     // so pretend this is a proper Shenandoah safepoint
     if (!Thread::current()->is_VM_thread()) return true;
 
-    // Otherwise check we are at proper safepoint type
+    // Otherwise check we are at proper operation type
     VM_Operation* vm_op = VMThread::vm_operation();
     if (vm_op == NULL) return false;
 


### PR DESCRIPTION
There are lots of Shenandoah-related test failures in current runs, triggered by new assert in JDK-8212107. The assert looks legitimate, and Shenandoah code should instead be more relaxed here, by checking it runs in VMThread before accessing its state.

Testing:
  - [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253778](https://bugs.openjdk.java.net/browse/JDK-8253778): ShenandoahSafepoint::is_at_shenandoah_safepoint should not access VMThread state from other threads


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer)
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/424/head:pull/424`
`$ git checkout pull/424`
