### PR TITLE
JDK-8254195: java/nio/file/Files/SubstDrive.java failed with "AssertionError: expected [144951656448] but found [144951640064]"

### DIFF
--- a/test/jdk/java/nio/file/Files/SubstDrive.java
+++ b/test/jdk/java/nio/file/Files/SubstDrive.java
@@ -216,14 +216,6 @@ public class SubstDrive {
             fileStore2.getBlockSize());
 
         assertEquals(
-            fileStore1.getUnallocatedSpace(),
-            fileStore2.getUnallocatedSpace());
-
-        assertEquals(
-            fileStore1.getUsableSpace(),
-            fileStore2.getUsableSpace());
-
-        assertEquals(
             fileStore1.name(),
             fileStore2.name());
 


### PR DESCRIPTION
Remove assertions for FileStore.getUnallocatedSpace() and FileStore.getUsableSpace() since the values are not guaranteed to be the same on a busy system.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (2/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8254195](https://bugs.openjdk.java.net/browse/JDK-8254195): java/nio/file/Files/SubstDrive.java failed with "AssertionError: expected [144951656448] but found [144951640064]"


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/565/head:pull/565`
`$ git checkout pull/565`
