### PR TITLE
8252015: [macos11] java.awt.TrayIcon requires updates for template images

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CTrayIcon.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CTrayIcon.java
@@ -194,6 +194,8 @@ public class CTrayIcon extends CFRetainedResource implements TrayIconPeer {
     }
 
     void updateNativeImage(Image image) {
+        boolean imageTemplate = Boolean.parseBoolean(System.getProperty("sun.awt.enableTemplateImages", "false"));
+
         MediaTracker tracker = new MediaTracker(new Button(""));
         tracker.addImage(image, 0);
         try {
@@ -211,13 +213,13 @@ public class CTrayIcon extends CFRetainedResource implements TrayIconPeer {
         if (cimage != null) {
             cimage.execute(imagePtr -> {
                 execute(ptr -> {
-                    setNativeImage(ptr, imagePtr, imageAutoSize);
+                    setNativeImage(ptr, imagePtr, imageAutoSize, imageTemplate);
                 });
             });
         }
     }
 
-    private native void setNativeImage(final long model, final long nsimage, final boolean autosize);
+    private native void setNativeImage(final long model, final long nsimage, final boolean autosize, final boolean template);
 
     private void postEvent(final AWTEvent event) {
         SunToolkit.executeOnEventHandlerThread(target, new Runnable() {

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CTrayIcon.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CTrayIcon.java
@@ -45,6 +45,8 @@ import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
 import java.awt.peer.TrayIconPeer;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 
 import javax.swing.Icon;
 import javax.swing.UIManager;
@@ -68,6 +70,10 @@ public class CTrayIcon extends CFRetainedResource implements TrayIconPeer {
     // on MOUSE_RELEASE. Click events are only generated if there were no drag
     // events between MOUSE_PRESSED and MOUSE_RELEASED for particular button
     private static int mouseClickButtons = 0;
+
+    private final static boolean useTemplateImages = AccessController.doPrivileged((PrivilegedAction<Boolean>)
+        () -> Boolean.getBoolean("apple.awt.enableTemplateImages")
+    );
 
     CTrayIcon(TrayIcon target) {
         super(0, true);
@@ -194,8 +200,6 @@ public class CTrayIcon extends CFRetainedResource implements TrayIconPeer {
     }
 
     void updateNativeImage(Image image) {
-        boolean imageTemplate = Boolean.parseBoolean(System.getProperty("sun.awt.enableTemplateImages", "false"));
-
         MediaTracker tracker = new MediaTracker(new Button(""));
         tracker.addImage(image, 0);
         try {
@@ -213,7 +217,7 @@ public class CTrayIcon extends CFRetainedResource implements TrayIconPeer {
         if (cimage != null) {
             cimage.execute(imagePtr -> {
                 execute(ptr -> {
-                    setNativeImage(ptr, imagePtr, imageAutoSize, imageTemplate);
+                    setNativeImage(ptr, imagePtr, imageAutoSize, useTemplateImages);
                 });
             });
         }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.h
@@ -37,35 +37,45 @@
 extern "C" {
 #endif
 
-@class AWTTrayIconView;
+@class AWTTrayIconDelegate;
 
 /*
  * AWTTrayIcon
  */
-@interface AWTTrayIcon : NSObject {
+@interface AWTTrayIcon : NSResponder {
     jobject peer;
-    AWTTrayIconView *view;
+    AWTTrayIconDelegate *menuDelegate;
     NSStatusItem *theItem;
+    NSTrackingArea *trackingArea;
 }
 
 - (id) initWithPeer:(jobject)thePeer;
 - (void) setTooltip:(NSString *)tooltip;
 - (NSStatusItem *)theItem;
 - (jobject) peer;
-- (void) setImage:(NSImage *) imagePtr sizing:(BOOL)autosize;
+- (void) setImage:(NSImage *) imagePtr sizing:(BOOL)autosize template:(BOOL)isTemplate;
 - (NSPoint) getLocationOnScreen;
 - (void) deliverJavaMouseEvent:(NSEvent*) event;
-
+- (void) setMenu:(NSMenu *)menu;
+- (void) mouseDown:(id)sender;
+- (void) mouseUp:(NSEvent *)event;
+- (void) mouseDragged:(NSEvent *)event;
+- (void) mouseMoved: (NSEvent *)event;
+- (void) rightMouseDown:(NSEvent *)event;
+- (void) rightMouseUp:(NSEvent *)event;
+- (void) rightMouseDragged:(NSEvent *)event;
+- (void) otherMouseDown:(NSEvent *)event;
+- (void) otherMouseUp:(NSEvent *)event;
+- (void) otherMouseDragged:(NSEvent *)event;
 @end //AWTTrayIcon
 
 //==================================================================================
 /*
- * AWTTrayIconView */
-@interface AWTTrayIconView : NSView <NSMenuDelegate> {
+ * AWTTrayIconDelegate */
+@interface AWTTrayIconDelegate : NSObject<NSMenuDelegate> {
 @public
     AWTTrayIcon *trayIcon;
     NSImage* image;
-    NSTrackingArea *trackingArea;
     BOOL isHighlighted;
 }
 -(id)initWithTrayIcon:(AWTTrayIcon *)theTrayIcon;
@@ -73,8 +83,10 @@ extern "C" {
 -(void)setImage:(NSImage*)anImage;
 -(void)setTrayIcon:(AWTTrayIcon*)theTrayIcon;
 -(void)addTrackingArea;
+-(void)updateMenuRes;
+-(NSMenu *)getMenu;
 
-@end //AWTTrayIconView
+@end //AWTTrayIconDelegate
 
 #ifdef __cplusplus
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.h
@@ -37,16 +37,15 @@
 extern "C" {
 #endif
 
-@class AWTTrayIconDelegate;
+@class AWTTrayIconView;
 
 /*
  * AWTTrayIcon
  */
-@interface AWTTrayIcon : NSResponder {
+@interface AWTTrayIcon : NSObject {
     jobject peer;
-    AWTTrayIconDelegate *menuDelegate;
+    AWTTrayIconView *view;
     NSStatusItem *theItem;
-    NSTrackingArea *trackingArea;
 }
 
 - (id) initWithPeer:(jobject)thePeer;
@@ -56,37 +55,24 @@ extern "C" {
 - (void) setImage:(NSImage *) imagePtr sizing:(BOOL)autosize template:(BOOL)isTemplate;
 - (NSPoint) getLocationOnScreen;
 - (void) deliverJavaMouseEvent:(NSEvent*) event;
-- (void) setMenu:(NSMenu *)menu;
-- (void) mouseDown:(id)sender;
-- (void) mouseUp:(NSEvent *)event;
-- (void) mouseDragged:(NSEvent *)event;
-- (void) mouseMoved: (NSEvent *)event;
-- (void) rightMouseDown:(NSEvent *)event;
-- (void) rightMouseUp:(NSEvent *)event;
-- (void) rightMouseDragged:(NSEvent *)event;
-- (void) otherMouseDown:(NSEvent *)event;
-- (void) otherMouseUp:(NSEvent *)event;
-- (void) otherMouseDragged:(NSEvent *)event;
+
 @end //AWTTrayIcon
 
 //==================================================================================
 /*
- * AWTTrayIconDelegate */
-@interface AWTTrayIconDelegate : NSObject<NSMenuDelegate> {
+ * AWTTrayIconView */
+@interface AWTTrayIconView : NSStatusBarButton <NSMenuDelegate> {
 @public
     AWTTrayIcon *trayIcon;
-    NSImage* image;
+    NSTrackingArea *trackingArea;
     BOOL isHighlighted;
 }
 -(id)initWithTrayIcon:(AWTTrayIcon *)theTrayIcon;
 -(void)setHighlighted:(BOOL)aFlag;
--(void)setImage:(NSImage*)anImage;
 -(void)setTrayIcon:(AWTTrayIcon*)theTrayIcon;
 -(void)addTrackingArea;
--(void)updateMenuRes;
--(NSMenu *)getMenu;
 
-@end //AWTTrayIconDelegate
+@end //AWTTrayIconView
 
 #ifdef __cplusplus
 }

--- a/src/java.desktop/share/classes/java/awt/TrayIcon.java
+++ b/src/java.desktop/share/classes/java/awt/TrayIcon.java
@@ -71,6 +71,15 @@ import java.security.AccessController;
  * a {@code TrayIcon}. Otherwise the constructor will throw a
  * SecurityException.
  *
+ * <p>
+ * @implnote
+ * When the {@systemProperty apple.awt.enableTemplateImages} property is
+ * set, all images associated with instances of this class are treated
+ * as template images by the native desktop system. This means all color
+ * information is discarded, and the image is adapted automatically to
+ * be visible when desktop theme and/or colors change. This property
+ * only affects MacOSX.
+ *
  * <p> See the {@link SystemTray} class overview for an example on how
  * to use the {@code TrayIcon} API.
  *


### PR DESCRIPTION
### Issue
[JDK-8252015: [macos11] java.awt.TrayIcon requires updates for template images](https://bugs.openjdk.java.net/browse/JDK-8252015)

### Problem
According to Apple's human interface guidelines, developers should use template images for tray icons. This way icons look good when desktop theme or wallpaper change. On the API level, this means setting the `NSImage::isTemplate` flag. Currently there's no way in Java to set this flag. Even if one uses a template (black and transparent pixels only) image, MacOS will treat it as regular image. As a result, the image will not be visible when using dark theme.

### Solution:
* Add a new system property, `java.awt.enableTemplateImages`, to indicate that template images are being used by tray icons.When this property is set, all tray icon images are treated as templates. It's the developers' responsibility to ensure their images are indeed templates. This property allows us to avoid new API and accidental behavior changes
* Value of this property is passed from Java into `NSImage::setTemplate`
* We need the tray icon image rendered by MacOS, so we use a button (rather than a view) to host the image

To do after CSR approval:
- [ ] Rename property `java.awt.`
- [ ] Add `TrayIcon` javadoc, use `@systemProperty` tag there

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252015](https://bugs.openjdk.java.net/browse/JDK-8252015): [macos11] java.awt.TrayIcon requires updates for template images


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Contributors
 * Tres Finocchiaro `<tres.finocchiaro@gmail.com>`
 * Peter Zhelezniakov `<peterz@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/481/head:pull/481`
`$ git checkout pull/481`
