### PR TITLE
8253938: ZGC: Clean up argument names after JDK-8253030

### DIFF
--- a/src/hotspot/share/gc/z/zMark.hpp
+++ b/src/hotspot/share/gc/z/zMark.hpp
@@ -95,8 +95,8 @@ private:
   void work_with_timeout(ZMarkCache* cache,
                          ZMarkStripe* stripe,
                          ZMarkThreadLocalStacks* stacks,
-                         uint64_t timeout_in_millis);
-  void work(uint64_t timeout_in_millis);
+                         uint64_t timeout_in_micros);
+  void work(uint64_t timeout_in_micros);
 
   void verify_all_stacks_empty() const;
 


### PR DESCRIPTION
JDK-8253030 changed some variable names from timeout_in_millis to timeout_in_micros, but missed to do the same rename in the header file. This trivial patch renames two arguments in zMark.hpp accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253938](https://bugs.openjdk.java.net/browse/JDK-8253938): ZGC: Clean up argument names after JDK-8253030


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/483/head:pull/483`
`$ git checkout pull/483`
