### PR TITLE
8254024: Enhance native libs for AWT and Swing to work with GraalVM Native Image

### DIFF
--- a/src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.h
+++ b/src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ typedef struct {
 typedef mlib_image *(*MlibCreateFP_t)(mlib_type, mlib_s32, mlib_s32,
                                        mlib_s32);
 typedef mlib_image *(*MlibCreateStructFP_t)(mlib_type, mlib_s32, mlib_s32,
-                                             mlib_s32, mlib_s32, void *);
+                                             mlib_s32, mlib_s32, const void *);
 typedef void (*MlibDeleteFP_t)(mlib_image *);
 
 typedef struct {

--- a/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
+++ b/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
@@ -300,9 +300,12 @@ Java_java_awt_TextField_initIDs
 {
 }
 
+#ifndef STATIC_BUILD
+// The same function exists in libawt.a::awt_LoadLibrary.c
 JNIEXPORT jboolean JNICALL AWTIsHeadless() {
     return JNI_FALSE;
 }
+#endif
 
 JNIEXPORT void JNICALL Java_java_awt_Dialog_initIDs (JNIEnv *env, jclass cls)
 {
@@ -811,8 +814,13 @@ Window get_xawt_root_shell(JNIEnv *env) {
  */
 
 JNIEXPORT void JNICALL
-Java_sun_awt_motif_XsessionWMcommand(JNIEnv *env, jobject this,
+#ifdef STATIC_BUILD
+Java_sun_xawt_motif_XsessionWMcommand(JNIEnv *env, jobject this,
     jobject frame, jstring jcommand)
+#else
+Java_sun_awt_motif_XsessionWMcommand(JNIEnv *env, jobject this,
+        jobject frame, jstring jcommand)
+#endif
 {
     const char *command;
     XTextProperty text_prop;
@@ -856,7 +864,11 @@ Java_sun_awt_motif_XsessionWMcommand(JNIEnv *env, jobject this,
  * name.  It's not!  It's just a plain function.
  */
 JNIEXPORT void JNICALL
+#ifdef STATIC_BUILD
+Java_sun_xawt_motif_XsessionWMcommand_New(JNIEnv *env, jobjectArray jarray)
+#else
 Java_sun_awt_motif_XsessionWMcommand_New(JNIEnv *env, jobjectArray jarray)
+#endif
 {
     jsize length;
     char ** array;


### PR DESCRIPTION
The following PR fixes https://bugs.openjdk.java.net/browse/JDK-8254024

Starting from version 11.0.9, all JDK libraries also build as static libraries (JEP 178: Statically-Linked JNI Libraries).
The purpose of using static libraries is to build GraalVM Native image statically linked with Java native libraries, to shipping single executable without runtime dependencies from JRE.

For some static libraries, it leads to an issue: if one static library is trying to load another static library in runtime using `dlopen` (and then uses `dlsym` to find symbols). With static libraries, this is not possible and all dynamic calls should be replaced.

This happens in `libawt` while it loads `awt-xawt` or `awt_headless` and in `mlib_image`.

Current PR fixes this issue for AWT libraries that allow building Swing/AWT applications as a Native image and have no runtime dependencies from JRE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254024](https://bugs.openjdk.java.net/browse/JDK-8254024): Enhance native libs for AWT and Swing to work with GraalVM Native Image


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Bob Vandette](https://openjdk.java.net/census#bobv) (@bobvandette - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/562/head:pull/562`
`$ git checkout pull/562`
