### PR TITLE
8253876: jdk/test/lib/hexdump/ASN1FormatterTest.java fails with "AssertionError: Lines expected [126] but found [202]"

### DIFF
--- a/test/lib-test/ProblemList.txt
+++ b/test/lib-test/ProblemList.txt
@@ -37,6 +37,3 @@
 # More than one label is allowed but must be on the same line.
 #
 #############################################################################
-
-
-jdk/test/lib/hexdump/ASN1FormatterTest.java         8253876 generic-all

--- a/test/lib-test/jdk/test/lib/hexdump/ASN1FormatterTest.java
+++ b/test/lib-test/jdk/test/lib/hexdump/ASN1FormatterTest.java
@@ -102,7 +102,7 @@ public class ASN1FormatterTest {
     }
 
     @Test
-    static void testIndefinate() {
+    static void testIndefinite() {
         byte[] bytes = {0x24, (byte) 0x80, 4, 2, 'a', 'b', 4, 2, 'c', 'd', 0, 0};
         HexPrinter p = HexPrinter.simple()
                 .formatter(ASN1Formatter.formatter(), "; ", 100);

--- a/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
+++ b/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
@@ -165,8 +165,11 @@ public class ASN1Formatter implements HexPrinter.Formatter {
                 // multi-byte encoded length
                 int nbytes = len & 0x7f;
                 if (nbytes > 4) {
-                    out.append("***** Tag: " + tagName(tag) +
-                            ", Range of length error: " + len + " bytes");
+                    out.append("***** Tag: ")
+                            .append(tagName(tag))
+                            .append(", Range of length error: ")
+                            .append(Integer.toString(len))
+                            .append(" bytes");
                     out.append(System.lineSeparator());
                     return available;       // return the unread length
                 }

--- a/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
+++ b/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
@@ -167,7 +167,7 @@ public class ASN1Formatter implements HexPrinter.Formatter {
                 if (nbytes > 4) {
                     out.append("***** Tag: " + tagName(tag) +
                             ", Range of length error: " + len + " bytes");
-                    out.append('\n');       // End with NL
+                    out.append(System.lineSeparator());
                     return available;       // return the unread length
                 }
                 len = 0;
@@ -187,7 +187,7 @@ public class ASN1Formatter implements HexPrinter.Formatter {
             switch (tag) {
                 case TAG_EndOfContent:    // End-of-contents octets; len == 0
                     out.append("END-OF-CONTENT");
-                    out.append('\n');  // End with NL
+                    out.append(System.lineSeparator());
                     // end of indefinite-length constructed, return zero remaining
                     return 0;
                 case TAG_Integer:
@@ -321,7 +321,7 @@ public class ASN1Formatter implements HexPrinter.Formatter {
                     }
                 }
             }
-            out.append('\n');   // End with NL
+            out.append(System.lineSeparator());
         }
         return available;
     }

--- a/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
+++ b/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
@@ -166,7 +166,8 @@ public class ASN1Formatter implements HexPrinter.Formatter {
                 int nbytes = len & 0x7f;
                 if (nbytes > 4) {
                     out.append("***** Tag: " + tagName(tag) +
-                            ", Range of length error: " + len + " bytes" + System.lineSeparator());
+                            ", Range of length error: " + len + " bytes");
+                    out.append('\n');       // End with NL
                     return available;       // return the unread length
                 }
                 len = 0;
@@ -185,9 +186,10 @@ public class ASN1Formatter implements HexPrinter.Formatter {
             out.append(prefix);     // start with indent
             switch (tag) {
                 case TAG_EndOfContent:    // End-of-contents octets; len == 0
-                    out.append("END-OF-CONTENT " + System.lineSeparator());
-                    // end of indefinite-length constructed, return any remaining
-                    return 0;          // unknown, but nothing left
+                    out.append("END-OF-CONTENT");
+                    out.append('\n');  // End with NL
+                    // end of indefinite-length constructed, return zero remaining
+                    return 0;
                 case TAG_Integer:
                 case TAG_Enumerated:
                     switch (len) {
@@ -319,7 +321,7 @@ public class ASN1Formatter implements HexPrinter.Formatter {
                     }
                 }
             }
-            out.append(System.lineSeparator());   // End with EOL
+            out.append('\n');   // End with NL
         }
         return available;
     }

--- a/test/lib/jdk/test/lib/hexdump/HexPrinter.java
+++ b/test/lib/jdk/test/lib/hexdump/HexPrinter.java
@@ -1099,7 +1099,9 @@ public final class HexPrinter {
                             dest.append(info);
                             info = "";
                         } else {
-                            dest.append(info, 0, nl);
+                            // append up to the newline (ignoring \r if present)
+                            dest.append(info, 0,
+                                    (nl > 0 && info.charAt(nl - 1) == '\r') ? nl - 1 : nl);
                             info = info.substring(nl + 1);
                         }
                     }


### PR DESCRIPTION
The HexPrinter test utility should be ignoring \r characters from the formatter.
It looks for \n and generates System.lineSeparator() at the end of each line.

With this fix, the ASN1FormatterTest can be removed from the ProblemList.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (langtools/tier1)](https://github.com/RogerRiggs/jdk/runs/1221843816)

### Issue
 * [JDK-8253876](https://bugs.openjdk.java.net/browse/JDK-8253876): jdk/test/lib/hexdump/ASN1FormatterTest.java fails with "AssertionError: Lines expected [126] but found [202]"


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 6f1f564d255f01545e50227e107e1d09df1f3a21
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/486/head:pull/486`
`$ git checkout pull/486`
