### PR TITLE
8253843: AArch64: Use ishst for storestore barrier

### DIFF
--- a/src/hotspot/os_cpu/linux_aarch64/atomic_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/atomic_linux_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2019, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -37,7 +37,7 @@ struct Atomic::PlatformAdd {
   template<typename D, typename I>
   D add_and_fetch(D volatile* dest, I add_value, atomic_memory_order order) const {
     D res = __atomic_add_fetch(dest, add_value, __ATOMIC_RELEASE);
-    FULL_MEM_BARRIER;
+    OrderAccess::fence();
     return res;
   }
 
@@ -54,7 +54,7 @@ inline T Atomic::PlatformXchg<byte_size>::operator()(T volatile* dest,
                                                      atomic_memory_order order) const {
   STATIC_ASSERT(byte_size == sizeof(T));
   T res = __atomic_exchange_n(dest, exchange_value, __ATOMIC_RELEASE);
-  FULL_MEM_BARRIER;
+  OrderAccess::fence();
   return res;
 }
 
@@ -73,10 +73,10 @@ inline T Atomic::PlatformCmpxchg<byte_size>::operator()(T volatile* dest __attri
     return value;
   } else {
     T value = compare_value;
-    FULL_MEM_BARRIER;
+    OrderAccess::fence();
     __atomic_compare_exchange(dest, &value, &exchange_value, /*weak*/false,
                               __ATOMIC_RELAXED, __ATOMIC_RELAXED);
-    FULL_MEM_BARRIER;
+    OrderAccess::fence();
     return value;
   }
 }

--- a/src/hotspot/share/runtime/orderAccess.hpp
+++ b/src/hotspot/share/runtime/orderAccess.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,28 +120,28 @@
 //
 // The following table shows the implementations on some architectures:
 //
-//                       Constraint     x86          sparc TSO          ppc
-// ---------------------------------------------------------------------------
-// fence                 LoadStore  |   lock         membar #StoreLoad  sync
+//                       Constraint     x86          sparc TSO          ppc      AArch64
+// ---------------------------------------------------------------------------------------
+// fence                 LoadStore  |   lock         membar #StoreLoad  sync     dmb ish
 //                       StoreStore |   addl 0,(sp)
 //                       LoadLoad   |
 //                       StoreLoad
 //
-// release               LoadStore  |                                   lwsync
+// release               LoadStore  |                                   lwsync   dmb ish
 //                       StoreStore
 //
-// acquire               LoadLoad   |                                   lwsync
+// acquire               LoadLoad   |                                   lwsync   dmb ishld
 //                       LoadStore
 //
-// release_store                        <store>      <store>            lwsync
+// release_store                        <store>      <store>            lwsync   stlr
 //                                                                      <store>
 //
-// release_store_fence                  xchg         <store>            lwsync
-//                                                   membar #StoreLoad  <store>
+// release_store_fence                  xchg         <store>            lwsync   stlr
+//                                                   membar #StoreLoad  <store>  dmb ish
 //                                                                      sync
 //
 //
-// load_acquire                         <load>       <load>             <load>
+// load_acquire                         <load>       <load>             <load>   ldar
 //                                                                      lwsync
 //
 // Ordering a load relative to preceding stores requires a StoreLoad,


### PR DESCRIPTION
AArch64 orderAccess uses gcc built in atomic functions, which expand
inline to DMB barrier instructions.  Specifically, they call the following:

FULL_MEM_BARRIER -> DMB ISH
READ_MEM_BARRIER -> DMB ISHLD
WRITE_MEM_BARRIER -> DMB ISH

However, storestore should be optimised to use ISHST.

In addition, __sync_synchronize is marked as legacy. See:
https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html

In order for the code to match, I switched everything to call dmbs directly.

Also, add AArch64 to the orderAccess documentation table.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 gc)](https://github.com/a74nh/jdk/runs/1187086474)

### Issue
 * [JDK-8253843](https://bugs.openjdk.java.net/browse/JDK-8253843): AArch64: Use ishst for storestore barrier


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/427/head:pull/427`
`$ git checkout pull/427`
