### PR TITLE
JDK-8253879: Simplify redundant code in IndexBuilder

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
@@ -165,7 +165,7 @@ public class IndexBuilder {
                 String name = utils.getSimpleName(element);
                 Character ch = keyCharacter(name);
                 SortedSet<IndexItem> set = indexMap.computeIfAbsent(ch, c -> new TreeSet<>(comparator));
-                set.add(new IndexItem(element, typeElement, configuration.utils));
+                set.add(new IndexItem(element, typeElement, utils));
             }
         }
     }
@@ -181,7 +181,7 @@ public class IndexBuilder {
                 String name = utils.getSimpleName(typeElement);
                 Character ch = keyCharacter(name);
                 SortedSet<IndexItem> set = indexMap.computeIfAbsent(ch, c -> new TreeSet<>(comparator));
-                set.add(new IndexItem(typeElement, configuration.utils));
+                set.add(new IndexItem(typeElement, utils));
             }
         }
     }
@@ -197,7 +197,7 @@ public class IndexBuilder {
         for (ModuleElement m : configuration.modules) {
             Character ch = keyCharacter(m.getQualifiedName().toString());
             SortedSet<IndexItem> set = indexMap.computeIfAbsent(ch, c -> new TreeSet<>(comparator));
-            set.add(new IndexItem(m, configuration.utils));
+            set.add(new IndexItem(m, utils));
         }
     }
 
@@ -210,7 +210,7 @@ public class IndexBuilder {
         if (shouldIndex(packageElement)) {
             Character ch = keyCharacter(utils.getPackageName(packageElement));
             SortedSet<IndexItem> set = indexMap.computeIfAbsent(ch, c -> new TreeSet<>(comparator));
-            set.add(new IndexItem(packageElement, configuration.utils));
+            set.add(new IndexItem(packageElement, utils));
         }
     }
 
@@ -225,14 +225,14 @@ public class IndexBuilder {
         if (utils.isPackage(element)) {
             // Do not add to index map if -nodeprecated option is set and the
             // package is marked as deprecated.
-            return !(noDeprecated && configuration.utils.isDeprecated(element));
+            return !(noDeprecated && utils.isDeprecated(element));
         } else {
             // Do not add to index map if -nodeprecated option is set and if the
             // element is marked as deprecated or the containing package is marked as
             // deprecated.
             return !(noDeprecated &&
-                    (configuration.utils.isDeprecated(element) ||
-                    configuration.utils.isDeprecated(utils.containingPackage(element))));
+                    (utils.isDeprecated(element) ||
+                    utils.isDeprecated(utils.containingPackage(element))));
         }
     }
 


### PR DESCRIPTION
Trivial cleanup to simplify `configuration.utils` to just `utils`, removing the redundant `configuration.`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253879](https://bugs.openjdk.java.net/browse/JDK-8253879): Simplify redundant code in IndexBuilder


### Reviewers
 * [Kumar Srinivasan](https://openjdk.java.net/census#ksrini) (@kusrinivasan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/445/head:pull/445`
`$ git checkout pull/445`
