### PR TITLE
8253948: Memory leak in ImageFileReader

### DIFF
--- a/src/java.base/share/native/libjimage/imageFile.cpp
+++ b/src/java.base/share/native/libjimage/imageFile.cpp
@@ -349,7 +349,7 @@ ImageFileReader* ImageFileReader::id_to_reader(u8 id) {
 
 // Constructor intializes to a closed state.
 ImageFileReader::ImageFileReader(const char* name, bool big_endian) :
-  _module_data(NULL) {
+    _module_data(NULL) {
     // Copy the image file name.
      int len = (int) strlen(name) + 1;
     _name = new char[len];

--- a/src/java.base/share/native/libjimage/imageFile.cpp
+++ b/src/java.base/share/native/libjimage/imageFile.cpp
@@ -372,7 +372,7 @@ ImageFileReader::~ImageFileReader() {
     }
 
     if (_module_data != NULL) {
-      delete _module_data;
+        delete _module_data;
     }
 }
 
@@ -443,8 +443,8 @@ void ImageFileReader::close() {
     }
 
     if (_module_data != NULL) {
-      delete _module_data;
-      _module_data = NULL;
+        delete _module_data;
+        _module_data = NULL;
     }
 }
 
@@ -578,5 +578,5 @@ void ImageFileReader::get_resource(ImageLocation& location, u1* uncompressed_dat
 
 // Return the ImageModuleData for this image
 ImageModuleData * ImageFileReader::get_image_module_data() {
-        return _module_data;
+    return _module_data;
 }

--- a/src/java.base/share/native/libjimage/imageFile.cpp
+++ b/src/java.base/share/native/libjimage/imageFile.cpp
@@ -348,7 +348,8 @@ ImageFileReader* ImageFileReader::id_to_reader(u8 id) {
 }
 
 // Constructor intializes to a closed state.
-ImageFileReader::ImageFileReader(const char* name, bool big_endian) {
+ImageFileReader::ImageFileReader(const char* name, bool big_endian) :
+  _module_data(NULL) {
     // Copy the image file name.
      int len = (int) strlen(name) + 1;
     _name = new char[len];
@@ -368,6 +369,10 @@ ImageFileReader::~ImageFileReader() {
     if (_name) {
         delete[] _name;
         _name = NULL;
+    }
+
+    if (_module_data != NULL) {
+      delete _module_data;
     }
 }
 
@@ -419,9 +424,9 @@ bool ImageFileReader::open() {
     _string_bytes = _index_data + string_bytes_offset;
 
     // Initialize the module data
-    module_data = new ImageModuleData(this);
+    _module_data = new ImageModuleData(this);
     // Successful open (if memory allocation succeeded).
-    return module_data != NULL;
+    return _module_data != NULL;
 }
 
 // Close image file.
@@ -435,6 +440,11 @@ void ImageFileReader::close() {
     if (_fd != -1) {
         osSupport::close(_fd);
         _fd = -1;
+    }
+
+    if (_module_data != NULL) {
+      delete _module_data;
+      _module_data = NULL;
     }
 }
 
@@ -568,5 +578,5 @@ void ImageFileReader::get_resource(ImageLocation& location, u1* uncompressed_dat
 
 // Return the ImageModuleData for this image
 ImageModuleData * ImageFileReader::get_image_module_data() {
-        return module_data;
+        return _module_data;
 }

--- a/src/java.base/share/native/libjimage/imageFile.hpp
+++ b/src/java.base/share/native/libjimage/imageFile.hpp
@@ -423,7 +423,7 @@ private:
     u4* _offsets_table;  // Location offset table
     u1* _location_bytes; // Location attributes
     u1* _string_bytes;   // String table
-    ImageModuleData *module_data;       // The ImageModuleData for this image
+    ImageModuleData *_module_data;       // The ImageModuleData for this image
 
     ImageFileReader(const char* name, bool big_endian);
     ~ImageFileReader();


### PR DESCRIPTION
ImageFileReader allocates ImageModuleData in ImageFileReader::open(), but never free.

Also renamed module_data to _module_data to be consistent with other member variables.

Test:
- [x] tier1 on Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253948](https://bugs.openjdk.java.net/browse/JDK-8253948): Memory leak in ImageFileReader


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/490/head:pull/490`
`$ git checkout pull/490`
