### PR TITLE
8156071: List.of: reduce array copying during creation

### DIFF
--- a/src/java.base/share/classes/java/util/List.java
+++ b/src/java.base/share/classes/java/util/List.java
@@ -842,7 +842,7 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3) {
-        return new ImmutableCollections.ListN<>(e1, e2, e3);
+        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3);
     }
 
     /**
@@ -861,7 +861,7 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4) {
-        return new ImmutableCollections.ListN<>(e1, e2, e3, e4);
+        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4);
     }
 
     /**
@@ -881,7 +881,7 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4, E e5) {
-        return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5);
+        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4, e5);
     }
 
     /**
@@ -902,8 +902,8 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
-        return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
-                                                e6);
+        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4, e5,
+                                                           e6);
     }
 
     /**
@@ -925,8 +925,8 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
-        return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
-                                                e6, e7);
+        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4, e5,
+                                                           e6, e7);
     }
 
     /**
@@ -949,8 +949,8 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
-        return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
-                                                e6, e7, e8);
+        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4, e5,
+                                                           e6, e7, e8);
     }
 
     /**
@@ -974,8 +974,8 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
-        return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
-                                                e6, e7, e8, e9);
+        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4, e5,
+                                                           e6, e7, e8, e9);
     }
 
     /**
@@ -1000,8 +1000,8 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
-        return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
-                                                e6, e7, e8, e9, e10);
+        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4, e5,
+                                                           e6, e7, e8, e9, e10);
     }
 
     /**
@@ -1042,7 +1042,7 @@ public interface List<E> extends Collection<E> {
             case 2:
                 return new ImmutableCollections.List12<>(elements[0], elements[1]);
             default:
-                return new ImmutableCollections.ListN<>(elements);
+                return ImmutableCollections.ListN.fromArray(elements);
         }
     }
 

--- a/src/java.base/share/classes/java/util/stream/Collectors.java
+++ b/src/java.base/share/classes/java/util/stream/Collectors.java
@@ -56,6 +56,8 @@ import java.util.function.ToDoubleFunction;
 import java.util.function.ToIntFunction;
 import java.util.function.ToLongFunction;
 
+import jdk.internal.access.SharedSecrets;
+
 /**
  * Implementations of {@link Collector} that implement various useful reduction
  * operations, such as accumulating elements into collections, summarizing
@@ -296,7 +298,8 @@ public final class Collectors {
     Collector<T, ?, List<T>> toUnmodifiableList() {
         return new CollectorImpl<>((Supplier<List<T>>) ArrayList::new, List::add,
                                    (left, right) -> { left.addAll(right); return left; },
-                                   list -> (List<T>)List.of(list.toArray()),
+                                   list -> (List<T>)SharedSecrets.getJavaUtilCollectionAccess()
+                                                                 .listFromTrustedArray(list.toArray()),
                                    CH_NOID);
     }
 

--- a/src/java.base/share/classes/jdk/internal/access/JavaUtilCollectionAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaUtilCollectionAccess.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.access;
+
+import java.util.List;
+
+public interface JavaUtilCollectionAccess {
+    <E> List<E> listFromTrustedArray(Object[] array);
+}

--- a/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
+++ b/src/java.base/share/classes/jdk/internal/access/SharedSecrets.java
@@ -70,12 +70,26 @@ public class SharedSecrets {
     private static JavaNetUriAccess javaNetUriAccess;
     private static JavaNetURLAccess javaNetURLAccess;
     private static JavaNioAccess javaNioAccess;
+    private static JavaUtilCollectionAccess javaUtilCollectionAccess;
     private static JavaUtilJarAccess javaUtilJarAccess;
     private static JavaUtilZipFileAccess javaUtilZipFileAccess;
     private static JavaUtilResourceBundleAccess javaUtilResourceBundleAccess;
     private static JavaSecurityAccess javaSecurityAccess;
     private static JavaSecuritySignatureAccess javaSecuritySignatureAccess;
     private static JavaxCryptoSealedObjectAccess javaxCryptoSealedObjectAccess;
+
+    public static void setJavaUtilCollectionAccess(JavaUtilCollectionAccess juca) {
+        javaUtilCollectionAccess = juca;
+    }
+
+    public static JavaUtilCollectionAccess getJavaUtilCollectionAccess() {
+        if (javaUtilCollectionAccess == null) {
+            try {
+                Class.forName("java.util.ImmutableCollections$Access", true, null);
+            } catch (ClassNotFoundException e) {};
+        }
+        return javaUtilCollectionAccess;
+    }
 
     public static JavaUtilJarAccess javaUtilJarAccess() {
         if (javaUtilJarAccess == null) {

--- a/test/micro/org/openjdk/bench/java/util/ListArgs.java
+++ b/test/micro/org/openjdk/bench/java/util/ListArgs.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.util;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Microbenchmarks for List.of fixed vs varargs implementations.
+ * Run with -Xint to avoid JIT compilation, in order to test
+ * common use cases of these methods being called from static
+ * initializers. Use parallel GC and set initial heap size to avoid
+ * GC during runs.
+ */
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 3, jvmArgsAppend = { "-verbose:gc", "-XX:+UseParallelGC", "-Xms4g", "-Xmx4g", "-Xint" })
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+public class ListArgs {
+
+    @Benchmark
+    public Object list00() {
+        return List.of();
+    }
+
+    @Benchmark
+    public Object list01() {
+        return List.of("a");
+    }
+
+    @Benchmark
+    public Object list02() {
+        return List.of("a", "b");
+    }
+
+    @Benchmark
+    public Object list03() {
+        return List.of("a", "b", "c");
+    }
+
+    @Benchmark
+    public Object list04() {
+        return List.of("a", "b", "c", "d");
+    }
+
+    @Benchmark
+    public Object list05() {
+        return List.of("a", "b", "c", "d", "e");
+    }
+
+    @Benchmark
+    public Object list06() {
+        return List.of("a", "b", "c", "d", "e",
+                       "f");
+    }
+
+    @Benchmark
+    public Object list07() {
+        return List.of("a", "b", "c", "d", "e",
+                       "f", "g");
+    }
+
+    @Benchmark
+    public Object list08() {
+        return List.of("a", "b", "c", "d", "e",
+                       "f", "g", "h");
+    }
+
+    @Benchmark
+    public Object list09() {
+        return List.of("a", "b", "c", "d", "e",
+                       "f", "g", "h", "i");
+    }
+
+    @Benchmark
+    public Object list10() {
+        return List.of("a", "b", "c", "d", "e",
+                       "f", "g", "h", "i", "j");
+    }
+
+    @Benchmark
+    public Object list11() {
+        return List.of("a", "b", "c", "d", "e",
+                       "f", "g", "h", "i", "j", "k");
+    }
+}


### PR DESCRIPTION
Plumb new internal static factory method to trust the array passed in, avoiding unnecessary copying. JMH results for the benchmark show about 15% improvement for the cases that were optimized, namely the 3 to 10 fixed arg cases.

\# VM options: -verbose:gc -XX:+UseParallelGC -Xms4g -Xmx4g --enable-preview -verbose:gc -XX:+UsePara
llelGC -Xms4g -Xmx4g -Xint
\# Warmup: 5 iterations, 1 s each
\# Measurement: 5 iterations, 2 s each

WITHOUT varargs optimization:

Benchmark         Mode  Cnt     Score     Error   Units
ListArgs.list00  thrpt   15  6019.539 ± 144.040  ops/ms
ListArgs.list01  thrpt   15  1985.009 ±  40.606  ops/ms
ListArgs.list02  thrpt   15  1854.812 ±  17.488  ops/ms
ListArgs.list03  thrpt   15   963.866 ±  10.262  ops/ms
ListArgs.list04  thrpt   15   908.116 ±   6.278  ops/ms
ListArgs.list05  thrpt   15   848.607 ±  16.701  ops/ms
ListArgs.list06  thrpt   15   822.282 ±   8.905  ops/ms
ListArgs.list07  thrpt   15   780.057 ±  11.214  ops/ms
ListArgs.list08  thrpt   15   745.295 ±  19.204  ops/ms
ListArgs.list09  thrpt   15   704.596 ±  14.003  ops/ms
ListArgs.list10  thrpt   15   696.436 ±   4.914  ops/ms
ListArgs.list11  thrpt   15   661.908 ±  11.041  ops/ms

WITH varargs optimization:

Benchmark         Mode  Cnt     Score    Error   Units
ListArgs.list00  thrpt   15  6172.298 ± 62.736  ops/ms
ListArgs.list01  thrpt   15  1987.724 ± 45.468  ops/ms
ListArgs.list02  thrpt   15  1843.419 ± 10.693  ops/ms
ListArgs.list03  thrpt   15  1126.946 ± 30.952  ops/ms
ListArgs.list04  thrpt   15  1050.440 ± 17.859  ops/ms
ListArgs.list05  thrpt   15   999.275 ± 23.656  ops/ms
ListArgs.list06  thrpt   15   948.844 ± 19.615  ops/ms
ListArgs.list07  thrpt   15   897.541 ± 15.531  ops/ms
ListArgs.list08  thrpt   15   853.359 ± 18.755  ops/ms
ListArgs.list09  thrpt   15   826.394 ±  8.284  ops/ms
ListArgs.list10  thrpt   15   779.231 ±  4.104  ops/ms
ListArgs.list11  thrpt   15   650.888 ±  3.948  ops/ms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8156071](https://bugs.openjdk.java.net/browse/JDK-8156071): List.of: reduce array copying during creation


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * redestad - **Reviewer** ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/449/head:pull/449`
`$ git checkout pull/449`
