### PR TITLE
8253899: Make IsClassUnloadingEnabled signature match specification

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -9949,9 +9949,11 @@ myInit() {
           there is a <code>jint</code> parameter, the event handler should be
           declared:
 <example>
-    void JNICALL myHandler(jvmtiEnv* jvmti_env, jint myInt, ...)
+    void JNICALL myHandler(jvmtiEnv* jvmti_env, ...)
 </example>
           Note the terminal "<code>...</code>" which indicates varargs.
+          The <code>jint</code> argument inside <code>myHandler</code> needs to be extracted using
+          the <code>va_*</code> syntax of the C programming language.
         </description>
         <parameters>
           <param id="jvmti_env">

--- a/src/hotspot/share/prims/jvmtiExtensions.cpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.cpp
@@ -34,7 +34,14 @@ GrowableArray<jvmtiExtensionEventInfo*>* JvmtiExtensions::_ext_events;
 
 
 // extension function
-static jvmtiError JNICALL IsClassUnloadingEnabled(const jvmtiEnv* env, jboolean* enabled, ...) {
+static jvmtiError JNICALL IsClassUnloadingEnabled(const jvmtiEnv* env, ...) {
+  jboolean* enabled = NULL;
+  va_list ap;
+
+  va_start(ap, env);
+  enabled = va_arg(ap, jboolean *);
+  va_end(ap);
+
   if (enabled == NULL) {
     return JVMTI_ERROR_NULL_POINTER;
   }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/extension/EX03/ex03t001/ex03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/extension/EX03/ex03t001/ex03t001.cpp
@@ -41,7 +41,15 @@ static jrawMonitorID eventMon;
 /* ============================================================================= */
 
 static void JNICALL
-ClassUnload(jvmtiEnv* jvmti_env, JNIEnv* jni_env, const char* name, ...) {
+ClassUnload(jvmtiEnv* jvmti_env, ...) {
+    JNIEnv *jni_env = NULL;
+    va_list ap;
+
+    va_start(ap, jvmti_env);
+    jni_env = va_arg(ap, JNIEnv *);
+    const char * name = va_arg(ap, const char *);
+    va_end(ap);
+    
     // The name argument should never be null
     if (name == NULL) {
         nsk_jvmti_setFailStatus();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/extension/EX03/ex03t001/ex03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/extension/EX03/ex03t001/ex03t001.cpp
@@ -49,7 +49,7 @@ ClassUnload(jvmtiEnv* jvmti_env, ...) {
     jni_env = va_arg(ap, JNIEnv *);
     const char * name = va_arg(ap, const char *);
     va_end(ap);
-    
+
     // The name argument should never be null
     if (name == NULL) {
         nsk_jvmti_setFailStatus();


### PR DESCRIPTION
Please review this change for hotspot and one test.
There is few JVMTI callback/event functions in jdk which signature doesn't match specification.
for example:
static jvmtiError JNICALL IsClassUnloadingEnabled(const jvmtiEnv* env, jboolean* enabled, ...)
but according to jvmti specs it should be:
static jvmtiError JNICALL IsClassUnloadingEnabled(const jvmtiEnv* env, ...)
same with ClassUnload(jvmtiEnv* jvmti_env, JNIEnv* jni_env, const char* name, ...)  in tests
for many years that didn't matter but with coming JEP-391 it becomes important to make it match the spec
https://developer.apple.com/documentation/apple_silicon/addressing_architectural_differences_in_your_macos_code
This commit makes the above mentioned functions to have signature matching jvmti specification

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (2/9 running) | ⏳ (7/9 running) | ⏳ (1/9 running) |

### Issue
 * [JDK-8253899](https://bugs.openjdk.java.net/browse/JDK-8253899): Make IsClassUnloadingEnabled signature match specification


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to 1ef832d21f65f9f91b2f387068def7cab02b69ce
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/466/head:pull/466`
`$ git checkout pull/466`
