### PR TITLE
8254078: DataOutputStream is very slow post-disabling of Biased Locking

### DIFF
--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * way. An application uses a data output stream to write data that
  * can later be read by a data input stream.
  * <p>
- * A DataOutputStream is not safe for use by multiple concurrent
+ * A DataInputStream is not safe for use by multiple concurrent
  * threads. If a DataOutputStream is to be used by more than one
  * thread then access to the data output stream should be controlled
  * by appropriate synchronization.

--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -33,9 +33,10 @@ import java.util.Objects;
  * way. An application uses a data output stream to write data that
  * can later be read by a data input stream.
  * <p>
- * DataInputStream is not necessarily safe for multithreaded access.
- * Thread safety is optional and is the responsibility of users of
- * methods in this class.
+ * A DataOutputStream is not safe for use by multiple concurrent
+ * threads. If a DataOutputStream is to be used by more than one
+ * thread then access to the data output stream should be controlled
+ * by appropriate synchronization.
  *
  * @author  Arthur van Hoff
  * @see     java.io.DataOutputStream

--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  * can later be read by a data input stream.
  * <p>
  * A DataInputStream is not safe for use by multiple concurrent
- * threads. If a DataOutputStream is to be used by more than one
+ * threads. If a DataInputStream is to be used by more than one
  * thread then access to the data output stream should be controlled
  * by appropriate synchronization.
  *

--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -35,7 +35,7 @@ import java.util.Objects;
  * <p>
  * A DataInputStream is not safe for use by multiple concurrent
  * threads. If a DataInputStream is to be used by more than one
- * thread then access to the data output stream should be controlled
+ * thread then access to the data input stream should be controlled
  * by appropriate synchronization.
  *
  * @author  Arthur van Hoff

--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -163,8 +163,9 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
      * @see        java.io.FilterOutputStream#out
      */
     public final void writeShort(int v) throws IOException {
-        out.write((v >>> 8) & 0xFF);
-        out.write((v >>> 0) & 0xFF);
+        writeBuffer[0] = (byte)(v >>> 8);
+        writeBuffer[1] = (byte)(v >>> 0);
+        out.write(writeBuffer, 0, 2);
         incCount(2);
     }
 
@@ -178,8 +179,9 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
      * @see        java.io.FilterOutputStream#out
      */
     public final void writeChar(int v) throws IOException {
-        out.write((v >>> 8) & 0xFF);
-        out.write((v >>> 0) & 0xFF);
+        writeBuffer[0] = (byte)(v >>> 8);
+        writeBuffer[1] = (byte)(v >>> 0);
+        out.write(writeBuffer, 0, 2);
         incCount(2);
     }
 
@@ -193,10 +195,11 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
      * @see        java.io.FilterOutputStream#out
      */
     public final void writeInt(int v) throws IOException {
-        out.write((v >>> 24) & 0xFF);
-        out.write((v >>> 16) & 0xFF);
-        out.write((v >>>  8) & 0xFF);
-        out.write((v >>>  0) & 0xFF);
+        writeBuffer[0] = (byte)(v >>> 24);
+        writeBuffer[1] = (byte)(v >>> 16);
+        writeBuffer[2] = (byte)(v >>>  8);
+        writeBuffer[3] = (byte)(v >>>  0);
+        out.write(writeBuffer, 0, 4);
         incCount(4);
     }
 

--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -29,6 +29,10 @@ package java.io;
  * A data output stream lets an application write primitive Java data
  * types to an output stream in a portable way. An application can
  * then use a data input stream to read the data back in.
+ * <p>
+ * DataInputStream is not necessarily safe for multithreaded access.
+ * Thread safety is optional and is the responsibility of users of
+ * methods in this class.
  *
  * @author  unascribed
  * @see     java.io.DataInputStream

--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -30,9 +30,10 @@ package java.io;
  * types to an output stream in a portable way. An application can
  * then use a data input stream to read the data back in.
  * <p>
- * DataInputStream is not necessarily safe for multithreaded access.
- * Thread safety is optional and is the responsibility of users of
- * methods in this class.
+ * A DataOutputStream is not safe for use by multiple concurrent
+ * threads. If a DataOutputStream is to be used by more than one
+ * thread then access to the data output stream should be controlled
+ * by appropriate synchronization.
  *
  * @author  unascribed
  * @see     java.io.DataInputStream

--- a/test/micro/org/openjdk/bench/java/io/DataOutputStreamTest.java
+++ b/test/micro/org/openjdk/bench/java/io/DataOutputStreamTest.java
@@ -41,22 +41,19 @@ public class DataOutputStreamTest {
 
     @Param({"4096"}) int size;
     final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(size);
-    final File f = new File("DataOutputStreamTest.tmp");
+    File f;
     String outputString;
     FileOutputStream fileOutputStream;
     DataOutput bufferedFileStream, rawFileStream, byteArrayStream;
 
     @Setup(Level.Trial)
-    public void setup() {
-        try {
-            fileOutputStream = new FileOutputStream(f);
-            byteArrayStream = new DataOutputStream(byteArrayOutputStream);
-            rawFileStream = new DataOutputStream(fileOutputStream);
-            bufferedFileStream = new DataOutputStream(new BufferedOutputStream(fileOutputStream));
-            outputString = new String(new byte[size]);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    public void setup() throws Exception {
+        f = File.createTempFile("DataOutputStreamTest","out");
+        fileOutputStream = new FileOutputStream(f);
+        byteArrayStream = new DataOutputStream(byteArrayOutputStream);
+        rawFileStream = new DataOutputStream(fileOutputStream);
+        bufferedFileStream = new DataOutputStream(new BufferedOutputStream(fileOutputStream));
+        outputString = new String(new byte[size]);
     }
 
     public void writeChars(DataOutput dataOutput)
@@ -104,24 +101,21 @@ public class DataOutputStreamTest {
     }
 
     @Benchmark
-    public void dataOutputStreamOverByteArray()
-            throws Exception {
+    public void dataOutputStreamOverByteArray() throws Exception {
         byteArrayOutputStream.reset();
         write(byteArrayStream);
         byteArrayOutputStream.flush();
     }
 
     @Benchmark
-    public void dataOutputStreamOverRawFileStream()
-            throws Exception {
+    public void dataOutputStreamOverRawFileStream() throws Exception {
         fileOutputStream.getChannel().position(0);
         write(rawFileStream);
         fileOutputStream.flush();
     }
 
     @Benchmark
-    public void dataOutputStreamOverBufferedFileStream()
-            throws Exception{
+    public void dataOutputStreamOverBufferedFileStream() throws Exception{
         fileOutputStream.getChannel().position(0);
         write(bufferedFileStream);
         fileOutputStream.flush();

--- a/test/micro/org/openjdk/bench/java/io/DataOutputStreamTest.java
+++ b/test/micro/org/openjdk/bench/java/io/DataOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,36 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
-/*
-
-Sample runs on Ryzen 2950X:
-
-Before JDK-8254078:
-
-Benchmark                                                    (BASIC_TYPE)  (SIZE)  Mode  Cnt     Score     Error  Units
-DataOutputStreamTest.dataOutputStreamOverBufferedFileStream          char    4096  avgt    6    58.884 ±   1.018  us/op
-DataOutputStreamTest.dataOutputStreamOverBufferedFileStream         short    4096  avgt    6    59.821 ±   0.928  us/op
-DataOutputStreamTest.dataOutputStreamOverBufferedFileStream           int    4096  avgt    6    59.596 ±   1.036  us/op
-DataOutputStreamTest.dataOutputStreamOverByteArray                   char    4096  avgt    6    48.122 ±   5.672  us/op
-DataOutputStreamTest.dataOutputStreamOverByteArray                  short    4096  avgt    6    49.669 ±   6.732  us/op
-DataOutputStreamTest.dataOutputStreamOverByteArray                    int    4096  avgt    6    53.289 ±   5.453  us/op
-DataOutputStreamTest.dataOutputStreamOverRawFileStream               char    4096  avgt    6  5479.807 ±  84.198  us/op
-DataOutputStreamTest.dataOutputStreamOverRawFileStream              short    4096  avgt    6  5442.496 ± 116.902  us/op
-DataOutputStreamTest.dataOutputStreamOverRawFileStream                int    4096  avgt    6  5458.223 ±  95.796  us/op
-
-After:
-DataOutputStreamTest.dataOutputStreamOverBufferedFileStream          char    4096  avgt    6    29.819 ±  0.805  us/op
-DataOutputStreamTest.dataOutputStreamOverBufferedFileStream         short    4096  avgt    6    29.763 ±  0.510  us/op
-DataOutputStreamTest.dataOutputStreamOverBufferedFileStream           int    4096  avgt    6    14.590 ±  0.603  us/op
-DataOutputStreamTest.dataOutputStreamOverByteArray                   char    4096  avgt    6    30.153 ±  1.285  us/op
-DataOutputStreamTest.dataOutputStreamOverByteArray                  short    4096  avgt    6    29.437 ±  1.286  us/op
-DataOutputStreamTest.dataOutputStreamOverByteArray                    int    4096  avgt    6    17.165 ±  5.683  us/op
-DataOutputStreamTest.dataOutputStreamOverRawFileStream               char    4096  avgt    6  3488.750 ± 77.946  us/op
-DataOutputStreamTest.dataOutputStreamOverRawFileStream              short    4096  avgt    6  3458.778 ± 68.897  us/op
-DataOutputStreamTest.dataOutputStreamOverRawFileStream                int    4096  avgt    6  1709.026 ± 35.592  us/op
-
-*/
 
 package org.openjdk.bench.java.io;
 

--- a/test/micro/org/openjdk/bench/java/io/DataOutputStreamTest.java
+++ b/test/micro/org/openjdk/bench/java/io/DataOutputStreamTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+
+Sample runs on Ryzen 2950X:
+
+Before JDK-8254078:
+
+Benchmark                                                    (BASIC_TYPE)  (SIZE)  Mode  Cnt     Score     Error  Units
+DataOutputStreamTest.dataOutputStreamOverBufferedFileStream          char    4096  avgt    6    58.884 ±   1.018  us/op
+DataOutputStreamTest.dataOutputStreamOverBufferedFileStream         short    4096  avgt    6    59.821 ±   0.928  us/op
+DataOutputStreamTest.dataOutputStreamOverBufferedFileStream           int    4096  avgt    6    59.596 ±   1.036  us/op
+DataOutputStreamTest.dataOutputStreamOverByteArray                   char    4096  avgt    6    48.122 ±   5.672  us/op
+DataOutputStreamTest.dataOutputStreamOverByteArray                  short    4096  avgt    6    49.669 ±   6.732  us/op
+DataOutputStreamTest.dataOutputStreamOverByteArray                    int    4096  avgt    6    53.289 ±   5.453  us/op
+DataOutputStreamTest.dataOutputStreamOverRawFileStream               char    4096  avgt    6  5479.807 ±  84.198  us/op
+DataOutputStreamTest.dataOutputStreamOverRawFileStream              short    4096  avgt    6  5442.496 ± 116.902  us/op
+DataOutputStreamTest.dataOutputStreamOverRawFileStream                int    4096  avgt    6  5458.223 ±  95.796  us/op
+
+After:
+DataOutputStreamTest.dataOutputStreamOverBufferedFileStream          char    4096  avgt    6    29.819 ±  0.805  us/op
+DataOutputStreamTest.dataOutputStreamOverBufferedFileStream         short    4096  avgt    6    29.763 ±  0.510  us/op
+DataOutputStreamTest.dataOutputStreamOverBufferedFileStream           int    4096  avgt    6    14.590 ±  0.603  us/op
+DataOutputStreamTest.dataOutputStreamOverByteArray                   char    4096  avgt    6    30.153 ±  1.285  us/op
+DataOutputStreamTest.dataOutputStreamOverByteArray                  short    4096  avgt    6    29.437 ±  1.286  us/op
+DataOutputStreamTest.dataOutputStreamOverByteArray                    int    4096  avgt    6    17.165 ±  5.683  us/op
+DataOutputStreamTest.dataOutputStreamOverRawFileStream               char    4096  avgt    6  3488.750 ± 77.946  us/op
+DataOutputStreamTest.dataOutputStreamOverRawFileStream              short    4096  avgt    6  3458.778 ± 68.897  us/op
+DataOutputStreamTest.dataOutputStreamOverRawFileStream                int    4096  avgt    6  1709.026 ± 35.592  us/op
+
+*/
+
+package org.openjdk.bench.java.io;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.io.*;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(value = 1, warmups = 0)
+@Measurement(iterations = 6, time = 1)
+@Warmup(iterations=2, time = 2)
+public class DataOutputStreamTest {
+
+    enum BasicType { CHAR, SHORT, INT, STRING }
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkState {
+        @Param({"4096"}) int SIZE;
+        @Param({"char", "short", "int", /*"string"*/}) String BASIC_TYPE;
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(SIZE);
+        final File f = new File("DataOutputStreamTest.tmp");
+        String outputString;
+        FileOutputStream fileOutputStream;
+        DataOutput bufferedFileStream, rawFileStream, byteArrayStream;
+        BasicType basicType;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            try {
+                fileOutputStream = new FileOutputStream(f);
+                byteArrayStream = new DataOutputStream(byteArrayOutputStream);
+                rawFileStream = new DataOutputStream(fileOutputStream);
+                bufferedFileStream = new DataOutputStream(new BufferedOutputStream(fileOutputStream));
+                switch (BASIC_TYPE.toLowerCase()) {
+                    case "char": basicType = BasicType.CHAR; break;
+                    case "short": basicType =  BasicType.SHORT; break;
+                    case "int": basicType = BasicType.INT; break;
+                    case "string": basicType = BasicType.STRING; break;
+                    default: throw new RuntimeException("Unhandled basic type:" + BASIC_TYPE);
+                };
+                outputString = new String(new byte[SIZE]);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public void writeChars(BenchmarkState state, DataOutput dataOutput) {
+        try {
+            for (int i = 0; i < state.SIZE; i += 2) {
+                dataOutput.writeChar(i);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void writeShorts(BenchmarkState state, DataOutput dataOutput) {
+        try {
+            for (int i = 0; i < state.SIZE; i += 2) {
+                dataOutput.writeShort(i);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void writeInts(BenchmarkState state, DataOutput dataOutput) {
+        try {
+            for (int i = 0; i < state.SIZE; i += 4) {
+                dataOutput.writeInt(i);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void writeString(BenchmarkState state, DataOutput dataOutput) {
+        try {
+            dataOutput.writeChars(state.outputString);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void write(BenchmarkState state, DataOutput dataOutput) {
+        switch (state.basicType) {
+            case CHAR: writeChars(state, dataOutput); break;
+            case SHORT: writeShorts(state, dataOutput); break;
+            case INT: writeInts(state, dataOutput); break;
+            case STRING: writeString(state, dataOutput); break;
+        }
+    }
+    @Benchmark
+    public void dataOutputStreamOverByteArray(BenchmarkState state)
+            throws IOException {
+        state.byteArrayOutputStream.reset();
+        write(state, state.byteArrayStream);
+        state.byteArrayOutputStream.flush();
+    }
+
+    @Benchmark
+    public void dataOutputStreamOverRawFileStream(BenchmarkState state)
+            throws IOException {
+        state.fileOutputStream.getChannel().position(0);
+        write(state, state.rawFileStream);
+        state.fileOutputStream.flush();
+    }
+
+    @Benchmark
+    public void dataOutputStreamOverBufferedFileStream(BenchmarkState state)
+            throws IOException{
+        state.fileOutputStream.getChannel().position(0);
+        write(state, state.bufferedFileStream);
+        state.fileOutputStream.flush();
+    }
+}


### PR DESCRIPTION
DataOutputStream is very slow post-disabling of Biased Locking. This
was discovered when benchmarking a transaction library, which showed
significant performance loss when moving to JDK 15. WIth some small
changes to DataOutputStream we can get the performance back. There's a
JMH benchmark at
http://cr.openjdk.java.net/~aph/JDK-8254078/jmh-tests.tar

Some Stream classes use very fine-grained locking.

In particular, writeInt is defined like this:

        out.write((v >>> 24) & 0xFF);
        out.write((v >>> 16) & 0xFF);
        out.write((v >>> 8) & 0xFF);
        out.write((v >>> 0) & 0xFF);
        incCount(4);

Unfortunately, ByteArrayOutputStream.write(byte) is defined like this:

    public synchronized void write(int b) {
        ensureCapacity(count + 1);
        buf[count] = (byte) b;
        count += 1;
    }

so we acquire and release a lock for every byte that is output. 

 For example, writing 4kb of ints goes from 17.3 us/op to 53.9 us/op when biased locking is disabled: 


+UseBiasedLocking DataOutputStreamTest.dataOutputStreamOverByteArray avgt 6 53.895 ± 5.126 us/op
-UseBiasedLocking DataOutputStreamTest.dataOutputStreamOverByteArray avgt 6 17.291 ± 4.430 us/op

There are refactorings of DataOutputStream we can do to mitigate this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254078](https://bugs.openjdk.java.net/browse/JDK-8254078): DataOutputStream is very slow post-disabling of Biased Locking


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 43be1998075dede16d318b8f01fae064c217399c
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/542/head:pull/542`
`$ git checkout pull/542`
