### PR TITLE
8250921: Manpage of javadoc contains wrong example for -doctitle option

### DIFF
--- a/src/jdk.javadoc/share/man/javadoc.1
+++ b/src/jdk.javadoc/share/man/javadoc.1
@@ -596,7 +596,7 @@ it does, you must enclose the title in quotation marks.
 Additional quotation marks within the \f[CB]title\f[R] tag must be
 escaped.
 For example,
-\f[CB]javadoc\ \-header\ "<b>My\ Library</b><br>v1.0"\ com.mypackage.\f[R]
+\f[CB]javadoc\ \-doctitle\ "<b>My\ Library</b><br>v1.0"\ com.mypackage.\f[R]
 .RS
 .RE
 .TP


### PR DESCRIPTION
Fix javadoc's manpage by replacing wrong option `-header` with the correct one: `-doctitle`