### PR TITLE
(docs) Update building.md for a problem with the github cli

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -7,7 +7,7 @@ the time. They assume that you have installed Mercurial (and Cygwin if running
 on Windows) and cloned the top-level JDK repository that you want to build.
 
  1. [Get the complete source code](#getting-the-source-code): \
-    `hg clone http://hg.openjdk.java.net/jdk/jdk`
+    `gh clone http://hg.openjdk.java.net/jdk/jdk`
 
  2. [Run configure](#running-configure): \
     `bash configure`


### PR DESCRIPTION
There is a problem with the snippet to clone the repository
I think you have to use the github cli command: gh clone

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/440/head:pull/440`
`$ git checkout pull/440`
