### PR TITLE
8254146: Avoid unnecessary volatile write on new AtomicBoolean(false)

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicBoolean.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicBoolean.java
@@ -68,7 +68,9 @@ public class AtomicBoolean implements java.io.Serializable {
      * @param initialValue the initial value
      */
     public AtomicBoolean(boolean initialValue) {
-        value = initialValue ? 1 : 0;
+        if (initialValue) {
+            value = 1;
+        }
     }
 
     /**


### PR DESCRIPTION
Hi,

the following PR optimizes `new AtomicBoolean(boolean)` by avoiding the volatile write in case `false` is passed. Essentially, it changes the ternary operator to a simple `if` without the `else` that would cause the volatile write.

The resulting bytecode seems to also benefit from the change:
```
    Code:
       0: aload_0
       1: invokespecial #1                  // Method java/lang/Object."<init>":()V
       4: aload_0
       5: iload_1
       6: ifeq          13
       9: iconst_1
      10: goto          14
      13: iconst_0
      14: putfield      #7                  // Field value:I
      17: return
```

After:
```
    Code:
       0: aload_0
       1: invokespecial #1                  // Method java/lang/Object."<init>":()V
       4: iload_1
       5: ifeq          13
       8: aload_0
       9: iconst_1
      10: putfield      #7                  // Field value:I
      13: return
```

A simple benchmark that returns `new AtomicBoolean(false)` shows the following results, that brings it on par to `new AtomicBoolean()`:
```
MyBenchmark.empty                                         avgt   10     3,103 ±   0,246   ns/op
MyBenchmark.explicitNew                                   avgt   10     2,966 ±   0,071   ns/op
MyBenchmark.explicitOld                                   avgt   10     7,738 ±   0,321   ns/op
```

In case you think this is worthwhile I'd be happy if this is sponsored.
Cheers,
Christoph

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254146](https://bugs.openjdk.java.net/browse/JDK-8254146): Avoid unnecessary volatile write on new AtomicBoolean(false)


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/510/head:pull/510`
`$ git checkout pull/510`
