### PR TITLE
8254297: Zero and Minimal VMs are broken with undeclared identifier 'DerivedPointerTable' after JDK-8253180

### DIFF
--- a/src/hotspot/share/compiler/oopMap.cpp
+++ b/src/hotspot/share/compiler/oopMap.cpp
@@ -191,7 +191,9 @@ void OopMapSet::add_gc_map(int pc_offset, OopMap *map ) {
 }
 
 static void add_derived_oop(oop* base, oop* derived, OopClosure* oop_fn) {
+#if COMPILER2_OR_JVMCI
   DerivedPointerTable::add(derived, base);
+#endif // COMPILER2_OR_JVMCI
 }
 
 static void ignore_derived_oop(oop* base, oop* derived, OopClosure* oop_fn) {

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1044,9 +1044,13 @@ void frame::oops_do(OopClosure* f, CodeBlobClosure* cf, const RegisterMap* map,
 }
 
 void frame::oops_do(OopClosure* f, CodeBlobClosure* cf, const RegisterMap* map) const {
+#if COMPILER2_OR_JVMCI
   oops_do_internal(f, cf, map, true, DerivedPointerTable::is_active() ?
                                      DerivedPointerIterationMode::_with_table :
                                      DerivedPointerIterationMode::_ignore);
+#else
+  oops_do_internal(f, cf, map, true, DerivedPointerIterationMode::_ignore);
+#endif
 }
 
 void frame::oops_do_internal(OopClosure* f, CodeBlobClosure* cf, const RegisterMap* map,

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -211,7 +211,7 @@ void VMError::print_stack_trace(outputStream* st, JavaThread* jt,
     st->cr();
 
     // Print the frames
-    StackFrameStream sfs(jt);
+    StackFrameStream sfs(jt, true /* update */, true /* process_frames */);
     for(int i = 0; !sfs.is_done(); sfs.next(), i++) {
       sfs.current()->zero_print_on_error(i, st, buf, buflen);
       st->cr();


### PR DESCRIPTION
The change fixes Zero and Minimal builds broken after JDK-8253180.

Two build errors were fixed:
  1 ./src/hotspot/share/runtime/frame.cpp:1047:38: error: use of undeclared identifier 'DerivedPointerTable'
       oops_do_internal(f, cf, map, true, DerivedPointerTable::is_active() ?

  2. ./src/hotspot/share/utilities/vmError.cpp: In static member function 'static void VMError::print_stack_trace(outputStream*, JavaThread*, char*, int, bool)':
     ./src/hotspot/share/utilities/vmError.cpp:214:28: error: no matching function for call to 'StackFrameStream::StackFrameStream(JavaThread*&)'
         StackFrameStream sfs(jt);
                            ^

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ⏳ (1/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (6/9 running) |    |  ⏳ (1/9 running) |

### Issue
 * [JDK-8254297](https://bugs.openjdk.java.net/browse/JDK-8254297): Zero and Minimal VMs are broken with undeclared identifier 'DerivedPointerTable' after JDK-8253180


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/578/head:pull/578`
`$ git checkout pull/578`
