### PR TITLE
8254104: MethodCounters must exist before nmethod is installed

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -974,8 +974,8 @@ void ciEnv::register_method(ciMethod* target,
   {
     methodHandle method(THREAD, target->get_Method());
 
-    if (TieredCompilation && method->get_method_counters(THREAD) == NULL) {
-      // Tiered policy requires method counters.
+    // We require method counters to store some method state (max compilation levels) required by the compilation policy.
+    if (method->get_method_counters(THREAD) == NULL) {
       record_failure("can't create method counters");
       // All buffers in the CodeBuffer are allocated in the CodeCache.
       // If the code buffer is created on each compile attempt

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -972,6 +972,18 @@ void ciEnv::register_method(ciMethod* target,
   VM_ENTRY_MARK;
   nmethod* nm = NULL;
   {
+    methodHandle method(THREAD, target->get_Method());
+
+    if (TieredCompilation && method->get_method_counters(THREAD) == NULL) {
+      // Tiered policy requires method counters.
+      record_failure("can't create method counters");
+      // All buffers in the CodeBuffer are allocated in the CodeCache.
+      // If the code buffer is created on each compile attempt
+      // as in C2, then it must be freed.
+      code_buffer->free_blob();
+      return;
+    }
+
     // To prevent compile queue updates.
     MutexLocker locker(THREAD, MethodCompileQueue_lock);
 
@@ -1011,9 +1023,6 @@ void ciEnv::register_method(ciMethod* target,
       // Check for {class loads, evolution, breakpoints, ...} during compilation
       validate_compile_task_dependencies(target);
     }
-
-    methodHandle method(THREAD, target->get_Method());
-
 #if INCLUDE_RTM_OPT
     if (!failing() && (rtm_state != NoRTM) &&
         (method()->method_data() != NULL) &&

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1577,8 +1577,14 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
     nmethod_mirror_index = -1;
   }
 
-  JVMCI::CodeInstallResult result;
-  {
+  JVMCI::CodeInstallResult result(JVMCI::ok);
+
+  if (TieredCompilation && method->get_method_counters(THREAD) == NULL) {
+    // Tiered policy requires method counters.
+    result = JVMCI::cache_full;
+  }
+
+  if (result == JVMCI::ok) {
     // To prevent compile queue updates.
     MutexLocker locker(THREAD, MethodCompileQueue_lock);
 

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1579,8 +1579,8 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
 
   JVMCI::CodeInstallResult result(JVMCI::ok);
 
-  if (TieredCompilation && method->get_method_counters(THREAD) == NULL) {
-    // Tiered policy requires method counters.
+  // We require method counters to store some method state (max compilation levels) required by the compilation policy.
+  if (method->get_method_counters(THREAD) == NULL) {
     result = JVMCI::cache_full;
     failure_detail = (char*) "can't create method counters";
   }

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1582,6 +1582,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
   if (TieredCompilation && method->get_method_counters(THREAD) == NULL) {
     // Tiered policy requires method counters.
     result = JVMCI::cache_full;
+    failure_detail = (char*) "can't create method counters";
   }
 
   if (result == JVMCI::ok) {


### PR DESCRIPTION
Ensure that MethodCounters for a particular method exist during the nmethod install (for methods that were never run before). Tiered compilation policy depends on the state stored in the counters to function properly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (langtools/tier1)](https://github.com/veresov/jdk/runs/1221831410)

### Issue
 * [JDK-8254104](https://bugs.openjdk.java.net/browse/JDK-8254104): MethodCounters must exist before nmethod is installed


### Reviewers
 * [Doug Simon](https://openjdk.java.net/census#dnsimon) (@dougxc - Committer) ⚠️ Review applies to b626ad9c987d702e1232a6fe81d3de8b0f8862b9
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/543/head:pull/543`
`$ git checkout pull/543`
