### PR TITLE
8253913: unify gtest test names

### DIFF
--- a/src/hotspot/share/logging/logStream.hpp
+++ b/src/hotspot/share/logging/logStream.hpp
@@ -32,8 +32,9 @@
 
 
 class LogStream : public outputStream {
-  friend class LogStreamTest_TestLineBufferAllocation_test_vm_Test; // see test/native/logging/test_logStream.cpp
-  friend class LogStreamTest_TestLineBufferAllocationCap_test_vm_Test; // see test/native/logging/test_logStream.cpp
+  // see test/hotspot/gtest/logging/test_logStream.cpp
+  friend class LogStreamTest_TestLineBufferAllocation_vm_Test;
+  friend class LogStreamTest_TestLineBufferAllocationCap_vm_Test;
 
   // Helper class, maintains the line buffer. For small line lengths,
   // we avoid malloc and use a fixed sized member char array. If LogStream

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -94,6 +94,10 @@ static int init_jvm(int argc, char **argv, bool disable_error_handling) {
   return JNI_CreateJavaVM(&jvm, (void**)&env, &args);
 }
 
+static bool is_same_vm_test(const char* name) {
+  return is_suffix("_vm", name) && !is_suffix("_other_vm", name);
+}
+
 class JVMInitializerListener : public ::testing::EmptyTestEventListener {
  private:
   int _argc;
@@ -110,7 +114,7 @@ class JVMInitializerListener : public ::testing::EmptyTestEventListener {
 
   virtual void OnTestStart(const ::testing::TestInfo& test_info) {
     const char* name = test_info.name();
-    if (!_is_initialized && is_suffix("_test_vm", name)) {
+    if (!_is_initialized && is_same_vm_test(name)) {
       // we want to have hs_err and core files when we execute regular tests
       int ret_val = init_jvm(_argc, _argv, false);
       if (ret_val != 0) {
@@ -205,8 +209,8 @@ static void runUnitTestsInner(int argc, char** argv) {
   if (::testing::internal::GTEST_FLAG(internal_run_death_test).length() > 0) {
     // when we execute death test, filter value equals to test name
     const char* test_name = ::testing::GTEST_FLAG(filter).c_str();
-    const char* const othervm_suffix = "_other_vm_test"; // TEST_OTHER_VM
-    const char* const vmassert_suffix = "_vm_assert_test"; // TEST_VM_ASSERT(_MSG)
+    const char* const othervm_suffix = "_other_vm"; // TEST_OTHER_VM
+    const char* const vmassert_suffix = "_vm_assert"; // TEST_VM_ASSERT(_MSG)
     if (is_suffix(othervm_suffix, test_name)) {
       is_othervm_test = true;
     } else if (is_suffix(vmassert_suffix, test_name)) {

--- a/test/hotspot/gtest/unittest.hpp
+++ b/test/hotspot/gtest/unittest.hpp
@@ -70,12 +70,12 @@
 
 #define CONCAT(a, b) a ## b
 
-#define TEST(category, name) GTEST_TEST(category, CONCAT(name, _test))
+#define TEST(category, name) GTEST_TEST(category, name)
 
-#define TEST_VM(category, name) GTEST_TEST(category, CONCAT(name, _test_vm))
+#define TEST_VM(category, name) GTEST_TEST(category, CONCAT(name, _vm))
 
 #define TEST_VM_F(test_fixture, name)                               \
-  GTEST_TEST_(test_fixture, name ## _test_vm, test_fixture,         \
+  GTEST_TEST_(test_fixture, name ## _vm, test_fixture,              \
               ::testing::internal::GetTypeId<test_fixture>())
 
 #define TEST_OTHER_VM(category, name)                               \
@@ -131,7 +131,7 @@
   TEST(category, CONCAT(name, _vm_assert)) {                        \
     ASSERT_EXIT(child_ ## category ## _ ## name ## _(),             \
                 ::testing::ExitedWithCode(1),                       \
-                "^assert failed: " msg);                             \
+                "^assert failed: " msg);                            \
   }                                                                 \
                                                                     \
   void test_ ## category ## _ ## name ## _()


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that unifies the names of hotspot gtests? in some cases, "_test" is added to gtest names, in others it isn't. given some tests specify "test" in their names, so we get "test_test" like in `UninitializedDoubleElementWorkerDataArrayTest.sum_test_test_vm`. the patch removes `_test` from the suffixes added by `TEST*` macros.

testing:
✅ `make test TEST=gtest` on macosx-x64
✅ `test/hotspot/jtreg/gtest/` on {linux,windows,macosx}-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253913](https://bugs.openjdk.java.net/browse/JDK-8253913): unify gtest test names


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/475/head:pull/475`
`$ git checkout pull/475`
