### PR TITLE
8253756: C2 CompilerThread0 crash in Node::add_req(Node*)

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1105,7 +1105,7 @@ void LoopNode::verify_strip_mined(int expect_skeleton) const {
     bool has_skeleton = outer_le->in(1)->bottom_type()->singleton() && outer_le->in(1)->bottom_type()->is_int()->get_con() == 0;
     if (has_skeleton) {
       assert(expect_skeleton == 1 || expect_skeleton == -1, "unexpected skeleton node");
-      assert(outer->outcnt() == 2, "only phis");
+      assert(outer->outcnt() == 2, "only control nodes");
     } else {
       assert(expect_skeleton == 0 || expect_skeleton == -1, "no skeleton node?");
       uint phis = 0;
@@ -1726,6 +1726,7 @@ void OuterStripMinedLoopNode::adjust_strip_mined_loop(PhaseIterGVN* igvn) {
     igvn->replace_node(outer_le, iff);
     inner_cl->clear_strip_mined();
   }
+  igvn->C->print_method(PHASE_DEBUG, 2);
 }
 
 const Type* OuterStripMinedLoopEndNode::Value(PhaseGVN* phase) const {
@@ -1733,7 +1734,28 @@ const Type* OuterStripMinedLoopEndNode::Value(PhaseGVN* phase) const {
   if (phase->type(in(0)) == Type::TOP)
     return Type::TOP;
 
+  // Until expansion, the loop end condition is not set so this should not constant fold.
+  if (is_expanded(phase)) {
+    return IfNode::Value(phase);
+  }
+
   return TypeTuple::IFBOTH;
+}
+
+bool OuterStripMinedLoopEndNode::is_expanded(PhaseGVN *phase) const {
+  // The outer strip mined loop head only has Phi uses after expansion
+  if (phase->is_IterGVN()) {
+    Node* backedge = proj_out_or_null(true);
+    if (backedge != NULL) {
+      Node* head = backedge->unique_ctrl_out();
+      if (head != NULL && head->is_OuterStripMinedLoop()) {
+        if (head->find_out_with(Op_Phi) != NULL) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
 }
 
 Node *OuterStripMinedLoopEndNode::Ideal(PhaseGVN *phase, bool can_reshape) {

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1726,7 +1726,6 @@ void OuterStripMinedLoopNode::adjust_strip_mined_loop(PhaseIterGVN* igvn) {
     igvn->replace_node(outer_le, iff);
     inner_cl->clear_strip_mined();
   }
-  igvn->C->print_method(PHASE_DEBUG, 2);
 }
 
 const Type* OuterStripMinedLoopEndNode::Value(PhaseGVN* phase) const {

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -469,6 +469,8 @@ public:
 
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
+
+  bool is_expanded(PhaseGVN *phase) const;
 };
 
 // -----------------------------IdealLoopTree----------------------------------

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestOuterStripMinedDeadAfterExpansion.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestOuterStripMinedDeadAfterExpansion.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8253756
+ * @summary dead outer strip mined not optimized out after expansion
+ * @requires vm.compiler2.enabled
+ *
+ * @run main/othervm -XX:-BackgroundCompilation -XX:LoopMaxUnroll=2 TestOuterStripMinedDeadAfterExpansion
+ *
+ */
+
+public class TestOuterStripMinedDeadAfterExpansion {
+    private static int field;
+
+    public static void main(String[] args) {
+        int[] array = new int[100];
+        for (int i = 0; i < 20_000; i++) {
+            test(array, array, array.length);
+            test_helper(array, 100);
+        }
+    }
+
+    private static int test(int[] src, int[] dst, int length) {
+        field = 4 << 17;
+        System.arraycopy(src, 0, dst, 0, length);
+        int stop = field >>> 17;
+        return test_helper(dst, stop);
+    }
+
+    private static int test_helper(int[] dst, int stop) {
+        int res = 0;
+        for (int i = 0; i < stop; i++) {
+            res += dst[i];
+        }
+        return res;
+    }
+}


### PR DESCRIPTION
The outer strip mined loop is initially created as a skeleton and then
expanded once loop opts are over. As long as it is a skeleton, the
OuterStripMinedLoopEndNode cannot be constant folded because its input
is a place holder. So OuterStripMinedLoopEndNode::Value() blocks
constant folding. This bug triggers because the
OuterStripMinedLoopEndNode input after expansion is a constant but the
OuterStripMinedLoopEndNode is not constant folded (i.e. it's a dead
loop but it stays in the graph). The fix I propose is to change the
behavior OuterStripMinedLoopEndNode::Value() so it blocks constant
folding only until expansion but not after.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (langtools/tier1)](https://github.com/rwestrel/jdk/runs/1221555809)

### Issue
 * [JDK-8253756](https://bugs.openjdk.java.net/browse/JDK-8253756): C2 CompilerThread0 crash in Node::add_req(Node*)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/537/head:pull/537`
`$ git checkout pull/537`
