### PR TITLE
8254141: Typo in copyright year

### DIFF
--- a/test/jdk/javax/swing/plaf/synth/7158712/bug7158712.java
+++ b/test/jdk/javax/swing/plaf/synth/7158712/bug7158712.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012,2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Fix typo in copyright

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254141](https://bugs.openjdk.java.net/browse/JDK-8254141): Typo in copyright year


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/536/head:pull/536`
`$ git checkout pull/536`
