### PR TITLE
8254263: Remove special_runtime_exit_condition() check from ~ThreadInVMForHandshake()

### DIFF
--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -406,6 +406,10 @@ HandshakeOperation* HandshakeState::pop() {
 };
 
 void HandshakeState::process_by_self() {
+  assert(Thread::current() == _handshakee, "should call from _handshakee");
+  assert(!_handshakee->is_terminated(), "should not be a terminated thread");
+  assert(_handshakee->thread_state() != _thread_blocked, "should not be in a blocked state");
+  assert(_handshakee->thread_state() != _thread_in_native, "should not be in native");
   ThreadInVMForHandshake tivm(_handshakee);
   {
     NoSafepointVerifier nsv;
@@ -414,11 +418,6 @@ void HandshakeState::process_by_self() {
 }
 
 void HandshakeState::process_self_inner() {
-  assert(Thread::current() == _handshakee, "should call from _handshakee");
-  assert(!_handshakee->is_terminated(), "should not be a terminated thread");
-  assert(_handshakee->thread_state() != _thread_blocked, "should not be in a blocked state");
-  assert(_handshakee->thread_state() != _thread_in_native, "should not be in native");
-
   while (should_process()) {
     HandleMark hm(_handshakee);
     CautiouslyPreserveExceptionMark pem(_handshakee);

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -128,22 +128,7 @@ class ThreadStateTransition : public StackObj {
 
 class ThreadInVMForHandshake : public ThreadStateTransition {
   const JavaThreadState _original_state;
-
-  void transition_back() {
-    // This can be invoked from transition states and must return to the original state properly
-    assert(_thread->thread_state() == _thread_in_vm, "should only call when leaving VM after handshake");
-
-    _thread->set_thread_state(_original_state);
-
-    if (_original_state != _thread_blocked_trans &&  _original_state != _thread_in_vm_trans &&
-        _thread->has_special_runtime_exit_condition()) {
-      _thread->handle_special_runtime_exit_condition(
-          !_thread->is_at_poll_safepoint() && (_original_state != _thread_in_native_trans));
-    }
-  }
-
  public:
-
   ThreadInVMForHandshake(JavaThread* thread) : ThreadStateTransition(thread),
       _original_state(thread->thread_state()) {
 
@@ -158,7 +143,8 @@ class ThreadInVMForHandshake : public ThreadStateTransition {
   }
 
   ~ThreadInVMForHandshake() {
-    transition_back();
+    assert(_thread->thread_state() == _thread_in_vm, "should only call when leaving VM after handshake");
+    _thread->set_thread_state(_original_state);
   }
 
 };

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -943,19 +943,21 @@ void ThreadSafepointState::print_on(outputStream *st) const {
 
 // Process pending operation.
 void ThreadSafepointState::handle_polling_page_exception() {
+  JavaThread* self = thread();
+  assert(self == Thread::current()->as_Java_thread(), "wrong thread");
 
   // Step 1: Find the nmethod from the return address
-  address real_return_addr = thread()->saved_exception_pc();
+  address real_return_addr = self->saved_exception_pc();
 
   CodeBlob *cb = CodeCache::find_blob(real_return_addr);
   assert(cb != NULL && cb->is_compiled(), "return address should be in nmethod");
   CompiledMethod* nm = (CompiledMethod*)cb;
 
   // Find frame of caller
-  frame stub_fr = thread()->last_frame();
+  frame stub_fr = self->last_frame();
   CodeBlob* stub_cb = stub_fr.cb();
   assert(stub_cb->is_safepoint_stub(), "must be a safepoint stub");
-  RegisterMap map(thread(), true, false);
+  RegisterMap map(self, true, false);
   frame caller_fr = stub_fr.sender(&map);
 
   // Should only be poll_return or poll
@@ -976,17 +978,18 @@ void ThreadSafepointState::handle_polling_page_exception() {
       // to keep it in a handle.
       oop result = caller_fr.saved_oop_result(&map);
       assert(oopDesc::is_oop_or_null(result), "must be oop");
-      return_value = Handle(thread(), result);
+      return_value = Handle(self, result);
       assert(Universe::heap()->is_in_or_null(result), "must be heap pointer");
     }
 
     // We get here if compiled return polls found a reason to call into the VM.
     // One condition for that is that the top frame is not yet safe to use.
     // The following stack watermark barrier poll will catch such situations.
-    StackWatermarkSet::after_unwind(thread());
+    StackWatermarkSet::after_unwind(self);
 
     // Process pending operation
-    SafepointMechanism::process_if_requested(thread());
+    SafepointMechanism::process_if_requested(self);
+    self->check_and_handle_async_exceptions();
 
     // restore oop result, if any
     if (return_oop) {
@@ -1002,21 +1005,21 @@ void ThreadSafepointState::handle_polling_page_exception() {
     assert(real_return_addr == caller_fr.pc(), "must match");
 
     // Process pending operation
-    SafepointMechanism::process_if_requested(thread());
+    SafepointMechanism::process_if_requested(self);
     set_at_poll_safepoint(false);
 
     // If we have a pending async exception deoptimize the frame
     // as otherwise we may never deliver it.
-    if (thread()->has_async_condition()) {
-      ThreadInVMfromJavaNoAsyncException __tiv(thread());
-      Deoptimization::deoptimize_frame(thread(), caller_fr.id());
+    if (self->has_async_condition()) {
+      ThreadInVMfromJavaNoAsyncException __tiv(self);
+      Deoptimization::deoptimize_frame(self, caller_fr.id());
     }
 
     // If an exception has been installed we must check for a pending deoptimization
     // Deoptimize frame if exception has been thrown.
 
-    if (thread()->has_pending_exception() ) {
-      RegisterMap map(thread(), true, false);
+    if (self->has_pending_exception() ) {
+      RegisterMap map(self, true, false);
       frame caller_fr = stub_fr.sender(&map);
       if (caller_fr.is_deoptimized_frame()) {
         // The exception patch will destroy registers that are still

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -944,7 +944,7 @@ void ThreadSafepointState::print_on(outputStream *st) const {
 // Process pending operation.
 void ThreadSafepointState::handle_polling_page_exception() {
   JavaThread* self = thread();
-  assert(self == Thread::current()->as_Java_thread(), "wrong thread");
+  assert(self == Thread::current()->as_Java_thread(), "must be self");
 
   // Step 1: Find the nmethod from the return address
   address real_return_addr = self->saved_exception_pc();

--- a/src/hotspot/share/runtime/safepointMechanism.cpp
+++ b/src/hotspot/share/runtime/safepointMechanism.cpp
@@ -80,7 +80,7 @@ void SafepointMechanism::process(JavaThread *thread) {
     // Any load in ::block must not pass the global poll load.
     // Otherwise we might load an old safepoint counter (for example).
     OrderAccess::loadload();
-    SafepointSynchronize::block(thread);
+    SafepointSynchronize::block(thread); // Recursive
   }
 
   // The call to start_processing fixes the thread's oops and the first few frames.
@@ -92,7 +92,7 @@ void SafepointMechanism::process(JavaThread *thread) {
   StackWatermarkSet::start_processing(thread, StackWatermarkKind::gc);
 
   if (thread->handshake_state()->should_process()) {
-    thread->handshake_state()->process_by_self(); // Recursive
+    thread->handshake_state()->process_by_self();
   }
 }
 


### PR DESCRIPTION
Hi all,

Please review the following patch that removes the call to handle_special_runtime_exit_condition() in ~ThreadInVMForHandshake(). This check was added by 8223572 to prevent a JavaThread that was suspended while trying to process a handshake to transition back to java without noticing it was suspended. Since 8238761, a JavaThread executing HandshakeState::process_by_self() will never become safe. It comes from an unsafe state and remains unsafe, so it cannot be suspended during that time. Removing this check also removes one of the reasons SafepointMechanism::process_if_requested() is recursive (the other one remains SafepointSynchronize::block()).
Tested in mach5, tiers 1-7.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ❌ (2/5 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (8/8 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build hotspot minimal)](https://github.com/pchilano/jdk/runs/1250201367)
- [Linux x64 (build hotspot zero)](https://github.com/pchilano/jdk/runs/1250201349)

### Issue
 * [JDK-8254263](https://bugs.openjdk.java.net/browse/JDK-8254263): Remove special_runtime_exit_condition() check from ~ThreadInVMForHandshake()


### Reviewers
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - Committer) ⚠️ Review applies to d442af8c22ae110744f6187e08950266eb479c15
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to d1222d982b959cca0e64ca71e54da2c4c3c1ffdb
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/577/head:pull/577`
`$ git checkout pull/577`
