### PR TITLE
8253952: Refine ZipOutputStream.putNextEntry() to recalculate ZipEntry's compressed size

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarOutputStream.java
+++ b/src/java.base/share/classes/java/util/jar/JarOutputStream.java
@@ -76,8 +76,15 @@ public class JarOutputStream extends ZipOutputStream {
     /**
      * Begins writing a new JAR file entry and positions the stream
      * to the start of the entry data. This method will also close
-     * any previous entry. The default compression method will be
-     * used if no compression method was specified for the entry.
+     * any previous entry.
+     * <p>
+     * The default compression method will be used if no compression
+     * method was specified for the entry. When writing a compressed
+     * (DEFLATED) entry, and the compressed size has not been explicitly
+     * set with the {@link ZipEntry#setCompressedSize(long)} method,
+     * then the compressed size will be set to the actual compressed
+     * size after deflation.
+     * <p>
      * The current time will be used if the entry has no set modification
      * time.
      *

--- a/src/java.base/share/classes/java/util/zip/ZipEntry.java
+++ b/src/java.base/share/classes/java/util/zip/ZipEntry.java
@@ -53,6 +53,8 @@ public class ZipEntry implements ZipConstants, Cloneable {
     long crc = -1;      // crc-32 of entry data
     long size = -1;     // uncompressed size of entry data
     long csize = -1;    // compressed size of entry data
+    boolean csizeSet = false; // Only true if csize was explicitely set by
+                        // a call to setCompressedSize()
     int method = -1;    // compression method
     int flag = 0;       // general purpose flag
     byte[] extra;       // optional extra field data for entry
@@ -127,6 +129,7 @@ public class ZipEntry implements ZipConstants, Cloneable {
         crc = e.crc;
         size = e.size;
         csize = e.csize;
+        csizeSet = e.csizeSet;
         method = e.method;
         flag = e.flag;
         extra = e.extra;
@@ -447,6 +450,7 @@ public class ZipEntry implements ZipConstants, Cloneable {
      */
     public void setCompressedSize(long csize) {
         this.csize = csize;
+        this.csizeSet = true;
     }
 
     /**

--- a/test/jdk/java/util/zip/CopyZipFile.java
+++ b/test/jdk/java/util/zip/CopyZipFile.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test behaviour when copying ZipEntries between zip files.
+ * @run main/othervm CopyZipFile
+ */
+
+import java.io.File;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Enumeration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.CRC32;
+import java.util.zip.Deflater;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+public class CopyZipFile {
+    private static final String ZIP_FILE = "first.zip";
+    private static final String TEST_STRING = "TestTestTest";
+
+    private static void createZip(String zipFile) throws Exception {
+        File f = new File(zipFile);
+        f.deleteOnExit();
+        try (OutputStream os = new FileOutputStream(f);
+             ZipOutputStream zos = new ZipOutputStream(os)) {
+            // First file will be compressed with DEFAULT_COMPRESSION (i.e. -1 or 6)
+            zos.putNextEntry(new ZipEntry("test1.txt"));
+            zos.write(TEST_STRING.getBytes());
+            zos.closeEntry();
+            // Second file won't be compressed at all (i.e. STORED)
+            zos.setMethod(ZipOutputStream.STORED);
+            ZipEntry ze = new ZipEntry("test2.txt");
+            int length = TEST_STRING.length();
+            ze.setSize(length);
+            ze.setCompressedSize(length);
+            CRC32 crc = new CRC32();
+            crc.update(TEST_STRING.getBytes("utf8"), 0, length);
+            ze.setCrc(crc.getValue());
+            zos.putNextEntry(ze);
+            zos.write(TEST_STRING.getBytes());
+            // Third file will be compressed with NO_COMPRESSION (i.e. 0)
+            zos.setMethod(ZipOutputStream.DEFLATED);
+            zos.setLevel(Deflater.NO_COMPRESSION);
+            zos.putNextEntry(new ZipEntry("test3.txt"));
+            zos.write(TEST_STRING.getBytes());
+            // Fourth file will be compressed with BEST_SPEED (i.e. 1)
+            zos.setLevel(Deflater.BEST_SPEED);
+            zos.putNextEntry(new ZipEntry("test4.txt"));
+            zos.write(TEST_STRING.getBytes());
+            // Fifth file will be compressed with BEST_COMPRESSION (i.e. 9)
+            zos.setLevel(Deflater.BEST_COMPRESSION);
+            zos.putNextEntry(new ZipEntry("test5.txt"));
+            zos.write(TEST_STRING.getBytes());
+        }
+    }
+
+    public static void main(String args[]) throws Exception {
+        // By default, ZipOutputStream creates zip files with Local File Headers
+        // without size, compressedSize and crc values and an extra Data
+        // Descriptor (see https://en.wikipedia.org/wiki/Zip_(file_format)
+        // after the data belonging to that entry with these values if in the
+        // corresponding ZipEntry one of the size, compressedSize or crc fields is
+        // equal to '-1' (which is the default for newly created ZipEntries).
+        createZip(ZIP_FILE);
+
+        // Now read all the entries of the newly generated zip file with a ZipInputStream
+        // and copy them to a new zip file with the help of a ZipOutputStream.
+        // This only works reliably because the generated zip file has no values for the
+        // size, compressedSize and crc values of a zip entry in the local file header and
+        // therefore the ZipEntry objects created by ZipOutputStream.getNextEntry() will have
+        // all these fields set to '-1'.
+        ZipEntry entry;
+        byte[] buf = new byte[512];
+        try (InputStream is = new FileInputStream(ZIP_FILE);
+             ZipInputStream zis = new ZipInputStream(is);
+             OutputStream os = new ByteArrayOutputStream();
+             ZipOutputStream zos = new ZipOutputStream(os)) {
+            while((entry = zis.getNextEntry())!=null) {
+                // ZipInputStream.getNextEntry() only reads the Local File Header of a zip entry,
+                // so for the zip file we've just generated the ZipEntry fields 'size', 'compressedSize`
+                // and 'crc' for deflated entries should be uninitialized (i.e. '-1').
+                System.out.println(
+                    String.format("name=%s, clen=%d, len=%d, crc=%d",
+                                  entry.getName(), entry.getCompressedSize(), entry.getSize(), entry.getCrc()));
+                if (entry.getMethod() == ZipEntry.DEFLATED &&
+                    (entry.getCompressedSize() != -1 || entry.getSize() != -1 || entry.getCrc() != -1)) {
+                    throw new Exception("'size', 'compressedSize' and 'crc' shouldn't be initialized at this point.");
+                }
+                zos.putNextEntry(entry);
+                zis.transferTo(zos);
+                // After all the data belonging to a zip entry has been inflated (i.e. after ZipInputStream.read()
+                // returned '-1'), it is guaranteed that the ZipInputStream will also have consumed the Data
+                // Descriptor (if any) after the data and will have updated the 'size', 'compressedSize' and 'crc'
+                // fields of the ZipEntry object.
+                System.out.println(
+                    String.format("name=%s, clen=%d, len=%d, crc=%d\n",
+                                  entry.getName(), entry.getCompressedSize(), entry.getSize(), entry.getCrc()));
+                if (entry.getCompressedSize() == -1 || entry.getSize() == -1) {
+                    throw new Exception("'size' and 'compressedSize' must be initialized at this point.");
+                }
+            }
+        }
+
+        // Now we read all the entries of the initially generated zip file with the help
+        // of the ZipFile class. The ZipFile class reads all the zip entries from the Central
+        // Directory which must have accurate information for size, compressedSize and crc.
+        // This means that all ZipEntry objects returned from ZipFile will have correct
+        // settings for these fields.
+        // If the compression level was different in the initial zip file (which we can't find
+        // out any more now because the zip file format doesn't record this information) the
+        // size of the re-compressed entry we are writing to the ZipOutputStream might differ
+        // from the original compressed size recorded in the ZipEntry. This would result in an
+        // "invalid entry compressed size" ZipException if ZipOutputStream wouldn't ignore
+        // the implicitely set compressed size attribute of ZipEntries read from a ZipFile
+        // or ZipInputStream.
+        try (OutputStream os = new ByteArrayOutputStream();
+             ZipOutputStream zos = new ZipOutputStream(os);
+             ZipFile zf = new ZipFile(ZIP_FILE)) {
+            Enumeration<? extends ZipEntry> entries = zf.entries();
+            while (entries.hasMoreElements()) {
+                entry = entries.nextElement();
+                System.out.println(
+                    String.format("name=%s, clen=%d, len=%d, crc=%d\n",
+                                  entry.getName(), entry.getCompressedSize(),
+                                  entry.getSize(), entry.getCrc()));
+                if (entry.getCompressedSize() == -1 || entry.getSize() == -1) {
+                    throw new Exception("'size' and 'compressedSize' must be initialized at this point.");
+                }
+                InputStream is = zf.getInputStream(entry);
+                zos.putNextEntry(entry);
+                is.transferTo(zos);
+                zos.closeEntry();
+            }
+        }
+
+        // The compressed size attribute of a ZipEntry shouldn't be ignored if it was set
+        // explicitely by calling ZipEntry.setCpompressedSize()
+        try (OutputStream os = new ByteArrayOutputStream();
+             ZipOutputStream zos = new ZipOutputStream(os);
+             ZipFile zf = new ZipFile(ZIP_FILE)) {
+            Enumeration<? extends ZipEntry> entries = zf.entries();
+            while (entries.hasMoreElements()) {
+                try {
+                    entry = entries.nextElement();
+                    entry.setCompressedSize(entry.getCompressedSize());
+                    InputStream is = zf.getInputStream(entry);
+                    zos.putNextEntry(entry);
+                    is.transferTo(zos);
+                    zos.closeEntry();
+                    if ("test3.txt".equals(entry.getName())) {
+                        throw new Exception(
+                            "Should throw a ZipException if ZipEntry.setCpompressedSize() was called.");
+                    }
+                } catch (ZipException ze) {
+                    if ("test1.txt".equals(entry.getName()) || "test2.txt".equals(entry.getName())) {
+                        throw new Exception(
+                            "Shouldn't throw a ZipExcpetion for STORED files or files compressed with DEFAULT_COMPRESSION");
+                    }
+                    // Hack to fix and close the offending zip entry with the correct compressed size.
+                    // The exception message is something like:
+                    //   "invalid entry compressed size (expected 12 but got 7 bytes)"
+                    // and we need to extract the second integer.
+                    Pattern cSize = Pattern.compile("\\d+");
+                    Matcher m = cSize.matcher(ze.getMessage());
+                    m.find();
+                    m.find();
+                    entry.setCompressedSize(Integer.parseInt(m.group()));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Work around wrong usage of `ZipOutputStream.putNextEntry()` in user code which can lead to the `ZipException "invalid entry compressed size"`.

### Motivation

In general it is not safe to directly write a ZipEntry obtained from `ZipInputStream.getNextEntry()`, `ZipFile.entries()`, `ZipFile.getEntry()` or `ZipFile.stream()` with `ZipOutputStream.putNextEntry()` to a `ZipOutputStream` and then read the entries data from the `ZipInputStream` and write it to the `ZipOutputStream` as follows:
```
 ZipEntry entry;
 ZipInputStream zis = new ZipInputStream(...);
 ZipOutputStream zos = new ZipOutputStream(...);
 while((entry = zis.getNextEntry()) != null) {
     zos.putNextEntry(entry);
     zis.transferTo(zos);
 }
```
The problem with this code is that the zip file format does not record the compression level used for deflation in its entries. In general, it doesn't even mandate a predefined compression ratio per compression level. Therefore the compressed size recorded in a `ZipEntry` read from a zip file might differ from the new compressed size produced by the receiving `ZipOutputStream`. Such a difference will result in a `ZipException` with the following message:
```
 java.util.zip.ZipException: invalid entry compressed size (expected 12 but got 7 bytes)
``` 
The correct way of copying all entries from one zip file into another requires the creation of a new `ZipEntry` or at least resetting of the compressed size field. E.g.:
```
 while((entry = zis.getNextEntry()) != null) {
     ZipEntry newEntry = new ZipEntry(entry.getName());
     zos.putNextEntry(newEntry);
     zis.transferTo(zos);
 }
```
or:
```
 while((entry = zis.getNextEntry()) != null) {
     entry.setCompressedSize(-1);
     zos.putNextEntry(entry);
     zis.transferTo(zos);
 }
```
Unfortunately, there's a lot of user code out there which gets this wrong and uses the bad coding pattern described before. Searching for `"java.util.zip.ZipException: invalid entry compressed size (expected 12 but got 7 bytes)"` gives ~2500 hits (~100 on StackOverflow). It's also no hard to find plenty of instances of this anti-pattern on GitHub when doing a code search for `ZipEntry` and `putNextEntry()`. E.g. [Gradle 4.x wrapper task][1] is affected as well as the latest version of the [mockableAndroidJar task][2]. I've recently fixed two occurrences of this pattern in OpenJDK (see [JDK-8240333][3] and [JDK-8240235][4]) but there still exist more of them (e.g. [`test/jdk/java/util/zip/ZipFile/CopyJar.java`][5] which is there since 1999 :).

### Description

So while this has clearly been a problem before, it apparently wasn't painful enough to trigger any action from the side of the JDK. However, recently quite some zlib forks with [superior deflate/inflate performance have evolved][6]. Using them with OpenJDK is quite straight-forward: one just has to configure the alternative implementations by setting `LD_LIBRARY_PATH` or `LD_PRELOAD` correspondingly. We've seen big saving by using these new zlib implementations for selected services in production and the only reason why we haven't enabled them by default until now is the problem I've just described. The reason why these new libraries uncover the described anti-pattern much more often is because their compression ratio is slightly different from that of the default zlib library. This can easily trigger a `ZipException` even if an application is not using a different compression levels but just a zip file created with another zlib version.

I'd therefore like to propose the following workaround for the wrong `ZipOutputStream.putNextEntry()` usage in user code:

-  ignore the compressed size if it was implicitly determined from the zip file and not explicitly set by calling `ZipEntry.setCompressedSize()`.

- Change the API-documentation of `ZipOutputStream.putNextEntry()` and `JarOutputStream.putNextEntry()` to explain the problem and why `putNextEntry()` will ignore the compressed size of a `ZipEntry` if that was set implicitely when reading that entry from a `ZipFile` or `ZipInputStream`.


### Technical Details

A zip file consists of a stream of File Entries followed by a Central Directory (see [here for a more detailed specification][7]). Each File Entry is composed of a Local File Header (LFH) followed by the compressed Data and an optional Data Descriptor. The LFH contains the File Name and among other attributes the Compressed and Uncompressed size and CRC of the Data. In the case where the latter three attributes are not available at the time when the LFH is created, this fact will be recorded in a flag of the LFH and will trigger the creation of a Data Descriptor with the corresponding information right after the Data section. Finally, the Central Directory contains one Central Directory File Header (CDFH) for each entry of the  zip archive. The CDFH is an extended version of the LFH and the ultimate reference for the contents of the zip archive. The redundancy between LFH and CDFH is a tribute to zip's long history when it was used to store archives on multiple floppy discs and the CDFH allowed to update the archive by only writing to the last disc which contained the Central Directory.

`ZipEntries` read with `ZipInputStream.getNextEntry()` will initially only contain the information from the LFH. Only after the next entry was read (or after `ZipInputStream.closeEntry()` was called explicitly), will the previously read entry be updated with the data from the Data Descriptor. `ZipInputStream` doesn't inspect the Central Directory at all.

On the other hand, `ZipFile` only queries the Central Directory for `ZipEntry` information so all `ZipEntries` returned by `ZipFile.entries()`, `ZipFile.getEntry()` and `ZipFile.stream()` will always instantly contain the full Compressed and Uncompressed Size and CRC information for each entry independently of the LFH contents.

### Risks and Assumptions

If we choose to ignore the implicitly recorded compressed size in a `ZipEntry` read from a zip file when writing it to a `ZipOutputStream`, this will lead to zip files with incomplete information in the LFH and an additional Data Descriptor as described before. However, the result is still fully compatible to the zip file specification. It's also not unusual, because by default all new zip files created with `ZipOutputStream` will contain LFHs without Compressed and Uncompressed Size and CRC information and an additional Data Descriptor. Theoretically it is possible to create new zip files with `ZipOutputStream` class and Compressed and Uncompressed Size and CRC information in the LFH but that's complex and inefficient because it requires two steps. A first step to determine the crc and compressed size of the data and a second step to actually write the data to the `ZipOutputStream` (which will compress it a second time). This is because the current API offers no possibility to write already compressed data to a `ZipOutputStream`.

Consequently, the only straight-forward way of creating zip files from Java which have all the data in the LFH and no Data Descriptor is by copying `ZipEntries` from an existing zip file with the buggy method described before. This incidentally worked more or less reliable for a long time but breaks miserably when using different zlib implementations. Ignoring the implicitly set compressed size of `ZipEntries` can easily fix this problem.

I'm not aware of any tool which can not handle such files and if it exists it would have problems with the majority of Java created zip files anyway (e.g. all jar-files created with the jar tool have zip entries with incomplete LFH data and additional Data Descriptor).

Ignoring the implicitly set compressed size of `ZipEntries` has no measurable performance impact and will increase the size of zip archives which used to have the complete file information in the LFH before by 16 bytes per entry. On the other hand it will give us the freedom to use whatever zip implementation we like :)


[1]: https://github.com/gradle/gradle/blob/e76905e3a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java#L152-L158
[2]: https://android.googlesource.com/platform/tools/base/+/refs/heads/master/build-system/builder/src/main/java/com/android/builder/testing/MockableJarGenerator.java#86
[3]: https://bugs.openjdk.java.net/browse/JDK-8240333
[4]: https://bugs.openjdk.java.net/browse/JDK-8240235
[5]: https://github.com/openjdk/jdk/blob/master/test/jdk/java/util/zip/ZipFile/CopyJar.java
[6]: https://github.com/simonis/zlib-bench/blob/master/Results.md
[7]: https://en.wikipedia.org/wiki/Zip_(file_format)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8253952](https://bugs.openjdk.java.net/browse/JDK-8253952): Refine ZipOutputStream.putNextEntry() to recalculate ZipEntry's compressed size


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 7f032e0ff5064a3f29aab8434d96362dccda6626


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/520/head:pull/520`
`$ git checkout pull/520`
