### PR TITLE
8253872: ArgumentHandler must use the same delimiters as in jvmti_tools.cpp

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/ArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/ArgumentHandler.java
@@ -154,7 +154,7 @@ public class ArgumentHandler extends ArgumentParser {
         if (optionString == null)
             return;
 
-        StringTokenizer st = new StringTokenizer(optionString, " ~,");
+        StringTokenizer st = new StringTokenizer(optionString, " ,~");
         while (st.hasMoreTokens()) {
             String token = st.nextToken();
             int start = token.startsWith("-")? 1 : 0;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/ArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/ArgumentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,7 +154,7 @@ public class ArgumentHandler extends ArgumentParser {
         if (optionString == null)
             return;
 
-        StringTokenizer st = new StringTokenizer(optionString);
+        StringTokenizer st = new StringTokenizer(optionString, " ~,");
         while (st.hasMoreTokens()) {
             String token = st.nextToken();
             int start = token.startsWith("-")? 1 : 0;


### PR DESCRIPTION
separating the commit from  #370 / [8252003](https://bugs.openjdk.java.net/browse/JDK-8253872)[[1]] 

jvmti_tools.cpp supports ` `, `~` and/or `,` as delimiters[[2]] in -agentlib options, but `nsk/share/jvmti/ArgumentHandler` takes these options (via `getAgentOptionsString`) and then parse in `parseOptionString`, where `StringTokenizer` is used w/ default delimiters, ie `\t\n\r\f`, and as a result, it doesn't split options correctly in tests which use delimiters other than ` `. and in fact, `nsk/jvmti/scenarios/contention/TC05/tc05t001` is using `,` and gets wrong options/values.

testing: ✅ `nsk/jvmti/scenarios/contention/TC05/tc05t001`

[1]: https://github.com/openjdk/jdk/pull/370/commits/5219b11650c00f9af5564758b3292458a48e7f21#r497658983 
[2]: https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp#L224

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253872](https://bugs.openjdk.java.net/browse/JDK-8253872): ArgumentHandler must use the same delimiters as in jvmti_tools.cpp


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/438/head:pull/438`
`$ git checkout pull/438`
