### PR TITLE
8253842: [JVMCI] Allow implicit exception to dispatch to other address in jvmci compilers.

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -897,8 +897,14 @@ JVMCI::CodeInstallResult CodeInstaller::initialize_buffer(CodeBuffer& buffer, bo
           JVMCI_ERROR_OK("method contains safepoint, but has no deopt rescue slot");
         }
         if (JVMCIENV->equals(reason, jvmci_env()->get_site_InfopointReason_IMPLICIT_EXCEPTION())) {
-          JVMCI_event_4("implicit exception at %i", pc_offset);
-          _implicit_exception_table.add_deoptimize(pc_offset);
+          if (jvmci_env()->isa_site_ImplicitExceptionDispatch(site)) {
+            jint dispatch_offset = jvmci_env()->get_site_ImplicitExceptionDispatch_dispatchOffset(site);
+            JVMCI_event_4("implicit exception at %i, dispatch to %i", pc_offset, dispatch_offset);
+            _implicit_exception_table.append(pc_offset, dispatch_offset);
+          } else {
+            JVMCI_event_4("implicit exception at %i", pc_offset);
+            _implicit_exception_table.add_deoptimize(pc_offset);
+          }
         }
       } else {
         JVMCI_event_4("infopoint at %i", pc_offset);

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
@@ -177,6 +177,9 @@
     object_field(site_Call, target, "Ljdk/vm/ci/meta/InvokeTarget;")                                          \
     boolean_field(site_Call, direct)                                                                          \
   end_class                                                                                                   \
+  start_class(site_ImplicitExceptionDispatch, jdk_vm_ci_code_site_ImplicitExceptionDispatch)                  \
+    int_field(site_ImplicitExceptionDispatch, dispatchOffset)                                                 \
+  end_class                                                                                                   \
   start_class(site_DataPatch, jdk_vm_ci_code_site_DataPatch)                                                  \
     object_field(site_DataPatch, reference, "Ljdk/vm/ci/code/site/Reference;")                                \
   end_class                                                                                                   \

--- a/src/hotspot/share/jvmci/vmSymbols_jvmci.hpp
+++ b/src/hotspot/share/jvmci/vmSymbols_jvmci.hpp
@@ -92,6 +92,7 @@
   template(jdk_vm_ci_code_site_DataSectionReference,              "jdk/vm/ci/code/site/DataSectionReference")                             \
   template(jdk_vm_ci_code_site_ExceptionHandler,                  "jdk/vm/ci/code/site/ExceptionHandler")                                 \
   template(jdk_vm_ci_code_site_Mark,                              "jdk/vm/ci/code/site/Mark")                                             \
+  template(jdk_vm_ci_code_site_ImplicitExceptionDispatch,         "jdk/vm/ci/code/site/ImplicitExceptionDispatch")                        \
   template(jdk_vm_ci_code_site_Infopoint,                         "jdk/vm/ci/code/site/Infopoint")                                        \
   template(jdk_vm_ci_code_stack_InspectedFrameVisitor,            "jdk/vm/ci/code/stack/InspectedFrameVisitor")                           \
   template(jdk_vm_ci_code_site_Site,                              "jdk/vm/ci/code/site/Site")                                             \

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/site/ImplicitExceptionDispatch.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/site/ImplicitExceptionDispatch.java
@@ -27,11 +27,11 @@ package jdk.vm.ci.code.site;
 import jdk.vm.ci.code.DebugInfo;
 
 /**
- * Represents an implicit exception dispatch in the code. Implicit exception is a platform-specific
- * optimization that makes use of operating system's trap mechanism, to turn specific branches into
- * sequential code with implicit traps. Information contained in this class will be used by the
- * runtime to register implicit exception dispatch, i.e., a mapping from an exceptional PC offset to
- * a continuation PC offset.
+ * Represents an implicit exception dispatch in the code. Implicit exception dispatch is a
+ * platform-specific optimization that makes use of an operating system's trap mechanism, to turn
+ * specific branches into sequential code with implicit traps. Information contained in this class
+ * will be used by the runtime to register implicit exception dispatch, i.e., a mapping from an
+ * exceptional PC offset to a continuation PC offset.
  */
 public final class ImplicitExceptionDispatch extends Infopoint {
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/site/ImplicitExceptionDispatch.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/site/ImplicitExceptionDispatch.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.vm.ci.code.site;
+
+import jdk.vm.ci.code.DebugInfo;
+
+/**
+ * Represents an implicit exception dispatch in the code. Implicit exception is a platform-specific
+ * optimization that makes use of operating system's trap mechanism, to turn specific branches into
+ * sequential code with implicit traps. Information contained in this class will be used by the
+ * runtime to register implicit exception dispatch, i.e., a mapping from an exceptional PC offset to
+ * a continuation PC offset.
+ */
+public final class ImplicitExceptionDispatch extends Infopoint {
+
+    public final int dispatchOffset;
+
+    /**
+     * Construct an implicit exception dispatch.
+     *
+     * @param pcOffset the exceptional PC offset
+     * @param dispatchOffset the continuation PC offset
+     * @param debugInfo debugging information at the exceptional PC
+     */
+    public ImplicitExceptionDispatch(int pcOffset, int dispatchOffset, DebugInfo debugInfo) {
+        super(pcOffset, debugInfo, InfopointReason.IMPLICIT_EXCEPTION);
+        this.dispatchOffset = dispatchOffset;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof ImplicitExceptionDispatch && super.equals(obj)) {
+            ImplicitExceptionDispatch that = (ImplicitExceptionDispatch) obj;
+            if (this.dispatchOffset == that.dispatchOffset) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(pcOffset);
+        sb.append("->");
+        sb.append(dispatchOffset);
+
+        if (debugInfo != null) {
+            appendDebugInfo(sb, debugInfo);
+        }
+
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
This change allows JVMCI compilers to append an entry with flexible dispatch offset to the implicit exception table.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253842](https://bugs.openjdk.java.net/browse/JDK-8253842): [JVMCI] Allow implicit exception to dispatch to other address in jvmci compilers.


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/472/head:pull/472`
`$ git checkout pull/472`
