### PR TITLE
8254054: Pre-submit testing using GitHub Actions should not use the deprecated set-env command

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: "ubuntu-latest"
     outputs:
       should_run: ${{ steps.check_submit.outputs.should_run }}
+      bundle_id: ${{ steps.check_bundle_id.outputs.bundle_id }}
       platform_linux_x64: ${{ steps.check_platforms.outputs.platform_linux_x64 }}
       platform_windows_x64: ${{ steps.check_platforms.outputs.platform_windows_x64 }}
       platform_macos_x64: ${{ steps.check_platforms.outputs.platform_macos_x64 }}
@@ -36,7 +37,7 @@ jobs:
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Determine unique bundle identifier
-        run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+        run: echo "::set-output name=bundle_id::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Checkout the source
@@ -56,7 +57,7 @@ jobs:
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Determine the jtreg ref to checkout
-        run: "echo ::set-env name=JTREG_REF::jtreg${{ fromJson(steps.check_deps.outputs.dependencies).JTREG_VERSION }}-${{ fromJson(steps.check_deps.outputs.dependencies).JTREG_BUILD }}"
+        run: "echo JTREG_REF=jtreg${{ fromJson(steps.check_deps.outputs.dependencies).JTREG_VERSION }}-${{ fromJson(steps.check_deps.outputs.dependencies).JTREG_BUILD }} >> $GITHUB_ENV"
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Check if a jtreg image is present in the cache
@@ -88,7 +89,7 @@ jobs:
       - name: Store jtreg for use by later steps
         uses: actions/upload-artifact@v2
         with:
-          name: transient_jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ steps.check_bundle_id.outputs.bundle_id }}
           path: ~/jtreg/
         if: steps.check_submit.outputs.should_run != 'false'
 
@@ -121,9 +122,6 @@ jobs:
       BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
 
     steps:
-      - name: Determine unique bundle identifier
-        run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
-
       - name: Checkout the source
         uses: actions/checkout@v2
         with:
@@ -149,14 +147,14 @@ jobs:
         id: jtreg_restore
         uses: actions/download-artifact@v2
         with:
-          name: transient_jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
         uses: actions/download-artifact@v2
         with:
-          name: transient_jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         if: steps.jtreg_restore.outcome == 'failure'
 
@@ -192,7 +190,7 @@ jobs:
       - name: Persist test bundles
         uses: actions/upload-artifact@v2
         with:
-          name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: |
             jdk/build/linux-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz
             jdk/build/linux-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin-tests${{ matrix.artifact }}.tar.gz
@@ -251,9 +249,6 @@ jobs:
       BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
 
     steps:
-      - name: Determine unique bundle identifier
-        run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
-
       - name: Checkout the source
         uses: actions/checkout@v2
 
@@ -277,14 +272,14 @@ jobs:
         id: jtreg_restore
         uses: actions/download-artifact@v2
         with:
-          name: transient_jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
         uses: actions/download-artifact@v2
         with:
-          name: transient_jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         if: steps.jtreg_restore.outcome == 'failure'
 
@@ -292,14 +287,14 @@ jobs:
         id: build_restore
         uses: actions/download-artifact@v2
         with:
-          name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-linux-x64${{ matrix.artifact }}
         continue-on-error: true
 
       - name: Restore build artifacts (retry)
         uses: actions/download-artifact@v2
         with:
-          name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-linux-x64${{ matrix.artifact }}
         if: steps.build_restore.outcome == 'failure'
 
@@ -316,7 +311,7 @@ jobs:
       - name: Find root of jdk image dir
         run: |
           imageroot=`find ${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }} -name release -type f`
-          echo "::set-env name=imageroot::`dirname ${imageroot}`"
+          echo "imageroot=`dirname ${imageroot}`" >> $GITHUB_ENV
 
       - name: Run tests
         run: >
@@ -343,7 +338,7 @@ jobs:
 
       - name: Create suitable test log artifact name
         if: always()
-        run: echo "::set-env name=logsuffix::`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`"
+        run: echo "logsuffix=`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`" >> $GITHUB_ENV
 
       - name: Persist test logs
         if: always()
@@ -378,9 +373,6 @@ jobs:
       BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).WINDOWS_X64_BOOT_JDK_SHA256 }}"
 
     steps:
-      - name: Determine unique bundle identifier
-        run: echo ("::set-env name=bundleid::$env:GITHUB_ACTOR" + "_" + (-join "$env:GITHUB_SHA"[0..7]))
-
       - name: Restore cygwin packages from cache
         id: cygwin
         uses: actions/cache@v2
@@ -427,14 +419,14 @@ jobs:
         id: jtreg_restore
         uses: actions/download-artifact@v2
         with:
-          name: transient_jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
         uses: actions/download-artifact@v2
         with:
-          name: transient_jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         if: steps.jtreg_restore.outcome == 'failure'
 
@@ -464,7 +456,7 @@ jobs:
       - name: Persist test bundles
         uses: actions/upload-artifact@v2
         with:
-          name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: |
             jdk/build/windows-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }}.zip
             jdk/build/windows-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin-tests${{ matrix.artifact }}.tar.gz
@@ -524,9 +516,6 @@ jobs:
       BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).WINDOWS_X64_BOOT_JDK_SHA256 }}"
 
     steps:
-      - name: Determine unique bundle identifier
-        run: echo ("::set-env name=bundleid::$env:GITHUB_ACTOR" + "_" + (-join "$env:GITHUB_SHA"[0..7]))
-
       - name: Checkout the source
         uses: actions/checkout@v2
 
@@ -564,14 +553,14 @@ jobs:
         id: jtreg_restore
         uses: actions/download-artifact@v2
         with:
-          name: transient_jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
         uses: actions/download-artifact@v2
         with:
-          name: transient_jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         if: steps.jtreg_restore.outcome == 'failure'
 
@@ -579,14 +568,14 @@ jobs:
         id: build_restore
         uses: actions/download-artifact@v2
         with:
-          name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-windows-x64${{ matrix.artifact }}
         continue-on-error: true
 
       - name: Restore build artifacts (retry)
         uses: actions/download-artifact@v2
         with:
-          name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-windows-x64${{ matrix.artifact }}
         if: steps.build_restore.outcome == 'failure'
 
@@ -606,7 +595,7 @@ jobs:
           tar -xf "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin-tests${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin-tests${{ matrix.artifact }}"
 
       - name: Find root of jdk image dir
-        run: echo ("::set-env name=imageroot::" + (Get-ChildItem -Path $HOME/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }} -Filter release -Recurse -ErrorAction SilentlyContinue -Force).DirectoryName)
+        run: echo ("imageroot=" + (Get-ChildItem -Path $HOME/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }} -Filter release -Recurse -ErrorAction SilentlyContinue -Force).DirectoryName) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
 
       - name: Run tests
         run: >
@@ -636,7 +625,7 @@ jobs:
 
       - name: Create suitable test log artifact name
         if: always()
-        run: echo ("::set-env name=logsuffix::" + ("${{ matrix.test }}" -replace "/", "_" -replace " ", "_"))
+        run: echo ("logsuffix=" + ("${{ matrix.test }}" -replace "/", "_" -replace " ", "_")) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
 
       - name: Persist test logs
         if: always()
@@ -672,9 +661,6 @@ jobs:
       BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).MACOS_X64_BOOT_JDK_SHA256 }}"
 
     steps:
-      - name: Determine unique bundle identifier
-        run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
-
       - name: Checkout the source
         uses: actions/checkout@v2
         with:
@@ -700,14 +686,14 @@ jobs:
         id: jtreg_restore
         uses: actions/download-artifact@v2
         with:
-          name: transient_jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
         uses: actions/download-artifact@v2
         with:
-          name: transient_jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         if: steps.jtreg_restore.outcome == 'failure'
 
@@ -743,7 +729,7 @@ jobs:
       - name: Persist test bundles
         uses: actions/upload-artifact@v2
         with:
-          name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: |
             jdk/build/macos-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin${{ matrix.artifact }}.tar.gz
             jdk/build/macos-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin-tests${{ matrix.artifact }}.tar.gz
@@ -802,9 +788,6 @@ jobs:
       BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).MACOS_X64_BOOT_JDK_SHA256 }}"
 
     steps:
-      - name: Determine unique bundle identifier
-        run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
-
       - name: Checkout the source
         uses: actions/checkout@v2
 
@@ -828,14 +811,14 @@ jobs:
         id: jtreg_restore
         uses: actions/download-artifact@v2
         with:
-          name: transient_jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
         uses: actions/download-artifact@v2
         with:
-          name: transient_jtreg_${{ env.bundleid }}
+          name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         if: steps.jtreg_restore.outcome == 'failure'
 
@@ -843,14 +826,14 @@ jobs:
         id: build_restore
         uses: actions/download-artifact@v2
         with:
-          name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-macos-x64${{ matrix.artifact }}
         continue-on-error: true
 
       - name: Restore build artifacts (retry)
         uses: actions/download-artifact@v2
         with:
-          name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ env.bundleid }}
+          name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-macos-x64${{ matrix.artifact }}
         if: steps.build_restore.outcome == 'failure'
 
@@ -870,7 +853,7 @@ jobs:
       - name: Find root of jdk image dir
         run: |
           imageroot=`find ${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin${{ matrix.artifact }} -name release -type f`
-          echo "::set-env name=imageroot::`dirname ${imageroot}`"
+          echo "imageroot=`dirname ${imageroot}`" >> $GITHUB_ENV
 
       - name: Run tests
         run: >
@@ -897,7 +880,7 @@ jobs:
 
       - name: Create suitable test log artifact name
         if: always()
-        run: echo "::set-env name=logsuffix::`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`"
+        run: echo "logsuffix=`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`" >> $GITHUB_ENV
 
       - name: Persist test logs
         if: always()
@@ -959,11 +942,8 @@ jobs:
           -X DELETE "${url}";
           done
 
-      - name: Determine unique bundle identifier
-        run: echo "::set-env name=bundleid::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
-
       - name: Upload a combined test results artifact
         uses: actions/upload-artifact@v2
         with:
-          name: test-results_${{ env.bundleid }}
+          name: test-results_${{ needs.prerequisites.outputs.bundle_id }}
           path: test-results


### PR DESCRIPTION
The `set-env` command was recently deprecated in favor of a different method of setting environment variables, due to a security vulnerability [1]. The vulnerability does not affect our usage of GitHub Actions, but we should nevertheless update to avoid the associated deprecation warnings. 

[1] https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254054](https://bugs.openjdk.java.net/browse/JDK-8254054): Pre-submit testing using GitHub Actions should not use the deprecated set-env command


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/518/head:pull/518`
`$ git checkout pull/518`
