### PR TITLE
8254265: s390 and linux 32 bit builds broken

### DIFF
--- a/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
@@ -856,7 +856,7 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(Register frame_
 
   // Compute the beginning of the protected zone minus the requested frame size.
   __ z_sgr(tmp1, tmp2);
-  __ add2reg(tmp1, JavaThread::stack_guard_zone_size());
+  __ add2reg(tmp1, StackOverflow::stack_guard_zone_size());
 
   // Add in the size of the frame (which is the same as subtracting it from the
   // SP, which would take another register.

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1935,7 +1935,7 @@ void * os::Linux::dll_load_in_vmthread(const char *filename, char *ebuf,
       StackOverflow* overflow_state = jt->stack_overflow_state();
       if (!overflow_state->stack_guard_zone_unused() &&     // Stack not yet fully initialized
           overflow_state->stack_guards_enabled()) {         // No pending stack overflow exceptions
-        if (!os::guard_memory((char *)jt->stack_end(), overflow_state->stack_guard_zone_size())) {
+        if (!os::guard_memory((char *)jt->stack_end(), StackOverflow::stack_guard_zone_size())) {
           warning("Attempt to reguard stack yellow zone failed.");
         }
       }

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -838,8 +838,8 @@ void os::workaround_expand_exec_shield_cs_limit() {
   if (os::is_primordial_thread()) {
     address limit = Linux::initial_thread_stack_bottom();
     if (! DisablePrimordialThreadGuardPages) {
-      limit += JavaThread::stack_red_zone_size() +
-        JavaThread::stack_yellow_zone_size();
+      limit += StackOverflow::stack_red_zone_size() +
+               StackOverflow::stack_yellow_zone_size();
     }
     os::Linux::expand_stack_to(limit);
   }

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -860,7 +860,7 @@ void os::workaround_expand_exec_shield_cs_limit() {
    * we don't have much control or understanding of the address space, just let it slide.
    */
   char* hint = (char*)(Linux::initial_thread_stack_bottom() -
-                       (JavaThread::stack_guard_zone_size() + page_size));
+                       (StackOverflow::stack_guard_zone_size() + page_size));
   char* codebuf = os::attempt_reserve_memory_at(hint, page_size);
 
   if (codebuf == NULL) {


### PR DESCRIPTION
JDK-8253717 missed ocurrances of JavaThread::stack_guard_zone_size() which was moved to class StackOverflow.

I just verified s390 build. Can anybody check linux 32 bit?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254265](https://bugs.openjdk.java.net/browse/JDK-8254265): s390 and linux 32 bit builds broken


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 6ec8881e21c94e84e7d117d007b69ef576f74ea4


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/568/head:pull/568`
`$ git checkout pull/568`
