### PR TITLE
8180514: TestPrintMdo.java test fails with -XX:-TieredCompilation

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestPrintMdo.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestPrintMdo.java
@@ -45,7 +45,7 @@ public class TestPrintMdo {
         LingeredApp app = null;
         try {
             ClhsdbLauncher test = new ClhsdbLauncher();
-            app = LingeredApp.startApp("-XX:+ProfileInterpreter");
+            app = LingeredApp.startApp("-XX:+ProfileInterpreter", "-XX:CompileThreshold=100");
             System.out.println ("Started LingeredApp with pid " + app.getPid());
             List<String> cmds = List.of("printmdo -a");
 


### PR DESCRIPTION
Test fails with -XX:-TieredCompilation because j.l.Object hasn't been used enough time to trigger compilation. The default CompileThreshold value is good enough when tiered compilation is enabled (by default) but not for server-only mode. So it is needed to reduce CompileThreshold to ensure that methods are compiled in any mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * ⚠️ Failed to retrieve information on issue `8180514`.


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/447/head:pull/447`
`$ git checkout pull/447`
