### PR TITLE
8253765: C2: Control randomization in StressLCM and StressGCM

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -54,7 +54,7 @@
                                                                             \
   product(uint, StressSeed, 0, DIAGNOSTIC,                                  \
           "Seed for randomized stress testing (if unset, a random one is "  \
-          "generated")                                                      \
+          "generated)")                                                     \
           range(0, max_juint)                                               \
                                                                             \
   develop(bool, StressMethodHandleLinkerInlining, false,                    \

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -53,7 +53,7 @@
           "Randomize worklist traversal in IGVN")                           \
                                                                             \
   product(uint, StressSeed, 0, DIAGNOSTIC,                                  \
-          "Seed for IGVN stress testing (if unset, a random one is "        \
+          "Seed for randomized stress testing (if unset, a random one is "  \
           "generated")                                                      \
           range(0, max_juint)                                               \
                                                                             \

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -729,9 +729,9 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
   if (failing())  return;
   NOT_PRODUCT( verify_graph_edges(); )
 
-  // If IGVN is randomized for stress testing, seed random number
-  // generation and log the seed for repeatability.
-  if (StressIGVN) {
+  // If LCM, GCM, or IGVN are randomized for stress testing, seed
+  // random number generation and log the seed for repeatability.
+  if (StressLCM || StressGCM || StressIGVN) {
     _stress_seed = FLAG_IS_DEFAULT(StressSeed) ?
       static_cast<uint>(Ticks::now().nanoseconds()) : StressSeed;
     if (_log != NULL) {
@@ -4488,7 +4488,7 @@ int Compile::random() {
 #define RANDOMIZED_DOMAIN_MASK ((1 << (RANDOMIZED_DOMAIN_POW + 1)) - 1)
 bool Compile::randomized_select(int count) {
   assert(count > 0, "only positive");
-  return (os::random() & RANDOMIZED_DOMAIN_MASK) < (RANDOMIZED_DOMAIN / count);
+  return (random() & RANDOMIZED_DOMAIN_MASK) < (RANDOMIZED_DOMAIN / count);
 }
 
 CloneMap&     Compile::clone_map()                 { return _clone_map; }

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -1139,7 +1139,7 @@ class Compile : public Phase {
 
   // Auxiliary methods for randomized fuzzing/stressing
   int random();
-  static bool randomized_select(int count);
+  bool randomized_select(int count);
 
   // supporting clone_map
   CloneMap&     clone_map();

--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -1198,7 +1198,7 @@ Block* PhaseCFG::hoist_to_cheaper_block(Block* LCA, Block* early, Node* self) {
 #endif
     cand_cnt++;
     if (LCA_freq < least_freq              || // Better Frequency
-        (StressGCM && Compile::randomized_select(cand_cnt)) || // Should be randomly accepted in stress mode
+        (StressGCM && C->randomized_select(cand_cnt)) || // Should be randomly accepted in stress mode
          (!StressGCM                    &&    // Otherwise, choose with latency
           !in_latency                   &&    // No block containing latency
           LCA_freq < least_freq * delta &&    // No worse frequency

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -632,7 +632,7 @@ Node* PhaseCFG::select(
     cand_cnt++;
     if (choice < n_choice ||
         (choice == n_choice &&
-         ((StressLCM && Compile::randomized_select(cand_cnt)) ||
+         ((StressLCM && C->randomized_select(cand_cnt)) ||
           (!StressLCM &&
            (latency < n_latency ||
             (latency == n_latency &&

--- a/test/hotspot/jtreg/compiler/arraycopy/TestCloneAccessStressGCM.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestCloneAccessStressGCM.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key stress randomness
  * @bug 8235332 8248226
  * @summary Test cloning with more than 8 (=ArrayCopyLoadStoreMaxElem) fields with StressGCM
  * @library /

--- a/test/hotspot/jtreg/compiler/arraycopy/TestInitializingACLoadWithBadMem.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestInitializingACLoadWithBadMem.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key stress randomness
  * @bug 8182036
  * @summary Load from initializing arraycopy uses wrong memory state
  *

--- a/test/hotspot/jtreg/compiler/arraycopy/TestLoadBypassACWithWrongMem.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestLoadBypassACWithWrongMem.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key stress randomness
  * @bug 8181742
  * @summary Loads that bypass arraycopy ends up with wrong memory state
  *

--- a/test/hotspot/jtreg/compiler/controldependency/TestEliminatedCastPPAtPhi.java
+++ b/test/hotspot/jtreg/compiler/controldependency/TestEliminatedCastPPAtPhi.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key stress randomness
  * @bug 8139771
  * @summary Eliminating CastPP nodes at Phis when they all come from a unique input may cause crash
  * @requires vm.gc=="Serial" | vm.gc=="Parallel"

--- a/test/hotspot/jtreg/compiler/debug/TestGenerateStressSeed.java
+++ b/test/hotspot/jtreg/compiler/debug/TestGenerateStressSeed.java
@@ -32,10 +32,12 @@ import jdk.test.lib.Asserts;
  * @test
  * @bug 8252219
  * @requires vm.compiler2.enabled
- * @summary Tests that using -XX:+StressIGVN without -XX:StressSeed=N generates
+ * @summary Tests that using a stress option without -XX:StressSeed=N generates
  *          and logs a random seed.
  * @library /test/lib /
- * @run driver compiler.debug.TestGenerateStressSeed
+ * @run driver compiler.debug.TestGenerateStressSeed StressLCM
+ * @run driver compiler.debug.TestGenerateStressSeed StressGCM
+ * @run driver compiler.debug.TestGenerateStressSeed StressIGVN
  */
 
 public class TestGenerateStressSeed {
@@ -47,17 +49,18 @@ public class TestGenerateStressSeed {
     }
 
     public static void main(String[] args) throws Exception {
-        if (args.length == 0) {
+        if (args[0].startsWith("Stress")) {
             String className = TestGenerateStressSeed.class.getName();
+            String stressOpt = args[0];
             String log = "test.log";
             String[] procArgs = {
                 "-Xcomp", "-XX:-TieredCompilation", "-XX:+UnlockDiagnosticVMOptions",
-                "-XX:CompileOnly=" + className + "::sum", "-XX:+StressIGVN",
+                "-XX:CompileOnly=" + className + "::sum", "-XX:+" + stressOpt,
                 "-XX:+LogCompilation", "-XX:LogFile=" + log, className, "10"};
             ProcessTools.createJavaProcessBuilder(procArgs).start().waitFor();
             new OutputAnalyzer(Paths.get(log))
                 .shouldContain("stress_test seed");
-        } else if (args.length > 0) {
+        } else {
             sum(Integer.parseInt(args[0]));
         }
     }

--- a/test/hotspot/jtreg/compiler/loopopts/TestLoopUnswitchingLostCastDependency.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLoopUnswitchingLostCastDependency.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key stress randomness
  * @bug 8241900
  * @summary Loop unswitching may cause dependence on null check to be lost
  *

--- a/test/hotspot/jtreg/compiler/loopopts/TestPredicateLostDependency.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPredicateLostDependency.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key stress randomness
  * @bug 8069191
  * @summary predicate moved out of loops and CastPP removal causes dependency to be lost
  *

--- a/test/hotspot/jtreg/compiler/loopopts/TestRangeCheckPredicatesControl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRangeCheckPredicatesControl.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key stress randomness
  * @requires vm.gc.Z
  * @bug 8237859
  * @summary A LoadP node has a wrong control input (too early) which results in an out-of-bounds read of an object array with ZGC.

--- a/test/hotspot/jtreg/compiler/membars/DekkerTest.java
+++ b/test/hotspot/jtreg/compiler/membars/DekkerTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key stress randomness
  * @bug 8007898
  * @summary Incorrect optimization of Memory Barriers in Matcher::post_store_load_barrier().
  * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestExpandedWBLostNullCheckDep.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestExpandedWBLostNullCheckDep.java
@@ -23,6 +23,7 @@
 
 /**
  * @test TestExpandedWBLostNullCheckDep
+ * @key stress randomness
  * @summary Logic that moves a null check in the expanded barrier may cause a memory access that doesn't depend on the barrier to bypass the null check
  * @requires vm.gc.Shenandoah
  * @requires vm.flavor == "server"

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestWriteBarrierClearControl.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestWriteBarrierClearControl.java
@@ -23,6 +23,7 @@
 
 /**
  * @test TestWriteBarrierClearControl
+ * @key stress randomness
  * @summary Clearing control during final graph reshape causes memory barrier to loose dependency on null check
  * @requires vm.gc.Shenandoah
  * @requires vm.flavor == "server"


### PR DESCRIPTION
Use the compilation-local seed in `StressLCM` and `StressGCM` rather than the global one. As a consequence, these options use by default a fresh seed in every compilation, unless `StressSeed=N` is specified, in which case they behave deterministically. Annotate tests that use `StressLCM` and `StressGCM` with the `stress` and `randomness` keys to reflect this change in default behavior.

Tested on `tier1` and on all test cases that use `StressLCM` and `StressGCM` (10 times each).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (3/3 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8253765](https://bugs.openjdk.java.net/browse/JDK-8253765): C2: Control randomization in StressLCM and StressGCM 


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 64c653881727d41000cdc2231e0446f31d5c7653
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 64c653881727d41000cdc2231e0446f31d5c7653


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/572/head:pull/572`
`$ git checkout pull/572`
