### PR TITLE
8253928: G1: Remove G1ConcurrentMarkThread::set_in_progress declaration

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.hpp
@@ -100,7 +100,6 @@ class G1ConcurrentMarkThread: public ConcurrentGCThread {
   void set_idle();
   void start_full_mark();
   void start_undo_mark();
-  void set_in_progress();
 
   bool idle() const;
   // Returns true from the moment a concurrent cycle is


### PR DESCRIPTION
There is no definition of G1ConcurrentMarkThread::set_in_progress since JDK-8240556 any more, so also remove the declaration in this trivial change.

Testing: local compilation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253928](https://bugs.openjdk.java.net/browse/JDK-8253928): G1: Remove G1ConcurrentMarkThread::set_in_progress declaration


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/480/head:pull/480`
`$ git checkout pull/480`
