### PR TITLE
8253923: C2 doesn't always run loop opts for compilations that include loops

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -456,7 +456,6 @@ void LateInlineCallGenerator::do_late_inline() {
       result = (result_size == 1) ? kit.pop() : kit.pop_pair();
     }
 
-    C->set_has_loops(C->has_loops() || _inline_cg->method()->has_loops());
     C->env()->notice_inlined_method(_inline_cg->method());
     C->set_inlining_progress(true);
     C->set_do_cleanup(kit.stopped()); // path is dead; needs cleanup

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -922,7 +922,7 @@ void Compile::Init(int aliaslevel) {
 
   _fixed_slots = 0;
   set_has_split_ifs(false);
-  set_has_loops(has_method() && method()->has_loops()); // first approximation
+  set_has_loops(false); // first approximation
   set_has_stringbuilder(false);
   set_has_boxed_value(false);
   _trap_can_recompile = false;  // no traps emitted yet
@@ -1022,6 +1022,7 @@ void Compile::Init(int aliaslevel) {
 #ifdef ASSERT
   _type_verify_symmetry = true;
   _phase_optimize_finished = false;
+  _exception_backedge = false;
 #endif
 }
 

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -429,6 +429,7 @@ class Compile : public Phase {
   PrintInliningBuffer& print_inlining_current();
 
   void log_late_inline_failure(CallGenerator* cg, const char* msg);
+  DEBUG_ONLY(bool _exception_backedge;)
 
  public:
 
@@ -1166,6 +1167,8 @@ class Compile : public Phase {
 #endif // IA32
 #ifdef ASSERT
   bool _type_verify_symmetry;
+  void set_exception_backedge() { _exception_backedge = true; }
+  bool has_exception_backedge() const { return _exception_backedge; }
 #endif
 };
 

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -657,7 +657,6 @@ void Parse::do_call() {
 
   if (cg->is_inline()) {
     // Accumulate has_loops estimate
-    C->set_has_loops(C->has_loops() || cg->method()->has_loops());
     C->env()->notice_inlined_method(cg->method());
   }
 

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2915,6 +2915,31 @@ bool PhaseIdealLoop::process_expensive_nodes() {
   return progress;
 }
 
+#ifdef ASSERT
+bool PhaseIdealLoop::only_has_infinite_loops() {
+  for (LoopTreeIterator iter(_ltree_root); !iter.done(); iter.next()) {
+    IdealLoopTree* lpt = iter.current();
+    if (lpt->is_innermost()) {
+      uint i = 1;
+      for (; i < C->root()->req(); i++) {
+        Node* in = C->root()->in(i);
+        if (in != NULL &&
+            in->Opcode() == Op_Halt &&
+            in->in(0)->is_Proj() &&
+            in->in(0)->in(0)->Opcode() == Op_NeverBranch &&
+            in->in(0)->in(0)->in(0) == lpt->_head) {
+          break;
+        }
+      }
+      if (i == C->root()->req()) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+#endif
+
 
 //=============================================================================
 //----------------------------build_and_optimize-------------------------------
@@ -2970,6 +2995,13 @@ void PhaseIdealLoop::build_and_optimize(LoopOptsMode mode) {
     return;
   }
 
+  // Verify that the has_loops() flag set at parse time is consistent
+  // with the just built loop tree. With infinite loops, it could be
+  // that one pass of loop opts only finds infinite loops, clears the
+  // has_loops() flag but adds NeverBranch nodes so the next loop opts
+  // verification pass finds a non empty loop tree. When the back edge
+  // is an exception edge, parsing doesn't set has_loops().
+  assert(_ltree_root->_child == NULL || C->has_loops() || only_has_infinite_loops() || C->has_exception_backedge(), "parsing found no loops but there are some");
   // No loops after all
   if( !_ltree_root->_child && !_verify_only ) C->set_has_loops(false);
 

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -803,6 +803,9 @@ private:
   bool skeleton_predicate_has_opaque(IfNode* iff);
   void update_main_loop_skeleton_predicates(Node* ctrl, CountedLoopNode* loop_head, Node* init, int stride_con);
   void insert_loop_limit_check(ProjNode* limit_check_proj, Node* cmp_limit, Node* bol);
+#ifdef ASSERT
+  bool only_has_infinite_loops();
+#endif
 
 public:
 

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -435,6 +435,7 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
     C->set_parsed_irreducible_loop(true);
   }
 #endif
+  C->set_has_loops(C->has_loops() || method()->has_loops());
 
   if (_expected_uses <= 0) {
     _prof_factor = 1;
@@ -1599,6 +1600,11 @@ void Parse::merge_new_path(int target_bci) {
 // Merge the current mapping into the basic block starting at bci
 // The ex_oop must be pushed on the stack, unlike throw_to_exit.
 void Parse::merge_exception(int target_bci) {
+#ifdef ASSERT
+  if (target_bci < bci()) {
+    C->set_exception_backedge();
+  }
+#endif
   assert(sp() == 1, "must have only the throw exception on the stack");
   Block* target = successor_for_bci(target_bci);
   if (target == NULL) { handle_missing_successor(target_bci); return; }

--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -1210,6 +1210,7 @@ Node* PhaseStringOpts::int_stringSize(GraphKit& kit, Node* arg) {
 
     // Add loop predicate first.
     kit.add_empty_predicates();
+    C->set_has_loops(true);
 
     RegionNode *loop = new RegionNode(3);
     loop->init_req(1, kit.control());
@@ -1287,6 +1288,7 @@ void PhaseStringOpts::getChars(GraphKit& kit, Node* arg, Node* dst_array, BasicT
   // Add loop predicate first.
   kit.add_empty_predicates();
 
+  C->set_has_loops(true);
   RegionNode* head = new RegionNode(3);
   head->init_req(1, kit.control());
 


### PR DESCRIPTION
/cc hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 serviceability)](https://github.com/rwestrel/jdk/runs/1207921102)

### Issue
 * [JDK-8253923](https://bugs.openjdk.java.net/browse/JDK-8253923): C2 doesn't always run loop opts for compilations that include loops


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**) ⚠️ Review applies to 6ca8b0b43039ff60dee718a5d5ccb5ef374484f3
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/478/head:pull/478`
`$ git checkout pull/478`
