### PR TITLE
8238436: java/awt/Frame/FrameLocationTest/FrameLocationTest.java fails

### DIFF
--- a/test/jdk/java/awt/Frame/FrameLocationTest/FrameLocationTest.java
+++ b/test/jdk/java/awt/Frame/FrameLocationTest/FrameLocationTest.java
@@ -1,0 +1,119 @@
+/*
+  @test
+  @bug 4101435 8238436
+  @summary Frame.setLocation(int,int)works unstable when the Frame is visible
+  @author mohamed@siptech.co.in  : area= awt.Component
+  @key headful
+*/
+
+import java.awt.Frame;
+import java.awt.Toolkit;
+import java.awt.Robot;
+
+/**
+ * This test  sets location of frame 100 times and
+ * counts how many times the location was set incorrectly.
+ * if the Frame location is set incorrectly,
+ * the test will throw the exception."
+ */
+public class FrameLocationTest {
+
+    //Declare things used in the test, like buttons and labels here
+
+
+    private static int count = 0;
+    private static Frame my_frame;
+    private static Robot robot;
+
+    public static void main(final String[] args) throws Exception {
+        FrameLocationTest app = new FrameLocationTest();
+        app.init();
+        app.start();
+    }
+
+    public void init() throws Exception {
+
+        //Create instructions for the user here, as well as set up
+        // the environment -- set the layout manager, add buttons,
+        // etc.
+        // the frame instance is created with title 'TestFrame'.
+        my_frame  = new Frame("TestFrame");
+
+        //frame size setting
+        my_frame.setSize(150,100);
+
+        robot = new Robot();
+        robot.setAutoDelay(100);
+
+    }  //End  init()
+
+
+    public void start () {
+
+        //Get things going.  Request focus, set size, et cetera
+
+        //Visiblity setting for frame.
+        my_frame.setVisible(true);
+        robot.waitForIdle();
+        robot.delay(200);
+
+        // the following loop calls user defined method,it will return boolean value.
+        // if it is true(ie., the Frame locations are set correctly) the bug is not reproducible.
+        // false,  bug is reproducible(ie., the Frame locations are set incorrectly ).
+
+        setFrameLocation(my_frame);
+    }
+
+
+    // user defined method
+    // This method  sets location of frame 100 times and
+    // counts how many times the location was set incorrectly.
+    // if count >0 this method will  return false ,otherwise true
+    public void setFrameLocation(Frame frame) {
+        int height, width;
+        int x, y;
+        int actualX, actualY;
+        int i;
+
+        int minimumX = frame.getLocation().x;
+        int minimumY = frame.getLocation().y;
+
+        height = Toolkit.getDefaultToolkit().getScreenSize().height;
+        width = Toolkit.getDefaultToolkit().getScreenSize().width;
+
+        // This loop will execute 100 times generating random values
+        // which are used to set the frame Location
+        for (i=0; i<100; i++) {
+            // Random values
+            x = (new Double(Math.random()*(width-300))).intValue();
+            y = (new Double(Math.random()*(height-400))).intValue();
+
+            // The x, y can not be less than minimum possible values for the
+            //platform.
+            if (x < minimumX || y < minimumY) {
+                i--;
+                continue;
+            }
+
+            // Based on x& y,the frame location will set
+            frame.setLocation(x,y);
+            robot.waitForIdle();
+            robot.delay(200);
+
+            actualX = frame.getLocation().x;
+            actualY = frame.getLocation().y;
+
+            // if setLoction() is set incorrectly, the value of count will be increased
+            if (actualX != x || actualY != y) {
+                System.out.println("Failure.  Expected: (" + x + ", " + y + ")" +
+                        "  Saw: (" + actualX + ", " + actualY + ")");
+                count++;
+            }
+        }
+
+        frame.dispose();
+        if (count > 0)
+            throw new RuntimeException("Frame.setLocation(int, int) failed");
+    }
+
+} //class FrameLocationTest end


### PR DESCRIPTION
The test fail intermittently on all platforms, though issue is filled for only Ubuntu.
The test generated  random numbers and sets the frame location to those random numbers. There are two issues in the test.
1. The test has logic to make sure maximum location coordinates are such that the frame will always fit in the screen. There is no logic to set the minimum possible location for frame because of taskbar. Eg, on my Mac, if the y coordinate is < 23, the frame y location is set to 23 on frame.setLocation(), so the test will fail. The minimum x,y location coordinate will depend upon the platform.
2. The test is setting the frame location and then verifying the location in a loop, but there is no wait/delay added to let the frame.setLocation complete.

The fix sets the minimum location coordinates possible for the frame by using the frame location it is shown first time. Also, Robot is added to use delay/wait to let setLocation complete. The mach5 passes after the fix with multiple runs of the test. Link in JBS.

The test is moved from closed to open repo, so looks like a new test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (langtools/tier1)](https://github.com/pankaj-bansal/jdk/runs/1216141330)

### Issue
 * [JDK-8238436](https://bugs.openjdk.java.net/browse/JDK-8238436): java/awt/Frame/FrameLocationTest/FrameLocationTest.java fails


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/527/head:pull/527`
`$ git checkout pull/527`
