### PR TITLE
8254173: Add Zero, Minimal hotspot targets to submit workflow

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -106,8 +106,8 @@ jobs:
           - build release
           - build debug
           - build hotspot no-pch
-          - build debug hotspot no-pch zero
-          - build debug hotspot no-pch minimal
+          - build hotspot zero
+          - build hotspot minimal
         include:
           - flavor: build debug
             flags: --enable-debug
@@ -115,10 +115,10 @@ jobs:
           - flavor: build hotspot no-pch
             flags: --disable-precompiled-headers
             build-target: hotspot
-          - flavor: build debug hotspot no-pch zero
+          - flavor: build hotspot zero
             flags: --enable-debug --disable-precompiled-headers --with-jvm-variants=zero
             build-target: hotspot
-          - flavor: build debug hotspot no-pch minimal
+          - flavor: build hotspot minimal
             flags: --enable-debug --disable-precompiled-headers --with-jvm-variants=minimal
             build-target: hotspot
 

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -106,12 +106,20 @@ jobs:
           - build release
           - build debug
           - build hotspot no-pch
+          - build hotspot zero
+          - build hotspot minimal
         include:
           - flavor: build debug
             flags: --enable-debug
             artifact: -debug
           - flavor: build hotspot no-pch
             flags: --disable-precompiled-headers
+            build-target: hotspot
+          - flavor: build hotspot zero
+            flags: --disable-precompiled-headers --with-jvm-variants=zero
+            build-target: hotspot
+          - flavor: build hotspot minimal
+            flags: --disable-precompiled-headers --with-jvm-variants=minimal
             build-target: hotspot
 
     env:

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -106,8 +106,8 @@ jobs:
           - build release
           - build debug
           - build hotspot no-pch
-          - build hotspot zero
-          - build hotspot minimal
+          - build debug hotspot no-pch zero
+          - build debug hotspot no-pch minimal
         include:
           - flavor: build debug
             flags: --enable-debug
@@ -115,11 +115,11 @@ jobs:
           - flavor: build hotspot no-pch
             flags: --disable-precompiled-headers
             build-target: hotspot
-          - flavor: build hotspot zero
-            flags: --disable-precompiled-headers --with-jvm-variants=zero
+          - flavor: build debug hotspot no-pch zero
+            flags: --enable-debug --disable-precompiled-headers --with-jvm-variants=zero
             build-target: hotspot
-          - flavor: build hotspot minimal
-            flags: --disable-precompiled-headers --with-jvm-variants=minimal
+          - flavor: build debug hotspot no-pch minimal
+            flags: --enable-debug --disable-precompiled-headers --with-jvm-variants=minimal
             build-target: hotspot
 
     env:


### PR DESCRIPTION
Zero VM and Minimal VM builds are routinely discovering the problems with internal Hotspot dependencies. Mostly because they turn off the whole lot of VM features, and every path that is not guarded by a feature #ifdef or build file list fails. 

It would be good to add Zero and Minimal targets to submit workflow.

It seems to add two ~9 minute stages, compared to ~17 minute stage for building no-pch hotspot, and ~33 minutes for full JDK.

Attention @rwestberg.

Testing:
  - [x] GH workflow still works; see [latest run ](https://github.com/shipilev/jdk/actions/runs/293805791)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (5/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8254173](https://bugs.openjdk.java.net/browse/JDK-8254173): Add Zero, Minimal hotspot targets to submit workflow


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 7e3e6ad92d1db908ae18ae27f19ca49b274d9e2a
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/546/head:pull/546`
`$ git checkout pull/546`
