### PR TITLE
8253971: ZGC: Flush mark stacks after processing concurrent roots

### DIFF
--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -643,6 +643,7 @@ public:
 
 class ZMarkConcurrentRootsTask : public ZTask {
 private:
+  ZMark* const                        _mark;
   SuspendibleThreadSetJoiner          _sts_joiner;
   ZConcurrentRootsIteratorClaimStrong _roots;
   ZMarkConcurrentRootsIteratorClosure _cl;
@@ -650,6 +651,7 @@ private:
 public:
   ZMarkConcurrentRootsTask(ZMark* mark) :
       ZTask("ZMarkConcurrentRootsTask"),
+      _mark(mark),
       _sts_joiner(),
       _roots(),
       _cl() {
@@ -662,6 +664,12 @@ public:
 
   virtual void work() {
     _roots.oops_do(&_cl);
+
+    // Flush and free worker stacks. Needed here since
+    // the set of workers executing during root scanning
+    // can be different from the set of workers executing
+    // during mark.
+    _mark->flush_and_free();
   }
 };
 


### PR DESCRIPTION
I looked into why almost all mark cycles see non-zero "mark completions". In other words, we almost always have some amount of mark work left to handle in the mark end pause. It turns out that worker threads don't flush their mark stacks in ZMarkConcurrentRootsTask::work(), which means they can hide work (in their thread local mark stacks) until those stacks are finally flushed out in ZMark::try_end(). The reason work can be hidden is that the set of worker threads executing ZMarkConcurrentRootsTask is not necessarily the same set of worker threads executing ZMarkTask. As a result, the mark end pause often becomes longer than it otherwise would have.

After fixing this, I did some tests with Dacapo, which shows the following improvement:

Before: Mark End Pause (avg/max): 0.391 / 1.142 ms
After: Mark End Pause (avg/max): 0.130 / 0.294 ms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253971](https://bugs.openjdk.java.net/browse/JDK-8253971): ZGC: Flush mark stacks after processing concurrent roots


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/495/head:pull/495`
`$ git checkout pull/495`
