### PR TITLE
6646602: Spelling error in javadoc for javax.swing.tree.TreeModel

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/tree/TreeModel.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/TreeModel.java
@@ -33,7 +33,7 @@ import javax.swing.event.*;
  * <code>TreePath</code>s for identifying nodes in the <code>TreeModel</code>.
  * If a <code>TreeModel</code> returns the same object, as compared by
  * <code>equals</code>, at two different indices under the same parent
- * than the resulting <code>TreePath</code> objects will be considered equal
+ * then the resulting <code>TreePath</code> objects will be considered equal
  * as well. Some implementations may assume that if two
  * <code>TreePath</code>s are equal, they identify the same node. If this
  * condition is not met, painting problems and other oddities may result.


### PR DESCRIPTION
Fixed a typo in the documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6646602](https://bugs.openjdk.java.net/browse/JDK-6646602): Spelling error in javadoc for javax.swing.tree.TreeModel


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/453/head:pull/453`
`$ git checkout pull/453`
