### PR TITLE
8254095: remove jdk.test.lib.Utils::distro() method

### DIFF
--- a/test/lib/jdk/test/lib/Utils.java
+++ b/test/lib/jdk/test/lib/Utils.java
@@ -853,17 +853,6 @@ public final class Utils {
         return ProcessTools.executeCommand(cmds);
     }
 
-    /*
-     * Returns the system distro.
-     */
-    public static String distro() {
-        try {
-            return uname("-v").asLines().get(0);
-        } catch (Throwable t) {
-            throw new RuntimeException("Failed to determine distro.", t);
-        }
-    }
-
     /**
      * Creates an empty file in "user.dir" if the property set.
      * <p>


### PR DESCRIPTION
Hi all,

could you please review this trivial cleanup? from JBS:
> jdk.test.lib.Utils::distro() is not used by any of the tests and can be removed.

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254095](https://bugs.openjdk.java.net/browse/JDK-8254095): remove jdk.test.lib.Utils::distro() method


### Reviewers
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/532/head:pull/532`
`$ git checkout pull/532`
