### PR TITLE
8253833: mutexLocker assert_locked_or_safepoint should not access VMThread state from non-VM-thread

### DIFF
--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -169,9 +169,6 @@ void assert_locked_or_safepoint(const Mutex* lock) {
   if (lock->owned_by_self()) return;
   if (SafepointSynchronize::is_at_safepoint()) return;
   if (!Universe::is_fully_initialized()) return;
-  // see if invoker of VM operation owns it
-  VM_Operation* op = VMThread::vm_operation();
-  if (op != NULL && op->calling_thread() == lock->owner()) return;
   fatal("must own lock %s", lock->name());
 }
 


### PR DESCRIPTION
It's unsafe for all threads except VM thread to access the current vm operation.
This part of the assert is also faulty:
If we are not at safepoint and the operation requester (calling thread) would be the owner of the lock do not mean it is safe for current thread.

Passes t1-5. (also note VMThread::vm_operation() assert current thread is VM thread, and I have seen no such assert)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8253833](https://bugs.openjdk.java.net/browse/JDK-8253833): mutexLocker assert_locked_or_safepoint should not access VMThread state from non-VM-thread


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/563/head:pull/563`
`$ git checkout pull/563`
