### PR TITLE
8253475: Javadoc clean up in HttpExchange and HttpServer

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -43,7 +43,7 @@ import java.net.URI;
  *     <li>{@link #getRequestMethod()} to determine the command.
  *     <li>{@link #getRequestHeaders()} to examine the request headers (if
  *     needed).
- *     <li>{@link #getRequestBody()} returns a {@link java.io.InputStream} for
+ *     <li>{@link #getRequestBody()} returns an {@link java.io.InputStream} for
  *     reading the request body. After reading the request body, the stream
  *     should be closed.
  *     <li>{@link #getResponseHeaders()} to set any response headers, except
@@ -272,14 +272,14 @@ public abstract class HttpExchange implements AutoCloseable {
     public abstract void setAttribute(String name, Object value);
 
     /**
-     * Used by {@linkplain #Filter Filters} to wrap either (or both) of this exchange's InputStream
-     * and OutputStream, with the given filtered streams so that subsequent
-     * calls to {@link #getRequestBody()} will return the given
-     * {@link java.io.InputStream}, and calls to {@link #getResponseBody()} will
-     * return the given {@link java.io.OutputStream}. The streams provided to
-     * this call must wrap the original streams, and may be (but are not required
-     * to be) sub-classes of {@link java.io.FilterInputStream} and
-     * {@link java.io.FilterOutputStream}.
+     * Used by {@linkplain com.sun.net.httpserver.Filter Filters} to wrap either
+     * (or both) of this exchange's {@link java.io.InputStream} and
+     * {@link java.io.OutputStream}, with the given filtered streams so that
+     * subsequent calls to {@link #getRequestBody()} will return the given
+     * {@code InputStream}, and calls to {@link #getResponseBody()} will return
+     * the given {@code OutputStream}. The streams provided to this call must wrap
+     * the original streams, and may be (but are not required to be) sub-classes
+     * of {@link java.io.FilterInputStream} and {@link java.io.FilterOutputStream}.
      *
      * @param i the filtered input stream to set as this object's
      *          {@code Inputstream}, or {@code null} if no change

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -43,14 +43,14 @@ import java.net.URI;
  *     <li>{@link #getRequestMethod()} to determine the command.
  *     <li>{@link #getRequestHeaders()} to examine the request headers (if
  *     needed).
- *     <li>{@link #getRequestBody()} returns an {@link java.io.InputStream} for
+ *     <li>{@link #getRequestBody()} returns an {@link InputStream} for
  *     reading the request body. After reading the request body, the stream
  *     should be closed.
  *     <li>{@link #getResponseHeaders()} to set any response headers, except
  *     content-length.
  *     <li>{@link #sendResponseHeaders(int,long)} to send the response headers.
  *     Must be called before next step.
- *     <li>{@link #getResponseBody()} to get a {@link java.io.OutputStream} to
+ *     <li>{@link #getResponseBody()} to get a {@link OutputStream} to
  *     send the response body. When the response body has been written, the
  *     stream must be closed to terminate the exchange.
  * </ol>
@@ -131,8 +131,8 @@ public abstract class HttpExchange implements AutoCloseable {
     /**
      * Ends this exchange by doing the following in sequence:
      * <ol>
-     *      <li> close the request {@link java.io.InputStream}, if not already closed.
-     *      <li> close the response {@link java.io.OutputStream}, if not already closed.
+     *      <li> close the request {@link InputStream}, if not already closed.
+     *      <li> close the response {@link OutputStream}, if not already closed.
      * </ol>
      */
     public abstract void close();
@@ -142,7 +142,7 @@ public abstract class HttpExchange implements AutoCloseable {
      * Multiple calls to this method will return the same stream.
      * It is recommended that applications should consume (read) all of the data
      * from this stream before closing it. If a stream is closed before all data
-     * has been read, then the {@link java.io.InputStream#close()} call will read
+     * has been read, then the {@link InputStream#close()} call will read
      * and discard remaining data (up to an implementation specific number of
      * bytes).
      *
@@ -157,15 +157,15 @@ public abstract class HttpExchange implements AutoCloseable {
      * will return the same stream. In order to correctly terminate each exchange,
      * the output stream must be closed, even if no response body is being sent.
      *
-     * <p> Closing this stream implicitly closes the {@link java.io.InputStream}
+     * <p> Closing this stream implicitly closes the {@link InputStream}
      * returned from {@link #getRequestBody()} (if it is not already closed).
      *
      * <p> If the call to {@link #sendResponseHeaders(int, long)} specified a
      * fixed response body length, then the exact number of bytes specified in
      * that call must be written to this stream. If too many bytes are written,
-     * then {@link java.io.OutputStream#write()} will throw an {@code IOException}.
+     * then {@link OutputStream#write()} will throw an {@code IOException}.
      * If too few bytes are written then the stream
-     * {@link java.io.OutputStream#close()} will throw an {@code IOException}.
+     * {@link OutputStream#close()} will throw an {@code IOException}.
      * In both cases, the exchange is aborted and the underlying TCP connection
      * closed.
      *
@@ -183,7 +183,7 @@ public abstract class HttpExchange implements AutoCloseable {
      * amount of data. If the response length parameter is {@code zero}, then
      * chunked transfer encoding is used and an arbitrary amount of data may be
      * sent. The application terminates the response body by closing the
-     * {@link java.io.OutputStream}.
+     * {@link OutputStream}.
      * If response length has the value {@code -1} then no response body is
      * being sent.
      *
@@ -273,8 +273,8 @@ public abstract class HttpExchange implements AutoCloseable {
 
     /**
      * Used by {@linkplain com.sun.net.httpserver.Filter Filters} to wrap either
-     * (or both) of this exchange's {@link java.io.InputStream} and
-     * {@link java.io.OutputStream}, with the given filtered streams so that
+     * (or both) of this exchange's {@link InputStream} and
+     * {@link OutputStream}, with the given filtered streams so that
      * subsequent calls to {@link #getRequestBody()} will return the given
      * {@code InputStream}, and calls to {@link #getResponseBody()} will return
      * the given {@code OutputStream}. The streams provided to this call must wrap

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -36,30 +36,36 @@ import java.net.URI;
  * response to be generated in one exchange. It provides methods
  * for examining the request from the client, and for building and
  * sending the response.
- * <p>
- * The typical life-cycle of a HttpExchange is shown in the sequence
- * below.
- * <ol><li>{@link #getRequestMethod()} to determine the command
- * <li>{@link #getRequestHeaders()} to examine the request headers (if needed)
- * <li>{@link #getRequestBody()} returns a {@link java.io.InputStream} for reading the request body.
- *     After reading the request body, the stream should be closed.
- * <li>{@link #getResponseHeaders()} to set any response headers, except content-length
- * <li>{@link #sendResponseHeaders(int,long)} to send the response headers. Must be called before
- * next step.
- * <li>{@link #getResponseBody()} to get a {@link java.io.OutputStream} to send the response body.
- *      When the response body has been written, the stream must be closed to terminate the exchange.
+ *
+ * <p> The typical life-cycle of a {@code HttpExchange} is shown in the sequence
+ * below:
+ * <ol>
+ *     <li>{@link #getRequestMethod()} to determine the command.
+ *     <li>{@link #getRequestHeaders()} to examine the request headers (if
+ *     needed).
+ *     <li>{@link #getRequestBody()} returns a {@link java.io.InputStream} for
+ *     reading the request body. After reading the request body, the stream
+ *     should be closed.
+ *     <li>{@link #getResponseHeaders()} to set any response headers, except
+ *     content-length.
+ *     <li>{@link #sendResponseHeaders(int,long)} to send the response headers.
+ *     Must be called before next step.
+ *     <li>{@link #getResponseBody()} to get a {@link java.io.OutputStream} to
+ *     send the response body. When the response body has been written, the
+ *     stream must be closed to terminate the exchange.
  * </ol>
+ *
  * <b>Terminating exchanges</b>
- * <br>
- * Exchanges are terminated when both the request InputStream and response OutputStream are closed.
- * Closing the OutputStream, implicitly closes the InputStream (if it is not already closed).
- * However, it is recommended
- * to consume all the data from the InputStream before closing it.
- * The convenience method {@link #close()} does all of these tasks.
- * Closing an exchange without consuming all of the request body is not an error
- * but may make the underlying TCP connection unusable for following exchanges.
- * The effect of failing to terminate an exchange is undefined, but will typically
- * result in resources failing to be freed/reused.
+ * <br>Exchanges are terminated when both the request {@code InputStream} and
+ * response {@code OutputStream} are closed. Closing the {@code OutputStream},
+ * implicitly closes the {@code InputStream} (if it is not already closed).
+ * However, it is recommended to consume all the data from the {@code InputStream}
+ * before closing it. The convenience method {@link #close()} does all of these
+ * tasks. Closing an exchange without consuming all of the request body is not
+ * an error but may make the underlying TCP connection unusable for following
+ * exchanges. The effect of failing to terminate an exchange is undefined, but
+ * will typically result in resources failing to be freed/reused.
+ *
  * @since 1.6
  */
 
@@ -68,111 +74,124 @@ public abstract class HttpExchange implements AutoCloseable {
     /**
      * Constructor for subclasses to call.
      */
-    protected HttpExchange () {
+    protected HttpExchange() {
     }
 
     /**
-     * Returns an immutable Map containing the HTTP headers that were
-     * included with this request. The keys in this Map will be the header
-     * names, while the values will be a List of Strings containing each value
-     * that was included (either for a header that was listed several times,
-     * or one that accepts a comma-delimited list of values on a single line).
-     * In either of these cases, the values for the header name will be
-     * presented in the order that they were included in the request.
-     * <p>
-     * The keys in Map are case-insensitive.
-     * @return a read-only Map which can be used to access request headers
-     */
-    public abstract Headers getRequestHeaders () ;
-
-    /**
-     * Returns a mutable Map into which the HTTP response headers can be stored
-     * and which will be transmitted as part of this response. The keys in the
-     * Map will be the header names, while the values must be a List of Strings
-     * containing each value that should be included multiple times
-     * (in the order that they should be included).
-     * <p>
-     * The keys in Map are case-insensitive.
-     * @return a writable Map which can be used to set response headers.
-     */
-    public abstract Headers getResponseHeaders () ;
-
-    /**
-     * Get the request URI
+     * Returns an immutable {@link Map} containing the HTTP headers that were
+     * included with this request. The keys in this {@code Map} will be the header
+     * names, while the values will be a {@link java.util.List} of
+     * {@linkplain java.lang.String Strings} containing each value that was
+     * included (either for a header that was listed several times, or one that
+     * accepts a comma-delimited list of values on a single line). In either of
+     * these cases, the values for the header name will be presented in the
+     * order that they were included in the request.
      *
-     * @return the request URI
+     * <p> The keys in {@code Map} are case-insensitive.
+     *
+     * @return a read-only {@code Map} which can be used to access request headers
      */
-    public abstract URI getRequestURI () ;
+    public abstract Headers getRequestHeaders();
 
     /**
-     * Get the request method
+     * Returns a mutable {@link Map} into which the HTTP response headers can be
+     * stored and which will be transmitted as part of this response. The keys in
+     * the {@code Map} will be the header names, while the values must be a
+     * {@link java.util.List} of {@linkplain java.lang.String Strings} containing
+     * each value that should be included multiple times (in the order that they
+     * should be included).
+     *
+     * <p> The keys in {@code Map} are case-insensitive.
+     *
+     * @return a writable {@code Map} which can be used to set response headers.
+     */
+    public abstract Headers getResponseHeaders();
+
+    /**
+     * Get the request {@link URI}.
+     *
+     * @return the request {@code URI}
+     */
+    public abstract URI getRequestURI();
+
+    /**
+     * Get the request method.
+     *
      * @return the request method
      */
-    public abstract String getRequestMethod ();
+    public abstract String getRequestMethod();
 
     /**
-     * Get the HttpContext for this exchange
-     * @return the HttpContext
+     * Get the {@link HttpContext} for this exchange.
+     *
+     * @return the {@code HttpContext}
      */
-    public abstract HttpContext getHttpContext ();
+    public abstract HttpContext getHttpContext();
 
     /**
-     * Ends this exchange by doing the following in sequence:<ol>
-     * <li>close the request InputStream, if not already closed;</li>
-     * <li>close the response OutputStream, if not already closed.</li>
+     * Ends this exchange by doing the following in sequence:
+     * <ol>
+     *      <li> close the request {@link java.io.InputStream}, if not already closed.
+     *      <li> close the response {@link java.io.OutputStream}, if not already closed.
      * </ol>
      */
-    public abstract void close () ;
+    public abstract void close();
 
     /**
-     * returns a stream from which the request body can be read.
+     * Returns a stream from which the request body can be read.
      * Multiple calls to this method will return the same stream.
-     * It is recommended that applications should consume (read) all of the
-     * data from this stream before closing it. If a stream is closed
-     * before all data has been read, then the close() call will
-     * read and discard remaining data (up to an implementation specific
-     * number of bytes).
-     * @return the stream from which the request body can be read.
+     * It is recommended that applications should consume (read) all of the data
+     * from this stream before closing it. If a stream is closed before all data
+     * has been read, then the {@link java.io.InputStream#close()} call will read
+     * and discard remaining data (up to an implementation specific number of
+     * bytes).
+     *
+     * @return the stream from which the request body can be read
      */
-    public abstract InputStream getRequestBody () ;
+    public abstract InputStream getRequestBody();
 
     /**
-     * returns a stream to which the response body must be
-     * written. {@link #sendResponseHeaders(int,long)}) must be called prior to calling
-     * this method. Multiple calls to this method (for the same exchange)
-     * will return the same stream. In order to correctly terminate
-     * each exchange, the output stream must be closed, even if no
-     * response body is being sent.
-     * <p>
-     * Closing this stream implicitly
-     * closes the InputStream returned from {@link #getRequestBody()}
-     * (if it is not already closed).
-     * <P>
-     * If the call to sendResponseHeaders() specified a fixed response
-     * body length, then the exact number of bytes specified in that
-     * call must be written to this stream. If too many bytes are written,
-     * then write() will throw an IOException. If too few bytes are written
-     * then the stream close() will throw an IOException. In both cases,
-     * the exchange is aborted and the underlying TCP connection closed.
+     * Returns a stream to which the response body must be
+     * written. {@link #sendResponseHeaders(int,long)}) must be called prior to
+     * calling this method. Multiple calls to this method (for the same exchange)
+     * will return the same stream. In order to correctly terminate each exchange,
+     * the output stream must be closed, even if no response body is being sent.
+     *
+     * <p> Closing this stream implicitly closes the {@link java.io.InputStream}
+     * returned from {@link #getRequestBody()} (if it is not already closed).
+     *
+     * <p> If the call to {@link #sendResponseHeaders(int, long)} specified a
+     * fixed response body length, then the exact number of bytes specified in
+     * that call must be written to this stream. If too many bytes are written,
+     * then {@link java.io.OutputStream#write()} will throw an {@code IOException}.
+     * If too few bytes are written then the stream
+     * {@link java.io.OutputStream#close()} will throw an {@code IOException}.
+     * In both cases, the exchange is aborted and the underlying TCP connection
+     * closed.
+     *
      * @return the stream to which the response body is written
      */
-    public abstract OutputStream getResponseBody () ;
+    public abstract OutputStream getResponseBody();
 
 
     /**
-     * Starts sending the response back to the client using the current set of response headers
-     * and the numeric response code as specified in this method. The response body length is also specified
-     * as follows. If the response length parameter is greater than zero, this specifies an exact
-     * number of bytes to send and the application must send that exact amount of data.
-     * If the response length parameter is {@code zero}, then chunked transfer encoding is
-     * used and an arbitrary amount of data may be sent. The application terminates the
-     * response body by closing the OutputStream. If response length has the value {@code -1}
-     * then no response body is being sent.
-     * <p>
-     * If the content-length response header has not already been set then
-     * this is set to the appropriate value depending on the response length parameter.
-     * <p>
-     * This method must be called prior to calling {@link #getResponseBody()}.
+     * Starts sending the response back to the client using the current set of
+     * response headers and the numeric response code as specified in this
+     * method. The response body length is also specified as follows. If the
+     * response length parameter is greater than {@code zero}, this specifies an
+     * exact number of bytes to send and the application must send that exact
+     * amount of data. If the response length parameter is {@code zero}, then
+     * chunked transfer encoding is used and an arbitrary amount of data may be
+     * sent. The application terminates the response body by closing the
+     * {@link java.io.OutputStream}.
+     * If response length has the value {@code -1} then no response body is
+     * being sent.
+     *
+     * <p> If the content-length response header has not already been set then
+     * this is set to the appropriate value depending on the response length
+     * parameter.
+     *
+     * <p> This method must be called prior to calling {@link #getResponseBody()}.
      *
      * @implNote This implementation allows the caller to instruct the
      * server to force a connection close after the exchange terminates, by
@@ -180,94 +199,102 @@ public abstract class HttpExchange implements AutoCloseable {
      * #getResponseHeaders() response headers} before {@code sendResponseHeaders}
      * is called.
      *
-     * @param rCode the response code to send
-     * @param responseLength if {@literal > 0}, specifies a fixed response
-     *        body length and that exact number of bytes must be written
-     *        to the stream acquired from getResponseBody(), or else
-     *        if equal to 0, then chunked encoding is used,
-     *        and an arbitrary number of bytes may be written.
-     *        if {@literal <= -1}, then no response body length is specified and
-     *        no response body may be written.
-     * @see HttpExchange#getResponseBody()
+     * @param rCode          the response code to send
+     * @param responseLength if {@literal > 0}, specifies a fixed response body
+     *                       length and that exact number of bytes must be written
+     *                       to the stream acquired from {@link #getResponseCode()}
+     *                       If {@literal == 0}, then chunked encoding is used,
+     *                       and an arbitrary number of bytes may be written.
+     *                       If {@literal <= -1}, then no response body length is
+     *                       specified and no response body may be written.
+     *
+     * @see   HttpExchange#getResponseBody()
      */
-    public abstract void sendResponseHeaders (int rCode, long responseLength) throws IOException ;
+    public abstract void sendResponseHeaders(int rCode, long responseLength) throws IOException;
 
     /**
-     * Returns the address of the remote entity invoking this request
-     * @return the InetSocketAddress of the caller
+     * Returns the address of the remote entity invoking this request.
+     *
+     * @return the {@link InetSocketAddress} of the caller
      */
-    public abstract InetSocketAddress getRemoteAddress ();
+    public abstract InetSocketAddress getRemoteAddress();
 
     /**
-     * Returns the response code, if it has already been set
+     * Returns the response code, if it has already been set.
+     *
      * @return the response code, if available. {@code -1} if not available yet.
      */
-    public abstract int getResponseCode ();
+    public abstract int getResponseCode();
 
     /**
-     * Returns the local address on which the request was received
-     * @return the InetSocketAddress of the local interface
+     * Returns the local address on which the request was received.
+     *
+     * @return the {@link InetSocketAddress} of the local interface
      */
-    public abstract InetSocketAddress getLocalAddress ();
+    public abstract InetSocketAddress getLocalAddress();
 
     /**
      * Returns the protocol string from the request in the form
      * <i>protocol/majorVersion.minorVersion</i>. For example,
-     * "HTTP/1.1"
+     * "{@code HTTP/1.1}".
+     *
      * @return the protocol string from the request
      */
-    public abstract String getProtocol ();
+    public abstract String getProtocol();
 
     /**
-     * Filter modules may store arbitrary objects with HttpExchange
-     * instances as an out-of-band communication mechanism. Other Filters
+     * {@Link Filter} modules may store arbitrary objects with {@code HttpExchange}
+     * instances as an out-of-band communication mechanism. Other filters
      * or the exchange handler may then access these objects.
-     * <p>
-     * Each Filter class will document the attributes which they make
+     *
+     * <p> Each {@code Filter} class will document the attributes which they make
      * available.
+     *
      * @param name the name of the attribute to retrieve
-     * @return the attribute object, or null if it does not exist
+     * @return the attribute object, or {@code null} if it does not exist
      * @throws NullPointerException if name is {@code null}
      */
-    public abstract Object getAttribute (String name) ;
+    public abstract Object getAttribute(String name);
 
     /**
-     * Filter modules may store arbitrary objects with HttpExchange
-     * instances as an out-of-band communication mechanism. Other Filters
+     * {@link Filter} modules may store arbitrary objects with {@code HttpExchange}
+     * instances as an out-of-band communication mechanism. Other filters
      * or the exchange handler may then access these objects.
-     * <p>
-     * Each Filter class will document the attributes which they make
+     *
+     * <p> Each {@code Filter} class will document the attributes which they make
      * available.
-     * @param name the name to associate with the attribute value
+     *
+     * @param name  the name to associate with the attribute value
      * @param value the object to store as the attribute value. {@code null}
-     * value is permitted.
+     *              value is permitted.
      * @throws NullPointerException if name is {@code null}
      */
-    public abstract void setAttribute (String name, Object value) ;
+    public abstract void setAttribute(String name, Object value);
 
     /**
-     * Used by Filters to wrap either (or both) of this exchange's InputStream
-     * and OutputStream, with the given filtered streams so
-     * that subsequent calls to {@link #getRequestBody()} will
-     * return the given {@link java.io.InputStream}, and calls to
-     * {@link #getResponseBody()} will return the given
-     * {@link java.io.OutputStream}. The streams provided to this
-     * call must wrap the original streams, and may be (but are not
-     * required to be) sub-classes of {@link java.io.FilterInputStream}
-     * and {@link java.io.FilterOutputStream}.
-     * @param i the filtered input stream to set as this object's inputstream,
-     *          or {@code null} if no change.
-     * @param o the filtered output stream to set as this object's outputstream,
-     *          or {@code null} if no change.
+     * Used by {@linkplain #Filter Filters} to wrap either (or both) of this exchange's InputStream
+     * and OutputStream, with the given filtered streams so that subsequent
+     * calls to {@link #getRequestBody()} will return the given
+     * {@link java.io.InputStream}, and calls to {@link #getResponseBody()} will
+     * return the given {@link java.io.OutputStream}. The streams provided to
+     * this call must wrap the original streams, and may be (but are not required
+     * to be) sub-classes of {@link java.io.FilterInputStream} and
+     * {@link java.io.FilterOutputStream}.
+     *
+     * @param i the filtered input stream to set as this object's
+     *          {@code Inputstream}, or {@code null} if no change
+     * @param o the filtered output stream to set as this object's
+     *          {@code Outputstream}, or {@code null} if no change
      */
-    public abstract void setStreams (InputStream i, OutputStream o);
+    public abstract void setStreams(InputStream i, OutputStream o);
 
 
     /**
-     * If an authenticator is set on the HttpContext that owns this exchange,
+     * If an authenticator is set on the {@link HttpContext} that owns this exchange,
      * then this method will return the {@link HttpPrincipal} that represents
-     * the authenticated user for this HttpExchange.
-     * @return the HttpPrincipal, or {@code null} if no authenticator is set.
+     * the authenticated user for this {@code HttpExchange}.
+     *
+     * @return the {@code HttpPrincipal}, or {@code null} if no authenticator is set
      */
-    public abstract HttpPrincipal getPrincipal ();
+    public abstract HttpPrincipal getPrincipal();
 }

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpServer.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpServer.java
@@ -33,62 +33,73 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.Executor;
 
 /**
- * This class implements a simple HTTP server. A HttpServer is bound to an IP address
+ * This class implements a simple HTTP server. A {@code HttpServer} is bound to an IP address
  * and port number and listens for incoming TCP connections from clients on this address.
  * The sub-class {@link HttpsServer} implements a server which handles HTTPS requests.
- * <p>
- * One or more {@link HttpHandler} objects must be associated with a server
- * in order to process requests. Each such HttpHandler is registered
- * with a root URI path which represents the
- * location of the application or service on this server. The mapping of a handler
- * to a HttpServer is encapsulated by a {@link HttpContext} object. HttpContexts
- * are created by calling {@link #createContext(String,HttpHandler)}.
+ *
+ * <p>One or more {@link HttpHandler} objects must be associated with a server
+ * in order to process requests. Each such {@code HttpHandler} is registered with
+ * a root URI path which represents the location of the application or service
+ * on this server. The mapping of a handler to a {@code HttpServer} is
+ * encapsulated by a {@link HttpContext} object. HttpContexts are created by
+ * calling {@link #createContext(String,HttpHandler)}.
  * Any request for which no handler can be found is rejected with a 404 response.
  * Management of threads can be done external to this object by providing a
  * {@link java.util.concurrent.Executor} object. If none is provided a default
  * implementation is used.
- * <p>
- * <a id="mapping_description"></a>
- * <b>Mapping request URIs to HttpContext paths</b><p>
- * When a HTTP request is received,
- * the appropriate HttpContext (and handler) is located by finding the context
- * whose path is the longest matching prefix of the request URI's path.
- * Paths are matched literally, which means that the strings are compared
- * case sensitively, and with no conversion to or from any encoded forms.
- * For example. Given a HttpServer with the following HttpContexts configured.
+ *
+ * <p> <a id="mapping_description"></a> <b>Mapping request URIs to HttpContext paths</b>
+ *
+ * <p>When a HTTP request is received, the appropriate {@code HttpContext}
+ * (and handler) is located by finding the context whose path is the longest
+ * matching prefix of the request URI's path. Paths are matched literally,
+ * which means that the strings are compared case sensitively, and with no
+ * conversion to or from any encoded forms. For example, given a {@code HttpServer}
+ * with the following HttpContexts configured:
+ *
  * <table class="striped"><caption style="display:none">description</caption>
- * <thead>
- * <tr><th scope="col"><i>Context</i></th><th scope="col"><i>Context path</i></th></tr>
- * </thead>
- * <tbody>
- * <tr><th scope="row">ctx1</th><td>"/"</td></tr>
- * <tr><th scope="row">ctx2</th><td>"/apps/"</td></tr>
- * <tr><th scope="row">ctx3</th><td>"/apps/foo/"</td></tr>
- * </tbody>
+ *      <thead>
+ *          <tr>
+ *              <th scope="col"><i>Context</i></th>
+ *              <th scope="col"><i>Context path</i></th>
+ *          </tr>
+ *      </thead>
+ *      <tbody>
+ *              <tr><th scope="row">ctx1</th><td>"/"</td></tr>
+ *              <tr><th scope="row">ctx2</th><td>"/apps/"</td></tr>
+ *              <tr><th scope="row">ctx3</th><td>"/apps/foo/"</td></tr>
+ *      </tbody>
  * </table>
- * <p>
- * the following table shows some request URIs and which, if any context they would
- * match with.
+ *
+ * <p>The following table shows some request URIs and which, if any context they would
+ * match with:
  * <table class="striped"><caption style="display:none">description</caption>
- * <thead>
- * <tr><th scope="col"><i>Request URI</i></th><th scope="col"><i>Matches context</i></th></tr>
- * </thead>
- * <tbody>
- * <tr><th scope="row">"http://foo.com/apps/foo/bar"</th><td>ctx3</td></tr>
- * <tr><th scope="row">"http://foo.com/apps/Foo/bar"</th><td>no match, wrong case</td></tr>
- * <tr><th scope="row">"http://foo.com/apps/app1"</th><td>ctx2</td></tr>
- * <tr><th scope="row">"http://foo.com/foo"</th><td>ctx1</td></tr>
- * </tbody>
+ *      <thead>
+ *          <tr>
+ *              <th scope="col"><i>Request URI</i></th>
+ *              <th scope="col"><i>Matches context</i></th>
+ *          </tr>
+ *      </thead>
+ *      <tbody>
+ *          <tr><th scope="row">"http://foo.com/apps/foo/bar"</th><td>ctx3</td></tr>
+ *          <tr><th scope="row">"http://foo.com/apps/Foo/bar"</th><td>no match, wrong case</td></tr>
+ *          <tr><th scope="row">"http://foo.com/apps/app1"</th><td>ctx2</td></tr>
+ *          <tr><th scope="row">"http://foo.com/foo"</th><td>ctx1</td></tr>
+ *      </tbody>
  * </table>
- * <p>
- * <b>Note about socket backlogs</b><p>
- * When binding to an address and port number, the application can also specify an integer
- * <i>backlog</i> parameter. This represents the maximum number of incoming TCP connections
- * which the system will queue internally. Connections are queued while they are waiting to
- * be accepted by the HttpServer. When the limit is reached, further connections may be
- * rejected (or possibly ignored) by the underlying TCP implementation. Setting the right
- * backlog value is a compromise between efficient resource usage in the TCP layer (not setting
- * it too high) and allowing adequate throughput of incoming requests (not setting it too low).
+ *
+ * <p><b>Note about socket backlogs</b>
+ *
+ * <p>When binding to an address and port number, the application can also
+ * specify an integer <i>backlog</i> parameter. This represents the maximum
+ * number of incoming TCP connections which the system will queue internally.
+ * Connections are queued while they are waiting to be accepted by the
+ * {@code HttpServer}. When the limit is reached, further connections may be
+ * rejected (or possibly ignored) by the underlying TCP implementation. Setting
+ * the right backlog value is a compromise between efficient resource usage in
+ * the TCP layer (not setting it too high) and allowing adequate throughput of
+ * incoming requests (not setting it too low).
+ *
  * @since 1.6
  */
 
@@ -97,177 +108,191 @@ public abstract class HttpServer {
     /**
      * Constructor for subclasses to call.
      */
-    protected HttpServer () {
+    protected HttpServer() {
     }
 
     /**
-     * creates a HttpServer instance which is initially not bound to any local address/port.
-     * The HttpServer is acquired from the currently installed {@link HttpServerProvider}
-     * The server must be bound using {@link #bind(InetSocketAddress,int)} before it can be used.
+     * Creates a {@code HttpServer} instance which is initially not bound to any
+     * local address/port. The {@code HttpServer} is acquired from the currently
+     * installed {@link HttpServerProvider}. The server must be bound using
+     * {@link #bind(InetSocketAddress,int)} before it can be used.
      *
      * @throws IOException if an I/O error occurs
-     * @return An instance of HttpServer
+     * @return an instance of {@code HttpServer}
      */
-    public static HttpServer create () throws IOException {
+    public static HttpServer create() throws IOException {
         return create (null, 0);
     }
 
     /**
-     * Create a <code>HttpServer</code> instance which will bind to the
-     * specified {@link java.net.InetSocketAddress} (IP address and port number)
+     * Create a {@code HttpServer} instance which will bind to the
+     * specified {@link java.net.InetSocketAddress} (IP address and port number).
      *
      * A maximum backlog can also be specified. This is the maximum number of
      * queued incoming connections to allow on the listening socket.
-     * Queued TCP connections exceeding this limit may be rejected by the TCP implementation.
-     * The HttpServer is acquired from the currently installed {@link HttpServerProvider}
+     * Queued TCP connections exceeding this limit may be rejected by the TCP
+     * implementation. The {@code HttpServer} is acquired from the currently
+     * installed {@link HttpServerProvider}
      *
-     * @param addr the address to listen on, if <code>null</code> then bind() must be called
-     *  to set the address
+     * @param addr the address to listen on, if {@code null} then
+     *             {@link #bind(InetSocketAddress, int)} must be called to set
+     *             the address
      * @param backlog the socket backlog. If this value is less than or equal to zero,
-     *          then a system default value is used.
-     * @throws BindException if the server cannot bind to the requested address,
-     *          or if the server is already bound.
+     *                then a system default value is used
      * @throws IOException if an I/O error occurs
-     * @return An instance of HttpServer
+     * @throws BindException if the server cannot bind to the requested address,
+     * or if the server is already bound
+     * @return an instance of {@code HttpServer}
      */
 
-    public static HttpServer create (
-        InetSocketAddress addr, int backlog
-    ) throws IOException {
+    public static HttpServer create(InetSocketAddress addr, int backlog) throws IOException {
         HttpServerProvider provider = HttpServerProvider.provider();
         return provider.createHttpServer (addr, backlog);
     }
 
     /**
-     * Binds a currently unbound HttpServer to the given address and port number.
-     * A maximum backlog can also be specified. This is the maximum number of
-     * queued incoming connections to allow on the listening socket.
-     * Queued TCP connections exceeding this limit may be rejected by the TCP implementation.
+     * Binds a currently unbound {@code HttpServer} to the given address and
+     * port number. A maximum backlog can also be specified. This is the maximum
+     * number of queued incoming connections to allow on the listening socket.
+     * Queued TCP connections exceeding this limit may be rejected by the TCP
+     * implementation.
+     *
      * @param addr the address to listen on
-     * @param backlog the socket backlog. If this value is less than or equal to zero,
-     *          then a system default value is used.
-     * @throws BindException if the server cannot bind to the requested address or if the server
-     *          is already bound.
-     * @throws NullPointerException if addr is <code>null</code>
+     * @param backlog the socket backlog. If this value is less than or equal to
+     *                zero, then a system default value is used
+     * @throws BindException if the server cannot bind to the requested address
+     * or if the server is already bound
+     * @throws NullPointerException if addr is {@code null}
      */
-    public abstract void bind (InetSocketAddress addr, int backlog) throws IOException;
+    public abstract void bind(InetSocketAddress addr, int backlog) throws IOException;
 
     /**
      * Starts this server in a new background thread. The background thread
      * inherits the priority, thread group and context class loader
      * of the caller.
      */
-    public abstract void start () ;
+    public abstract void start();
 
     /**
-     * sets this server's {@link java.util.concurrent.Executor} object. An
-     * Executor must be established before {@link #start()} is called.
+     * Sets this server's {@link java.util.concurrent.Executor} object. An
+     * {@code Executor} must be established before {@link #start()} is called.
      * All HTTP requests are handled in tasks given to the executor.
-     * If this method is not called (before start()) or if it is
-     * called with a <code>null</code> Executor, then
-     * a default implementation is used, which uses the thread
-     * which was created by the {@link #start()} method.
-     * @param executor the Executor to set, or <code>null</code> for  default
-     *          implementation
+     * If this method is not called (before {@link #start()}) or if it is called
+     * with a {@code null Executor}, then a default implementation is used,
+     * which uses the thread which was created by the {@link #start()} method.
+     *
+     * @param executor the {@code Executor} to set, or {@code null} for  default
+     *                 implementation
      * @throws IllegalStateException if the server is already started
      */
-    public abstract void setExecutor (Executor executor);
+    public abstract void setExecutor(Executor executor);
 
 
     /**
-     * returns this server's Executor object if one was specified with
-     * {@link #setExecutor(Executor)}, or <code>null</code> if none was
-     * specified.
-     * @return the Executor established for this server or <code>null</code> if not set.
+     * Returns this server's {@code Executor} object if one was specified with
+     * {@link #setExecutor(Executor)}, or {@code null} if none was specified.
+     *
+     * @return the {@code Executor} established for this server or {@code null} if not set.
      */
-    public abstract Executor getExecutor () ;
+    public abstract Executor getExecutor() ;
 
     /**
-     * stops this server by closing the listening socket and disallowing
+     * Stops this server by closing the listening socket and disallowing
      * any new exchanges from being processed. The method will then block
      * until all current exchange handlers have completed or else when
      * approximately <i>delay</i> seconds have elapsed (whichever happens
      * sooner). Then, all open TCP connections are closed, the background
-     * thread created by start() exits, and the method returns.
-     * Once stopped, a HttpServer cannot be re-used.
+     * thread created by {@link #start()} exits, and the method returns.
+     * Once stopped, a {@code HttpServer} cannot be re-used.
      *
-     * @param delay the maximum time in seconds to wait until exchanges have finished.
-     * @throws IllegalArgumentException if delay is less than zero.
+     * @param delay the maximum time in seconds to wait until exchanges have finished
+     * @throws IllegalArgumentException if delay is less than zero
      */
-    public abstract void stop (int delay);
+    public abstract void stop(int delay);
 
     /**
-     * Creates a HttpContext. A HttpContext represents a mapping from a
-     * URI path to a exchange handler on this HttpServer. Once created, all requests
-     * received by the server for the path will be handled by calling
-     * the given handler object. The context is identified by the path, and
-     * can later be removed from the server using this with the {@link #removeContext(String)} method.
-     * <p>
-     * The path specifies the root URI path for this context. The first character of path must be
-     * '/'. <p>
-     * The class overview describes how incoming request URIs are <a href="#mapping_description">mapped</a>
-     * to HttpContext instances.
-     * @apiNote The path should generally, but is not required to, end with '/'. If the path does not
-     * end with '/', eg such as with {@code "/foo"} then this would match requests with a path of
-     * {@code "/foobar"} or {@code "/foo/bar"}.
+     * Creates a {@code HttpContext}. A  {@code HttpContext} represents a mapping
+     * from a URI path to a exchange handler on this  {@code HttpServer}. Once
+     * created, all requests received by the server for the path will be handled
+     * by calling the given handler object. The context is identified by the
+     * path, and can later be removed from the server using this with the
+     * {@link #removeContext(String)} method.
+     *
+     * <p> The path specifies the root URI path for this context. The first
+     * character of path must be '/'.
+     *
+     * <p>The class overview describes how incoming request URIs are
+     * <a href="#mapping_description">mapped</a> to HttpContext instances.
+     *
+     * @apiNote The path should generally, but is not required to, end with '/'.
+     * If the path does not end with '/', eg such as with {@code "/foo"} then
+     * this would match requests with a path of {@code "/foobar"} or
+     * {@code "/foo/bar"}.
      *
      * @param path the root URI path to associate the context with
-     * @param handler the handler to invoke for incoming requests.
+     * @param handler the handler to invoke for incoming requests
      * @throws IllegalArgumentException if path is invalid, or if a context
-     *          already exists for this path
-     * @throws NullPointerException if either path, or handler are <code>null</code>
-     * @return An instance of HttpContext
+     * already exists for this path
+     * @throws NullPointerException if either path, or handler are {@code null}
+     * @return an instance of {@code HttpContext}
      */
-    public abstract HttpContext createContext (String path, HttpHandler handler) ;
+    public abstract HttpContext createContext(String path, HttpHandler handler);
 
     /**
-     * Creates a HttpContext without initially specifying a handler. The handler must later be specified using
-     * {@link HttpContext#setHandler(HttpHandler)}.  A HttpContext represents a mapping from a
-     * URI path to an exchange handler on this HttpServer. Once created, and when
-     * the handler has been set, all requests
-     * received by the server for the path will be handled by calling
-     * the handler object. The context is identified by the path, and
-     * can later be removed from the server using this with the {@link #removeContext(String)} method.
-     * <p>
-     * The path specifies the root URI path for this context. The first character of path must be
-     * '/'. <p>
-     * The class overview describes how incoming request URIs are <a href="#mapping_description">mapped</a>
-     * to HttpContext instances.
-     * @apiNote The path should generally, but is not required to, end with '/'. If the path does not
-     * end with '/', eg such as with {@code "/foo"} then this would match requests with a path of
-     * {@code "/foobar"} or {@code "/foo/bar"}.
+     * Creates a HttpContext without initially specifying a handler. The handler
+     * must later be specified using {@link HttpContext#setHandler(HttpHandler)}.
+     * A {@code HttpContext} represents a mapping from a URI path to an exchange
+     * handler on this {@code HttpServer}. Once created, and when the handler has
+     * been set, all requests received by the server for the path will be handled
+     * by calling the handler object. The context is identified by the path, and
+     * can later be removed from the server using this with the
+     * {@link #removeContext(String)} method.
+     *
+     * <p>The path specifies the root URI path for this context. The first character of path must be
+     * '/'.
+     *
+     * <p>The class overview describes how incoming request URIs are
+     * <a href="#mapping_description">mapped</a> to {@code HttpContext} instances.
+     *
+     * @apiNote The path should generally, but is not required to, end with '/'.
+     * If the path does not end with '/', eg such as with {@code "/foo"} then
+     * this would match requests with a path of {@code "/foobar"} or
+     * {@code "/foo/bar"}.
      *
      * @param path the root URI path to associate the context with
      * @throws IllegalArgumentException if path is invalid, or if a context
-     *          already exists for this path
-     * @throws NullPointerException if path is <code>null</code>
-     * @return An instance of HttpContext
+     * already exists for this path
+     * @throws NullPointerException if path is {@code null}
+     * @return an instance of {@code HttpContext}
      */
-    public abstract HttpContext createContext (String path) ;
+    public abstract HttpContext createContext(String path);
 
     /**
      * Removes the context identified by the given path from the server.
      * Removing a context does not affect exchanges currently being processed
      * but prevents new ones from being accepted.
+     *
      * @param path the path of the handler to remove
      * @throws IllegalArgumentException if no handler corresponding to this
-     *          path exists.
-     * @throws NullPointerException if path is <code>null</code>
+     * path exists.
+     * @throws NullPointerException if path is {@code null}
      */
-    public abstract void removeContext (String path) throws IllegalArgumentException ;
+    public abstract void removeContext(String path) throws IllegalArgumentException;
 
     /**
      * Removes the given context from the server.
      * Removing a context does not affect exchanges currently being processed
      * but prevents new ones from being accepted.
+     *
      * @param context the context to remove
-     * @throws NullPointerException if context is <code>null</code>
+     * @throws NullPointerException if context is {@code null}
      */
-    public abstract void removeContext (HttpContext context) ;
+    public abstract void removeContext(HttpContext context);
 
     /**
-     * returns the address this server is listening on
-     * @return the address/port number the server is listening on
+     * Returns the address this server is listening on
+     *
+     * @return the {@code InetSocketAddress} the server is listening on
      */
-    public abstract InetSocketAddress getAddress() ;
+    public abstract InetSocketAddress getAddress();
 }


### PR DESCRIPTION
Hi,

Could someone please review my doc-only fix for JDK-8253475 - 'Javadoc clean up in HttpExchange and HttpServer' ?

This fix is set of formatting changes intended to clean up the javadoc of the following classes :

`com.sun.net.httpserver.HttpExchange`
`com.sun.net.httpserver.HttpServer`

This issue is a sub-task of [JDK-8252822](https://bugs.openjdk.java.net/browse/JDK-8252822)

Kind regards,
Patrick

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (langtools/tier1)](https://github.com/pconcannon/jdk/runs/1216337098)

### Issue
 * [JDK-8253475](https://bugs.openjdk.java.net/browse/JDK-8253475): Javadoc clean up in HttpExchange and HttpServer


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/506/head:pull/506`
`$ git checkout pull/506`
