### PR TITLE
8253865: Pre-submit testing using GitHub Actions does not detect failures reliably

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -304,6 +304,15 @@ jobs:
           TEST="${{ matrix.suites }}"
           TEST_OPTS_JAVA_OPTIONS=
           JTREG_KEYWORDS="!headful"
+          JTREG="JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash"
+
+      - name: Parse test results
+        if: always()
+        run: >
+          if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
+            cat build/*/test-results/*/text/newfailures.txt ;
+            exit 1 ;
+          fi
 
       - name: Create suitable test log artifact name
         if: always()
@@ -561,6 +570,15 @@ jobs:
           TEST=${{ matrix.suites }}
           TEST_OPTS_JAVA_OPTIONS=
           JTREG_KEYWORDS="!headful"
+          JTREG="JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash"
+
+      - name: Parse test results
+        if: always()
+        run: >
+          if ((Get-ChildItem -Path build\*\test-results\test-summary.txt -Recurse | Select-String -Pattern "TEST SUCCESS" ).Count -eq 0) {
+            Get-Content -Path build\*\test-results\*\*\newfailures.txt ;
+            exit 1
+          }
 
       - name: Create suitable test log artifact name
         if: always()
@@ -786,6 +804,15 @@ jobs:
           TEST=${{ matrix.suites }}
           TEST_OPTS_JAVA_OPTIONS=
           JTREG_KEYWORDS="!headful"
+          JTREG="JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash"
+
+      - name: Parse test results
+        if: always()
+        run: >
+          if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
+            cat build/*/test-results/*/text/newfailures.txt ;
+            exit 1 ;
+          fi
 
       - name: Create suitable test log artifact name
         if: always()

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -146,10 +146,19 @@ jobs:
         if: steps.bootjdk.outputs.cache-hit != 'true'
 
       - name: Restore jtreg artifact
+        id: jtreg_restore
         uses: actions/download-artifact@v2
         with:
           name: transient_jtreg_${{ env.bundleid }}
           path: ~/jtreg/
+        continue-on-error: true
+
+      - name: Restore jtreg artifact (retry)
+        uses: actions/download-artifact@v2
+        with:
+          name: transient_jtreg_${{ env.bundleid }}
+          path: ~/jtreg/
+        if: steps.jtreg_restore.outcome == 'failure'
 
       - name: Checkout gtest sources
         uses: actions/checkout@v2
@@ -265,16 +274,34 @@ jobs:
         if: steps.bootjdk.outputs.cache-hit != 'true'
 
       - name: Restore jtreg artifact
+        id: jtreg_restore
         uses: actions/download-artifact@v2
         with:
           name: transient_jtreg_${{ env.bundleid }}
           path: ~/jtreg/
+        continue-on-error: true
+
+      - name: Restore jtreg artifact (retry)
+        uses: actions/download-artifact@v2
+        with:
+          name: transient_jtreg_${{ env.bundleid }}
+          path: ~/jtreg/
+        if: steps.jtreg_restore.outcome == 'failure'
 
       - name: Restore build artifacts
+        id: build_restore
         uses: actions/download-artifact@v2
         with:
           name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ env.bundleid }}
           path: ~/jdk-linux-x64${{ matrix.artifact }}
+        continue-on-error: true
+
+      - name: Restore build artifacts (retry)
+        uses: actions/download-artifact@v2
+        with:
+          name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          path: ~/jdk-linux-x64${{ matrix.artifact }}
+        if: steps.build_restore.outcome == 'failure'
 
       - name: Unpack jdk
         run: |
@@ -306,7 +333,7 @@ jobs:
           JTREG_KEYWORDS="!headful"
           JTREG="JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash"
 
-      - name: Parse test results
+      - name: Check that all tests executed successfully
         if: always()
         run: >
           if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
@@ -397,10 +424,19 @@ jobs:
           path: gtest
 
       - name: Restore jtreg artifact
+        id: jtreg_restore
         uses: actions/download-artifact@v2
         with:
           name: transient_jtreg_${{ env.bundleid }}
           path: ~/jtreg/
+        continue-on-error: true
+
+      - name: Restore jtreg artifact (retry)
+        uses: actions/download-artifact@v2
+        with:
+          name: transient_jtreg_${{ env.bundleid }}
+          path: ~/jtreg/
+        if: steps.jtreg_restore.outcome == 'failure'
 
       - name: Configure
         run: >
@@ -525,16 +561,34 @@ jobs:
           Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
 
       - name: Restore jtreg artifact
+        id: jtreg_restore
         uses: actions/download-artifact@v2
         with:
           name: transient_jtreg_${{ env.bundleid }}
           path: ~/jtreg/
+        continue-on-error: true
+
+      - name: Restore jtreg artifact (retry)
+        uses: actions/download-artifact@v2
+        with:
+          name: transient_jtreg_${{ env.bundleid }}
+          path: ~/jtreg/
+        if: steps.jtreg_restore.outcome == 'failure'
 
       - name: Restore build artifacts
+        id: build_restore
         uses: actions/download-artifact@v2
         with:
           name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ env.bundleid }}
           path: ~/jdk-windows-x64${{ matrix.artifact }}
+        continue-on-error: true
+
+      - name: Restore build artifacts (retry)
+        uses: actions/download-artifact@v2
+        with:
+          name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          path: ~/jdk-windows-x64${{ matrix.artifact }}
+        if: steps.build_restore.outcome == 'failure'
 
       - name: Unpack jdk
         run: |
@@ -572,7 +626,7 @@ jobs:
           JTREG_KEYWORDS="!headful"
           JTREG="JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash"
 
-      - name: Parse test results
+      - name: Check that all tests executed successfully
         if: always()
         run: >
           if ((Get-ChildItem -Path build\*\test-results\test-summary.txt -Recurse | Select-String -Pattern "TEST SUCCESS" ).Count -eq 0) {
@@ -643,10 +697,19 @@ jobs:
         if: steps.bootjdk.outputs.cache-hit != 'true'
 
       - name: Restore jtreg artifact
+        id: jtreg_restore
         uses: actions/download-artifact@v2
         with:
           name: transient_jtreg_${{ env.bundleid }}
           path: ~/jtreg/
+        continue-on-error: true
+
+      - name: Restore jtreg artifact (retry)
+        uses: actions/download-artifact@v2
+        with:
+          name: transient_jtreg_${{ env.bundleid }}
+          path: ~/jtreg/
+        if: steps.jtreg_restore.outcome == 'failure'
 
       - name: Checkout gtest sources
         uses: actions/checkout@v2
@@ -762,16 +825,34 @@ jobs:
         if: steps.bootjdk.outputs.cache-hit != 'true'
 
       - name: Restore jtreg artifact
+        id: jtreg_restore
         uses: actions/download-artifact@v2
         with:
           name: transient_jtreg_${{ env.bundleid }}
           path: ~/jtreg/
+        continue-on-error: true
+
+      - name: Restore jtreg artifact (retry)
+        uses: actions/download-artifact@v2
+        with:
+          name: transient_jtreg_${{ env.bundleid }}
+          path: ~/jtreg/
+        if: steps.jtreg_restore.outcome == 'failure'
 
       - name: Restore build artifacts
+        id: build_restore
         uses: actions/download-artifact@v2
         with:
           name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ env.bundleid }}
           path: ~/jdk-macos-x64${{ matrix.artifact }}
+        continue-on-error: true
+
+      - name: Restore build artifacts (retry)
+        uses: actions/download-artifact@v2
+        with:
+          name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          path: ~/jdk-macos-x64${{ matrix.artifact }}
+        if: steps.build_restore.outcome == 'failure'
 
       - name: Unpack jdk
         run: |
@@ -806,7 +887,7 @@ jobs:
           JTREG_KEYWORDS="!headful"
           JTREG="JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash"
 
-      - name: Parse test results
+      - name: Check that all tests executed successfully
         if: always()
         run: >
           if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then


### PR DESCRIPTION
The pre-submit test definitions utilizing GitHub Actions can sometimes report success even when there are failing tests. The failure detection depended on make returning a non-zero exit code on failures, which doesn't seem to work. 

To properly determine test outcome we should check the "test-summary.txt" result file for the string "TEST SUCCESS". If it isn't found, the tests must have failed. This change also includes a reliability improvement.

Here's an example of a run with the updated test definitions: https://github.com/rwestberg/jdk/actions/runs/280529475

Note! There is a failure now properly detected in langtools/tier1 on Windows (tools/javac/launcher/SourceLauncherTest.java) which is tracked by https://bugs.openjdk.java.net/browse/JDK-8249095 - could be of interest to either fix or ProblemList that one before integrating this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8253865](https://bugs.openjdk.java.net/browse/JDK-8253865): Pre-submit testing using GitHub Actions does not detect failures reliably
 * [JDK-8253867](https://bugs.openjdk.java.net/browse/JDK-8253867): Pre-submit testing using GitHub Actions can fail to download intermediate artifacts


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/437/head:pull/437`
`$ git checkout pull/437`
