### PR TITLE
8253945: Missed default constructor for StreamPrintServiceFactory.java

### DIFF
--- a/src/java.desktop/share/classes/javax/print/StreamPrintServiceFactory.java
+++ b/src/java.desktop/share/classes/javax/print/StreamPrintServiceFactory.java
@@ -53,6 +53,11 @@ import sun.awt.AppContext;
 public abstract class StreamPrintServiceFactory {
 
     /**
+     * Constructor for subclasses to call.
+     */
+     protected StreamPrintServiceFactory() {}
+
+    /**
      * Contains a list of factories.
      */
     static class Services {


### PR DESCRIPTION
Running a test build with the doclint warning found this missed case

A CSR has been created https://bugs.openjdk.java.net/browse/JDK-8253946

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253945](https://bugs.openjdk.java.net/browse/JDK-8253945): Missed default constructor for StreamPrintServiceFactory.java


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/488/head:pull/488`
`$ git checkout pull/488`
