### PR TITLE
8254080: fix for JDK-8204256 causes jlink test failures

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
@@ -276,7 +276,7 @@ public class JlinkTask {
 
             return EXIT_OK;
         } catch (FindException e) {
-            log.println(taskHelper.getMessage("err.prefix") + " " + e.getMessage());
+            log.println(taskHelper.getMessage("error.prefix") + " " + e.getMessage());
             e.printStackTrace(log);
             return EXIT_ERROR;
         } catch (PluginException | IllegalArgumentException |


### PR DESCRIPTION
This commit fixes an incorrect resource name from the fix for JDK-8204256

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254080](https://bugs.openjdk.java.net/browse/JDK-8254080): fix for JDK-8204256 causes jlink test failures


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/526/head:pull/526`
`$ git checkout pull/526`
