### PR TITLE
8253433: Remove -XX:+Debugging product option

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -553,6 +553,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "UseSemaphoreGCThreadsSynchronization", JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "ForceNUMA",                     JDK_Version::jdk(15), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "InsertMemBarAfterArraycopy",    JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
+  { "Debugging",                     JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
 
 #ifdef TEST_VERIFY_SPECIAL_JVM_FLAGS
   // These entries will generate build errors.  Their purpose is to test the macros.

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -395,10 +395,6 @@ const intx ObjectAlignmentInBytes = 8;
   notproduct(bool, WalkStackALot, false,                                    \
           "Trace stack (no print) at every exit from the runtime system")   \
                                                                             \
-  product(bool, Debugging, false, DIAGNOSTIC,                               \
-          "Set when executing debug methods in debug.cpp "                  \
-          "(to prevent triggering assertions)")                             \
-                                                                            \
   notproduct(bool, VerifyLastFrame, false,                                  \
           "Verify oops on last frame on entry to VM")                       \
                                                                             \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -395,7 +395,7 @@ const intx ObjectAlignmentInBytes = 8;
   notproduct(bool, WalkStackALot, false,                                    \
           "Trace stack (no print) at every exit from the runtime system")   \
                                                                             \
-  product(bool, Debugging, false,                                           \
+  product(bool, Debugging, false, DIAGNOSTIC,                               \
           "Set when executing debug methods in debug.cpp "                  \
           "(to prevent triggering assertions)")                             \
                                                                             \

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -71,6 +71,9 @@ static intx g_asserting_thread = 0;
 static void* g_assertion_context = NULL;
 #endif // CAN_SHOW_REGISTERS_ON_ASSERT
 
+// Set to suppress secondary error reporting.
+bool Debugging = false;
+
 #ifndef ASSERT
 #  ifdef _DEBUG
    // NOTE: don't turn the lines below into a comment -- if you're getting
@@ -367,9 +370,9 @@ class Command : public StackObj {
   }
 
   ~Command() {
-        tty->flush();
-        Debugging = debug_save;
-        level--;
+    tty->flush();
+    Debugging = debug_save;
+    level--;
   }
 };
 

--- a/src/hotspot/share/utilities/debug.hpp
+++ b/src/hotspot/share/utilities/debug.hpp
@@ -152,6 +152,10 @@ enum VMErrorType {
   OOM_MMAP_ERROR   = 0xe0000002
 };
 
+// Set to suppress secondary error reporting.
+// Really should have a qualified name or something.
+extern bool Debugging;
+
 // error reporting helper functions
 void report_vm_error(const char* file, int line, const char* error_msg);
 void report_vm_error(const char* file, int line, const char* error_msg,


### PR DESCRIPTION
The Debugging option shouldn't be used on the command line.  There's a SuppressErrorAt option to ignore certain asserts, if there is some situation needing that. Debugging should never be used.

Tested with tier1 tests on 4 platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253433](https://bugs.openjdk.java.net/browse/JDK-8253433): Remove -XX:+Debugging product option


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/434/head:pull/434`
`$ git checkout pull/434`
