### PR TITLE
8253404: C2: assert(C->live_nodes() <= C->max_node_limit()) failed: Live Node limit exceeded limit

### DIFF
--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -583,10 +583,13 @@ void Node::setup_is_top() {
 //------------------------------~Node------------------------------------------
 // Fancy destructor; eagerly attempt to reclaim Node numberings and storage
 void Node::destruct() {
-  // Eagerly reclaim unique Node numberings
   Compile* compile = Compile::current();
+  // If this is the most recently created node, reclaim its index. Otherwise,
+  // record the node as dead to keep liveness information accurate.
   if ((uint)_idx+1 == compile->unique()) {
     compile->set_unique(compile->unique()-1);
+  } else {
+    compile->record_dead_node(_idx);
   }
   // Clear debug info:
   Node_Notes* nn = compile->node_notes_at(_idx);

--- a/test/hotspot/jtreg/compiler/conversions/TestChainOfIntAddsToLongConversion.java
+++ b/test/hotspot/jtreg/compiler/conversions/TestChainOfIntAddsToLongConversion.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.conversions;
+
+/*
+ * @test
+ * @bug 8253404
+ * @requires vm.compiler2.enabled
+ * @summary Tests that the optimization of a chain of integer additions followed
+ *          by a long conversion does not lead to an explosion of live nodes.
+ * @library /test/lib /
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *      -XX:CompileOnly=compiler.conversions.TestChainOfIntAddsToLongConversion::main
+ *      -XX:MaxNodeLimit=1000 -XX:NodeLimitFudgeFactor=25
+ *      compiler.conversions.TestChainOfIntAddsToLongConversion
+ */
+
+public class TestChainOfIntAddsToLongConversion {
+    public static void main(String[] args) {
+        long out = 0;
+        for (int i = 0; i < 2; i++) {
+            int foo = i;
+            for (int j = 0; j < 17; j++) {
+                // Int addition to be turned into a chain by loop unrolling.
+                foo = foo + foo;
+            }
+            // Int to long conversion.
+            out = foo;
+        }
+        System.out.println(out);
+    }
+}


### PR DESCRIPTION
Record nodes as dead in `Node::destruct()` if their index cannot be directly reclaimed. This prevents the "Live Node limit exceeded limit" assertion failure by improving the accuracy of `Compile::live_nodes()` when "hook" nodes in `ConvI2LNode::Ideal()` are created and deleted non-consecutively.

This addition might result in multiple calls to `compile::record_dead_node()` for the same node (e.g. from `PhaseIdealLoop::spinup()`), but this is safe, as `compile::record_dead_node()` is idempotent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8253404](https://bugs.openjdk.java.net/browse/JDK-8253404): C2: assert(C->live_nodes() <= C->max_node_limit()) failed: Live Node limit exceeded limit


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/540/head:pull/540`
`$ git checkout pull/540`
