### PR TITLE
8254046: Remove double semicolon introduced by JDK-8235521

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/AWTAccessor.java
+++ b/src/java.desktop/share/classes/sun/awt/AWTAccessor.java
@@ -41,7 +41,7 @@ import java.awt.image.BufferStrategy;
 import java.awt.peer.ComponentPeer;
 
 import java.awt.peer.MenuComponentPeer;
-import java.lang.invoke.MethodHandles;;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationTargetException;
 import java.security.AccessControlContext;
 


### PR DESCRIPTION
Please review this very minor fix to remove a double semicolon introduced by JDK-8235521 in src/java.desktop/share/classes/sun/awt/AWTAccessor.java. It causes an error in my Eclipse IDE.

https://github.com/openjdk/jdk/commit/71d646a16018778fc09f9ec407e35cf12c9e8f1d#diff-1b28189652c11b47b155b5a20a49fe8bR44

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254046](https://bugs.openjdk.java.net/browse/JDK-8254046): Remove double semicolon introduced by JDK-8235521


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/515/head:pull/515`
`$ git checkout pull/515`
