### PR TITLE
8254102: use ProcessHandle::pid instead of ManagementFactory::getRuntimeMXBean to get pid in tests

### DIFF
--- a/test/failure_handler/test/sanity/Suicide.java
+++ b/test/failure_handler/test/sanity/Suicide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,10 +21,6 @@
  * questions.
  */
 
-
-
-import java.lang.management.ManagementFactory;
-
 /*
  * @test
  * @summary Suicide test
@@ -34,8 +30,7 @@ public class Suicide {
     public static void main(String[] args) {
         String cmd = null;
         try {
-            String pidStr = ManagementFactory.getRuntimeMXBean().getName()
-                    .split("@")[0];
+            String pidStr = String.valueOf(ProcessHandle.current().pid());
             String osName = System.getProperty("os.name");
             if (osName.contains("Windows")) {
                 cmd = "taskkill.exe /F /PID " + pidStr;

--- a/test/failure_handler/test/sanity/Suicide.java
+++ b/test/failure_handler/test/sanity/Suicide.java
@@ -30,12 +30,12 @@ public class Suicide {
     public static void main(String[] args) {
         String cmd = null;
         try {
-            String pidStr = String.valueOf(ProcessHandle.current().pid());
+            long pid = ProcessHandle.current().pid();
             String osName = System.getProperty("os.name");
             if (osName.contains("Windows")) {
-                cmd = "taskkill.exe /F /PID " + pidStr;
+                cmd = "taskkill.exe /F /PID " + pid;
             } else {
-                cmd = "kill -9 " + pidStr;
+                cmd = "kill -9 " + pid;
             }
 
             System.out.printf("executing `%s'%n", cmd);

--- a/test/hotspot/jtreg/compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
+++ b/test/hotspot/jtreg/compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
+++ b/test/hotspot/jtreg/compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
@@ -126,7 +126,7 @@ public class RedefineMethodUsedByMultipleMethodHandles {
     }
 
     public static void runAgent(Path agent) throws Exception {
-        String pid = String.valueOf(ProcessHandle.current().pid());
+        String pid = Long.toString(ProcessHandle.current().pid());
         ClassLoader cl = ClassLoader.getSystemClassLoader();
         Class<?> c = Class.forName("com.sun.tools.attach.VirtualMachine", true, cl);
         Method attach = c.getDeclaredMethod("attach", String.class);

--- a/test/hotspot/jtreg/compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
+++ b/test/hotspot/jtreg/compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java
@@ -29,7 +29,6 @@
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.compiler
  *          java.instrument
- *          java.management
  *          jdk.attach
  * @requires vm.jvmti
  *
@@ -53,7 +52,6 @@ import java.lang.instrument.Instrumentation;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
-import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -128,10 +126,7 @@ public class RedefineMethodUsedByMultipleMethodHandles {
     }
 
     public static void runAgent(Path agent) throws Exception {
-        String vmName = ManagementFactory.getRuntimeMXBean().getName();
-        int p = vmName.indexOf('@');
-        assert p != -1 : "VM name not in <pid>@<host> format: " + vmName;
-        String pid = vmName.substring(0, p);
+        String pid = String.valueOf(ProcessHandle.current().pid());
         ClassLoader cl = ClassLoader.getSystemClassLoader();
         Class<?> c = Class.forName("com.sun.tools.attach.VirtualMachine", true, cl);
         Method attach = c.getDeclaredMethod("attach", String.class);

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/RedefineClassTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/RedefineClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/RedefineClassTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/RedefineClassTest.java
@@ -45,7 +45,6 @@ import java.io.InputStream;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.lang.instrument.Instrumentation;
-import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -134,10 +133,7 @@ public class RedefineClassTest extends TypeUniverse {
     }
 
     public static void loadAgent(Path agent) throws Exception {
-        String vmName = ManagementFactory.getRuntimeMXBean().getName();
-        int p = vmName.indexOf('@');
-        assumeTrue(p != -1);
-        String pid = vmName.substring(0, p);
+        String pid = String.valueOf(ProcessHandle.current().pid());
         ClassLoader cl = ClassLoader.getSystemClassLoader();
         Class<?> c = Class.forName("com.sun.tools.attach.VirtualMachine", true, cl);
         Method attach = c.getDeclaredMethod("attach", String.class);

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/RedefineClassTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/RedefineClassTest.java
@@ -133,7 +133,7 @@ public class RedefineClassTest extends TypeUniverse {
     }
 
     public static void loadAgent(Path agent) throws Exception {
-        String pid = String.valueOf(ProcessHandle.current().pid());
+        String pid = Long.toString(ProcessHandle.current().pid());
         ClassLoader cl = ClassLoader.getSystemClassLoader();
         Class<?> c = Class.forName("com.sun.tools.attach.VirtualMachine", true, cl);
         Method attach = c.getDeclaredMethod("attach", String.class);

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Agent.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Agent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Agent.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Agent.java
@@ -28,7 +28,6 @@ import jdk.test.lib.Utils;
 
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
-import java.lang.management.ManagementFactory;
 import java.nio.file.Paths;
 import java.security.ProtectionDomain;
 
@@ -84,9 +83,7 @@ public class Agent implements ClassFileTransformer {
         // Create speculative trap entries
         Test.m();
 
-        String nameOfRunningVM = ManagementFactory.getRuntimeMXBean().getName();
-        int p = nameOfRunningVM.indexOf('@');
-        String pid = nameOfRunningVM.substring(0, p);
+        String pid = String.valueOf(ProcessHandle.current().pid());
 
         // Make the nmethod go away
         for (int i = 0; i < 10; i++) {

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Agent.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Agent.java
@@ -83,7 +83,7 @@ public class Agent implements ClassFileTransformer {
         // Create speculative trap entries
         Test.m();
 
-        String pid = String.valueOf(ProcessHandle.current().pid());
+        String pid = Long.toString(ProcessHandle.current().pid());
 
         // Make the nmethod go away
         for (int i = 0; i < 10; i++) {

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
@@ -27,7 +27,6 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.instrument
- *          java.management
  * @requires vm.jvmti
  * @build compiler.profiling.spectrapredefineclass.Agent
  * @run driver ClassFileInstaller compiler.profiling.spectrapredefineclass.Agent

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Agent.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Agent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Agent.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Agent.java
@@ -28,7 +28,6 @@ import jdk.test.lib.Utils;
 
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
-import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -66,9 +65,7 @@ public class Agent implements ClassFileTransformer {
         // references m4() (loaded by loader2).
         m3.invoke(Test_class.newInstance(), loader1);
 
-        String nameOfRunningVM = ManagementFactory.getRuntimeMXBean().getName();
-        int p = nameOfRunningVM.indexOf('@');
-        String pid = nameOfRunningVM.substring(0, p);
+        String pid = String.valueOf(ProcessHandle.current().pid());
 
         // Make the nmethod go away
         for (int i = 0; i < 10; i++) {

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Agent.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Agent.java
@@ -65,7 +65,7 @@ public class Agent implements ClassFileTransformer {
         // references m4() (loaded by loader2).
         m3.invoke(Test_class.newInstance(), loader1);
 
-        String pid = String.valueOf(ProcessHandle.current().pid());
+        String pid = Long.toString(ProcessHandle.current().pid());
 
         // Make the nmethod go away
         for (int i = 0; i < 10; i++) {

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
@@ -27,7 +27,6 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.instrument
- *          java.management
  * @requires vm.jvmti
  * @build compiler.profiling.spectrapredefineclass_classloaders.Agent
  *        compiler.profiling.spectrapredefineclass_classloaders.Test

--- a/test/hotspot/jtreg/runtime/Thread/TestThreadDumpMonitorContention.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestThreadDumpMonitorContention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/Thread/TestThreadDumpMonitorContention.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestThreadDumpMonitorContention.java
@@ -49,7 +49,7 @@ public class TestThreadDumpMonitorContention {
     // so use getTestJDKTool() instead of getCompileJDKTool() or even
     // getJDKTool() which can fall back to "compile.jdk".
     final static String JSTACK = JDKToolFinder.getTestJDKTool("jstack");
-    final static String PID = String.valueOf(ProcessHandle.current().pid());
+    final static String PID = Long.toString(ProcessHandle.current().pid());
 
     // looking for header lines with these patterns:
     // "ContendingThread-1" #19 prio=5 os_prio=64 tid=0x000000000079c000 nid=0x23 runnable [0xffff80ffb8b87000]

--- a/test/hotspot/jtreg/runtime/Thread/TestThreadDumpMonitorContention.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestThreadDumpMonitorContention.java
@@ -30,14 +30,11 @@
  *
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- *          java.management
  * @run main/othervm TestThreadDumpMonitorContention
  */
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -52,7 +49,7 @@ public class TestThreadDumpMonitorContention {
     // so use getTestJDKTool() instead of getCompileJDKTool() or even
     // getJDKTool() which can fall back to "compile.jdk".
     final static String JSTACK = JDKToolFinder.getTestJDKTool("jstack");
-    final static String PID = getPid();
+    final static String PID = String.valueOf(ProcessHandle.current().pid());
 
     // looking for header lines with these patterns:
     // "ContendingThread-1" #19 prio=5 os_prio=64 tid=0x000000000079c000 nid=0x23 runnable [0xffff80ffb8b87000]
@@ -512,22 +509,6 @@ public class TestThreadDumpMonitorContention {
             System.err.println("WARNING: the primary scenario for 8036823" +
                 " has not been exercised by this test run.");
         }
-    }
-
-    // This helper relies on RuntimeMXBean.getName() returning a string
-    // that looks like this: 5436@mt-haku
-    //
-    // The testlibrary has tryFindJvmPid(), but that uses a separate
-    // process which is much more expensive for finding out your own PID.
-    //
-    static String getPid() {
-        RuntimeMXBean runtimebean = ManagementFactory.getRuntimeMXBean();
-        String vmname = runtimebean.getName();
-        int i = vmname.indexOf('@');
-        if (i != -1) {
-            vmname = vmname.substring(0, i);
-        }
-        return vmname;
     }
 
     static void usage() {


### PR DESCRIPTION
Hi all,

could you please review this small cleanup which replaces `ManagementFactory.getRuntimeMXBean().getName().split("@")[0]` w/ `ProcessHandle.current().pid()` to get current process pid?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (8/9 running) |    |  ⏳ (8/9 running) |

### Issue
 * [JDK-8254102](https://bugs.openjdk.java.net/browse/JDK-8254102): use ProcessHandle::pid instead of ManagementFactory::getRuntimeMXBean to get pid in tests


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/534/head:pull/534`
`$ git checkout pull/534`
