### PR TITLE
8254349: The TestNoScreenMenuBar test should be updated

### DIFF
--- a/test/jdk/java/awt/MenuBar/TestNoScreenMenuBar.java
+++ b/test/jdk/java/awt/MenuBar/TestNoScreenMenuBar.java
@@ -29,29 +29,36 @@
  * @bug 8146310
  * @summary [macosx] setDefaultMenuBar does not initialize screen menu bar
  * @author Alan Snyder
+ * @library /test/lib
  * @run main/othervm TestNoScreenMenuBar
  * @requires (os.family == "mac")
  */
 
 import java.awt.AWTException;
 import java.awt.Desktop;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
 import java.awt.Robot;
 import java.awt.event.InputEvent;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.SwingUtilities;
 
+import jdk.test.lib.process.ProcessTools;
+
 public class TestNoScreenMenuBar
 {
     static TestNoScreenMenuBar theTest;
     private Robot robot;
-    private boolean isApplicationOpened;
+    private Process process;
     private boolean isActionPerformed;
 
-    public TestNoScreenMenuBar(String[] args)
+    public TestNoScreenMenuBar()
     {
         try {
             robot = new Robot();
@@ -60,11 +67,9 @@ public class TestNoScreenMenuBar
             throw new RuntimeException(ex);
         }
 
-        if (!(args.length > 0 && args[0].equals("baseline"))) {
-            // activate another application
-            openOtherApplication();
-            robot.delay(500);
-        }
+        // activate another java application
+        openOtherApplication();
+        robot.delay(2000);
 
         // The failure mode is installing the default menu bar while the application is inactive
         Desktop desktop = Desktop.getDesktop();
@@ -134,23 +139,21 @@ public class TestNoScreenMenuBar
     }
 
     private void openOtherApplication() {
-        String[] cmd = { "/usr/bin/open", "/Applications/System Preferences.app" };
-        execute(cmd);
-        isApplicationOpened = true;
+        process = execute();
     }
 
     private void closeOtherApplication() {
-        if (isApplicationOpened) {
-            String[] cmd = { "/usr/bin/osascript", "-e", "tell application \"System Preferences\" to close window 1" };
-            execute(cmd);
+        if (process != null) {
+            process.destroyForcibly();
         }
     }
 
-    private void execute(String[] cmd) {
+    private Process execute() {
         try {
-            Process p = Runtime.getRuntime().exec(cmd);
-            p.waitFor();
-        } catch (IOException | InterruptedException ex) {
+            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                    TestNoScreenMenuBar.class.getSimpleName(), "mark");
+            return ProcessTools.startProcess("Other frame", pb);
+        } catch (IOException ex) {
             throw new RuntimeException("Unable to execute command");
         }
     }
@@ -171,10 +174,20 @@ public class TestNoScreenMenuBar
             System.out.println("This test is for MacOS only. Automatically passed on other platforms.");
             return;
         }
-
+        if (args.length != 0) {
+            Frame frame = new Frame();
+            MenuBar mb = new MenuBar();
+            mb.add(new Menu("Hello"));
+            frame.setMenuBar(mb);
+            frame.setSize(300, 300);
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+            frame.toFront();
+            return;
+        }
         System.setProperty("apple.laf.useScreenMenuBar", "true");
         try {
-            runSwing(() -> theTest = new TestNoScreenMenuBar(args));
+            runSwing(() -> theTest = new TestNoScreenMenuBar());
             theTest.performMenuItemTest();
         } finally {
             if (theTest != null) {


### PR DESCRIPTION
This test tries to run an external application to make itself non-active and then sets and checks the global menu.

But it has a few issues:
 - As an external app, the "System Settings" app is used, but it looks like in macOS Catalina this app was moved, and nothing actually starts
 - The external app is closed via osascript which required special permission, and it is requested via a modal dialog if not granted already
 - It looks like the attempt to close(already closed app, since the open step failed) the "System Settings" via osascript actually activates it instead 

So to prevent one more permission, and usage of some external app I just use the same java test as an external app but in a separate process. I have checked that the test fails if the fix for JDK-8146310 is removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ❌ (1/5 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build hotspot minimal)](https://github.com/mrserb/jdk/runs/1234776025)
- [Windows x64 (hs/tier1 compiler)](https://github.com/mrserb/jdk/runs/1234888406)

### Issue
 * [JDK-8254349](https://bugs.openjdk.java.net/browse/JDK-8254349): The TestNoScreenMenuBar test should be updated


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/587/head:pull/587`
`$ git checkout pull/587`
