### PR TITLE
8254164: G1 only removes self forwarding pointers for last collection set increment 

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -259,8 +259,10 @@ G1ParRemoveSelfForwardPtrsTask::G1ParRemoveSelfForwardPtrsTask(G1RedirtyCardsQue
 void G1ParRemoveSelfForwardPtrsTask::work(uint worker_id) {
   RemoveSelfForwardPtrHRClosure rsfp_cl(_rdcqs, worker_id);
 
-  // We need to check all regions whether they need self forward removals, not only
-  // the last collection set increment. Reference processing may copy over and fail
-  // evacuation in any region in the collection set.
+  // We need to check all collection set regions whether they need self forward
+  // removals, not only the last collection set increment. The reason is that
+  // reference processing (e.g. finalizers) can make it necessary to resurrect an
+  // otherwise unreachable object at the very end of the collection. That object
+  // might cause an evacuation failure in any region in the collection set.
   _g1h->collection_set_par_iterate_all(&rsfp_cl, &_hrclaimer, worker_id);
 }

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,5 +259,8 @@ G1ParRemoveSelfForwardPtrsTask::G1ParRemoveSelfForwardPtrsTask(G1RedirtyCardsQue
 void G1ParRemoveSelfForwardPtrsTask::work(uint worker_id) {
   RemoveSelfForwardPtrHRClosure rsfp_cl(_rdcqs, worker_id);
 
-  _g1h->collection_set_iterate_increment_from(&rsfp_cl, &_hrclaimer, worker_id);
+  // We need to check all regions whether they need self forward removals, not only
+  // the last collection set increment. Reference processing may copy over and fail
+  // evacuation in any region in the collection set.
+  _g1h->collection_set_par_iterate_all(&rsfp_cl, &_hrclaimer, worker_id);
 }


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes a previously hard to reproduce crash that started showing up much more frequently in conjunction with changes to young gen sizing (JDK-8244603)?

The issues is that the code to process regions where evacuation failed only processes the last increment. This leaves forwarded pointers in the mark word of some objects. Obviously other code does not like that, e.g. the crashes in JDK-8248438 which I plan to close as duplicate.

Only checking the last collection set increment for regions that failed evacuation is wrong in case there is an evacuation failure caused by reference processing in a region that has been evacuated in earlier evacuation increments. Reference processing (e.g. finalizers) can make it necessary to resurrect an otherwise unreachable object at the very end of the collection that can't be copied and is located in a region evacuated in an earlier increment.

This optimization to only look at the last increment for removal of self forwarding pointers has been introduced in JDK-8218668.

Until changes to young gen sizing in JDK-8244603 this crashes has been a very rare occurrence, but with that it has been common in some tier8 tests (KitchenSink8/24h, DaCapo24h) particularly with some additional targeted verification (enable verification only at the end of mixed gcs with optional evacuation). Without this fix both tests fail within 10 minutes to 2 hours. With the patch everything completes fine.

Testing:
- tier1-5
- KitchenSink/Dacapo24h with verification code and JDK-8244603.

Note: since this change strictly does more work during evacuation failure handling I consider this amount of testing sufficient, i.e. with JDK-8244603. It is very hard to reproduce without JDK-8244603.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (0/0 passed) | ✔️ (0/0 passed) | ✔️ (0/0 passed) |

### Issue
 * [JDK-8254164](https://bugs.openjdk.java.net/browse/JDK-8254164): G1 only removes self forwarding pointers for last collection set increment


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to b37d02eb44956b409ef9d584b9bed5684081de2d
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/556/head:pull/556`
`$ git checkout pull/556`
