### PR TITLE
8254286: Wrong inference in switch expression with "null" arm

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2026,7 +2026,10 @@ public class Attr extends JCTree.Visitor {
             // both are known to be reference types.  The result is
             // lub(thentype,elsetype). This cannot fail, as it will
             // always be possible to infer "Object" if nothing better.
-            return types.lub(condTypes.stream().map(t -> t.baseType()).collect(List.collector()));
+            return types.lub(condTypes.stream()
+                        .map(t -> t.baseType())
+                        .filter(t -> !t.hasTag(BOT))
+                        .collect(List.collector()));
         }
 
     final static TypeTag[] primitiveTags = new TypeTag[]{

--- a/test/langtools/tools/javac/switchexpr/ExpressionSwitchInfer.java
+++ b/test/langtools/tools/javac/switchexpr/ExpressionSwitchInfer.java
@@ -53,6 +53,28 @@ public class ExpressionSwitchInfer {
             case 2 -> null;
         };
         t3.m();
+        var t4 = switch (s) {
+            case 1 -> i1;
+            default -> null;
+        };
+        t4.m();
+        var t5 = switch (s) {
+            default -> null;
+            case 1 -> i1;
+        };
+        t5.m();
+        var t6 = switch (s) {
+            default -> null;
+        };
+        var t7 = switch (s) {
+            case 1 -> null;
+            default -> null;
+        };
+        var t8 = switch (s) {
+            case 1 -> null;
+            case 2 -> null;
+            default -> null;
+        };
     }
 
     interface I {

--- a/test/langtools/tools/javac/switchexpr/ExpressionSwitchInfer.java
+++ b/test/langtools/tools/javac/switchexpr/ExpressionSwitchInfer.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8206986
+ * @bug 8206986 8254286
  * @summary Check types inferred for switch expressions.
  * @compile/fail/ref=ExpressionSwitchInfer.out -XDrawDiagnostics ExpressionSwitchInfer.java
  */
@@ -33,5 +33,32 @@ public class ExpressionSwitchInfer {
 
         return null;
     }
+
+    void bug8254286(I1 i1, I2 i2, int s) {
+        var t1 = switch (s) {
+            case 1 -> i1;
+            case 2 -> null;
+            default -> i2;
+        };
+        t1.m();
+        var t2 = switch (s) {
+            case 2 -> null;
+            case 1 -> i1;
+            default -> i2;
+        };
+        t2.m();
+        var t3 = switch (s) {
+            case 1 -> i1;
+            default -> i2;
+            case 2 -> null;
+        };
+        t3.m();
+    }
+
+    interface I {
+        void m();
+    }
+    interface I1 extends I {}
+    interface I2 extends I {}
 
 }

--- a/test/langtools/tools/javac/switchexpr/ExpressionSwitchInfer.out
+++ b/test/langtools/tools/javac/switchexpr/ExpressionSwitchInfer.out
@@ -1,4 +1,7 @@
 ExpressionSwitchInfer.java:17:95: compiler.err.cant.resolve.location.args: kindname.method, substring, , int, (compiler.misc.location: kindname.interface, java.lang.CharSequence, null)
 ExpressionSwitchInfer.java:26:38: compiler.err.cant.resolve.location.args: kindname.method, substring, , int, (compiler.misc.location: kindname.interface, java.lang.CharSequence, null)
 ExpressionSwitchInfer.java:30:23: compiler.err.prob.found.req: (compiler.misc.incompatible.type.in.switch.expression: (compiler.misc.inconvertible.types: int, java.lang.String))
-3 errors
+ExpressionSwitchInfer.java:66:13: compiler.err.cant.infer.local.var.type: t6, (compiler.misc.local.cant.infer.null)
+ExpressionSwitchInfer.java:69:13: compiler.err.cant.infer.local.var.type: t7, (compiler.misc.local.cant.infer.null)
+ExpressionSwitchInfer.java:73:13: compiler.err.cant.infer.local.var.type: t8, (compiler.misc.local.cant.infer.null)
+6 errors


### PR DESCRIPTION
Basically, for code like:

        var t1 = switch (s) {
            case 1 -> i1;
            case 2 -> null;
            default -> i2;
        };

Attr.condType is currently passing <type-of-i1>, BOT, <type-of-i2> to Types.lub. But Types.lub needs the list without BOT, so filtering BOT(s) out of the list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ❌ (2/5 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build hotspot minimal)](https://github.com/lahodaj/jdk/runs/1241682393)
- [Linux x64 (build hotspot zero)](https://github.com/lahodaj/jdk/runs/1241682376)

### Issue
 * [JDK-8254286](https://bugs.openjdk.java.net/browse/JDK-8254286): Wrong inference in switch expression with "null" arm


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/583/head:pull/583`
`$ git checkout pull/583`
