### PR TITLE
8253926: Use extra_size correctly in anon_mmap_aligned 

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3667,7 +3667,7 @@ static char* anon_mmap_aligned(char* req_addr, size_t bytes, size_t alignment) {
     extra_size += alignment;
   }
 
-  char* start = anon_mmap(req_addr, bytes);
+  char* start = anon_mmap(req_addr, extra_size);
   if (start != NULL) {
     if (req_addr != NULL) {
       if (start != req_addr) {


### PR DESCRIPTION
A recent cleanup ([8253638: Cleanup os::reserve_memory and remove MAP_FIXED](https://github.com/openjdk/jdk/pull/357/)) got a size mixed up in `anon_mmap_aligned()`. Instead of passing down the calculated `extra_size` to `anon_mmap()` it uses the original size `bytes`.

This resulted in an early crash when using large pages and with this fix the crash goes away.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253926](https://bugs.openjdk.java.net/browse/JDK-8253926): Use extra_size correctly in anon_mmap_aligned


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/479/head:pull/479`
`$ git checkout pull/479`
