### PR TITLE
6690021: typos in TransferHandler Javadoc

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/TransferHandler.java
+++ b/src/java.desktop/share/classes/javax/swing/TransferHandler.java
@@ -379,7 +379,7 @@ public class TransferHandler implements Serializable {
          * for the transfer - which must represent a drop. This is applicable to
          * those components that automatically
          * show the drop location when appropriate during a drag and drop
-         * operation). By default, the drop location is shown only when the
+         * operation. By default, the drop location is shown only when the
          * {@code TransferHandler} has said it can accept the import represented
          * by this {@code TransferSupport}. With this method you can force the
          * drop location to always be shown, or always not be shown.


### PR DESCRIPTION
Fixed a typo removing superfluous ")"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6690021](https://bugs.openjdk.java.net/browse/JDK-6690021): typos in TransferHandler Javadoc


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/452/head:pull/452`
`$ git checkout pull/452`
