### PR TITLE
8254027: gc/g1/TestHumongousConcurrentStartUndo.java failed with "'Concurrent Mark Cycle' missing from stdout/stderr"

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestHumongousConcurrentStartUndo.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousConcurrentStartUndo.java
@@ -108,13 +108,19 @@ public class TestHumongousConcurrentStartUndo {
 
             ArrayBlockingQueue a;
             for (int iterate = 0; iterate < 3; iterate++) {
+                // Start from an "empty" heap.
                 WHITE_BOX.fullGC();
-
+                // The queue only holds one element, so only one humongous object
+                // will be reachable and the concurrent operation should be undone.
                 a = new ArrayBlockingQueue(1);
                 allocateHumongous(humongousObjectAllocations, humongousObjectSize, a);
                 Helpers.waitTillCMCFinished(WHITE_BOX, 1);
                 a = null;
 
+                // Start from an "empty" heap.
+                WHITE_BOX.fullGC();
+                // The queue only holds all elements, so all humongous object
+                // will be reachable and the concurrent operation should be a regular mark.
                 a = new ArrayBlockingQueue(humongousObjectAllocations);
                 allocateHumongous(humongousObjectAllocations, humongousObjectSize, a);
                 Helpers.waitTillCMCFinished(WHITE_BOX, 1);


### PR DESCRIPTION
Hi all,

  can I get reviews for this change to the test to verify concurrent mark/undo cycles to make it more stable?

In the failing scenario, the second concurrent cycle that would typically result in a complete concurrent mark would start with too few strongly reachable humongous objects, so instead g1 performs an Undo cycle, resulting in that message.

The changes make sure that if the second concurrent start pause starts there are always enough strongly reachable humongous objects there to disallow an undo cycle (because the reason we started the cycle has been allocation of that amount of humongous objects that are all guaranteed to be kept reachable).

Testing: could not reproduce the failure, but 2k runs on linux/aarch64 did not show an issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (0/0 passed) | ✔️ (0/0 passed) | ✔️ (0/0 passed) |

### Issue
 * [JDK-8254027](https://bugs.openjdk.java.net/browse/JDK-8254027): gc/g1/TestHumongousConcurrentStartUndo.java failed with "'Concurrent Mark Cycle' missing from stdout/stderr"


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/523/head:pull/523`
`$ git checkout pull/523`
