### PR TITLE
8251544: CTW: C2 fails with assert(no_dead_loop) failed: dead loop detected

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -315,37 +315,60 @@ static bool check_compare_clipping( bool less_than, IfNode *iff, ConNode *limit,
 
 //------------------------------is_unreachable_region--------------------------
 // Find if the Region node is reachable from the root.
-bool RegionNode::is_unreachable_region(PhaseGVN *phase) const {
-  assert(req() == 2, "");
+bool RegionNode::is_unreachable_region(const PhaseGVN* phase) {
+  Node* top = phase->C->top();
+  assert(req() == 2 || (req() == 3 && in(1) != NULL && in(2) == top), "sanity check arguments");
+  if (_is_unreachable_region) {
+    // Return cached result from previous evaluation which should still be valid
+    assert(is_unreachable_from_root(phase), "walk the graph again and check if its indeed unreachable");
+    return true;
+  }
 
   // First, cut the simple case of fallthrough region when NONE of
   // region's phis references itself directly or through a data node.
+  if (is_possible_unsafe_loop(phase)) {
+    // If we have a possible unsafe loop, check if the region node is actually unreachable from root.
+    if (is_unreachable_from_root(phase)) {
+      _is_unreachable_region = true;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool RegionNode::is_possible_unsafe_loop(const PhaseGVN* phase) const {
   uint max = outcnt();
   uint i;
   for (i = 0; i < max; i++) {
-    Node* phi = raw_out(i);
-    if (phi != NULL && phi->is_Phi()) {
-      assert(phase->eqv(phi->in(0), this) && phi->req() == 2, "");
-      if (phi->outcnt() == 0)
+    Node* n = raw_out(i);
+    if (n != NULL && n->is_Phi()) {
+      PhiNode* phi = n->as_Phi();
+      assert(phase->eqv(phi->in(0), this), "sanity check phi");
+      if (phi->outcnt() == 0) {
         continue; // Safe case - no loops
+      }
       if (phi->outcnt() == 1) {
         Node* u = phi->raw_out(0);
         // Skip if only one use is an other Phi or Call or Uncommon trap.
         // It is safe to consider this case as fallthrough.
-        if (u != NULL && (u->is_Phi() || u->is_CFG()))
+        if (u != NULL && (u->is_Phi() || u->is_CFG())) {
           continue;
+        }
       }
       // Check when phi references itself directly or through an other node.
-      if (phi->as_Phi()->simple_data_loop_check(phi->in(1)) >= PhiNode::Unsafe)
+      if (phi->as_Phi()->simple_data_loop_check(phi->in(1)) >= PhiNode::Unsafe) {
         break; // Found possible unsafe data loop.
+      }
     }
   }
-  if (i >= max)
+  if (i >= max) {
     return false; // An unsafe case was NOT found - don't need graph walk.
+  }
+  return true;
+}
 
-  // Unsafe case - check if the Region node is reachable from root.
+bool RegionNode::is_unreachable_from_root(const PhaseGVN* phase) const {
   ResourceMark rm;
-
   Node_List nstack;
   VectorSet visited;
 
@@ -367,7 +390,6 @@ bool RegionNode::is_unreachable_region(PhaseGVN *phase) const {
       }
     }
   }
-
   return true; // The Region node is unreachable - it is dead.
 }
 
@@ -1927,16 +1949,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     // Determine if this input is backedge of a loop.
     // (Skip new phis which have no uses and dead regions).
     if (outcnt() > 0 && r->in(0) != NULL) {
-      // First, take the short cut when we know it is a loop and
-      // the EntryControl data path is dead.
-      // Loop node may have only one input because entry path
-      // is removed in PhaseIdealLoop::Dominators().
-      assert(!r->is_Loop() || r->req() <= 3, "Loop node should have 3 or less inputs");
-      bool is_loop = (r->is_Loop() && r->req() == 3);
-      // Then, check if there is a data loop when phi references itself directly
-      // or through other data nodes.
-      if ((is_loop && !uin->eqv_uncast(in(LoopNode::EntryControl))) ||
-          (!is_loop && is_unsafe_data_reference(uin))) {
+      if (is_data_loop(r->as_Region(), uin, phase)) {
         // Break this data loop to avoid creation of a dead loop.
         if (can_reshape) {
           return top;
@@ -2373,6 +2386,22 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 #endif
 
   return progress;              // Return any progress
+}
+
+bool PhiNode::is_data_loop(RegionNode* r, Node* uin, const PhaseGVN* phase) {
+  // First, take the short cut when we know it is a loop and the EntryControl data path is dead.
+  // The loop node may only have one input because the entry path was removed in PhaseIdealLoop::Dominators().
+  // Then, check if there is a data loop when the phi references itself directly or through other data nodes.
+  assert(!r->is_Loop() || r->req() <= 3, "Loop node should have 3 or less inputs");
+  const bool is_loop = (r->is_Loop() && r->req() == 3);
+  const Node* top = phase->C->top();
+  if (is_loop) {
+    return !uin->eqv_uncast(in(LoopNode::EntryControl));
+  } else {
+    // We have a data loop either with an unsafe data reference or if a region is unreachable.
+    return is_unsafe_data_reference(uin)
+           || (r->req() == 3 && (r->in(1) != top && r->in(2) == top && r->is_unreachable_region(phase)));
+  }
 }
 
 //------------------------------is_tripcount-----------------------------------

--- a/test/hotspot/jtreg/compiler/c2/TestDeadDataLoopIGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDeadDataLoopIGVN.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8251544
+ * @summary A dead data loop in dying code is not correctly removed resulting in unremovable data nodes.
+ * @requires vm.compiler2.enabled
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *          java.base/jdk.internal.access
+ *          java.base/jdk.internal.reflect
+ *
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:-TieredCompilation -Xbatch
+ *                   compiler.c2.TestDeadDataLoopIGVN
+ */
+
+package compiler.c2;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.Vector;
+import java.util.ListIterator;
+import jdk.internal.access.SharedSecrets;
+import jdk.internal.misc.Unsafe;
+import jdk.internal.reflect.ConstantPool;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.lang.reflect.Executable;
+
+import compiler.whitebox.CompilerWhiteBoxTest;
+import sun.hotspot.WhiteBox;
+
+public class TestDeadDataLoopIGVN {
+
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+    private static final int TIERED_STOP_AT_LEVEL = WB.getIntxVMFlag("TieredStopAtLevel").intValue();
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    // The original test only failed with CTW due to different inlining and virtual call decisions compared to an
+    // execution with -Xcomp. This test adapts the behavior of CTW and compiles the methods with the Whitebox API
+    // in order to reproduce the bug.
+    public static void main(String[] strArr) throws Exception {
+        // Required to get the same inlining/virtual call decisions as for CTW
+        callSomeMethods(new ArrayList<String>());
+        callSomeMethods(new Vector<String>());
+
+        if (TIERED_STOP_AT_LEVEL != CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION) {
+            throw new RuntimeException("Sanity check if C2 is available");
+        }
+
+        // To trigger the assertion, we only need to compile Test
+        compileClass(Test.class);
+    }
+
+    private static void callSomeMethods(List<String> list) {
+        list.add("bla");
+        list.add("foo");
+        ListIterator<String> it = list.listIterator();
+        it.hasNext();
+        for (String s : list) {
+            s.charAt(0);
+        }
+    }
+
+    // Adaptation from CTW to compile and deoptimize the same methods
+    private static void compileClass(Class<?> aClass) throws Exception {
+        aClass = Class.forName(aClass.getCanonicalName(), true, aClass.getClassLoader());
+        ConstantPool constantPool = SharedSecrets.getJavaLangAccess().getConstantPool(aClass);
+        preloadClasses(constantPool);
+        UNSAFE.ensureClassInitialized(aClass);
+        WB.enqueueInitializerForCompilation(aClass, 4); // Level 4 for C2
+
+        for (Executable method : aClass.getDeclaredConstructors()) {
+            WB.deoptimizeMethod(method);
+            WB.enqueueMethodForCompilation(method, 4);
+            WB.deoptimizeMethod(method);
+        }
+
+        for (Executable method : aClass.getDeclaredMethods()) {
+            WB.deoptimizeMethod(method);
+            WB.enqueueMethodForCompilation(method, 4);
+            WB.deoptimizeMethod(method);
+        }
+    }
+
+    private static void preloadClasses(ConstantPool constantPool) throws Exception {
+        for (int i = 0, n = constantPool.getSize(); i < n; ++i) {
+            try {
+                constantPool.getClassAt(i);
+            } catch (IllegalArgumentException ignore) {
+            }
+        }
+    }
+}
+
+// The actual class that failed by executing it with CTW
+class Test {
+
+    public static A a = new A();
+
+    Test() {
+        LinkedList<A> l = new LinkedList<A>();
+        for (int i = 0; i < 34; i++) {
+            A instance = new A();
+            instance.id = i;
+            l.add(instance);
+        }
+        test(l, 34);
+    }
+
+    public void test(LinkedList<A> list, int max) {
+        Integer[] numbers = new Integer[max + 1];
+        A[] numbers2 = new A[max + 1];
+        int n = 0;
+        ListIterator<A> it = list.listIterator();
+        while (it.hasNext()) {
+            A b = it.next();
+            numbers[b.get()] = n;
+            numbers2[n] = b;
+            n++;
+        }
+
+        Integer[] iArr = new Integer[max + 1];
+
+        A a = getA();
+        Integer x = numbers[a.get()];
+        iArr[x] = x;
+
+        boolean flag = true;
+        while (flag) {
+            flag = false;
+            it = list.listIterator(34);
+            while (it.hasPrevious()) {
+                A b = it.previous();
+                if (b == a) {
+                    continue;
+                }
+            }
+        }
+
+        HashMap<A, A> map = new HashMap<A, A>();
+        for (Integer i = 0; i < max - 34; i++) {
+            map.put(numbers2[i], numbers2[iArr[i]]);
+        }
+    }
+
+    public A getA() {
+        return a;
+    }
+}
+
+// Helper class
+class A {
+    int id;
+
+    public int get() {
+        return id;
+    }
+}


### PR DESCRIPTION
In the testcase, we hit a dead data loop while dead nodes are being removed on a dead control path. A region node, lets say `r`, that represents a loop (has three inputs: self, a loop entry and backedge) but is not a loop node, yet, becomes dead when its entry control is replaced by top in the first IGVN run after parsing. All its phi nodes also become dead by replacing the corresponding entry control input by top. The problem is now that some phi nodes of `r` are processed by IGVN before the corresponding (dead) region node `r`. In `PhiNode::Ideal`, we actually check if there is a dead loop. But after some of the phis of `r` were already removed, `is_unsafe_data_reference()` on [L1939](https://github.com/openjdk/jdk/compare/master...chhagedorn:JDK-8251544#diff-efe6b3bde157b833249cd9a8d8b6645bL1939) returns false. As a result, we do not realize in `PhiNode::Ideal` for one of the remaining phis that it is actually dead and we apply the normal propagation in `PhiNode::Identity` which replaces the phi by its only non-top input. We later apply an additional optimization for a `LoadNode` input of an `AddINode` in which we replace the `LoadNode` by the `AddINode` itself (because of the data loop) and we end up with a dead data loop and fail with the dead loop assertion.

The order in which the nodes are processed in IGVN is crucial. I could only reproduce this bug with a very specific CTW-like testcase which makes this quite an edge case. I can think of two ways ways how to fix this:

1. Delay phi nodes which have only one non-top input left and whose region node is not a loop node, has three inputs from which the entry control is top and the region has not been processed by IGVN, yet.
2. Extend the dead data loop check in `PhiNode::Ideal()` to already do an unreachable region check as done in `RegionNode::Ideal()`. The result can be cached as a region should not become reachable anymore once we figured out it is dead.

I chose the second approach because I think it is preferable as we are not delaying IGVN and all other phi nodes can already use the information of a dead region before it is processed. This avoid any further unwanted optimizations on dead nodes.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251544](https://bugs.openjdk.java.net/browse/JDK-8251544): CTW: C2 fails with assert(no_dead_loop) failed: dead loop detected


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/425/head:pull/425`
`$ git checkout pull/425`
