### PR TITLE
8254262: jdk.test.lib.Utils::createTemp* don't pass attrs

### DIFF
--- a/test/lib/jdk/test/lib/Utils.java
+++ b/test/lib/jdk/test/lib/Utils.java
@@ -802,7 +802,7 @@ public final class Utils {
      */
     public static Path createTempFile(String prefix, String suffix, FileAttribute<?>... attrs) throws IOException {
         Path dir = Paths.get(System.getProperty("user.dir", "."));
-        return Files.createTempFile(dir, prefix, suffix);
+        return Files.createTempFile(dir, prefix, suffix, attrs);
     }
 
     /**
@@ -822,6 +822,6 @@ public final class Utils {
      */
     public static Path createTempDirectory(String prefix, FileAttribute<?>... attrs) throws IOException {
         Path dir = Paths.get(System.getProperty("user.dir", "."));
-        return Files.createTempDirectory(dir, prefix);
+        return Files.createTempDirectory(dir, prefix, attrs);
     }
 }


### PR DESCRIPTION
Hi all,

`jdk.test.lib.Utils::createTempFile` and `createTempDirectory` methods accept `attrs`, but don't pass it to `java.nio.file.Files::createTempFile` and `createTempDirectory` methods respectively. could you please review this trivial patch which fixes that?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (1/5 running) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |  ⏳ (9/9 running) |

### Issue
 * [JDK-8254262](https://bugs.openjdk.java.net/browse/JDK-8254262): jdk.test.lib.Utils::createTemp* don't pass attrs


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/567/head:pull/567`
`$ git checkout pull/567`
