### PR TITLE
8067127: Tags cleanup

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -296,8 +296,8 @@ public class BufferedInputStream extends FilterInputStream {
      * starting at the given offset.
      *
      * <p> This method implements the general contract of the corresponding
-     * <code>{@link InputStream#read(byte[], int, int) read}</code> method of
-     * the <code>{@link InputStream}</code> class.  As an additional
+     * {@link InputStream#read(byte[], int, int) read} method of
+     * the {@link InputStream} class.  As an additional
      * convenience, it attempts to read as many bytes as possible by repeatedly
      * invoking the {@code read} method of the underlying stream.  This
      * iterated {@code read} continues until one of the following
@@ -394,8 +394,8 @@ public class BufferedInputStream extends FilterInputStream {
      * many bytes will not block, but may read or skip fewer bytes.
      * <p>
      * This method returns the sum of the number of bytes remaining to be read in
-     * the buffer (<code>count&nbsp;- pos</code>) and the result of calling the
-     * {@link java.io.FilterInputStream#in in}.available().
+     * the buffer ({@code count - pos}) and the result of calling the
+     * {@link java.io.FilterInputStream#in in}{@code .available()}.
      *
      * @return     an estimate of the number of bytes that can be read (or skipped
      *             over) from this input stream without blocking.

--- a/src/java.base/share/classes/java/io/BufferedReader.java
+++ b/src/java.base/share/classes/java/io/BufferedReader.java
@@ -232,8 +232,8 @@ public class BufferedReader extends Reader {
      * Reads characters into a portion of an array.
      *
      * <p> This method implements the general contract of the corresponding
-     * <code>{@link Reader#read(char[], int, int) read}</code> method of the
-     * <code>{@link Reader}</code> class.  As an additional convenience, it
+     * {@link Reader#read(char[], int, int) read} method of the
+     * {@link Reader} class.  As an additional convenience, it
      * attempts to read as many characters as possible by repeatedly invoking
      * the {@code read} method of the underlying stream.  This iterated
      * {@code read} continues until one of the following conditions becomes

--- a/src/java.base/share/classes/java/io/EOFException.java
+++ b/src/java.base/share/classes/java/io/EOFException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class EOFException extends IOException {
     /**
      * Constructs an {@code EOFException} with the specified detail
      * message. The string {@code s} may later be retrieved by the
-     * <code>{@link java.lang.Throwable#getMessage}</code> method of class
+     * {@link java.lang.Throwable#getMessage} method of class
      * {@code java.lang.Throwable}.
      *
      * @param   s   the detail message.

--- a/src/java.base/share/classes/java/io/FileFilter.java
+++ b/src/java.base/share/classes/java/io/FileFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,9 +29,9 @@ package java.io;
 /**
  * A filter for abstract pathnames.
  *
- * <p> Instances of this interface may be passed to the <code>{@link
- * File#listFiles(java.io.FileFilter) listFiles(FileFilter)}</code> method
- * of the <code>{@link java.io.File}</code> class.
+ * <p> Instances of this interface may be passed to the
+ * {@link File#listFiles(java.io.FileFilter) listFiles(FileFilter)} method
+ * of the {@link java.io.File} class.
  *
  * @since 1.2
  */

--- a/src/java.base/share/classes/java/io/FileNotFoundException.java
+++ b/src/java.base/share/classes/java/io/FileNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class FileNotFoundException extends IOException {
      * Constructs a {@code FileNotFoundException} with the
      * specified detail message. The string {@code s} can be
      * retrieved later by the
-     * <code>{@link java.lang.Throwable#getMessage}</code>
+     * {@link java.lang.Throwable#getMessage}
      * method of class {@code java.lang.Throwable}.
      *
      * @param   s   the detail message.

--- a/src/java.base/share/classes/java/io/InterruptedIOException.java
+++ b/src/java.base/share/classes/java/io/InterruptedIOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class InterruptedIOException extends IOException {
      * Constructs an {@code InterruptedIOException} with the
      * specified detail message. The string {@code s} can be
      * retrieved later by the
-     * <code>{@link java.lang.Throwable#getMessage}</code>
+     * {@link java.lang.Throwable#getMessage}
      * method of class {@code java.lang.Throwable}.
      *
      * @param   s   the detail message.

--- a/src/java.base/share/classes/java/io/PipedInputStream.java
+++ b/src/java.base/share/classes/java/io/PipedInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,8 +79,8 @@ public class PipedInputStream extends InputStream {
     /**
      * The index of the position in the circular buffer at which the
      * next byte of data will be stored when received from the connected
-     * piped output stream. <code>in&lt;0</code> implies the buffer is empty,
-     * {@code in==out} implies the buffer is full
+     * piped output stream. {@code in < 0} implies the buffer is empty,
+     * {@code in == out} implies the buffer is full
      * @since   1.1
      */
     protected int in = -1;

--- a/src/java.base/share/classes/java/io/PipedReader.java
+++ b/src/java.base/share/classes/java/io/PipedReader.java
@@ -58,8 +58,8 @@ public class PipedReader extends Reader {
     /**
      * The index of the position in the circular buffer at which the
      * next character of data will be stored when received from the connected
-     * piped writer. <code>in&lt;0</code> implies the buffer is empty,
-     * {@code in==out} implies the buffer is full
+     * piped writer. {@code in < 0} implies the buffer is empty,
+     * {@code in == out} implies the buffer is full
      */
     int in = -1;
 

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -692,7 +692,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * Reads a signed eight-bit value from this file. This method reads a
      * byte from the file, starting from the current file pointer.
      * If the byte read is {@code b}, where
-     * <code>0&nbsp;&lt;=&nbsp;b&nbsp;&lt;=&nbsp;255</code>,
+     * {@code 0 <= b <= 255},
      * then the result is:
      * <blockquote><pre>
      *     (byte)(b)
@@ -766,7 +766,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * two bytes from the file, starting at the current file pointer.
      * If the bytes read, in order, are
      * {@code b1} and {@code b2}, where
-     * <code>0&nbsp;&lt;=&nbsp;b1, b2&nbsp;&lt;=&nbsp;255</code>,
+     * {@code 0 <= b1, b2 <= 255},
      * then the result is equal to:
      * <blockquote><pre>
      *     (b1 &lt;&lt; 8) | b2
@@ -794,7 +794,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * bytes from the file, starting at the current file pointer.
      * If the bytes read, in order, are
      * {@code b1} and {@code b2}, where
-     * <code>0&nbsp;&lt;=&nbsp;b1,&nbsp;b2&nbsp;&lt;=&nbsp;255</code>,
+     * {@code 0 <= b1, b2 <= 255},
      * then the result is equal to:
      * <blockquote><pre>
      *     (char)((b1 &lt;&lt; 8) | b2)
@@ -822,7 +822,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * bytes from the file, starting at the current file pointer.
      * If the bytes read, in order, are {@code b1},
      * {@code b2}, {@code b3}, and {@code b4}, where
-     * <code>0&nbsp;&lt;=&nbsp;b1, b2, b3, b4&nbsp;&lt;=&nbsp;255</code>,
+     * {@code 0 <= b1, b2, b3, b4 <= 255},
      * then the result is equal to:
      * <blockquote><pre>
      *     (b1 &lt;&lt; 24) | (b2 &lt;&lt; 16) + (b3 &lt;&lt; 8) + b4

--- a/src/java.base/share/classes/java/io/Serial.java
+++ b/src/java.base/share/classes/java/io/Serial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import java.lang.annotation.*;
  * serialization-related declarations, analogous to the checking
  * enabled by the {@link java.lang.Override} annotation type to
  * validate method overriding. {@code Serializable} classes are encouraged to
- * use <code>&#64;Serial</code> annotations to help a compiler catch
+ * use {@code @Serial} annotations to help a compiler catch
  * mis-declared serialization-related fields and methods,
  * mis-declarations that may otherwise be difficult to detect.
  *
@@ -60,7 +60,7 @@ import java.lang.annotation.*;
  * </ul>
  *
  * Compilers are encouraged to validate that a method or field marked with a
- * <code>&#64;Serial</code> annotation is one of the defined serialization-related
+ * {@code @Serial} annotation is one of the defined serialization-related
  * methods or fields declared in a meaningful context and issue a warning
  * if that is not the case.
  *

--- a/src/java.base/share/classes/java/io/StreamTokenizer.java
+++ b/src/java.base/share/classes/java/io/StreamTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,7 +264,7 @@ public class StreamTokenizer {
 
     /**
      * Specifies that all characters <i>c</i> in the range
-     * <code>low&nbsp;&lt;=&nbsp;<i>c</i>&nbsp;&lt;=&nbsp;high</code>
+     * {@code low <= c <= high}
      * are word constituents. A word token consists of a word constituent
      * followed by zero or more word constituents or number constituents.
      *
@@ -282,7 +282,7 @@ public class StreamTokenizer {
 
     /**
      * Specifies that all characters <i>c</i> in the range
-     * <code>low&nbsp;&lt;=&nbsp;<i>c</i>&nbsp;&lt;=&nbsp;high</code>
+     * {@code low <= c <= high}
      * are white space characters. White space characters serve only to
      * separate tokens in the input stream.
      *
@@ -303,7 +303,7 @@ public class StreamTokenizer {
 
     /**
      * Specifies that all characters <i>c</i> in the range
-     * <code>low&nbsp;&lt;=&nbsp;<i>c</i>&nbsp;&lt;=&nbsp;high</code>
+     * {@code low <= c <= high}
      * are "ordinary" in this tokenizer. See the
      * {@code ordinaryChar} method for more information on a
      * character being ordinary.

--- a/src/java.base/share/classes/java/io/StringBufferInputStream.java
+++ b/src/java.base/share/classes/java/io/StringBufferInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,7 +153,7 @@ public class StringBufferInputStream extends InputStream {
      * Returns the number of bytes that can be read from the input
      * stream without blocking.
      *
-     * @return     the value of <code>count&nbsp;-&nbsp;pos</code>, which is the
+     * @return     the value of {@code count - pos}, which is the
      *             number of bytes remaining to be read from the input buffer.
      */
     public synchronized int available() {

--- a/src/java.base/share/classes/java/io/UTFDataFormatException.java
+++ b/src/java.base/share/classes/java/io/UTFDataFormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ public class UTFDataFormatException extends IOException {
      * Constructs a {@code UTFDataFormatException} with the
      * specified detail message. The string {@code s} can be
      * retrieved later by the
-     * <code>{@link java.lang.Throwable#getMessage}</code>
+     * {@link java.lang.Throwable#getMessage}
      * method of class {@code java.lang.Throwable}.
      *
      * @param   s   the detail message.


### PR DESCRIPTION
Please review this change to update some javadoc tags in the java.io package. The changes are to replace some occurrences of <code>some_code</code> with {@code some_code}. Not all such constructs were replaced as being infeasible, e.g., tag contains an entity such as <code>*&#47;</code> (DataOutput, Serial), or multiple {@code} tags would be needed or the result would be ugly (File). It is unclear whether some of the changes which remove the non-breaking space entity (&nbsp;) are desirable.

Thanks,

Brian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (langtools/tier1)](https://github.com/bplb/jdk/runs/1218018555)

### Issue
 * [JDK-8067127](https://bugs.openjdk.java.net/browse/JDK-8067127): Tags cleanup


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 2e9b077022d4666e67e576ade67acb91fcbbeb41
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/513/head:pull/513`
`$ git checkout pull/513`
