### PR TITLE
8253980: javax/swing/plaf/synth/7158712/bug7158712.java fails on windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -834,7 +834,6 @@ javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.ja
 javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
 javax/swing/JMenuItem/4171437/bug4171437.java 8233641 macosx-all
 javax/swing/JMenu/4692443/bug4692443.java 8171998 macosx-all
-javax/swing/plaf/synth/7158712/bug7158712.java 8238720 windows-all
 javax/swing/plaf/basic/BasicComboPopup/JComboBoxPopupLocation/JComboBoxPopupLocation.java 8238720 windows-all
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all

--- a/test/jdk/javax/swing/plaf/synth/7158712/bug7158712.java
+++ b/test/jdk/javax/swing/plaf/synth/7158712/bug7158712.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012,2020 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,13 +27,19 @@
  * @bug 7158712
  * @summary Synth Property "ComboBox.popupInsets" is ignored
  * @library ../../../regtesthelpers
- * @author Pavel Porvatov
+ * @run main/othervm -Dsun.java2d.uiScale=1 bug7158712
  */
 
-import javax.swing.*;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
 import javax.swing.plaf.basic.BasicComboPopup;
 import javax.swing.plaf.synth.SynthLookAndFeel;
-import java.awt.*;
+import javax.swing.UIManager;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Robot;
+import java.awt.Point;
 import java.awt.event.InputEvent;
 import java.io.ByteArrayInputStream;
 import java.util.concurrent.Callable;
@@ -59,7 +65,7 @@ public class bug7158712 {
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
 
-        robot.setAutoDelay(500);
+        robot.setAutoDelay(100);
 
         SynthLookAndFeel laf = new SynthLookAndFeel();
 
@@ -67,7 +73,7 @@ public class bug7158712 {
 
         UIManager.setLookAndFeel(laf);
 
-        EventQueue.invokeAndWait(new Runnable() {
+        SwingUtilities.invokeAndWait(new Runnable() {
             public void run() {
                 comboBox = new JComboBox<>(
                         new String[]{"Very Looooooooooooooooooooong Text Item 1", "Item 2"});
@@ -83,6 +89,7 @@ public class bug7158712 {
         });
 
         robot.waitForIdle();
+        robot.delay(1000);
 
         Point comboBoxLocation = Util.invokeOnEDT(new Callable<Point>() {
             @Override


### PR DESCRIPTION
This test was seen to be failing in mach5 hidpi system on windows.
The test actually checks for the fact that popup size should be 10 pixels wider than the comboBox width and the popup should overlap the comboBox by 5 pixels (negative y-offset) which maynot exactly be same in hidpi mode.
Fix is to make it run for scale 1 as the fix is not dependant on hidpi mode.
Also, some cleanup is done like changing setAutoDelay() which is normally set to 100ms for several other tests to make it consistent.
Also, mach5 run for several iterations is green and link is posted in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253980](https://bugs.openjdk.java.net/browse/JDK-8253980): javax/swing/plaf/synth/7158712/bug7158712.java fails on windows


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/500/head:pull/500`
`$ git checkout pull/500`
