### PR TITLE
8232840: java/math/BigInteger/largeMemory/SymmetricRangeTests.java fails due to "OutOfMemoryError: Requested array size exceeds VM limit"

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -28,4 +28,3 @@
 #############################################################################
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
-java/math/BigInteger/largeMemory/SymmetricRangeTests.java 8232840 generic-all

--- a/test/jdk/java/math/BigInteger/largeMemory/SymmetricRangeTests.java
+++ b/test/jdk/java/math/BigInteger/largeMemory/SymmetricRangeTests.java
@@ -26,7 +26,7 @@
  * @bug 6910473 8021204 8021203 9005933 8074460 8078672
  * @summary Test range of BigInteger values (use -Dseed=X to set PRNG seed)
  * @library /test/lib
- * @requires (sun.arch.data.model == "64" & os.maxMemory > 8g)
+ * @requires (sun.arch.data.model == "64" & os.maxMemory >= 10g)
  * @run main/timeout=180/othervm -Xmx8g -XX:+CompactStrings SymmetricRangeTests
  * @author Dmitry Nadezhin
  * @key randomness


### PR DESCRIPTION
SymmetricRangeTests.java was added to ProblemList as it was throwing OOM time ago. Now, tests have been executed multiple times again with a combination of VM options with 100% pass rate, the issue could not be reproduced anymore, it seems quite stable to be removed from the ProblemList at this time.

Required os.maxMemory has been increased as a preventive measure to run the tests only in an system where memory available is enough to give the JVM some elbow room

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8232840](https://bugs.openjdk.java.net/browse/JDK-8232840): java/math/BigInteger/largeMemory/SymmetricRangeTests.java fails due to "OutOfMemoryError: Requested array size exceeds VM limit"


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/432/head:pull/432`
`$ git checkout pull/432`
