### PR TITLE
8253824: Revert JDK-8253089 since VS warning C4307 has been disabled

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlagLookup.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagLookup.cpp
@@ -30,9 +30,9 @@
 #define DO_FLAG(type, name,...) DO_HASH(FLAG_MEMBER_ENUM(name), XSTR(name))
 
 #define DO_HASH(flag_enum, flag_name) {          \
-  u2 hash = hash_code(flag_name);                \
+  unsigned int hash = hash_code(flag_name);      \
   int bucket_index = (int)(hash % NUM_BUCKETS);  \
-  _hashes[flag_enum] = hash;                     \
+  _hashes[flag_enum] = (u2)(hash);               \
   _table[flag_enum] = _buckets[bucket_index];    \
   _buckets[bucket_index] = (short)flag_enum;     \
 }
@@ -54,10 +54,10 @@ constexpr JVMFlagLookup::JVMFlagLookup() : _buckets(), _table(), _hashes() {
 constexpr JVMFlagLookup _flag_lookup_table;
 
 JVMFlag* JVMFlagLookup::find_impl(const char* name, size_t length) const {
-  u2 hash = hash_code(name, length);
+  unsigned int hash = hash_code(name, length);
   int bucket_index = (int)(hash % NUM_BUCKETS);
   for (int flag_enum = _buckets[bucket_index]; flag_enum >= 0; ) {
-    if (_hashes[flag_enum] == hash) {
+    if (_hashes[flag_enum] == (u2)hash) {
       JVMFlag* flag = JVMFlag::flags + flag_enum;
       if (strncmp(name, flag->name(), length) == 0) {
         // We know flag->name() has at least <length> bytes.

--- a/src/hotspot/share/runtime/flags/jvmFlagLookup.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagLookup.hpp
@@ -51,14 +51,14 @@ class JVMFlagLookup {
 
   // This is executed at build-time only, so it doesn't matter if we walk
   // the string twice.
-  static constexpr u2 hash_code(const char* s) {
+  static constexpr unsigned int hash_code(const char* s) {
     return hash_code(s, string_len(s));
   }
 
-  static constexpr u2 hash_code(const char* s, size_t len) {
-    u2 h = 0;
+  static constexpr unsigned int hash_code(const char* s, size_t len) {
+    unsigned int h = 0;
     while (len -- > 0) {
-      h = (u2)(31*h + (u2) *s);
+      h = 31*h + (unsigned int) *s;
       s++;
     }
     return h;


### PR DESCRIPTION
This reverts commit 3f455f09dc738b7c76210c1080df2aaa8e19a19d.

Testing:
 - [x] Linux x86_64 {fastdebug,release,slowdebug} builds
 - [x] Windows MSVC 2017 build (tested by Martin Doerr)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253824](https://bugs.openjdk.java.net/browse/JDK-8253824): Revert JDK-8253089 since VS warning C4307 has been disabled


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/426/head:pull/426`
`$ git checkout pull/426`
