### PR TITLE
8253891: Debug x86_32 builds fail after JDK-8239090

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -779,7 +779,7 @@ void VM_Version::get_processor_features() {
               cores_per_cpu(), threads_per_core(),
               cpu_family(), _model, _stepping, os::cpu_microcode_revision());
   assert(res > 0, "not enough temporary space allocated");
-  assert(exact_log2(CPU_MAX_FEATURE) + 1 == sizeof(_features_names) / sizeof(char*), "wrong size features_names");
+  assert(exact_log2_long(CPU_MAX_FEATURE) + 1 == sizeof(_features_names) / sizeof(char*), "wrong size features_names");
   insert_features_names(buf + res, sizeof(buf) - res, _features_names);
 
   _features_string = os::strdup(buf);


### PR DESCRIPTION
`CPU_MAX_FEATURE` is actually a `uint64_t`, with at least 46 bits set. `exact_log2` expects `intptr_t`. The implicit conversion works on 64-bit, but fails on 32-bit. Calling to `exact_log2_long` seems to cater for both bitnesses.

Testing:
  - [x] tier1 on Linux x86_64
  - [x] tier1 on Linux x86_32 (some unrelated failures)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253891](https://bugs.openjdk.java.net/browse/JDK-8253891): Debug x86_32 builds fail after JDK-8239090


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/455/head:pull/455`
`$ git checkout pull/455`
