### PR TITLE
4916923: In MetalRootPaneUI, MetalRootLayout does not correctly calculate minimumsize

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalRootPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalRootPaneUI.java
@@ -485,7 +485,7 @@ public class MetalRootPaneUI extends BasicRootPaneUI
             }
 
             return new Dimension(Math.max(Math.max(cpWidth, mbWidth), tpWidth) + i.left + i.right,
-                                 cpHeight + mbHeight + tpWidth + i.top + i.bottom);
+                                 cpHeight + mbHeight + tpHeight + i.top + i.bottom);
         }
 
         /**
@@ -536,7 +536,7 @@ public class MetalRootPaneUI extends BasicRootPaneUI
             }
 
             return new Dimension(Math.max(Math.max(cpWidth, mbWidth), tpWidth) + i.left + i.right,
-                                 cpHeight + mbHeight + tpWidth + i.top + i.bottom);
+                                 cpHeight + mbHeight + tpHeight + i.top + i.bottom);
         }
 
         /**


### PR DESCRIPTION
Please review a fix for an issue where minimumLayoutSize and preferredlayoutSize of MetalRootLayout class wrongly uses the width of the title pane in the height calculation:
Proposed fix is to rectify the anomaly and use tpHeight for height calculation.

All closed, open jtreg and JCK tests and SwingSet2 Metal L&F are unaffected by this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-4916923](https://bugs.openjdk.java.net/browse/JDK-4916923): In MetalRootPaneUI, MetalRootLayout does not correctly calculate minimumsize


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/433/head:pull/433`
`$ git checkout pull/433`
