### PR TITLE
8254261: fix javadocs in jdk.test.lib.Utils

### DIFF
--- a/test/lib/jdk/test/lib/Utils.java
+++ b/test/lib/jdk/test/lib/Utils.java
@@ -246,6 +246,8 @@ public final class Utils {
         return prependTestJavaOpts(userArgs);
     }
 
+    private static final Pattern useGcPattern = Pattern.compile(
+            "(?:\\-XX\\:[\\+\\-]Use.+GC)");
     /**
      * Removes any options specifying which GC to use, for example "-XX:+UseG1GC".
      * Removes any options matching: -XX:(+/-)Use*GC
@@ -253,8 +255,6 @@ public final class Utils {
      * GC specified by the framework must first be removed.
      * @return A copy of given opts with all GC options removed.
      */
-    private static final Pattern useGcPattern = Pattern.compile(
-            "(?:\\-XX\\:[\\+\\-]Use.+GC)");
     public static List<String> removeGcOpts(List<String> opts) {
         List<String> optsWithoutGC = new ArrayList<String>();
         for (String opt : opts) {
@@ -564,7 +564,7 @@ public final class Utils {
     /**
      * Wait for condition to be true
      *
-     * @param condition, a condition to wait for
+     * @param condition a condition to wait for
      */
     public static final void waitForCondition(BooleanSupplier condition) {
         waitForCondition(condition, -1L, 100L);
@@ -573,7 +573,7 @@ public final class Utils {
     /**
      * Wait until timeout for condition to be true
      *
-     * @param condition, a condition to wait for
+     * @param condition a condition to wait for
      * @param timeout a time in milliseconds to wait for condition to be true
      * specifying -1 will wait forever
      * @return condition value, to determine if wait was successful
@@ -586,7 +586,7 @@ public final class Utils {
     /**
      * Wait until timeout for condition to be true for specified time
      *
-     * @param condition, a condition to wait for
+     * @param condition a condition to wait for
      * @param timeout a time in milliseconds to wait for condition to be true,
      * specifying -1 will wait forever
      * @param sleepTime a time to sleep value in milliseconds
@@ -619,13 +619,13 @@ public final class Utils {
      * Filters out an exception that may be thrown by the given
      * test according to the given filter.
      *
-     * @param test - method that is invoked and checked for exception.
-     * @param filter - function that checks if the thrown exception matches
-     *                 criteria given in the filter's implementation.
-     * @return - exception that matches the filter if it has been thrown or
-     *           {@code null} otherwise.
-     * @throws Throwable - if test has thrown an exception that does not
-     *                     match the filter.
+     * @param test method that is invoked and checked for exception.
+     * @param filter function that checks if the thrown exception matches
+     *               criteria given in the filter's implementation.
+     * @return exception that matches the filter if it has been thrown or
+     *         {@code null} otherwise.
+     * @throws Throwable if test has thrown an exception that does not
+     *                   match the filter.
      */
     public static Throwable filterException(ThrowingRunnable test,
             Function<Throwable, Boolean> filter) throws Throwable {
@@ -786,19 +786,21 @@ public final class Utils {
     /**
      * Creates an empty file in "user.dir" if the property set.
      * <p>
-     * This method is meant as a replacement for {@code Files#createTempFile(String, String, FileAttribute...)}
+     * This method is meant as a replacement for {@link Files#createTempFile(String, String, FileAttribute...)}
      * that doesn't leave files behind in /tmp directory of the test machine
      * <p>
      * If the property "user.dir" is not set, "." will be used.
      *
-     * @param prefix
-     * @param suffix
-     * @param attrs
+     * @param prefix the prefix string to be used in generating the file's name;
+     *               may be null
+     * @param suffix the suffix string to be used in generating the file's name;
+     *               may be null, in which case ".tmp" is used
+     * @param attrs an optional list of file attributes to set atomically when creating the file
      * @return the path to the newly created file that did not exist before this
      *         method was invoked
-     * @throws IOException
+     * @throws IOException if an I/O error occurs or dir does not exist
      *
-     * @see {@link Files#createTempFile(String, String, FileAttribute...)}
+     * @see Files#createTempFile(String, String, FileAttribute...)
      */
     public static Path createTempFile(String prefix, String suffix, FileAttribute<?>... attrs) throws IOException {
         Path dir = Paths.get(System.getProperty("user.dir", "."));
@@ -808,17 +810,17 @@ public final class Utils {
     /**
      * Creates an empty directory in "user.dir" or "."
      * <p>
-     * This method is meant as a replacement for {@code Files#createTempDirectory(String, String, FileAttribute...)}
+     * This method is meant as a replacement for {@link Files#createTempDirectory(Path, String, FileAttribute...)}
      * that doesn't leave files behind in /tmp directory of the test machine
      * <p>
      * If the property "user.dir" is not set, "." will be used.
      *
-     * @param prefix
-     * @param attrs
+     * @param prefix the prefix string to be used in generating the directory's name; may be null
+     * @param attrs an optional list of file attributes to set atomically when creating the directory
      * @return the path to the newly created directory
-     * @throws IOException
+     * @throws IOException if an I/O error occurs or dir does not exist
      *
-     * @see {@link Files#createTempDirectory(String, String, FileAttribute...)}
+     * @see Files#createTempDirectory(Path, String, FileAttribute...)
      */
     public static Path createTempDirectory(String prefix, FileAttribute<?>... attrs) throws IOException {
         Path dir = Paths.get(System.getProperty("user.dir", "."));


### PR DESCRIPTION
Hi all,

could you please review this trivial fix of javadocs in `jdk.test.lib.Utils`?

-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254261](https://bugs.openjdk.java.net/browse/JDK-8254261): fix javadocs in jdk.test.lib.Utils


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/566/head:pull/566`
`$ git checkout pull/566`
