### PR TITLE
8253681: closed java/awt/dnd/MouseEventAfterStartDragTest/MouseEventAfterStartDragTest.html test failed

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/dnd/SunDragSourceContextPeer.java
+++ b/src/java.desktop/share/classes/sun/awt/dnd/SunDragSourceContextPeer.java
@@ -75,7 +75,7 @@ public abstract class SunDragSourceContextPeer implements DragSourceContextPeer 
     private int               sourceActions;
 
     private static volatile boolean dragDropInProgress = false;
-    private static boolean discardingMouseEvents = false;
+    private static volatile boolean discardingMouseEvents = false;
 
     /*
      * dispatch constants


### PR DESCRIPTION
The "discardingMouseEvents" flag in the SunDragSourceContextPeer class is used on the different threads without any synchronization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (langtools/tier1)](https://github.com/mrserb/jdk/runs/1201586284)

### Issue
 * [JDK-8253681](https://bugs.openjdk.java.net/browse/JDK-8253681): closed java/awt/dnd/MouseEventAfterStartDragTest/MouseEventAfterStartDragTest.html test failed


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/491/head:pull/491`
`$ git checkout pull/491`
