### PR TITLE
8254103: Shenandoah: Move updating thread roots to concurrent phase

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -446,12 +446,11 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
 
     // Perform update-refs phase.
     heap->vmop_entry_init_updaterefs();
+    heap->entry_updaterefs();
+    if (check_cancellation_or_degen(ShenandoahHeap::_degenerated_updaterefs)) return;
 
     // Concurrent update thread roots
     heap->entry_update_thread_roots();
-    if (check_cancellation_or_degen(ShenandoahHeap::_degenerated_updaterefs)) return;
-
-    heap->entry_updaterefs();
     if (check_cancellation_or_degen(ShenandoahHeap::_degenerated_updaterefs)) return;
 
     heap->vmop_entry_final_updaterefs();

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -444,12 +444,13 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
     heap->entry_evac();
     if (check_cancellation_or_degen(ShenandoahHeap::_degenerated_evac)) return;
 
+    // Perform update-refs phase.
+    heap->vmop_entry_init_updaterefs();
+
     // Concurrent update thread roots
     heap->entry_update_thread_roots();
     if (check_cancellation_or_degen(ShenandoahHeap::_degenerated_updaterefs)) return;
 
-    // Perform update-refs phase.
-    heap->vmop_entry_init_updaterefs();
     heap->entry_updaterefs();
     if (check_cancellation_or_degen(ShenandoahHeap::_degenerated_updaterefs)) return;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -444,6 +444,10 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
     heap->entry_evac();
     if (check_cancellation_or_degen(ShenandoahHeap::_degenerated_evac)) return;
 
+    // Concurrent update thread roots
+    heap->entry_update_thread_roots();
+    if (check_cancellation_or_degen(ShenandoahHeap::_degenerated_updaterefs)) return;
+
     // Perform update-refs phase.
     heap->vmop_entry_init_updaterefs();
     heap->entry_updaterefs();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1828,7 +1828,7 @@ void ShenandoahUpdateThreadClosure::do_thread(Thread* thread) {
 
 void ShenandoahHeap::op_update_thread_roots() {
   ShenandoahUpdateThreadClosure cl;
-    Handshake::execute(&cl);
+  Handshake::execute(&cl);
 }
 
 void ShenandoahHeap::op_stw_evac() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1806,6 +1806,31 @@ void ShenandoahHeap::op_conc_evac() {
   workers()->run_task(&task);
 }
 
+class ShenandoahUpdateThreadClosure : public HandshakeClosure {
+private:
+  ShenandoahUpdateRefsClosure _cl;
+public:
+  ShenandoahUpdateThreadClosure();
+  void do_thread(Thread* thread);
+};
+
+ShenandoahUpdateThreadClosure::ShenandoahUpdateThreadClosure() :
+  HandshakeClosure("Shenandoah Update Thread Roots") {
+}
+
+void ShenandoahUpdateThreadClosure::do_thread(Thread* thread) {
+  if (thread->is_Java_thread()) {
+    JavaThread* jt = thread->as_Java_thread();
+    ResourceMark rm;
+    jt->oops_do(&_cl, NULL);
+  }
+}
+
+void ShenandoahHeap::op_update_thread_roots() {
+  ShenandoahUpdateThreadClosure cl;
+    Handshake::execute(&cl);
+}
+
 void ShenandoahHeap::op_stw_evac() {
   ShenandoahEvacuationTask task(this, _collection_set, false);
   workers()->run_task(&task);
@@ -2735,8 +2760,6 @@ void ShenandoahHeap::op_final_updaterefs() {
 
   if (is_degenerated_gc_in_progress()) {
     concurrent_mark()->update_roots(ShenandoahPhaseTimings::degen_gc_update_roots);
-  } else {
-    concurrent_mark()->update_thread_roots(ShenandoahPhaseTimings::final_update_refs_roots);
   }
 
   // Has to be done before cset is clear
@@ -3017,6 +3040,19 @@ void ShenandoahHeap::entry_evac() {
   try_inject_alloc_failure();
   op_conc_evac();
 }
+
+void ShenandoahHeap::entry_update_thread_roots() {
+  TraceCollectorStats tcs(monitoring_support()->concurrent_collection_counters());
+
+  static const char* msg = "Concurrent update thread roots";
+  ShenandoahConcurrentPhase gc_phase(msg, ShenandoahPhaseTimings::conc_update_thread_roots);
+  EventMark em("%s", msg);
+
+  // No workers used in this phase, no setup required
+  try_inject_alloc_failure();
+  op_update_thread_roots();
+}
+
 
 void ShenandoahHeap::entry_updaterefs() {
   static const char* msg = "Concurrent update references";

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -396,6 +396,7 @@ public:
   void entry_cleanup_early();
   void entry_rendezvous_roots();
   void entry_evac();
+  void entry_update_thread_roots();
   void entry_updaterefs();
   void entry_cleanup_complete();
   void entry_uncommit(double shrink_before, size_t shrink_until);
@@ -421,6 +422,7 @@ private:
   void op_rendezvous_roots();
   void op_conc_evac();
   void op_stw_evac();
+  void op_update_thread_roots();
   void op_updaterefs();
   void op_cleanup_complete();
   void op_uncommit(double shrink_before, size_t shrink_until);

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -101,6 +101,7 @@ class outputStream;
   f(conc_rendezvous_roots,                          "Rendezvous")                      \
   SHENANDOAH_PAR_PHASE_DO(conc_strong_roots_,       "  CSR: ", f)                      \
   f(conc_evac,                                      "Concurrent Evacuation")           \
+  f(conc_update_thread_roots,                       "Concurrent Update Thread Roots")  \
                                                                                        \
   f(init_update_refs_gross,                         "Pause Init  Update Refs (G)")     \
   f(init_update_refs,                               "Pause Init  Update Refs (N)")     \

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -101,12 +101,12 @@ class outputStream;
   f(conc_rendezvous_roots,                          "Rendezvous")                      \
   SHENANDOAH_PAR_PHASE_DO(conc_strong_roots_,       "  CSR: ", f)                      \
   f(conc_evac,                                      "Concurrent Evacuation")           \
-  f(conc_update_thread_roots,                       "Concurrent Update Thread Roots")  \
                                                                                        \
   f(init_update_refs_gross,                         "Pause Init  Update Refs (G)")     \
   f(init_update_refs,                               "Pause Init  Update Refs (N)")     \
   f(init_update_refs_manage_gclabs,                 "  Manage GCLABs")                 \
                                                                                        \
+  f(conc_update_thread_roots,                       "Concurrent Update Thread Roots")  \
   f(conc_update_refs,                               "Concurrent Update Refs")          \
                                                                                        \
   f(final_update_refs_gross,                        "Pause Final Update Refs (G)")     \


### PR DESCRIPTION
Due to non-atomic LRB, there can be from-space oops in thread roots after evacuation.
To enforce to-space invariant, Shenandoah updates thread roots during final reference updating pause, but it can be done outside pause via thread handshake.

Test:

- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (langtools/tier1)](https://github.com/zhengyu123/jdk/runs/1221976076)

### Issue
 * [JDK-8254103](https://bugs.openjdk.java.net/browse/JDK-8254103): Shenandoah: Move updating thread roots to concurrent phase


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/541/head:pull/541`
`$ git checkout pull/541`
