### PR TITLE
JDK-8234393: [macos] printing ignores printer tray

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ import javax.print.attribute.standard.MediaPrintableArea;
 import javax.print.attribute.standard.MediaSize;
 import javax.print.attribute.standard.MediaSizeName;
 import javax.print.attribute.standard.PageRanges;
+import javax.print.attribute.Attribute;
 
 import sun.java2d.*;
 import sun.print.*;
@@ -63,6 +64,8 @@ public final class CPrinterJob extends RasterPrinterJob {
     private boolean noDefaultPrinter = false;
 
     private static Font defaultFont;
+
+    private String tray = null;
 
     // This is the NSPrintInfo for this PrinterJob. Protect multi thread
     //  access to it. It is used by the pageDialog, jobDialog, and printLoop.
@@ -178,6 +181,11 @@ public final class CPrinterJob extends RasterPrinterJob {
 
         if (attributes == null) {
             return;
+        }
+        Attribute attr = attributes.get(Media.class);
+        if (attr instanceof CustomMediaTray) {
+            CustomMediaTray customTray = (CustomMediaTray) attr;
+            tray = customTray.getChoiceName();
         }
 
         PageRanges pageRangesAttr =  (PageRanges)attributes.get(PageRanges.class);
@@ -629,6 +637,10 @@ public final class CPrinterJob extends RasterPrinterJob {
         PrintService service = getPrintService();
         if (service == null) return null;
         return service.getName();
+    }
+
+    private String getPrinterTray() {
+        return tray;
     }
 
     private void setPrinterServiceFromNative(String printerName) {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -546,6 +546,7 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPrinterJob_printLoop
     static JNF_MEMBER_CACHE(jm_getPageFormatArea, sjc_CPrinterJob, "getPageFormatArea", "(Ljava/awt/print/PageFormat;)Ljava/awt/geom/Rectangle2D;");
     static JNF_MEMBER_CACHE(jm_getPrinterName, sjc_CPrinterJob, "getPrinterName", "()Ljava/lang/String;");
     static JNF_MEMBER_CACHE(jm_getPageable, sjc_CPrinterJob, "getPageable", "()Ljava/awt/print/Pageable;");
+    static JNF_MEMBER_CACHE(jm_getPrinterTray, sjc_CPrinterJob, "getPrinterTray", "()Ljava/lang/String;");
 
     jboolean retVal = JNI_FALSE;
 
@@ -560,6 +561,13 @@ JNF_COCOA_ENTER(env);
         [printerView setFirstPage:firstPage lastPage:lastPage];
 
         NSPrintInfo* printInfo = (NSPrintInfo*)jlong_to_ptr(JNFCallLongMethod(env, jthis, sjm_getNSPrintInfo)); // AWT_THREADING Safe (known object)
+        jobject printerTrayObj = JNFCallObjectMethod(env, jthis, jm_getPrinterTray);
+        if (printerTrayObj != NULL) {
+            NSString *printerTray = JNFJavaToNSString(env, printerTrayObj);
+            if (printerTray != nil) {
+                [[printInfo printSettings] setObject:printerTray forKey:@"InputSlot"];
+            }
+        }
 
         // <rdar://problem/4156975> passing jthis CPrinterJob as well, so we can extract the printer name from the current job
         javaPageFormatToNSPrintInfo(env, jthis, page, printInfo);

--- a/src/java.desktop/share/classes/sun/print/CustomMediaTray.java
+++ b/src/java.desktop/share/classes/sun/print/CustomMediaTray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import javax.print.attribute.standard.MediaTray;
 import javax.print.attribute.standard.Media;
 import java.util.ArrayList;
 
-class CustomMediaTray extends MediaTray {
+public class CustomMediaTray extends MediaTray {
     private static ArrayList<String> customStringTable = new ArrayList<>();
     private static ArrayList<MediaTray> customEnumTable = new ArrayList<>();
     private String choiceName;

--- a/test/jdk/java/awt/print/PrinterJob/TestMediaTraySelection.java
+++ b/test/jdk/java/awt/print/PrinterJob/TestMediaTraySelection.java
@@ -23,7 +23,7 @@
 /*
  * @bug 6357887 8165146
  * @summary  Verifies if selected printertray is used
- * @requires os.family == "linux"
+ * @requires (os.family == "linux" | os.family == "mac")
  * @run main/manual TestMediaTraySelection
  */
 

--- a/test/jdk/java/awt/print/PrinterJob/TestMediaTraySelection.java
+++ b/test/jdk/java/awt/print/PrinterJob/TestMediaTraySelection.java
@@ -21,7 +21,7 @@
  * questions.
  */
 /*
- * @bug 6357887 8165146
+ * @bug 6357887 8165146 8234393
  * @summary  Verifies if selected printertray is used
  * @requires (os.family == "linux" | os.family == "mac")
  * @run main/manual TestMediaTraySelection


### PR DESCRIPTION
**Issue**

[https://bugs.openjdk.java.net/browse/JDK-8234393](https://bugs.openjdk.java.net/browse/JDK-8234393)

**Problem**

On a multi tray printer, irrespective of what tray is set, Java always prints from the last tray which is the default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8234393](https://bugs.openjdk.java.net/browse/JDK-8234393): [macos] printing ignores printer tray


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/509/head:pull/509`
`$ git checkout pull/509`
