### PR TITLE
8253354: A jshell command to open desktop browser with specific javadoc query

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -94,6 +94,7 @@ import jdk.jshell.Snippet.Kind;
 import jdk.jshell.Snippet.Status;
 import jdk.jshell.SnippetEvent;
 import jdk.jshell.SourceCodeAnalysis;
+import jdk.jshell.SourceCodeAnalysis.CompletionContext;
 import jdk.jshell.SourceCodeAnalysis.CompletionInfo;
 import jdk.jshell.SourceCodeAnalysis.Completeness;
 import jdk.jshell.SourceCodeAnalysis.Suggestion;
@@ -123,8 +124,6 @@ import jdk.internal.editor.external.ExternalEditor;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Collections.singletonList;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static jdk.jshell.Snippet.SubKind.TEMP_VAR_EXPRESSION_SUBKIND;
@@ -137,7 +136,6 @@ import static jdk.internal.jshell.debug.InternalDebugControl.DBG_FMGR;
 import static jdk.internal.jshell.debug.InternalDebugControl.DBG_GEN;
 import static jdk.internal.jshell.debug.InternalDebugControl.DBG_WRAP;
 import static jdk.internal.jshell.tool.ContinuousCompletionProvider.STARTSWITH_MATCHER;
-import jdk.jshell.SourceCodeAnalysis.CompletionContext;
 
 /**
  * Command line REPL tool for Java using the JShell API.

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -1008,7 +1008,7 @@ public class JShellTool implements MessageHandler {
         closeState();
         return exitCode;
     }
-    
+
     private void configBrowser() {
         browser = configTool(ToolType.BROWSER);
     }
@@ -1016,7 +1016,7 @@ public class JShellTool implements MessageHandler {
     private void configEditor() {
         editor = configTool(ToolType.EDITOR);
     }
-    
+
     private ToolSetting configTool(ToolType type) {
         // Read retained editor setting (if any)
         ToolSetting tool = ToolSetting.fromPrefs(prefs, type);
@@ -2110,7 +2110,7 @@ public class JShellTool implements MessageHandler {
             this.prefKey = prefKey;
             this.envVars = envVars;
         }
-        
+
     }
 
     static class ToolSetting {

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -1878,8 +1878,8 @@ public class JShellTool implements MessageHandler {
                                 feedback.modeCompletions(SET_MODE_OPTIONS_COMPLETION_PROVIDER),
                                 SET_MODE_OPTIONS_COMPLETION_PROVIDER)),
                         "prompt", feedback.modeCompletions(),
-                        "editor", fileCompletions(Files::isExecutable),
                         "browser", fileCompletions(Files::isExecutable),
+                        "editor", fileCompletions(Files::isExecutable),
                         "start", FILE_COMPLETION_PROVIDER,
                         "indent", EMPTY_COMPLETION_PROVIDER),
                         STARTSWITH_MATCHER)));
@@ -2096,15 +2096,17 @@ public class JShellTool implements MessageHandler {
 
     enum ToolType {
 
-        BROWSER(BROWSER_KEY, "JSHELLBROWSER", "BROWSER"),
-        EDITOR(EDITOR_KEY, "JSHELLEDITOR", "VISUAL", "EDITOR");
+        BROWSER("browser", BROWSER_KEY, "JSHELLBROWSER", "BROWSER"),
+        EDITOR("editor", EDITOR_KEY, "JSHELLEDITOR", "VISUAL", "EDITOR");
 
         private final ToolSetting defaultTool;
+        private final String toolName;
         private final String prefKey;
         private final String[] envVars;
 
-        private ToolType(String prefKey, String... envVars) {
+        private ToolType(String toolName, String prefKey, String... envVars) {
             this.defaultTool = new ToolSetting(null, false, this);
+            this.toolName = toolName;
             this.prefKey = prefKey;
             this.envVars = envVars;
         }
@@ -2225,11 +2227,11 @@ public class JShellTool implements MessageHandler {
                 ToolSetting retained = ToolSetting.fromPrefs(prefs, type);
                 if (retained != null) {
                     // retained editor is set
-                    hard("/set editor -retain %s", format(retained));
+                    hard("/set " + type.toolName + " -retain %s", format(retained));
                 }
                 if (retained == null || !retained.equals(tool)) {
                     // editor is not retained or retained is different from set
-                    hard("/set editor %s", format(tool)); //XXX: editor -> editor/browser
+                    hard("/set " + type.toolName + " %s", format(tool));
                 }
                 return true;
             }
@@ -2239,7 +2241,7 @@ public class JShellTool implements MessageHandler {
             install();
             if (retainOption && !deleteOption) {
                 tool.toPrefs(prefs);
-                fluffmsg("jshell.msg.set.editor.retain", format(tool));
+                fluffmsg("jshell.msg.set." + type.toolName + ".retain", format(tool));
             }
             return true;
         }
@@ -2275,7 +2277,7 @@ public class JShellTool implements MessageHandler {
             } else {
                 editor = tool;
             }
-            fluffmsg("jshell.msg.set.editor.set", format(tool));
+            fluffmsg("jshell.msg.set." + type.toolName + ".set", format(tool));
         }
 
         private String format(ToolSetting ed) {

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
@@ -740,6 +740,12 @@ entered that overwrites the setting.\n\
 On the command-line these options must have two dashes, e.g.: --module-path\n\
 On the jshell tool commands they can have one or two dashes, e.g.: -module-path
 
+help.doc.summary = show a documentation for specified element
+help.doc.args = element specification
+help.doc =\
+Show the documentation for a given element.\n\
+The element may be a type, a field or a method.
+
 help.id.summary = a description of snippet IDs and how use them
 help.id =\
 Every snippet of code you enter has its own unique snippet ID.  Even if you\n\
@@ -1049,6 +1055,44 @@ When the <mode> is specified only the prompts for that mode are shown.\n\
 Example:\n\t\
 /set prompt mymode\n\
 shows the prompts set for the mode mymode\n
+
+help.set.browser.summary =\
+Specify the command to launch for the /doc command
+
+help.set.browser =\
+Specify the command to launch for the /doc command:\n\
+\n\t\
+/set browser [-retain] <command>\n\
+\n\t\
+/set browser [-retain] -default\n\
+\n\t\
+/set browser [-retain] -delete\n\
+\n\
+Retain the current browser setting for future sessions:\n\
+\n\t\
+/set browser -retain\n\
+\n\
+Show the command to launch for the /doc command:\n\
+\n\t\
+/set browser\n\
+\n\
+The <command> is an operating system dependent string.\n\
+The <command> may include space-separated arguments (such as flags)\n\n\
+If the -default option is specified, the default browser will be used.\n\n\
+If the -delete option is specified, previous settings are ignored -- the browser\n\
+settings are initialized as when starting the jshell tool.  Specifically, if there\n\
+is a retained setting it is used (unless both -retain and -delete are specified --\n\
+which deletes the retained setting), if one of these environment variables is set\n\
+it will be used: JSHELLBROWSER, or BROWSER (in that order).  Otherwise the\n\
+default browser will be used.\n\n\
+If <command> is specified, it will be used as the external browser. The <command>\n\
+consists of the program and zero or more program arguments.  When <command>\n\
+is used, the URL that should be shown will be appended as the last argument.\n\
+\n\
+When the -retain option is used, the setting will be used in this and future\n\
+runs of the jshell tool.\n\
+\n\
+The form without <command> or options shows the browser setting.\n
 
 help.set.editor.summary =\
 Specify the command to launch for the /edit command

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
@@ -201,6 +201,12 @@ Use "i" for auto-import, "v" for variable creation, or "m" for method creation.\
 For more information see:\n\
    /help shortcuts
 
+jshell.no.browser.configured=No browser configured, please use /set browser <path-to-browser>.\n\
+Documentation URI:\n\
+{0}
+
+jshell.no.documentation.found=No source documentation found.
+
 help.usage = \
 Usage:   jshell <option>... <load-file>...\n\
 where possible options include:\n\

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
@@ -52,6 +52,8 @@ jshell.err.unexpected.exception = Unexpected exception: {0}
 jshell.err.invalid.command = Invalid command: {0}
 jshell.err.command.ambiguous = Command: ''{0}'' is ambiguous: {1}
 jshell.msg.set.restore = Setting new options and restoring state.
+jshell.msg.set.browser.set = Browser set to: {0}
+jshell.msg.set.browser.retain = Browser setting retained: {0}
 jshell.msg.set.editor.set = Editor set to: {0}
 jshell.msg.set.editor.retain = Editor setting retained: {0}
 jshell.msg.set.indent.set = Indent level set to: {0}
@@ -503,6 +505,9 @@ Set the jshell tool configuration information, including:\n\
 the external editor to use, the startup definitions to use, a new feedback mode,\n\
 the command prompt, the feedback mode to use, or the format of output.\n\
 \n\
+/set browser <command> <optional-arg>...\n\t\
+     Specify the command to launch for the /doc command.\n\t\
+     The <command> is an operating system dependent string\n\n\
 /set editor [-wait] <command> <optional-arg>...\n\t\
      Specify the command to launch for the /edit command.\n\t\
      The <command> is an operating system dependent string\n\n\

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
@@ -26,7 +26,6 @@
 package jdk.jshell;
 
 import java.net.URI;
-import java.net.URL;
 import java.util.Collection;
 import java.util.List;
 
@@ -101,8 +100,6 @@ public abstract class SourceCodeAnalysis {
      *                       addition to the signature
      * @return the documentations for the given user's input, if multiple elements match the input,
      *         multiple {@code Documentation} objects are returned.
-     *
-     * @since 16
      */
     public abstract List<Documentation> documentation(String input, int cursor, boolean computeJavadoc);
 
@@ -116,6 +113,8 @@ public abstract class SourceCodeAnalysis {
      *                       addition to the signature
      * @return the documentations for the given user's input, if multiple elements match the input,
      *         multiple {@code Documentation} objects are returned.
+     *
+     * @since 16
      */
     public List<Documentation> documentation(String input, int cursor, CompletionContext context, boolean computeJavadoc) {
         return context == CompletionContext.SNIPPET ? documentation(input, cursor, computeJavadoc)

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
@@ -25,6 +25,7 @@
 
 package jdk.jshell;
 
+import java.net.URL;
 import java.util.Collection;
 import java.util.List;
 
@@ -64,6 +65,21 @@ public abstract class SourceCodeAnalysis {
     public abstract List<Suggestion> completionSuggestions(String input, int cursor, int[] anchor);
 
     /**
+     * Compute possible follow-ups for the given input.
+     * Uses information from the current {@code JShell} state, including
+     * type information, to filter the suggestions.
+     * @param input the user input, so far
+     * @param cursor the current position of the cursors in the given {@code input} text
+     * @param context XXX
+     * @param anchor outgoing parameter - when an option will be completed, the text between
+     *               the anchor and cursor will be deleted and replaced with the given option
+     * @return list of candidate continuations of the given input.
+     */
+    public List<Suggestion> completionSuggestions(String input, int cursor, CompletionContext context, int[] anchor) {
+        return context == CompletionContext.SNIPPET ? completionSuggestions(input, cursor, anchor) : List.of();
+    }
+
+    /**
      * Compute documentation for the given user's input. Multiple {@code Documentation} objects may
      * be returned when multiple elements match the user's input (like for overloaded methods).
      * @param input the snippet the user wrote so far
@@ -74,6 +90,22 @@ public abstract class SourceCodeAnalysis {
      *         multiple {@code Documentation} objects are returned.
      */
     public abstract List<Documentation> documentation(String input, int cursor, boolean computeJavadoc);
+
+    /**
+     * Compute documentation for the given user's input.Multiple {@code Documentation} objects may
+     * be returned when multiple elements match the user's input (like for overloaded methods).
+     * @param input the snippet the user wrote so far
+     * @param cursor the current position of the cursors in the given {@code input} text
+     * @param context XXX
+     * @param computeJavadoc true if the javadoc for the given input should be computed in
+     *                       addition to the signature
+     * @return the documentations for the given user's input, if multiple elements match the input,
+     *         multiple {@code Documentation} objects are returned.
+     */
+    public List<Documentation> documentation(String input, int cursor, CompletionContext context, boolean computeJavadoc) {
+        return context == CompletionContext.SNIPPET ? documentation(input, cursor, computeJavadoc)
+                                                    : List.of();
+    }
 
     /**
      * Infer the type of the given expression. The expression spans from the beginning of {@code code}
@@ -316,6 +348,27 @@ public abstract class SourceCodeAnalysis {
          * @return the javadoc, or null if not found or not requested
          */
         String javadoc();
+
+        /**
+         * XXX.
+         *
+         * @return XXX
+         */
+        default URL url() { return null; } //TODO: better URI?
+    }
+
+    /**
+     * XXX
+     */
+    public enum CompletionContext {
+        /**
+         * XXX
+         */
+        SNIPPET,
+        /**
+         * XXX
+         */
+        LOOKUP;
     }
 
     /**

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
@@ -25,6 +25,7 @@
 
 package jdk.jshell;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.Collection;
 import java.util.List;
@@ -364,11 +365,13 @@ public abstract class SourceCodeAnalysis {
         String javadoc();
 
         /**
-         * XXX.
+         * URI of the full documentation of the given element, if known.
          *
-         * @return XXX
+         * @return the URI of the element's documentation.
+         *
+         * @since 16
          */
-        default URL url() { return null; } //TODO: better URI?
+        default URI uri() { return null; }
     }
 
     /**

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
@@ -56,6 +56,11 @@ public abstract class SourceCodeAnalysis {
      * Compute possible follow-ups for the given input.
      * Uses information from the current {@code JShell} state, including
      * type information, to filter the suggestions.
+     *
+     * It is equivalent to calling
+     * {@link #completionSuggestions(java.lang.String, int, jdk.jshell.SourceCodeAnalysis.CompletionContext, int[]) }
+     * with context {@link CompletionContext#SNIPPET}.
+     *
      * @param input the user input, so far
      * @param cursor the current position of the cursors in the given {@code input} text
      * @param anchor outgoing parameter - when an option will be completed, the text between
@@ -70,10 +75,12 @@ public abstract class SourceCodeAnalysis {
      * type information, to filter the suggestions.
      * @param input the user input, so far
      * @param cursor the current position of the cursors in the given {@code input} text
-     * @param context XXX
+     * @param context the context in which the completion has been invoked
      * @param anchor outgoing parameter - when an option will be completed, the text between
      *               the anchor and cursor will be deleted and replaced with the given option
      * @return list of candidate continuations of the given input.
+     *
+     * @since 16
      */
     public List<Suggestion> completionSuggestions(String input, int cursor, CompletionContext context, int[] anchor) {
         return context == CompletionContext.SNIPPET ? completionSuggestions(input, cursor, anchor) : List.of();
@@ -82,12 +89,19 @@ public abstract class SourceCodeAnalysis {
     /**
      * Compute documentation for the given user's input. Multiple {@code Documentation} objects may
      * be returned when multiple elements match the user's input (like for overloaded methods).
+     *
+     * It is equivalent to calling
+     * {@link #documentation(java.lang.String, int, jdk.jshell.SourceCodeAnalysis.CompletionContext, boolean) }
+     * with context {@link CompletionContext#SNIPPET}.
+     *
      * @param input the snippet the user wrote so far
      * @param cursor the current position of the cursors in the given {@code input} text
      * @param computeJavadoc true if the javadoc for the given input should be computed in
      *                       addition to the signature
      * @return the documentations for the given user's input, if multiple elements match the input,
      *         multiple {@code Documentation} objects are returned.
+     *
+     * @since 16
      */
     public abstract List<Documentation> documentation(String input, int cursor, boolean computeJavadoc);
 
@@ -96,7 +110,7 @@ public abstract class SourceCodeAnalysis {
      * be returned when multiple elements match the user's input (like for overloaded methods).
      * @param input the snippet the user wrote so far
      * @param cursor the current position of the cursors in the given {@code input} text
-     * @param context XXX
+     * @param context the context in which the documentation has been requested
      * @param computeJavadoc true if the javadoc for the given input should be computed in
      *                       addition to the signature
      * @return the documentations for the given user's input, if multiple elements match the input,
@@ -358,15 +372,18 @@ public abstract class SourceCodeAnalysis {
     }
 
     /**
-     * XXX
+     * A context in which completion or documentation is requested.
+     *
+     * @since 16
      */
     public enum CompletionContext {
         /**
-         * XXX
+         * The context is a snippet.
          */
         SNIPPET,
+
         /**
-         * XXX
+         * The context is an element reference.
          */
         LOOKUP;
     }

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -102,8 +102,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -1367,15 +1367,9 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
                 default -> null;
             };
         }
-        URL url;
-        try {
-            String baseURL = BASE_DOCUMENTATION_URL.get();
-            url = new URL(baseURL + moduleName + "/" + typeName.replace(".", "/") + ".html" + (anchor != null ? "#" + anchor : ""));
-        } catch (MalformedURLException ex) {
-            //should not happen?????
-            url = null;
-        }
-        return new DocumentationImpl(signature,  javadoc, url);
+        String baseURL = BASE_DOCUMENTATION_URI.get();
+        URI uri = URI.create(baseURL + moduleName + "/" + typeName.replace(".", "/") + ".html" + (anchor != null ? "#" + anchor : ""));
+        return new DocumentationImpl(signature,  javadoc, uri);
     }
 
     public void close() {
@@ -1392,12 +1386,12 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
 
         private final String signature;
         private final String javadoc;
-        private final URL url;
+        private final URI uri;
 
-        public DocumentationImpl(String signature, String javadoc, URL url) {
+        public DocumentationImpl(String signature, String javadoc, URI uri) {
             this.signature = signature;
             this.javadoc = javadoc;
-            this.url = url;
+            this.uri = uri;
         }
 
         @Override
@@ -1411,8 +1405,8 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
         }
 
         @Override
-        public URL url() {
-            return url;
+        public URI uri() {
+            return uri;
         }
 
     }
@@ -2012,7 +2006,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
         }
     }
 
-    private static Supplier<String> BASE_DOCUMENTATION_URL = () -> {
+    private static Supplier<String> BASE_DOCUMENTATION_URI = () -> {
         Runtime.Version version = Runtime.version();
         String template;
         //based on URLs hardcoded in javadoc:

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -78,6 +78,7 @@ import static jdk.internal.jshell.debug.InternalDebugControl.DBG_COMPA;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystem;
@@ -1368,7 +1369,13 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
             };
         }
         String baseURL = BASE_DOCUMENTATION_URI.get();
-        URI uri = URI.create(baseURL + moduleName + "/" + typeName.replace(".", "/") + ".html" + (anchor != null ? "#" + anchor : ""));
+        URI uri;
+        try {
+            uri = new URL(baseURL + moduleName + "/" + typeName.replace(".", "/") + ".html" + (anchor != null ? "#" + anchor : "")).toURI();
+        } catch (MalformedURLException | URISyntaxException ex) {
+            proc.debug(ex, "SourceCodeAnalysisImpl.element2String(..., " + el + ")");
+            uri = null;
+        }
         return new DocumentationImpl(signature,  javadoc, uri);
     }
 

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -1353,7 +1353,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
             proc.debug(ex, "SourceCodeAnalysisImpl.element2String(..., " + el + ")");
         }
         String signature = Util.expunge(elementHeader(at, el, !hasSyntheticParameterNames(el), true));
-        String moduleName = at.getElements().getModuleOf(el).getQualifiedName().toString(); //XXX - unnamed module
+        String moduleName = at.getElements().getModuleOf(el).getQualifiedName().toString();
         String typeName;
         String anchor;
         if (el.getKind().isClass() || el.getKind().isInterface()) {

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -754,6 +754,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
     private void addElements(Iterable<? extends Element> elements, Predicate<Element> accept, Predicate<Element> smart, List<Suggestion> result) {
         addElements(elements, accept, smart, DEFAULT_PAREN, result);
     }
+
     private void addElements(Iterable<? extends Element> elements, Predicate<Element> accept, Predicate<Element> smart, Function<Boolean, String> paren, List<Suggestion> result) {
         Set<String> hasParams = Util.stream(elements)
                 .filter(accept)

--- a/test/langtools/jdk/jshell/CommandCompletionTest.java
+++ b/test/langtools/jdk/jshell/CommandCompletionTest.java
@@ -359,7 +359,7 @@ public class CommandCompletionTest extends ReplToolTesting {
                 a -> assertCompletion(a, "/se|", false, "/set "),
                 a -> assertCompletion(a, "/set |", false, "browser ", "editor ", "feedback ", "format ", "indent ", "mode ", "prompt ", "start ", "truncation "),
 
-                // /set editor
+                // /set browser
                 a -> assertCompletion(a, "/set b|", false, "browser "),
                 a -> assertCompletion(a, "/set browser |", false, p1.toArray(new String[p1.size()])),
 

--- a/test/langtools/jdk/jshell/CompletionSuggestionTest.java
+++ b/test/langtools/jdk/jshell/CompletionSuggestionTest.java
@@ -722,6 +722,12 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("String s = m8(x -> {x.tri|", "trim()");
     }
 
+    public void testLookupCompletion() {
+        assertCompletion("Bool|", CompletionContext.LOOKUP, "Boolean");
+        assertCompletion("Boolean.val|", CompletionContext.LOOKUP, "valueOf");
+        assertCompletion("Boolean.boo|", CompletionContext.LOOKUP, "booleanValue");
+    }
+
     public void testDocURL() {
         assertDocumentationURL("java.lang.String|", CompletionContext.LOOKUP, "http://documentation/java.base/java/lang/String.html");
         assertDocumentationURL("java.lang.String.charAt|", CompletionContext.LOOKUP, "http://documentation/java.base/java/lang/String.html#charAt(int)");

--- a/test/langtools/jdk/jshell/CompletionSuggestionTest.java
+++ b/test/langtools/jdk/jshell/CompletionSuggestionTest.java
@@ -791,7 +791,7 @@ public class CompletionSuggestionTest extends KullaTesting {
     static {
         try {
             Class scai = Class.forName("jdk.jshell.SourceCodeAnalysisImpl");
-            Field baseDocumentation = scai.getDeclaredField("BASE_DOCUMENTATION_URL");
+            Field baseDocumentation = scai.getDeclaredField("BASE_DOCUMENTATION_URI");
             baseDocumentation.setAccessible(true);
             baseDocumentation.set(null, (Supplier<String>) () -> "http://documentation/");
         } catch (Throwable t) {

--- a/test/langtools/jdk/jshell/CompletionSuggestionTest.java
+++ b/test/langtools/jdk/jshell/CompletionSuggestionTest.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
@@ -55,6 +56,8 @@ import org.testng.annotations.Test;
 
 import static jdk.jshell.Snippet.Status.VALID;
 import static jdk.jshell.Snippet.Status.OVERWRITTEN;
+import jdk.jshell.SourceCodeAnalysis;
+import jdk.jshell.SourceCodeAnalysis.CompletionContext;
 
 @Test
 public class CompletionSuggestionTest extends KullaTesting {
@@ -719,6 +722,11 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("String s = m8(x -> {x.tri|", "trim()");
     }
 
+    public void testDocURL() {
+        assertDocumentationURL("java.lang.String|", CompletionContext.LOOKUP, "http://documentation/java.base/java/lang/String.html");
+        assertDocumentationURL("java.lang.String.charAt|", CompletionContext.LOOKUP, "http://documentation/java.base/java/lang/String.html#charAt(int)");
+    }
+
     @BeforeMethod
     public void setUp() {
         super.setUp();
@@ -772,5 +780,16 @@ public class CompletionSuggestionTest extends KullaTesting {
 
         assertEval("import p.*;");
         assertCompletion("Broke|", "BrokenA", "BrokenC");
+    }
+
+    static {
+        try {
+            Class scai = Class.forName("jdk.jshell.SourceCodeAnalysisImpl");
+            Field baseDocumentation = scai.getDeclaredField("BASE_DOCUMENTATION_URL");
+            baseDocumentation.setAccessible(true);
+            baseDocumentation.set(null, (Supplier<String>) () -> "http://documentation/");
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
     }
 }

--- a/test/langtools/jdk/jshell/KullaTesting.java
+++ b/test/langtools/jdk/jshell/KullaTesting.java
@@ -898,11 +898,19 @@ public class KullaTesting {
     }
 
     public void assertCompletion(String code, String... expected) {
-        assertCompletion(code, null, expected);
+        assertCompletion(code, CompletionContext.SNIPPET, expected);
+    }
+
+    public void assertCompletion(String code, CompletionContext context, String... expected) {
+        assertCompletion(code, null, context, expected);
     }
 
     public void assertCompletion(String code, Boolean isSmart, String... expected) {
-        List<String> completions = computeCompletions(code, isSmart);
+        assertCompletion(code, isSmart, CompletionContext.SNIPPET, expected);
+    }
+
+    public void assertCompletion(String code, Boolean isSmart, CompletionContext context, String... expected) {
+        List<String> completions = computeCompletions(code, isSmart, context);
         assertEquals(completions, Arrays.asList(expected), "Input: " + code + ", " + completions.toString());
     }
 
@@ -920,13 +928,17 @@ public class KullaTesting {
     }
 
     private List<String> computeCompletions(String code, Boolean isSmart) {
+        return computeCompletions(code, isSmart, CompletionContext.SNIPPET);
+    }
+
+    private List<String> computeCompletions(String code, Boolean isSmart, CompletionContext context) {
         waitIndexingFinished();
 
         int cursor =  code.indexOf('|');
         code = code.replace("|", "");
         assertTrue(cursor > -1, "'|' expected, but not found in: " + code);
         List<Suggestion> completions =
-                getAnalysis().completionSuggestions(code, cursor, new int[1]); //XXX: ignoring anchor for now
+                getAnalysis().completionSuggestions(code, cursor, context, new int[1]); //XXX: ignoring anchor for now
         return completions.stream()
                           .filter(s -> isSmart == null || isSmart == s.matchesType())
                           .map(s -> s.continuation())

--- a/test/langtools/jdk/jshell/KullaTesting.java
+++ b/test/langtools/jdk/jshell/KullaTesting.java
@@ -1004,9 +1004,9 @@ public class KullaTesting {
         code = code.replace("|", "");
         assertTrue(cursor > -1, "'|' expected, but not found in: " + code);
         List<Documentation> documentation = getAnalysis().documentation(code, cursor, context, false);
-        Set<String> urlSet = documentation.stream().map(doc -> doc.url().toString()).collect(Collectors.toSet());
+        Set<String> uriSet = documentation.stream().map(doc -> doc.uri().toString()).collect(Collectors.toSet());
         Set<String> expectedSet = Stream.of(expected).collect(Collectors.toSet());
-        assertEquals(urlSet, expectedSet, "Input: " + code);
+        assertEquals(uriSet, expectedSet, "Input: " + code);
     }
 
     public enum ClassType {

--- a/test/langtools/jdk/jshell/KullaTesting.java
+++ b/test/langtools/jdk/jshell/KullaTesting.java
@@ -82,6 +82,7 @@ import static java.util.stream.Collectors.toSet;
 import static jdk.jshell.Snippet.Status.*;
 import static org.testng.Assert.*;
 import static jdk.jshell.Snippet.SubKind.METHOD_SUBKIND;
+import jdk.jshell.SourceCodeAnalysis.CompletionContext;
 import jdk.jshell.SourceCodeAnalysis.Documentation;
 
 public class KullaTesting {
@@ -984,6 +985,16 @@ public class KullaTesting {
                                           .collect(Collectors.toSet());
         Set<String> expectedSet = Stream.of(expected).collect(Collectors.toSet());
         assertEquals(docSet, expectedSet, "Input: " + code);
+    }
+
+    public void assertDocumentationURL(String code, CompletionContext context, String... expected) {
+        int cursor =  code.indexOf('|');
+        code = code.replace("|", "");
+        assertTrue(cursor > -1, "'|' expected, but not found in: " + code);
+        List<Documentation> documentation = getAnalysis().documentation(code, cursor, context, false);
+        Set<String> urlSet = documentation.stream().map(doc -> doc.url().toString()).collect(Collectors.toSet());
+        Set<String> expectedSet = Stream.of(expected).collect(Collectors.toSet());
+        assertEquals(urlSet, expectedSet, "Input: " + code);
     }
 
     public enum ClassType {

--- a/test/langtools/jdk/jshell/ToolCommandOptionTest.java
+++ b/test/langtools/jdk/jshell/ToolCommandOptionTest.java
@@ -244,6 +244,123 @@ public class ToolCommandOptionTest extends ReplToolTesting {
         );
     }
 
+    public void setBrowserTest() {
+        test(
+                (a) -> assertCommand(a, "/set browser -furball",
+                        "|  Unknown option: -furball -- /set browser -furball"),
+                (a) -> assertCommand(a, "/set browser -furball prog",
+                        "|  Unknown option: -furball -- /set browser -furball prog"),
+                (a) -> assertCommand(a, "/set browser -furball -mattress",
+                        "|  Unknown option: -furball -mattress -- /set browser -furball -mattress"),
+                (a) -> assertCommand(a, "/set browser -default prog",
+                        "|  Specify -default option, -delete option, or program -- /set browser -default prog"),
+                (a) -> assertCommand(a, "/set browser prog",
+                        "|  Browser set to: prog"),
+                (a) -> assertCommand(a, "/set browser prog -default",
+                        "|  Browser set to: prog -default"),
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser prog -default"),
+                (a) -> assertCommand(a, "/se br prog -furball",
+                        "|  Browser set to: prog -furball"),
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser prog -furball"),
+                (a) -> assertCommand(a, "/se br -delete",
+                        "|  Browser set to: -default"),
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser -default"),
+                (a) -> assertCommand(a, "/set browser prog arg1 -furball arg3 -default arg4",
+                        "|  Browser set to: prog arg1 -furball arg3 -default arg4"),
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser prog arg1 -furball arg3 -default arg4"),
+                (a) -> assertCommand(a, "/set browser -default",
+                        "|  Browser set to: -default"),
+                (a) -> assertCommand(a, "/se br -def",
+                        "|  Browser set to: -default"),
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser -default")
+        );
+    }
+
+    public void retainBrowserTest() {
+        test(
+                (a) -> assertCommand(a, "/set browser -retain -furball",
+                        "|  Unknown option: -furball -- /set browser -retain -furball"),
+                (a) -> assertCommand(a, "/set browser -retain -furball prog",
+                        "|  Unknown option: -furball -- /set browser -retain -furball prog"),
+                (a) -> assertCommand(a, "/set browser -retain -furball -mattress",
+                        "|  Unknown option: -furball -mattress -- /set browser -retain -furball -mattress"),
+                (a) -> assertCommand(a, "/set browser -retain -default prog",
+                        "|  Specify -default option, -delete option, or program -- /set browser -retain -default prog"),
+                (a) -> assertCommand(a, "/set browser -retain prog",
+                        "|  Browser set to: prog\n" +
+                        "|  Browser setting retained: prog"),
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser -retain prog"),
+                (a) -> assertCommand(a, "/se br other",
+                        "|  Browser set to: other"),
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser -retain prog\n" +
+                        "|  /set browser other"),
+                (a) -> assertCommand(a, "/se br -delete",
+                        "|  Browser set to: prog"),
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser -retain prog"),
+                (a) -> assertCommand(a, "/set browser -retain prog -default",
+                        "|  Browser set to: prog -default\n" +
+                        "|  Browser setting retained: prog -default"),
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser -retain prog -default"),
+                (a) -> assertCommand(a, "/se br -retain prog -furball",
+                        "|  Browser set to: prog -furball\n" +
+                        "|  Browser setting retained: prog -furball"),
+                (a) -> assertCommand(a, "/set browser -retain prog arg1 -furball arg3 -default arg4",
+                        "|  Browser set to: prog arg1 -furball arg3 -default arg4\n" +
+                        "|  Browser setting retained: prog arg1 -furball arg3 -default arg4"),
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser -retain prog arg1 -furball arg3 -default arg4"),
+                (a) -> assertCommand(a, "/set browser -retain -default",
+                        "|  Browser set to: -default\n" +
+                        "|  Browser setting retained: -default"),
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser -retain -default"),
+                (a) -> assertCommand(a, "/se b -ret -def",
+                        "|  Browser set to: -default\n" +
+                        "|  Browser setting retained: -default"),
+                (a) -> assertCommand(a, "/set browser -retain",
+                        "|  Browser setting retained: -default")
+        );
+    }
+
+    public void setBwoserEnvTest() {
+        setEnvVar("BROWSER", "best one");
+        setBrowserEnvSubtest();
+        setEnvVar("BROWSER", "not this");
+        setEnvVar("JSHELLBROWSER", "best one");
+        setBrowserEnvSubtest();
+    }
+
+    private void setBrowserEnvSubtest() {
+        test(
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser best one"),
+                (a) -> assertCommand(a, "/set browser prog",
+                        "|  Browser set to: prog"),
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser prog"),
+                (a) -> assertCommand(a, "/set browser -delete",
+                        "|  Browser set to: best one"),
+                (a) -> assertCommand(a, "/set browser -retain stored browser",
+                        "|  Browser set to: stored browser\n" +
+                        "|  Browser setting retained: stored browser")
+        );
+        test(
+                (a) -> assertCommand(a, "/set browser",
+                        "|  /set browser -retain stored browser"),
+                (a) -> assertCommand(a, "/set browser -delete -retain",
+                        "|  Browser set to: best one")
+        );
+    }
+
     public void setStartTest() {
         Compiler compiler = new Compiler();
         Path startup = compiler.getPath("StartTest/startup.txt");

--- a/test/langtools/jdk/jshell/ToolRetainTest.java
+++ b/test/langtools/jdk/jshell/ToolRetainTest.java
@@ -151,7 +151,7 @@ public class ToolRetainTest extends ReplToolTesting {
         );
         test(
                 (a) -> assertCommand(a, "/set browser", "|  /set browser -retain nonexistent"),
-                (a) -> assertCommandOutputContains(a, "/doc String", "Edit Error:")
+                (a) -> assertCommandOutputContains(a, "/doc String", "Browser Error:")
         );
     }
 
@@ -163,7 +163,7 @@ public class ToolRetainTest extends ReplToolTesting {
         );
         test(
                 (a) -> assertCommandOutputContains(a, "int h =8", ""),
-                (a) -> assertCommandOutputContains(a, "/doc String", "Edit Error:")
+                (a) -> assertCommandOutputContains(a, "/doc String", "Browser Error:")
         );
     }
 

--- a/test/langtools/jdk/jshell/ToolRetainTest.java
+++ b/test/langtools/jdk/jshell/ToolRetainTest.java
@@ -142,6 +142,31 @@ public class ToolRetainTest extends ReplToolTesting {
         );
     }
 
+    public void testRetainBrowser() {
+        test(
+                (a) -> assertCommand(a, "/set browser -retain nonexistent",
+                        "|  Browser set to: nonexistent\n" +
+                        "|  Browser setting retained: nonexistent"),
+                (a) -> assertCommand(a, "/exit", "")
+        );
+        test(
+                (a) -> assertCommand(a, "/set browser", "|  /set browser -retain nonexistent"),
+                (a) -> assertCommandOutputContains(a, "/doc String", "Edit Error:")
+        );
+    }
+
+    public void testRetainBrowserBlank() {
+        test(
+                (a) -> assertCommand(a, "/set browser nonexistent", "|  Browser set to: nonexistent"),
+                (a) -> assertCommand(a, "/set browser -retain", "|  Browser setting retained: nonexistent"),
+                (a) -> assertCommand(a, "/exit", "")
+        );
+        test(
+                (a) -> assertCommandOutputContains(a, "int h =8", ""),
+                (a) -> assertCommandOutputContains(a, "/doc String", "Edit Error:")
+        );
+    }
+
     public void testRetainModeNeg() {
         test(
                 (a) -> assertCommandOutputStartsWith(a, "/set mode -retain verbose",


### PR DESCRIPTION
Adding a new command "/doc <element>" to JShell. This command opens the javadoc URL for the given element. A new setting, /set browser, is introduced to actually set the browser that should be used to open the URL. If none specified, JShell tries to use Desktop.browse (which may fail on some platforms).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8253354](https://bugs.openjdk.java.net/browse/JDK-8253354): A jshell command to open desktop browser with specific javadoc query


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/521/head:pull/521`
`$ git checkout pull/521`
