### PR TITLE
8253563: Change sun.security.jca.Providers.threadLists to be ThreadLocal

### DIFF
--- a/src/java.base/share/classes/sun/security/jca/Providers.java
+++ b/src/java.base/share/classes/sun/security/jca/Providers.java
@@ -37,7 +37,7 @@ import java.security.Provider;
 public class Providers {
 
     private static final ThreadLocal<ProviderList> threadLists =
-        new InheritableThreadLocal<>();
+        new ThreadLocal<>();
 
     // number of threads currently using thread-local provider lists
     // tracked to allow an optimization if == 0
@@ -205,7 +205,7 @@ public class Providers {
 
     /**
      * Methods to manipulate the thread local provider list. It is for use by
-     * JAR verification (see above) and the SunJSSE FIPS mode only.
+     * JAR verification (see above).
      *
      * It should be used as follows:
      *


### PR DESCRIPTION
Could someone help reviewing this one-line change? This changes the provider list used during jar verification from InheritableThreadLocal to ThreadLocal. Existing usage and handling uses this field as temporary thread-specific provider list for jar verification. There seems to be no reason for it to be InheritableThreadLocal.

Existing regression tests pass with this change.

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8253563](https://bugs.openjdk.java.net/browse/JDK-8253563): Change sun.security.jca.Providers.threadLists to be ThreadLocal


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/570/head:pull/570`
`$ git checkout pull/570`
