### PR TITLE
8239105 : Add exception for expiring Digicert root certificates to VerifyCACerts test

### DIFF
--- a/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
+++ b/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
@@ -267,6 +267,10 @@ public class VerifyCACerts {
             add("addtrustexternalca [jdk]");
             // Valid until: Sat May 30 10:44:50 GMT 2020
             add("addtrustqualifiedca [jdk]");
+            // Valid until: Fri Jan 01 15:59:59 PST 2021
+            add("verisigntsaca [jdk]");
+            // Valid until: Fri Jan 01 15:59:59 PST 2021
+            add("thawtepremiumserverca [jdk]");
         }
     };
 


### PR DESCRIPTION
/issue add 8239105
/summary "8239105: added verisigntsaca and thawtepremiumserverca to EXPIRY_EXC_ENTRIES list"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8239105](https://bugs.openjdk.java.net/browse/JDK-8239105): Add exception for expiring Digicert root certificates to VerifyCACerts test


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/484/head:pull/484`
`$ git checkout pull/484`
