### PR TITLE
8249095: tools/javac/launcher/SourceLauncherTest.java fails on Windows

### DIFF
--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -423,9 +423,9 @@ public class SourceLauncherTest extends TestRunner {
 
     @Test
     public void testNoSourceOnClassPath(Path base) throws IOException {
-        Path auxSrc = base.resolve("auxSrc");
-        tb.writeJavaFiles(auxSrc,
-            "public class Aux {\n" +
+        Path extraSrc = base.resolve("extraSrc");
+        tb.writeJavaFiles(extraSrc,
+            "public class Extra {\n" +
             "    static final String MESSAGE = \"Hello World\";\n" +
             "}\n");
 
@@ -434,18 +434,18 @@ public class SourceLauncherTest extends TestRunner {
             "import java.util.Arrays;\n" +
             "class HelloWorld {\n" +
             "    public static void main(String... args) {\n" +
-            "        System.out.println(Aux.MESSAGE + Arrays.toString(args));\n" +
+            "        System.out.println(Extra.MESSAGE + Arrays.toString(args));\n" +
             "    }\n" +
             "}");
 
-        List<String> javacArgs = List.of("-classpath", auxSrc.toString());
+        List<String> javacArgs = List.of("-classpath", extraSrc.toString());
         List<String> classArgs = List.of("1", "2", "3");
         String FS = File.separator;
         String expectStdErr =
             "testNoSourceOnClassPath" + FS + "mainSrc" + FS + "HelloWorld.java:4: error: cannot find symbol\n" +
-            "        System.out.println(Aux.MESSAGE + Arrays.toString(args));\n" +
+            "        System.out.println(Extra.MESSAGE + Arrays.toString(args));\n" +
             "                           ^\n" +
-            "  symbol:   variable Aux\n" +
+            "  symbol:   variable Extra\n" +
             "  location: class HelloWorld\n" +
             "1 error\n";
         Result r = run(mainSrc.resolve("HelloWorld.java"), javacArgs, classArgs);

--- a/test/langtools/tools/lib/toolbox/ToolBox.java
+++ b/test/langtools/tools/lib/toolbox/ToolBox.java
@@ -676,12 +676,15 @@ public class ToolBox {
                 return "module-info.java";
 
             matcher = packagePattern.matcher(source);
-            if (matcher.find())
+            if (matcher.find()) {
                 packageName = matcher.group(1).replace(".", "/");
+                validateName(packageName);
+            }
 
             matcher = classPattern.matcher(source);
             if (matcher.find()) {
                 String className = matcher.group(1) + ".java";
+                validateName(className);
                 return (packageName == null) ? className : packageName + "/" + className;
             } else if (packageName != null) {
                 return packageName + "/package-info.java";
@@ -706,6 +709,24 @@ public class ToolBox {
         return JavaSource.getJavaFileNameFromSource(source);
     }
 
+    private static final Set<String> RESERVED_NAMES = Set.of(
+        "con", "prn", "aux", "nul",
+        "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",  "com9",
+        "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8",  "lpt9"
+    );
+
+    /**Validate if a given name is a valid file name
+     * or path name on known platforms.
+     */
+    public static void validateName(String name) {
+        for (String part : name.split("\\.|/|\\\\")) {
+            if (RESERVED_NAMES.contains(part.toLowerCase(Locale.US))) {
+                throw new IllegalArgumentException("Name: " + name + " is" +
+                                                   "a reserved name on Windows, " +
+                                                   "and will not work!");
+            }
+        }
+    }
     /**
      * A memory file manager, for saving generated files in memory.
      * The file manager delegates to a separate file manager for listing and


### PR DESCRIPTION
@rwestberg  prepared a script that runs various tests in GitHub Actions. But, sadly, with a recently proposed fix for Windows handling (see https://github.com/openjdk/jdk/pull/437), the SourceLauncherTest is failing (the testNoSourceOnClassPath sub-test):
https://github.com/rwestberg/jdk/runs/1188397548

I don't think this has much to do with javac (or source launcher) itself - the test fails while it tries to write the test source file, before the source launcher is invoked. So this patch tries to: a) avoid doing that; b)  improve ToolBox to check and reject file names that are reserved.

Note that testHelloWorldWithAux uses the name "Aux" intentionally, and it passes because it never actually writes file with name "Aux" - the source file will be (I believe) named "HelloWorld", and while it will contain also a class named "Aux", the classfile will only ever exist in memory, and won't be written as a file, so will not cause the issue.

The use of name "Aux" in the testNoSourceOnClassPath test does not seem to be necessary, and the issue happens in the test set-up, not while doing the actual test, so it seems fine to change the name.

@jonathan-gibbons, could you please take a look? Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249095](https://bugs.openjdk.java.net/browse/JDK-8249095): tools/javac/launcher/SourceLauncherTest.java fails on Windows


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/456/head:pull/456`
`$ git checkout pull/456`
