### PR TITLE
8233214: Remove runtime code not needed with CMS removed

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -133,7 +133,7 @@ ClassLoaderData::ClassLoaderData(Handle h_class_loader, bool has_class_mirror_ho
   _metaspace_lock(new Mutex(Mutex::leaf+1, "Metaspace allocation lock", true,
                             Mutex::_safepoint_check_never)),
   _unloading(false), _has_class_mirror_holder(has_class_mirror_holder),
-  _modified_oops(true), _accumulated_modified_oops(false),
+  _modified_oops(true),
   // An unsafe anonymous class loader data doesn't have anything to keep
   // it from being unloaded during parsing of the unsafe anonymous class.
   // The null-class-loader should always be kept alive.

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -123,7 +123,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
                                  // to these class loader datas.
 
   // Remembered sets support for the oops in the class loader data.
-  bool _modified_oops;             // Card Table Equivalent (YC/CMS support)
+  bool _modified_oops;             // Card Table Equivalent (YC support)
 
   int _keep_alive;         // if this CLD is kept alive.
                            // Used for non-strong hidden classes, unsafe anonymous classes and the

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -123,7 +123,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
                                  // to these class loader datas.
 
   // Remembered sets support for the oops in the class loader data.
-  bool _modified_oops;             // Card Table Equivalent (YC support)
+  bool _modified_oops;     // Card Table Equivalent
 
   int _keep_alive;         // if this CLD is kept alive.
                            // Used for non-strong hidden classes, unsafe anonymous classes and the

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -124,7 +124,6 @@ class ClassLoaderData : public CHeapObj<mtClass> {
 
   // Remembered sets support for the oops in the class loader data.
   bool _modified_oops;             // Card Table Equivalent (YC/CMS support)
-  bool _accumulated_modified_oops; // Mod Union Equivalent (CMS support)
 
   int _keep_alive;         // if this CLD is kept alive.
                            // Used for non-strong hidden classes, unsafe anonymous classes and the
@@ -176,9 +175,6 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   void record_modified_oops()            { _modified_oops = true; }
   bool has_modified_oops()               { return _modified_oops; }
 
-  void accumulate_modified_oops()        { if (has_modified_oops()) _accumulated_modified_oops = true; }
-  void clear_accumulated_modified_oops() { _accumulated_modified_oops = false; }
-  bool has_accumulated_modified_oops()   { return _accumulated_modified_oops; }
   oop holder_no_keepalive() const;
   oop holder_phantom() const;
 

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -115,9 +115,6 @@ void CLDScanClosure::do_cld(ClassLoaderData* cld) {
   // If the cld has not been dirtied we know that there's
   // no references into  the young gen and we can skip it.
   if (cld->has_modified_oops()) {
-    if (_accumulate_modified_oops) {
-      cld->accumulate_modified_oops();
-    }
 
     // Tell the closure which CLD is being scanned so that it can be dirtied
     // if oops are left pointing into the young gen.
@@ -567,8 +564,7 @@ void DefNewGeneration::collect(bool   full,
   DefNewScanClosure       scan_closure(this);
   DefNewYoungerGenClosure younger_gen_closure(this, _old_gen);
 
-  CLDScanClosure cld_scan_closure(&scan_closure,
-                                  heap->rem_set()->cld_rem_set()->accumulate_modified_oops());
+  CLDScanClosure cld_scan_closure(&scan_closure);
 
   set_promo_failure_scan_stack_closure(&scan_closure);
   FastEvacuateFollowersClosure evacuate_followers(heap,

--- a/src/hotspot/share/gc/shared/cardTableRS.cpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,46 +37,6 @@
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
 #include "utilities/macros.hpp"
-
-class HasAccumulatedModifiedOopsClosure : public CLDClosure {
-  bool _found;
- public:
-  HasAccumulatedModifiedOopsClosure() : _found(false) {}
-  void do_cld(ClassLoaderData* cld) {
-    if (_found) {
-      return;
-    }
-
-    if (cld->has_accumulated_modified_oops()) {
-      _found = true;
-    }
-  }
-  bool found() {
-    return _found;
-  }
-};
-
-bool CLDRemSet::mod_union_is_clear() {
-  HasAccumulatedModifiedOopsClosure closure;
-  ClassLoaderDataGraph::cld_do(&closure);
-
-  return !closure.found();
-}
-
-
-class ClearCLDModUnionClosure : public CLDClosure {
- public:
-  void do_cld(ClassLoaderData* cld) {
-    if (cld->has_accumulated_modified_oops()) {
-      cld->clear_accumulated_modified_oops();
-    }
-  }
-};
-
-void CLDRemSet::clear_mod_union() {
-  ClearCLDModUnionClosure closure;
-  ClassLoaderDataGraph::cld_do(&closure);
-}
 
 CardTable::CardValue CardTableRS::find_unused_youngergenP_card_value() {
   for (CardValue v = youngergenP1_card;

--- a/src/hotspot/share/gc/shared/cardTableRS.hpp
+++ b/src/hotspot/share/gc/shared/cardTableRS.hpp
@@ -33,17 +33,6 @@ class DirtyCardToOopClosure;
 class Generation;
 class Space;
 
-// Helper to remember modified oops in all clds.
-class CLDRemSet {
-  bool _accumulate_modified_oops;
- public:
-  CLDRemSet() : _accumulate_modified_oops(false) {}
-  void set_accumulate_modified_oops(bool value) { _accumulate_modified_oops = value; }
-  bool accumulate_modified_oops() { return _accumulate_modified_oops; }
-  bool mod_union_is_clear();
-  void clear_mod_union();
-};
-
 // This RemSet uses a card table both as shared data structure
 // for a mod ref barrier set and for the rem set information.
 
@@ -52,8 +41,6 @@ class CardTableRS: public CardTable {
   // Below are private classes used in impl.
   friend class VerifyCTSpaceClosure;
   friend class ClearNoncleanCardWrapper;
-
-  CLDRemSet _cld_rem_set;
 
   void verify_space(Space* s, HeapWord* gen_start);
 
@@ -100,8 +87,6 @@ class CardTableRS: public CardTable {
 public:
   CardTableRS(MemRegion whole_heap, bool scanned_concurrently);
   ~CardTableRS();
-
-  CLDRemSet* cld_rem_set() { return &_cld_rem_set; }
 
   void younger_refs_in_space_iterate(Space* sp, HeapWord* gen_boundary, OopIterateClosure* cl, uint n_threads);
 

--- a/src/hotspot/share/gc/shared/genOopClosures.hpp
+++ b/src/hotspot/share/gc/shared/genOopClosures.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,12 +93,9 @@ public:
 
 class CLDScanClosure: public CLDClosure {
   DefNewScanClosure* _scavenge_closure;
-  // true if the the modified oops state should be saved.
-  bool               _accumulate_modified_oops;
  public:
-  CLDScanClosure(DefNewScanClosure* scavenge_closure,
-                 bool accumulate_modified_oops) :
-       _scavenge_closure(scavenge_closure), _accumulate_modified_oops(accumulate_modified_oops) {}
+  CLDScanClosure(DefNewScanClosure* scavenge_closure) :
+       _scavenge_closure(scavenge_closure) {}
   void do_cld(ClassLoaderData* cld);
 };
 


### PR DESCRIPTION
This change removes CMS code left over for ClassLoaderData walking.
Tested with Oracle platforms tier1 and built shenandoah with no errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8233214](https://bugs.openjdk.java.net/browse/JDK-8233214): Remove runtime code not needed with CMS removed


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to d3d781c15700180be79cc8b973f46afad08b88e1
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to d3d781c15700180be79cc8b973f46afad08b88e1
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to d3d781c15700180be79cc8b973f46afad08b88e1


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/574/head:pull/574`
`$ git checkout pull/574`
