### PR TITLE
8254314: Shenandoah: null checks in c2 should not skip over native load barrier

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -1058,10 +1058,12 @@ Node* ShenandoahBarrierSetC2::ideal_node(PhaseGVN* phase, Node* n, bool can_resh
   if (n->Opcode() == Op_CmpP) {
     Node* in1 = n->in(1);
     Node* in2 = n->in(2);
-    if (in1->bottom_type() == TypePtr::NULL_PTR) {
+    if (in1->bottom_type() == TypePtr::NULL_PTR &&
+        (in1->Opcode() != Op_ShenandoahLoadReferenceBarrier || !((ShenandoahLoadReferenceBarrierNode*)in1)->is_native())) {
       in2 = step_over_gc_barrier(in2);
     }
-    if (in2->bottom_type() == TypePtr::NULL_PTR) {
+    if (in2->bottom_type() == TypePtr::NULL_PTR &&
+        (in2->Opcode() != Op_ShenandoahLoadReferenceBarrier || !((ShenandoahLoadReferenceBarrierNode*)in2)->is_native())) {
       in1 = step_over_gc_barrier(in1);
     }
     PhaseIterGVN* igvn = phase->is_IterGVN();


### PR DESCRIPTION
C2 optimizes (CmpP (LoadBarrier o) NULL) as (CmpP o NULL). The ative
load barrier is not guaranteed to return a non null oop when passed a
non null oop so this optimization could lead to a crash.

/cc shenandoah,hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ❌ (2/5 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Build / test | ✔️ (0/0 passed) |    |     | 
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build hotspot minimal)](https://github.com/rwestrel/jdk/runs/1231700230)
- [Linux x64 (build hotspot zero)](https://github.com/rwestrel/jdk/runs/1231700210)

### Issue
 * [JDK-8254314](https://bugs.openjdk.java.net/browse/JDK-8254314): Shenandoah: null checks in c2 should not skip over native load barrier


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/576/head:pull/576`
`$ git checkout pull/576`
