### PR TITLE
8254028: G1 incorrectly updates scan_top for collection set regions during preparation of evacuation

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -909,8 +909,8 @@ void G1RemSet::scan_collection_set_regions(G1ParScanThreadState* pss,
 void G1RemSet::prepare_region_for_scan(HeapRegion* r) {
   uint hrm_index = r->hrm_index();
 
-  // The first condition is not absolutely necessary but it provides consistency:
-  // regions in the collection set (and free ones) should never be scanned.
+  // Only update non-collection set old regions, others must have already been set
+  // to NULL (don't scan) in the initialization.
   if (!r->in_collection_set() && r->is_old_or_humongous_or_archive()) {
     _scan_state->set_scan_top(hrm_index, r->top());
   } else {

--- a/src/hotspot/share/gc/g1/g1RemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.hpp
@@ -67,6 +67,8 @@ private:
   G1HotCardCache*        _hot_card_cache;
 
   void print_merge_heap_roots_stats();
+
+  void assert_scan_top_is_null(uint hrm_index) PRODUCT_RETURN;
 public:
 
   typedef CardTable::CardValue CardValue;


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that makes values of G1RemSetScanState::_scan_top for regions in the initial collection set consistent with ones in optional collection set?
So currently G1RemSetScanState::_scan_top is top() for regions in the initial collection set although they will never be scanned as enforced when dropping the remsets onto the card table. For the optional collection set, G1 sets scan_top manually to NULL when selecting the next few optional regions (using G1RemSet::exclude_region_from_scan()).

When debugging this discrepancy recently posed some slight surprise for me, so I would like to change this. Also there is some risk that future code that relies on that property will be surprised.

Testing: tier1-4; lots of kitchensink runs with JDK-8254164.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (0/0 passed) | ✔️ (0/0 passed) | ✔️ (0/0 passed) |

### Issue
 * [JDK-8254028](https://bugs.openjdk.java.net/browse/JDK-8254028): G1 incorrectly updates scan_top for collection set regions during preparation of evacuation


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/557/head:pull/557`
`$ git checkout pull/557`
