### PR TITLE
8254081: java/security/cert/PolicyNode/GetPolicyQualifiers.java fails due to an expired certificate

### DIFF
--- a/test/jdk/java/security/cert/PolicyNode/GetPolicyQualifiers.java
+++ b/test/jdk/java/security/cert/PolicyNode/GetPolicyQualifiers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.security.cert.*;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -52,6 +53,8 @@ public class GetPolicyQualifiers {
         PKIXParameters params = new PKIXParameters(trustAnchors);
         params.setPolicyQualifiersRejected(false);
         params.setRevocationEnabled(false);
+        // Certificates expired on Oct 6th, 2020
+        params.setDate(new Date("July 01, 2020"));
         List certList = Collections.singletonList(eeCert);
         CertPath cp = cf.generateCertPath(certList);
         PKIXCertPathValidatorResult result =

--- a/test/jdk/java/security/cert/PolicyNode/GetPolicyQualifiers.java
+++ b/test/jdk/java/security/cert/PolicyNode/GetPolicyQualifiers.java
@@ -30,10 +30,11 @@
 import java.io.File;
 import java.io.FileInputStream;
 import java.security.cert.*;
+import java.text.DateFormat;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 public class GetPolicyQualifiers {
@@ -54,7 +55,8 @@ public class GetPolicyQualifiers {
         params.setPolicyQualifiersRejected(false);
         params.setRevocationEnabled(false);
         // Certificates expired on Oct 6th, 2020
-        params.setDate(new Date("July 01, 2020"));
+        params.setDate(DateFormat.getDateInstance(DateFormat.MEDIUM,
+                Locale.US).parse("July 01, 2020"));
         List certList = Collections.singletonList(eeCert);
         CertPath cp = cf.generateCertPath(certList);
         PKIXCertPathValidatorResult result =


### PR DESCRIPTION
/issues add 8254081

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254081](https://bugs.openjdk.java.net/browse/JDK-8254081): java/security/cert/PolicyNode/GetPolicyQualifiers.java fails due to an expired certificate


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to f8ff3bbc5e05b1987c4ee74ee767323603b23757
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/528/head:pull/528`
`$ git checkout pull/528`
