### PR TITLE
8253832: CharsetDecoder : decode() mentioning CoderMalfunctionError behavior not as per spec

### DIFF
--- a/src/java.base/share/classes/java/nio/charset/Charset-X-Coder.java.template
+++ b/src/java.base/share/classes/java/nio/charset/Charset-X-Coder.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -583,9 +583,7 @@ public abstract class Charset$Coder$ {
             CoderResult cr;
             try {
                 cr = $code$Loop(in, out);
-            } catch (BufferUnderflowException x) {
-                throw new CoderMalfunctionError(x);
-            } catch (BufferOverflowException x) {
+            } catch (RuntimeException x) {
                 throw new CoderMalfunctionError(x);
             }
 

--- a/test/jdk/java/nio/charset/CharsetDecoder/CoderMalfunctionErrorTest.java
+++ b/test/jdk/java/nio/charset/CharsetDecoder/CoderMalfunctionErrorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8253832
+ * @run testng CoderMalfunctionErrorTest
+ * @summary Check CoderMalfunctionError is thrown for any RuntimeException
+ *      on CharsetDecoder.decodeLoop() invocation.
+ */
+
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.*;
+
+@Test
+public class CoderMalfunctionErrorTest {
+    @Test (expectedExceptions = CoderMalfunctionError.class)
+    public void testDecodeLoop() {
+        new CharsetDecoder(StandardCharsets.US_ASCII, 1, 1) {
+            @Override
+            protected CoderResult decodeLoop(ByteBuffer byteBuffer, CharBuffer charBuffer) {
+                throw new RuntimeException("This exception should be wrapped in CoderMalfunctionError");
+            }
+        }.decode(null, null, true);
+    }
+}

--- a/test/jdk/java/nio/charset/CharsetEncoder/CoderMalfunctionErrorTest.java
+++ b/test/jdk/java/nio/charset/CharsetEncoder/CoderMalfunctionErrorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8253832
+ * @run testng CoderMalfunctionErrorTest
+ * @summary Check CoderMalfunctionError is thrown for any RuntimeException
+ *      on CharsetEncoder.encodeLoop() invocation.
+ */
+
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.*;
+
+@Test
+public class CoderMalfunctionErrorTest {
+    @Test (expectedExceptions = CoderMalfunctionError.class)
+    public void testEncodeLoop() {
+        new CharsetEncoder(StandardCharsets.US_ASCII, 1, 1) {
+            @Override
+            protected CoderResult encodeLoop(CharBuffer charBuffer, ByteBuffer byteBuffer) {
+                throw new RuntimeException("This exception should be wrapped in CoderMalfunctionError");
+            }
+        }.encode(null, null, true);
+    }
+}


### PR DESCRIPTION
Hi,

Please review the fix to the subject issue. It now catches all unexpected exceptions and wrap it with CoderMalfunctionError, as specified in the spec.

Naoto

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253832](https://bugs.openjdk.java.net/browse/JDK-8253832): CharsetDecoder : decode() mentioning CoderMalfunctionError behavior not as per spec


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/508/head:pull/508`
`$ git checkout pull/508`
