### PR TITLE
8253739: java/awt/image/MultiResolutionImage/MultiResolutionImageObserverTest.java fails

### DIFF
--- a/test/jdk/java/awt/image/MultiResolutionImage/MultiResolutionImageObserverTest.java
+++ b/test/jdk/java/awt/image/MultiResolutionImage/MultiResolutionImageObserverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import javax.imageio.ImageIO;
 
 public class MultiResolutionImageObserverTest {
 
-    private static final int TIMEOUT = 500;
+    private static final int TIMEOUT = 2000;
 
     public static void main(String[] args) throws Exception {
 
@@ -70,7 +70,7 @@ public class MultiResolutionImageObserverTest {
         long endTime = System.currentTimeMillis() + TIMEOUT;
 
         while (!observer.loaded && System.currentTimeMillis() < endTime) {
-            Thread.sleep(TIMEOUT / 10);
+            Thread.sleep(TIMEOUT / 100);
         }
 
         if (!observer.loaded) {

--- a/test/jdk/java/awt/image/MultiResolutionImage/MultiResolutionImageObserverTest.java
+++ b/test/jdk/java/awt/image/MultiResolutionImage/MultiResolutionImageObserverTest.java
@@ -101,7 +101,7 @@ public class MultiResolutionImageObserverTest {
     private static class LoadImageObserver implements ImageObserver {
 
         private final int infoflags;
-        private boolean loaded;
+        private volatile boolean loaded;
 
         public LoadImageObserver(int flags) {
             this.infoflags = flags;


### PR DESCRIPTION
Locally when i run this test i am seeing both the observers getting called and flags are updated.
I suspect this to be an issue with less timeout which we are using for verifying whether observer is getting called or not. Also i have increased sleep time.
I have increased timeout and verified in CI pipeline there is no issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253739](https://bugs.openjdk.java.net/browse/JDK-8253739): java/awt/image/MultiResolutionImage/MultiResolutionImageObserverTest.java fails


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/450/head:pull/450`
`$ git checkout pull/450`
