### PR TITLE
8254285: G1: Remove "What is this about" comment in G1CollectedHeap.cpp

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2659,9 +2659,6 @@ void G1CollectedHeap::gc_epilogue(bool full) {
   // We are at the end of the GC. Total collections has already been increased.
   rem_set()->print_periodic_summary_info("After GC RS summary", total_collections() - 1);
 
-  // FIXME: what is this about?
-  // I'm ignoring the "fill_newgen()" call if "alloc_event_enabled"
-  // is set.
 #if COMPILER2_OR_JVMCI
   assert(DerivedPointerTable::is_empty(), "derived pointer present");
 #endif


### PR DESCRIPTION
Hi all,

  can I get quick reviews for this imho trivial change that removes some strange comment leftover from initial G1 import reading:

   // FIXME: what is this about?
  // I'm ignoring the "fill_newgen()" call if "alloc_event_enabled"
  // is set. 

None of the referenced identifiers are in any kind of recent code base (looking back to some pre-g1 7u changes). In its current context it does not make sense either and apparently whatever omission the comment suggests has not hurt G1 for years.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (0/0 passed) | ✔️ (0/0 passed) | ✔️ (0/0 passed) |

### Issue
 * [JDK-8254285](https://bugs.openjdk.java.net/browse/JDK-8254285): G1: Remove "What is this about" comment in G1CollectedHeap.cpp


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/573/head:pull/573`
`$ git checkout pull/573`
