### PR TITLE
8254175: Build no-pch configuration in debug mode for submit checks

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -105,12 +105,12 @@ jobs:
         flavor:
           - build release
           - build debug
-          - build debug hotspot no-pch
+          - build hotspot no-pch
         include:
           - flavor: build debug
             flags: --enable-debug
             artifact: -debug
-          - flavor: build debug hotspot no-pch
+          - flavor: build hotspot no-pch
             flags: --enable-debug --disable-precompiled-headers
             build-target: hotspot
 

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -105,13 +105,13 @@ jobs:
         flavor:
           - build release
           - build debug
-          - build hotspot no-pch
+          - build debug hotspot no-pch
         include:
           - flavor: build debug
             flags: --enable-debug
             artifact: -debug
-          - flavor: build hotspot no-pch
-            flags: --disable-precompiled-headers
+          - flavor: build debug hotspot no-pch
+            flags: --enable-debug --disable-precompiled-headers
             build-target: hotspot
 
     env:


### PR DESCRIPTION
no-pch configuration is supposed to expose missing include dependencies. But currently it runs with default (release) bits, which misses symbols hidden in debug code. We should consider building it in debug mode.

Attention @rwestberg.

Testing:
  - [x] GH workflow still works, see the builds in the [latest run](https://github.com/shipilev/jdk/actions/runs/293802758)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254175](https://bugs.openjdk.java.net/browse/JDK-8254175): Build no-pch configuration in debug mode for submit checks


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - Committer)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/547/head:pull/547`
`$ git checkout pull/547`
