### PR TITLE
8254348: Build fails when cds is disabled after JDK-8247536

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3869,7 +3869,11 @@ JVM_END
 
 JVM_ENTRY(jboolean, JVM_IsDumpingClassList(JNIEnv *env))
   JVMWrapper("JVM_IsDumpingClassList");
+#if INCLUDE_CDS
   return DumpLoadedClassList != NULL && classlist_file != NULL && classlist_file->is_open();
+#else
+  return false;
+#endif // INCLUDE_CDS
 JVM_END
 
 JVM_ENTRY(void, JVM_LogLambdaFormInvoker(JNIEnv *env, jstring line))


### PR DESCRIPTION
Please review this trivial fix.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (2/9 running) | ⏳ (7/9 running) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254348](https://bugs.openjdk.java.net/browse/JDK-8254348): Build fails when cds is disabled after JDK-8247536


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/586/head:pull/586`
`$ git checkout pull/586`
