### PR TITLE
JDK-8254052: improve type specificity of TagletWriter and friends

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractIndexWriter.java
@@ -41,6 +41,7 @@ import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 
+import com.sun.source.doctree.DeprecatedTree;
 import com.sun.source.doctree.DocTree;
 import jdk.javadoc.internal.doclets.formats.html.SearchIndexItem.Category;
 import jdk.javadoc.internal.doclets.formats.html.markup.Entity;
@@ -251,13 +252,12 @@ public class AbstractIndexWriter extends HtmlDocletWriter {
      * @param contentTree the content tree to which the comment will be added
      */
     protected void addComment(Element element, Content contentTree) {
-        List<? extends DocTree> tags;
         Content span = HtmlTree.SPAN(HtmlStyle.deprecatedLabel, getDeprecatedPhrase(element));
         HtmlTree div = new HtmlTree(TagName.DIV);
         div.setStyle(HtmlStyle.deprecationBlock);
         if (utils.isDeprecated(element)) {
             div.add(span);
-            tags = utils.getBlockTags(element, DocTree.Kind.DEPRECATED);
+            List<? extends DeprecatedTree> tags = utils.getDeprecatedTrees(element);
             if (!tags.isEmpty())
                 addInlineDeprecatedComment(element, tags.get(0), div);
             contentTree.add(div);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
@@ -41,6 +41,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.SimpleElementVisitor8;
 
+import com.sun.source.doctree.DeprecatedTree;
 import com.sun.source.doctree.DocTree;
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
 import jdk.javadoc.internal.doclets.formats.html.markup.Entity;
@@ -507,7 +508,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
 
     @Override
     public void addClassDeprecationInfo(Content classInfoTree) {
-        List<? extends DocTree> deprs = utils.getBlockTags(typeElement, DocTree.Kind.DEPRECATED);
+        List<? extends DeprecatedTree> deprs = utils.getDeprecatedTrees(typeElement);
         if (utils.isDeprecated(typeElement)) {
             Content deprLabel = HtmlTree.SPAN(HtmlStyle.deprecatedLabel, getDeprecatedPhrase(typeElement));
             Content div = HtmlTree.DIV(HtmlStyle.deprecationBlock, deprLabel);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
@@ -33,6 +33,7 @@ import javax.lang.model.type.TypeMirror;
 
 import com.sun.source.doctree.DocTree;
 
+import com.sun.source.doctree.SerialTree;
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
 import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
@@ -165,7 +166,7 @@ public class HtmlSerialFieldWriter extends FieldWriterImpl
         if (!utils.getFullBody(field).isEmpty()) {
             writer.addInlineComment(field, contentTree);
         }
-        List<? extends DocTree> tags = utils.getBlockTags(field, DocTree.Kind.SERIAL);
+        List<? extends SerialTree> tags = utils.getSerialTrees(field);
         if (!tags.isEmpty()) {
             writer.addInlineComment(field, tags.get(0), contentTree);
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
@@ -369,14 +369,14 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
             }
         });
         // Generate the map of all services listed using @provides, and the description.
-        utils.getBlockTags(mdle, DocTree.Kind.PROVIDES).forEach(tree -> {
+        utils.getProvidesTrees(mdle).forEach(tree -> {
             TypeElement t = ch.getServiceType(tree);
             if (t != null) {
                 providesTrees.put(t, commentTagsToContent(tree, mdle, ch.getDescription(tree), false, true));
             }
         });
         // Generate the map of all services listed using @uses, and the description.
-        utils.getBlockTags(mdle, DocTree.Kind.USES).forEach(tree -> {
+        utils.getUsesTrees(mdle).forEach(tree -> {
             TypeElement t = ch.getServiceType(tree);
             if (t != null) {
                 usesTrees.put(t, commentTagsToContent(tree, mdle, ch.getDescription(tree), false, true));
@@ -815,7 +815,7 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
      * @param div the content tree to which the deprecation information will be added
      */
     public void addDeprecationInfo(Content div) {
-        List<? extends DocTree> deprs = utils.getBlockTags(mdle, DocTree.Kind.DEPRECATED);
+        List<? extends DocTree> deprs = utils.getDeprecatedTrees(mdle);
         if (utils.isDeprecated(mdle)) {
             CommentHelper ch = utils.getCommentHelper(mdle);
             HtmlTree deprDiv = new HtmlTree(TagName.DIV);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
@@ -32,6 +32,7 @@ import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 
+import com.sun.source.doctree.DeprecatedTree;
 import com.sun.source.doctree.DocTree;
 import jdk.javadoc.internal.doclets.formats.html.markup.BodyContents;
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
@@ -142,7 +143,7 @@ public class PackageWriterImpl extends HtmlDocletWriter
      * @param div the content tree to which the deprecation information will be added
      */
     public void addDeprecationInfo(Content div) {
-        List<? extends DocTree> deprs = utils.getBlockTags(packageElement, DocTree.Kind.DEPRECATED);
+        List<? extends DeprecatedTree> deprs = utils.getDeprecatedTrees(packageElement);
         if (utils.isDeprecated(packageElement)) {
             CommentHelper ch = utils.getCommentHelper(packageElement);
             HtmlTree deprDiv = new HtmlTree(TagName.DIV);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SubWriterHolderWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SubWriterHolderWriter.java
@@ -30,6 +30,7 @@ import java.util.*;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
+import com.sun.source.doctree.DeprecatedTree;
 import com.sun.source.doctree.DocTree;
 import jdk.javadoc.internal.doclets.formats.html.markup.BodyContents;
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
@@ -108,7 +109,7 @@ public abstract class SubWriterHolderWriter extends HtmlDocletWriter {
      */
     protected void addIndexComment(Element member, List<? extends DocTree> firstSentenceTags,
             Content tdSummary) {
-        List<? extends DocTree> deprs = utils.getBlockTags(member, DocTree.Kind.DEPRECATED);
+        List<? extends DeprecatedTree> deprs = utils.getDeprecatedTrees(member);
         Content div;
         if (utils.isDeprecated(member)) {
             Content deprLabel = HtmlTree.SPAN(HtmlStyle.deprecatedLabel, getDeprecatedPhrase(member));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -37,10 +37,15 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.SimpleElementVisitor14;
 
+import com.sun.source.doctree.DeprecatedTree;
 import com.sun.source.doctree.DocTree;
 import com.sun.source.doctree.IndexTree;
+import com.sun.source.doctree.LiteralTree;
 import com.sun.source.doctree.ParamTree;
+import com.sun.source.doctree.ReturnTree;
+import com.sun.source.doctree.SeeTree;
 import com.sun.source.doctree.SystemPropertyTree;
+import com.sun.source.doctree.ThrowsTree;
 import jdk.javadoc.internal.doclets.formats.html.SearchIndexItem.Category;
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
@@ -109,16 +114,15 @@ public class TagletWriterImpl extends TagletWriter {
     }
 
     @Override
-    protected Content indexTagOutput(Element element, DocTree tag) {
+    protected Content indexTagOutput(Element element, IndexTree tag) {
         CommentHelper ch = utils.getCommentHelper(element);
-        IndexTree itt = (IndexTree)tag;
 
-        String tagText = ch.getText(itt.getSearchTerm());
+        String tagText = ch.getText(tag.getSearchTerm());
         if (tagText.charAt(0) == '"' && tagText.charAt(tagText.length() - 1) == '"') {
             tagText = tagText.substring(1, tagText.length() - 1)
                              .replaceAll("\\s+", " ");
         }
-        String desc = ch.getText(itt.getDescription());
+        String desc = ch.getText(tag.getDescription());
 
         return createAnchorAndSearchIndex(element, tagText, desc, false);
     }
@@ -137,7 +141,7 @@ public class TagletWriterImpl extends TagletWriter {
     public Content deprecatedTagOutput(Element element) {
         ContentBuilder result = new ContentBuilder();
         CommentHelper ch = utils.getCommentHelper(element);
-        List<? extends DocTree> deprs = utils.getBlockTags(element, DocTree.Kind.DEPRECATED);
+        List<? extends DeprecatedTree> deprs = utils.getDeprecatedTrees(element);
         if (utils.isTypeElement(element)) {
             if (utils.isDeprecated(element)) {
                 result.add(HtmlTree.SPAN(HtmlStyle.deprecatedLabel,
@@ -171,7 +175,7 @@ public class TagletWriterImpl extends TagletWriter {
     }
 
     @Override
-    protected Content literalTagOutput(Element element, DocTree tag) {
+    protected Content literalTagOutput(Element element, LiteralTree tag) {
         CommentHelper ch = utils.getCommentHelper(element);
         Content result = new StringContent(utils.normalizeNewlines(ch.getText(tag)));
         return result;
@@ -191,12 +195,12 @@ public class TagletWriterImpl extends TagletWriter {
 
     @Override
     @SuppressWarnings("preview")
-    public Content paramTagOutput(Element element, DocTree paramTag, String paramName) {
+    public Content paramTagOutput(Element element, ParamTree paramTag, String paramName) {
         ContentBuilder body = new ContentBuilder();
         CommentHelper ch = utils.getCommentHelper(element);
         // define id attributes for state components so that generated descriptions may refer to them
         boolean defineID = (element.getKind() == ElementKind.RECORD)
-                && (paramTag instanceof ParamTree) && !((ParamTree) paramTag).isTypeParameter();
+                && !paramTag.isTypeParameter();
         Content nameTree = new StringContent(paramName);
         body.add(HtmlTree.CODE(defineID ? HtmlTree.SPAN_ID("param-" + paramName, nameTree) : nameTree));
         body.add(" - ");
@@ -206,7 +210,7 @@ public class TagletWriterImpl extends TagletWriter {
     }
 
     @Override
-    public Content returnTagOutput(Element element, DocTree returnTag) {
+    public Content returnTagOutput(Element element, ReturnTree returnTag) {
         CommentHelper ch = utils.getCommentHelper(element);
         return new ContentBuilder(
                 HtmlTree.DT(contents.returns),
@@ -215,7 +219,7 @@ public class TagletWriterImpl extends TagletWriter {
     }
 
     @Override
-    public Content seeTagOutput(Element holder, List<? extends DocTree> seeTags) {
+    public Content seeTagOutput(Element holder, List<? extends SeeTree> seeTags) {
         ContentBuilder body = new ContentBuilder();
         for (DocTree dt : seeTags) {
             appendSeparatorIfNotEmpty(body);
@@ -279,9 +283,8 @@ public class TagletWriterImpl extends TagletWriter {
     }
 
     @Override
-    protected Content systemPropertyTagOutput(Element element, DocTree tag) {
-        SystemPropertyTree itt = (SystemPropertyTree) tag;
-        String tagText = itt.getPropertyName().toString();
+    protected Content systemPropertyTagOutput(Element element, SystemPropertyTree tag) {
+        String tagText = tag.getPropertyName().toString();
         return HtmlTree.CODE(createAnchorAndSearchIndex(element, tagText,
                 resources.getText("doclet.System_Property"), true));
     }
@@ -292,7 +295,7 @@ public class TagletWriterImpl extends TagletWriter {
     }
 
     @Override
-    public Content throwsTagOutput(Element element, DocTree throwsTag, TypeMirror substituteType) {
+    public Content throwsTagOutput(Element element, ThrowsTree throwsTag, TypeMirror substituteType) {
         ContentBuilder body = new ContentBuilder();
         CommentHelper ch = utils.getCommentHelper(element);
         Element exception = ch.getException(throwsTag);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MemberSummaryBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MemberSummaryBuilder.java
@@ -38,6 +38,7 @@ import javax.lang.model.util.ElementFilter;
 import com.sun.source.doctree.DocCommentTree;
 import com.sun.source.doctree.DocTree;
 import com.sun.source.doctree.DocTree.Kind;
+import com.sun.source.doctree.SinceTree;
 import com.sun.source.doctree.UnknownBlockTagTree;
 import jdk.javadoc.internal.doclets.toolkit.ClassWriter;
 import jdk.javadoc.internal.doclets.toolkit.Content;
@@ -335,7 +336,7 @@ public abstract class MemberSummaryBuilder extends AbstractMemberBuilder {
         }
 
         // copy certain tags
-        List<? extends DocTree> tags = utils.getBlockTags(property, Kind.SINCE);
+        List<? extends SinceTree> tags = utils.getBlockTags(property, Kind.SINCE, SinceTree.class);
         blockTags.addAll(tags);
 
         List<? extends DocTree> bTags = utils.getBlockTags(property,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/IndexTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/IndexTaglet.java
@@ -29,6 +29,7 @@ import java.util.EnumSet;
 import javax.lang.model.element.Element;
 
 import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.IndexTree;
 import jdk.javadoc.doclet.Taglet.Location;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 
@@ -46,6 +47,6 @@ public class IndexTaglet extends BaseTaglet {
 
     @Override
     public Content getInlineTagOutput(Element element, DocTree tag, TagletWriter writer) {
-        return writer.indexTagOutput(element, tag);
+        return writer.indexTagOutput(element, (IndexTree) tag);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/LiteralTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/LiteralTaglet.java
@@ -29,6 +29,7 @@ import java.util.EnumSet;
 import javax.lang.model.element.Element;
 
 import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.LiteralTree;
 import jdk.javadoc.doclet.Taglet.Location;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 /**
@@ -52,6 +53,6 @@ public class LiteralTaglet extends BaseTaglet {
 
     @Override
     public Content getInlineTagOutput(Element e, DocTree tag, TagletWriter writer) {
-        return writer.literalTagOutput(e, tag);
+        return writer.literalTagOutput(e, (LiteralTree) tag);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -165,7 +165,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
      * @return the content representation of these {@code @param DocTree}s.
      */
     private Content getTagletOutput(ParamKind kind, Element holder,
-            TagletWriter writer, List<? extends Element> formalParameters, List<? extends DocTree> paramTags) {
+            TagletWriter writer, List<? extends Element> formalParameters, List<? extends ParamTree> paramTags) {
         Content result = writer.getOutputInstance();
         Set<String> alreadyDocumented = new HashSet<>();
         if (!paramTags.isEmpty()) {
@@ -210,7 +210,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
                     CommentHelper ch = utils.getCommentHelper(holder);
                     ch.setOverrideElement(inheritedDoc.holder);
                     Content content = processParamTag(holder, kind, writer,
-                            inheritedDoc.holderTag,
+                            (ParamTree) inheritedDoc.holderTag,
                             lname,
                             alreadyDocumented.isEmpty());
                     result.add(content);
@@ -240,13 +240,13 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
      * @return the Content representation of this {@code @param DocTree}.
      */
     private Content processParamTags(Element e, ParamKind kind,
-            List<? extends DocTree> paramTags, Map<String, String> rankMap, TagletWriter writer,
+            List<? extends ParamTree> paramTags, Map<String, String> rankMap, TagletWriter writer,
             Set<String> alreadyDocumented) {
         Messages messages = writer.configuration().getMessages();
         Content result = writer.getOutputInstance();
         if (!paramTags.isEmpty()) {
             CommentHelper ch = writer.configuration().utils.getCommentHelper(e);
-            for (DocTree dt : paramTags) {
+            for (ParamTree dt : paramTags) {
                 String name = ch.getParameterName(dt);
                 String paramName = kind != ParamKind.TYPE_PARAMETER
                         ? name.toString()
@@ -294,7 +294,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
      *
      */
     private Content processParamTag(Element e, ParamKind kind,
-            TagletWriter writer, DocTree paramTag, String name,
+            TagletWriter writer, ParamTree paramTag, String name,
             boolean isFirstParam) {
         Content result = writer.getOutputInstance();
         if (isFirstParam) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ReturnTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ReturnTaglet.java
@@ -34,6 +34,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeMirror;
 
 import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.ReturnTree;
 import jdk.javadoc.doclet.Taglet.Location;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.Messages;
@@ -58,7 +59,7 @@ public class ReturnTaglet extends BaseTaglet implements InheritableTaglet {
 
     @Override
     public void inherit(DocFinder.Input input, DocFinder.Output output) {
-        List<? extends DocTree> tags = input.utils.getBlockTags(input.element, DocTree.Kind.RETURN);
+        List<? extends ReturnTree> tags = input.utils.getReturnTrees(input.element);
         CommentHelper ch = input.utils.getCommentHelper(input.element);
         if (!tags.isEmpty()) {
             output.holder = input.element;
@@ -74,7 +75,7 @@ public class ReturnTaglet extends BaseTaglet implements InheritableTaglet {
         Messages messages = writer.configuration().getMessages();
         Utils utils = writer.configuration().utils;
         TypeMirror returnType = utils.getReturnType(writer.getCurrentPageElement(), (ExecutableElement)holder);
-        List<? extends DocTree> tags = utils.getBlockTags(holder, DocTree.Kind.RETURN);
+        List<? extends ReturnTree> tags = utils.getReturnTrees(holder);
 
         //Make sure we are not using @return tag on method with void return type.
         if (returnType != null && utils.isVoid(returnType)) {
@@ -94,6 +95,6 @@ public class ReturnTaglet extends BaseTaglet implements InheritableTaglet {
             ch.setOverrideElement(inheritedDoc.holder);
             ntags.add(inheritedDoc.holderTag);
         }
-        return !ntags.isEmpty() ? writer.returnTagOutput(holder, ntags.get(0)) : null;
+        return !ntags.isEmpty() ? writer.returnTagOutput(holder, (ReturnTree) ntags.get(0)) : null;
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SeeTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SeeTaglet.java
@@ -31,6 +31,7 @@ import java.util.List;
 import javax.lang.model.element.Element;
 
 import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.SeeTree;
 import jdk.javadoc.doclet.Taglet.Location;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.util.CommentHelper;
@@ -68,7 +69,7 @@ public class SeeTaglet extends BaseTaglet implements InheritableTaglet {
     @Override
     public Content getAllBlockTagOutput(Element holder, TagletWriter writer) {
         Utils utils = writer.configuration().utils;
-        List<? extends DocTree> tags = utils.getSeeTrees(holder);
+        List<? extends SeeTree> tags = utils.getSeeTrees(holder);
         Element e = holder;
         if (tags.isEmpty() && utils.isExecutableElement(holder)) {
             Input input = new DocFinder.Input(utils, holder, this);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SystemPropertyTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SystemPropertyTaglet.java
@@ -26,6 +26,7 @@
 package jdk.javadoc.internal.doclets.toolkit.taglets;
 
 import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.SystemPropertyTree;
 import jdk.javadoc.doclet.Taglet.Location;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 
@@ -50,6 +51,6 @@ public class SystemPropertyTaglet extends BaseTaglet {
 
     @Override
     public Content getInlineTagOutput(Element element, DocTree tag, TagletWriter writer) {
-        return writer.systemPropertyTagOutput(element, tag);
+        return writer.systemPropertyTagOutput(element, (SystemPropertyTree) tag);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
@@ -34,6 +34,13 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
 import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.IndexTree;
+import com.sun.source.doctree.LiteralTree;
+import com.sun.source.doctree.ParamTree;
+import com.sun.source.doctree.ReturnTree;
+import com.sun.source.doctree.SeeTree;
+import com.sun.source.doctree.SystemPropertyTree;
+import com.sun.source.doctree.ThrowsTree;
 import jdk.javadoc.internal.doclets.toolkit.BaseConfiguration;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.taglets.Taglet.UnsupportedTagletOperationException;
@@ -85,7 +92,7 @@ public abstract class TagletWriter {
      *
      * @return the output
      */
-    protected abstract Content indexTagOutput(Element element, DocTree tag);
+    protected abstract Content indexTagOutput(Element element, IndexTree tag);
 
     /**
      * Returns the output for a {@code {@docRoot}} tag.
@@ -111,7 +118,7 @@ public abstract class TagletWriter {
      *
      * @return the output
      */
-    protected abstract Content literalTagOutput(Element element, DocTree tag);
+    protected abstract Content literalTagOutput(Element element, LiteralTree tag);
 
     /**
      * Returns the header for the {@code @param} tags.
@@ -133,7 +140,7 @@ public abstract class TagletWriter {
      *
      * @return the output
      */
-    protected abstract Content paramTagOutput(Element element, DocTree paramTag, String paramName);
+    protected abstract Content paramTagOutput(Element element, ParamTree paramTag, String paramName);
 
     /**
      * Returns the output for a {@code @return} tag.
@@ -143,7 +150,7 @@ public abstract class TagletWriter {
      *
      * @return the output
      */
-    protected abstract Content returnTagOutput(Element element, DocTree returnTag);
+    protected abstract Content returnTagOutput(Element element, ReturnTree returnTag);
 
     /**
      * Returns the output for {@code @see} tags.
@@ -153,7 +160,7 @@ public abstract class TagletWriter {
      *
      * @return the output
      */
-    protected abstract Content seeTagOutput(Element element, List<? extends DocTree> seeTags);
+    protected abstract Content seeTagOutput(Element element, List<? extends SeeTree> seeTags);
 
     /**
      * Returns the output for a series of simple tags.
@@ -174,7 +181,7 @@ public abstract class TagletWriter {
      *
      * @return the output
      */
-    protected abstract Content systemPropertyTagOutput(Element element, DocTree systemPropertyTag);
+    protected abstract Content systemPropertyTagOutput(Element element, SystemPropertyTree systemPropertyTag);
 
     /**
      * Returns the header for the {@code @throws} tag.
@@ -192,7 +199,7 @@ public abstract class TagletWriter {
      *
      * @return the output
      */
-    protected abstract Content throwsTagOutput(Element element, DocTree throwsTag, TypeMirror substituteType);
+    protected abstract Content throwsTagOutput(Element element, ThrowsTree throwsTag, TypeMirror substituteType);
 
     /**
      * Returns the output for a default {@code @throws} tag.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -43,6 +44,7 @@ import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeMirror;
 
 import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.ThrowsTree;
 
 import jdk.javadoc.doclet.Taglet.Location;
 import jdk.javadoc.internal.doclets.toolkit.Content;
@@ -129,7 +131,7 @@ public class ThrowsTaglet extends BaseTaglet
         Utils utils = writer.configuration().utils;
         Content result = writer.getOutputInstance();
         if (utils.isExecutableElement(holder)) {
-            Map<List<? extends DocTree>, ExecutableElement> declaredExceptionTags = new LinkedHashMap<>();
+            Map<List<? extends ThrowsTree>, ExecutableElement> declaredExceptionTags = new LinkedHashMap<>();
             for (TypeMirror declaredExceptionType : declaredExceptionTypes) {
                 Input input = new DocFinder.Input(utils, holder, this,
                         utils.getTypeName(declaredExceptionType, false));
@@ -143,7 +145,10 @@ public class ThrowsTaglet extends BaseTaglet
                     if (inheritedDoc.holder == null) {
                         inheritedDoc.holder = holder;
                     }
-                    declaredExceptionTags.put(inheritedDoc.tagList, (ExecutableElement)inheritedDoc.holder);
+                    List<? extends ThrowsTree> inheritedTags = inheritedDoc.tagList.stream()
+                            .map(t -> (ThrowsTree) t)
+                            .collect(Collectors.toList());
+                    declaredExceptionTags.put(inheritedTags, (ExecutableElement) inheritedDoc.holder);
                 }
             }
             result.add(throwsTagsOutput(declaredExceptionTags, writer, alreadyDocumented,
@@ -161,7 +166,7 @@ public class ThrowsTaglet extends BaseTaglet
         List<? extends TypeMirror> thrownTypes = instantiatedType.getThrownTypes();
         Map<String, TypeMirror> typeSubstitutions = getSubstitutedThrownTypes(
                 ((ExecutableElement) holder).getThrownTypes(), thrownTypes);
-        Map<List<? extends DocTree>, ExecutableElement> tagsMap = new LinkedHashMap<>();
+        Map<List<? extends ThrowsTree>, ExecutableElement> tagsMap = new LinkedHashMap<>();
         tagsMap.put(utils.getThrowsTrees(execHolder), execHolder);
         Content result = writer.getOutputInstance();
         HashSet<String> alreadyDocumented = new HashSet<>();
@@ -183,16 +188,16 @@ public class ThrowsTaglet extends BaseTaglet
      * @param allowDuplicates   {@code true} if we allow duplicate tags to be documented
      * @return the generated content for the tags
      */
-    protected Content throwsTagsOutput(Map<List<? extends DocTree>, ExecutableElement> throwTags,
+    protected Content throwsTagsOutput(Map<List<? extends ThrowsTree>, ExecutableElement> throwTags,
                                        TagletWriter writer, Set<String> alreadyDocumented,
                                        Map<String,TypeMirror> typeSubstitutions, boolean allowDuplicates) {
         Utils utils = writer.configuration().utils;
         Content result = writer.getOutputInstance();
         if (!throwTags.isEmpty()) {
-            for (Entry<List<? extends DocTree>, ExecutableElement> entry : throwTags.entrySet()) {
+            for (Entry<List<? extends ThrowsTree>, ExecutableElement> entry : throwTags.entrySet()) {
                 CommentHelper ch = utils.getCommentHelper(entry.getValue());
                 Element e = entry.getValue();
-                for (DocTree dt : entry.getKey()) {
+                for (ThrowsTree dt : entry.getKey()) {
                     Element te = ch.getException(dt);
                     String excName = ch.getExceptionName(dt).toString();
                     TypeMirror substituteType = typeSubstitutions.get(excName);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -91,14 +91,23 @@ import javax.tools.JavaFileManager;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.StandardLocation;
 
+import com.sun.source.doctree.DeprecatedTree;
 import com.sun.source.doctree.DocCommentTree;
 import com.sun.source.doctree.DocTree;
 import com.sun.source.doctree.DocTree.Kind;
 import com.sun.source.doctree.EndElementTree;
 import com.sun.source.doctree.ParamTree;
+import com.sun.source.doctree.ProvidesTree;
+import com.sun.source.doctree.ReturnTree;
+import com.sun.source.doctree.SeeTree;
+import com.sun.source.doctree.SerialDataTree;
+import com.sun.source.doctree.SerialFieldTree;
+import com.sun.source.doctree.SerialTree;
 import com.sun.source.doctree.StartElementTree;
 import com.sun.source.doctree.TextTree;
+import com.sun.source.doctree.ThrowsTree;
 import com.sun.source.doctree.UnknownBlockTagTree;
+import com.sun.source.doctree.UsesTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.LineMap;
 import com.sun.source.util.DocSourcePositions;
@@ -946,8 +955,8 @@ public class Utils {
         return set;
     }
 
-    public List<? extends DocTree> getSerialDataTrees(ExecutableElement member) {
-        return getBlockTags(member, SERIAL_DATA);
+    public List<? extends SerialDataTree> getSerialDataTrees(ExecutableElement member) {
+        return getBlockTags(member, SERIAL_DATA, SerialDataTree.class);
     }
 
     public FileObject getFileObject(TypeElement te) {
@@ -2590,8 +2599,20 @@ public class Utils {
                 .collect(Collectors.toList());
     }
 
+    public <T extends DocTree> List<? extends T> getBlockTags(Element element, Predicate<DocTree> filter, Class<T> tClass) {
+        return getBlockTags(element).stream()
+                .filter(t -> t.getKind() != ERRONEOUS)
+                .filter(filter)
+                .map(t -> tClass.cast(t))
+                .collect(Collectors.toList());
+    }
+
     public List<? extends DocTree> getBlockTags(Element element, DocTree.Kind kind) {
         return getBlockTags(element, t -> t.getKind() == kind);
+    }
+
+    public <T extends DocTree> List<? extends T> getBlockTags(Element element, DocTree.Kind kind, Class<T> tClass) {
+        return getBlockTags(element, t -> t.getKind() == kind, tClass);
     }
 
     public List<? extends DocTree> getBlockTags(Element element, DocTree.Kind kind, DocTree.Kind altKind) {
@@ -2659,7 +2680,7 @@ public class Utils {
      * The entries may come from the AST and DocCommentParser, or may be autromatically
      * generated comments for mandated elements and JavaFX properties.
      *
-     * @see CommentUtils.dcInfoMap
+     * @see CommentUtils#dcInfoMap
      */
     private final Map<Element, DocCommentInfo> dcTreeCache = new LinkedHashMap<>();
 
@@ -2779,28 +2800,30 @@ public class Utils {
                 : docCommentTree.getFullBody();
     }
 
-    public List<? extends DocTree> getDeprecatedTrees(Element element) {
-        return getBlockTags(element, DEPRECATED);
+    public List<? extends DeprecatedTree> getDeprecatedTrees(Element element) {
+        return getBlockTags(element, DEPRECATED, DeprecatedTree.class);
     }
 
-    public List<? extends DocTree> getProvidesTrees(Element element) {
-        return getBlockTags(element, PROVIDES);
+    public List<? extends ProvidesTree> getProvidesTrees(Element element) {
+        return getBlockTags(element, PROVIDES, ProvidesTree.class);
     }
 
-    public List<? extends DocTree> getSeeTrees(Element element) {
-        return getBlockTags(element, SEE);
+    public List<? extends SeeTree> getSeeTrees(Element element) {
+        return getBlockTags(element, SEE, SeeTree.class);
     }
 
-    public List<? extends DocTree> getSerialTrees(Element element) {
-        return getBlockTags(element, SERIAL);
+    public List<? extends SerialTree> getSerialTrees(Element element) {
+        return getBlockTags(element, SERIAL, SerialTree.class);
     }
 
-    public List<? extends DocTree> getSerialFieldTrees(VariableElement field) {
-        return getBlockTags(field, DocTree.Kind.SERIAL_FIELD);
+    public List<? extends SerialFieldTree> getSerialFieldTrees(VariableElement field) {
+        return getBlockTags(field, DocTree.Kind.SERIAL_FIELD, SerialFieldTree.class);
     }
 
-    public List<? extends DocTree> getThrowsTrees(Element element) {
-        return getBlockTags(element, DocTree.Kind.EXCEPTION, DocTree.Kind.THROWS);
+    public List<? extends ThrowsTree> getThrowsTrees(Element element) {
+        return getBlockTags(element,
+                t -> switch (t.getKind()) { case EXCEPTION, THROWS -> true; default -> false; },
+                ThrowsTree.class);
     }
 
     public List<? extends ParamTree> getTypeParamTrees(Element element) {
@@ -2812,22 +2835,17 @@ public class Utils {
     }
 
     private  List<? extends ParamTree> getParamTrees(Element element, boolean isTypeParameters) {
-        List<ParamTree> out = new ArrayList<>();
-        for (DocTree dt : getBlockTags(element, PARAM)) {
-            ParamTree pt = (ParamTree) dt;
-            if (pt.isTypeParameter() == isTypeParameters) {
-                out.add(pt);
-            }
-        }
-        return out;
+        return getBlockTags(element,
+                t -> t.getKind() == PARAM && ((ParamTree) t).isTypeParameter() == isTypeParameters,
+                ParamTree.class);
     }
 
-    public  List<? extends DocTree> getReturnTrees(Element element) {
-        return new ArrayList<>(getBlockTags(element, RETURN));
+    public  List<? extends ReturnTree> getReturnTrees(Element element) {
+        return new ArrayList<>(getBlockTags(element, RETURN, ReturnTree.class));
     }
 
-    public List<? extends DocTree> getUsesTrees(Element element) {
-        return getBlockTags(element, USES);
+    public List<? extends UsesTree> getUsesTrees(Element element) {
+        return getBlockTags(element, USES, UsesTree.class);
     }
 
     public List<? extends DocTree> getFirstSentenceTrees(Element element) {


### PR DESCRIPTION
The types of `DocTree` parameters in some methods in `TagletWriter` can be changed from `DocTree` to more specific subtypes. Doing so makes the code less prone to incorrect calls, and removes the need for downcasting the argument in the method bodies.

This means the implementation of those methods can often be simplified.

In addition, the call sites need to be improved, and with the help of some improvements to methods in `Utils`, the methods that access different kinds of trees can return the lists using a more specific subtype as well.

Finally, a quick analysis of some of the `Utils` methods to access different kinds of trees shows that there are some more convenient methods that can be used instead.

