### PR TITLE
8248262: Wrong link target in ModuleDescriptor#isAutomatic's API documentation

### DIFF
--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -1331,7 +1331,7 @@ public class ModuleDescriptor
      * <p> Returns {@code true} if this is an automatic module. </p>
      *
      * <p> This method is equivalent to testing if the set of {@link #modifiers()
-     * modifiers} contains the {@link Modifier#OPEN AUTOMATIC} modifier. </p>
+     * modifiers} contains the {@link Modifier#AUTOMATIC AUTOMATIC} modifier. </p>
      *
      * @return  {@code true} if this is an automatic module
      */


### PR DESCRIPTION
Fix target in `ModuleDescriptor#isAutomatic`'s API documentation to point to `Modifier.AUTOMATIC`.

https://bugs.openjdk.java.net/browse/JDK-8248262

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (9/9 running) |    |  ⏳ (9/9 running) |

### Issue
 * [JDK-8248262](https://bugs.openjdk.java.net/browse/JDK-8248262): Wrong link target in ModuleDescriptor#isAutomatic's API documentation


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/555/head:pull/555`
`$ git checkout pull/555`
