### PR TITLE
8253960: Memory leak in Java_java_lang_ClassLoader_defineClass0()

### DIFF
--- a/src/java.base/share/native/libjava/ClassLoader.c
+++ b/src/java.base/share/native/libjava/ClassLoader.c
@@ -260,7 +260,7 @@ Java_java_lang_ClassLoader_defineClass0(JNIEnv *env,
         utfName = NULL;
     }
 
-    return JVM_LookupDefineClass(env, lookup, utfName, body, length, pd, initialize, flags, classData);
+    result = JVM_LookupDefineClass(env, lookup, utfName, body, length, pd, initialize, flags, classData);
 
  free_body:
     free(body);


### PR DESCRIPTION
The memory leak is quite obvious. Early return results 'body' not been released.

Test:

- [x] tier1 on Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253960](https://bugs.openjdk.java.net/browse/JDK-8253960): Memory leak in Java_java_lang_ClassLoader_defineClass0() 


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/492/head:pull/492`
`$ git checkout pull/492`
