### PR TITLE
8254010: GrowableArrayView::print fails to compile

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -296,8 +296,8 @@ public:
   }
 
   void print() {
-    tty->print("Growable Array " INTPTR_FORMAT, this);
-    tty->print(": length %ld (_max %ld) { ", _len, _max);
+    tty->print("Growable Array " INTPTR_FORMAT, p2i(this));
+    tty->print(": length %d (_max %d) { ", _len, _max);
     for (int i = 0; i < _len; i++) {
       tty->print(INTPTR_FORMAT " ", *(intptr_t*)&(_data[i]));
     }


### PR DESCRIPTION
When adding some debugging code, I've noticed that the (currently unused) GrowableArrayView::print fails to compile. The fix is to use the `%d` format specifier for the int fields `_len` and `_max` and cast `this` to `intptr_t`.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254010](https://bugs.openjdk.java.net/browse/JDK-8254010): GrowableArrayView::print fails to compile


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/502/head:pull/502`
`$ git checkout pull/502`
