### PR TITLE
8253901: ARM32: SIGSEGV during monitorexit due to incorrect register use (after JDK-8253540)

### DIFF
--- a/src/hotspot/cpu/arm/interp_masm_arm.cpp
+++ b/src/hotspot/cpu/arm/interp_masm_arm.cpp
@@ -729,7 +729,7 @@ void InterpreterMacroAssembler::remove_activation(TosState state, Register ret_a
   // BasicObjectLock will be first in list, since this is a synchronized method. However, need
   // to check that the object has not been unlocked by an explicit monitorexit bytecode.
 
-  const Register Rmonitor = R1;                  // fixed in unlock_object()
+  const Register Rmonitor = R0;                  // fixed in unlock_object()
   const Register Robj = R2;
 
   // address of first monitor
@@ -772,8 +772,8 @@ void InterpreterMacroAssembler::remove_activation(TosState state, Register ret_a
     // Unlock does not block, so don't have to worry about the frame
 
     push(state);
-    mov(R1, Rcur);
-    unlock_object(R1);
+    mov(Rmonitor, Rcur);
+    unlock_object(Rmonitor);
 
     if (install_monitor_exception) {
       call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::new_illegal_monitor_state_exception));
@@ -987,7 +987,7 @@ void InterpreterMacroAssembler::lock_object(Register Rlock) {
 // Throw an IllegalMonitorException if object is not locked by current thread
 // Blows volatile registers R0-R3, Rtemp, LR. Calls VM.
 void InterpreterMacroAssembler::unlock_object(Register Rlock) {
-  assert(Rlock == R1, "the second argument");
+  assert(Rlock == R0, "the first argument");
 
   if (UseHeavyMonitors) {
     call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), Rlock);

--- a/src/hotspot/cpu/arm/templateInterpreterGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/templateInterpreterGenerator_arm.cpp
@@ -1033,8 +1033,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 
   if (synchronized) {
     // address of first monitor
-    __ sub(R1, FP, - (frame::interpreter_frame_monitor_block_bottom_offset - frame::interpreter_frame_monitor_size()) * wordSize);
-    __ unlock_object(R1);
+    __ sub(R0, FP, - (frame::interpreter_frame_monitor_block_bottom_offset - frame::interpreter_frame_monitor_size()) * wordSize);
+    __ unlock_object(R0);
   }
 
   // jvmti/dtrace support

--- a/src/hotspot/cpu/arm/templateTable_arm.cpp
+++ b/src/hotspot/cpu/arm/templateTable_arm.cpp
@@ -4435,6 +4435,7 @@ void TemplateTable::monitorexit() {
   const Register Rcur = R1_tmp;
   const Register Rbottom = R2_tmp;
   const Register Rcur_obj = Rtemp;
+  const Register Rmonitor = R0;      // fixed in unlock_object()
 
   // check for NULL object
   __ null_check(Robj, Rtemp);
@@ -4477,7 +4478,8 @@ void TemplateTable::monitorexit() {
   // Rcur: points to monitor entry
   __ bind(found);
   __ push_ptr(Robj);                             // make sure object is on stack (contract with oopMaps)
-  __ unlock_object(Rcur);
+  __ mov(Rmonitor, Rcur);
+  __ unlock_object(Rmonitor);
   __ pop_ptr(Robj);                              // discard object
 }
 


### PR DESCRIPTION
[JDK-8253540](https://bugs.openjdk.java.net/browse/JDK-8253540) changed InterpreterRuntime::monitorexit call from call_VM to call_VM_leaf.
This requires additional arrangement for ARM32: the parameter must be in R0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8253901](https://bugs.openjdk.java.net/browse/JDK-8253901): ARM32: SIGSEGV during monitorexit due to incorrect register use (after JDK-8253540)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/503/head:pull/503`
`$ git checkout pull/503`
