### PR TITLE
8253880: clean up sun/hotspot/tools/ctw/Utils class

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Utils.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Utils.java
@@ -26,9 +26,6 @@ package sun.hotspot.tools.ctw;
 import com.sun.management.HotSpotDiagnosticMXBean;
 import java.lang.management.ManagementFactory;
 
-import java.io.File;
-import java.util.regex.Pattern;
-
 /**
  * Auxiliary methods.
  */
@@ -57,11 +54,6 @@ public class Utils {
      * Initial compilation level.
      */
     public static final int INITIAL_COMP_LEVEL;
-    /**
-     * Compiled path-separator regexp.
-     */
-    public static final Pattern PATH_SEPARATOR = Pattern.compile(
-            File.pathSeparator, Pattern.LITERAL);
     /**
      * Value of {@code -DCompileTheWorldStopAt}. Last class to consider.
      */


### PR DESCRIPTION
Hi all,

could you please review this trivial clean up in sun/hotspot/tools/ctw/Utils which removes unused `PATH_SEPARATOR` field and unused imports?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253880](https://bugs.openjdk.java.net/browse/JDK-8253880): clean up sun/hotspot/tools/ctw/Utils class


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/444/head:pull/444`
`$ git checkout pull/444`
