### PR TITLE
8254084: Remove TemplateTable::pd_initialize

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -44,12 +44,6 @@
 
 #define __ _masm->
 
-// Platform-dependent initialization
-
-void TemplateTable::pd_initialize() {
-  // No aarch64 specific initialization
-}
-
 // Address computation: local variables
 
 static inline Address iaddress(int n) {

--- a/src/hotspot/cpu/arm/templateTable_arm.cpp
+++ b/src/hotspot/cpu/arm/templateTable_arm.cpp
@@ -44,13 +44,6 @@
 #define __ _masm->
 
 //----------------------------------------------------------------------------------------------------
-// Platform-dependent initialization
-
-void TemplateTable::pd_initialize() {
-  // No arm specific initialization
-}
-
-//----------------------------------------------------------------------------------------------------
 // Address computation
 
 // local variables

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -80,13 +80,6 @@ static void do_oop_load(InterpreterMacroAssembler* _masm,
   __ load_heap_oop(dst, offset, base, tmp1, tmp2, false, decorators);
 }
 
-// ============================================================================
-// Platform-dependent initialization
-
-void TemplateTable::pd_initialize() {
-  // No ppc64 specific initialization.
-}
-
 Address TemplateTable::at_bcp(int offset) {
   // Not used on ppc.
   ShouldNotReachHere();

--- a/src/hotspot/cpu/s390/templateTable_s390.cpp
+++ b/src/hotspot/cpu/s390/templateTable_s390.cpp
@@ -110,12 +110,6 @@
   }
 #endif // ASSERT
 
-// Platform-dependent initialization.
-
-void TemplateTable::pd_initialize() {
-  // No specific initialization.
-}
-
 // Address computation: local variables
 
 static inline Address iaddress(int n) {

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -47,11 +47,6 @@
 static const Register rbcp     = LP64_ONLY(r13) NOT_LP64(rsi);
 static const Register rlocals  = LP64_ONLY(r14) NOT_LP64(rdi);
 
-// Platform-dependent initialization
-void TemplateTable::pd_initialize() {
-  // No x86 specific initialization
-}
-
 // Address Computation: local variables
 static inline Address iaddress(int n) {
   return Address(rlocals, Interpreter::local_offset_in_bytes(n));

--- a/src/hotspot/share/interpreter/templateTable.cpp
+++ b/src/hotspot/share/interpreter/templateTable.cpp
@@ -498,8 +498,6 @@ void TemplateTable::initialize() {
   def(Bytecodes::_nofast_iload        , ubcp|____|clvm|____, vtos, itos, nofast_iload        ,  _           );
 
   def(Bytecodes::_shouldnotreachhere   , ____|____|____|____, vtos, vtos, shouldnotreachhere ,  _           );
-  // platform specific bytecodes
-  pd_initialize();
 }
 
 void TemplateTable::unimplemented_bc() {

--- a/src/hotspot/share/interpreter/templateTable.hpp
+++ b/src/hotspot/share/interpreter/templateTable.hpp
@@ -328,7 +328,7 @@ class TemplateTable: AllStatic {
   // initialization helpers
   static void def(Bytecodes::Code code, int flags, TosState in, TosState out, void (*gen)(            ), char filler );
   static void def(Bytecodes::Code code, int flags, TosState in, TosState out, void (*gen)(int arg     ), int arg     );
- static void def(Bytecodes::Code code, int flags, TosState in, TosState out, void (*gen)(bool arg    ), bool arg    );
+  static void def(Bytecodes::Code code, int flags, TosState in, TosState out, void (*gen)(bool arg    ), bool arg    );
   static void def(Bytecodes::Code code, int flags, TosState in, TosState out, void (*gen)(TosState tos), TosState tos);
   static void def(Bytecodes::Code code, int flags, TosState in, TosState out, void (*gen)(Operation op), Operation op);
   static void def(Bytecodes::Code code, int flags, TosState in, TosState out, void (*gen)(Condition cc), Condition cc);
@@ -341,7 +341,6 @@ class TemplateTable: AllStatic {
  public:
   // Initialization
   static void initialize();
-  static void pd_initialize();
 
   // Templates
   static Template* template_for     (Bytecodes::Code code)  { Bytecodes::check     (code); return &_template_table     [code]; }


### PR DESCRIPTION
TemplateTable::pd_initialize is empty on all platforms, and has been so for some time. I suggest removing them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254084](https://bugs.openjdk.java.net/browse/JDK-8254084): Remove TemplateTable::pd_initialize


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to b50edaf934b46848c07a03d3900b7f7b56635a57


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/529/head:pull/529`
`$ git checkout pull/529`
