### PR TITLE
8254351: Minimal VM build fails with undeclared identifier 'MaxVectorSize' after JDK-8252847

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1037,18 +1037,6 @@ public:
                 Register rax, Register rcx, Register rdx, Register tmp);
 #endif
 
-#ifdef _LP64
-  void arraycopy_avx3_special_cases(XMMRegister xmm, KRegister mask, Register from,
-                                    Register to, Register count, int shift,
-                                    Register index, Register temp,
-                                    bool use64byteVector, Label& L_entry, Label& L_exit);
-
-  void arraycopy_avx3_special_cases_conjoint(XMMRegister xmm, KRegister mask, Register from,
-                                             Register to, Register start_index, Register end_index,
-                                             Register count, int shift, Register temp,
-                                             bool use64byteVector, Label& L_entry, Label& L_exit);
-#endif
-
 private:
 
   // these are private because users should be doing movflt/movdbl
@@ -1738,6 +1726,17 @@ public:
   void cache_wb(Address line);
   void cache_wbsync(bool is_pre);
 
+#if COMPILER2_OR_JVMCI
+  void arraycopy_avx3_special_cases(XMMRegister xmm, KRegister mask, Register from,
+                                    Register to, Register count, int shift,
+                                    Register index, Register temp,
+                                    bool use64byteVector, Label& L_entry, Label& L_exit);
+
+  void arraycopy_avx3_special_cases_conjoint(XMMRegister xmm, KRegister mask, Register from,
+                                             Register to, Register start_index, Register end_index,
+                                             Register count, int shift, Register temp,
+                                             bool use64byteVector, Label& L_entry, Label& L_exit);
+
   void copy64_masked_avx(Register dst, Register src, XMMRegister xmm,
                          KRegister mask, Register length, Register index,
                          Register temp, int shift = Address::times_1, int offset = 0,
@@ -1753,6 +1752,7 @@ public:
   void copy64_avx(Register dst, Register src, Register index, XMMRegister xmm,
                   bool conjoint, int shift = Address::times_1, int offset = 0,
                   bool use64byteVector = false);
+#endif // COMPILER2_OR_JVMCI
 
 #endif // _LP64
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86_arrayCopy_avx3.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_arrayCopy_avx3.cpp
@@ -37,6 +37,8 @@
 
 #ifdef _LP64
 
+#if COMPILER2_OR_JVMCI
+
 void MacroAssembler::arraycopy_avx3_special_cases(XMMRegister xmm, KRegister mask, Register from,
                                                   Register to, Register count, int shift,
                                                   Register index, Register temp,
@@ -111,7 +113,7 @@ void MacroAssembler::arraycopy_avx3_special_cases_conjoint(XMMRegister xmm, KReg
                                                            bool use64byteVector, Label& L_entry, Label& L_exit) {
   Label L_entry_64, L_entry_96, L_entry_128;
   Label L_entry_160, L_entry_192;
-  bool avx3 = COMPILER2_OR_JVMCI_PRESENT((MaxVectorSize > 32 && AVX3Threshold == 0) ||) false;
+  bool avx3 = MaxVectorSize > 32 && AVX3Threshold == 0;
 
   int size_mat[][6] = {
   /* T_BYTE */ {32 , 64,  96 , 128 , 160 , 192 },
@@ -245,5 +247,7 @@ void MacroAssembler::copy64_avx(Register dst, Register src, Register index, XMMR
     evmovdquq(Address(dst, index, scale, offset), xmm, Assembler::AVX_512bit);
   }
 }
+
+#endif // COMPILER2_OR_JVMCI
 
 #endif

--- a/src/hotspot/cpu/x86/macroAssembler_x86_arrayCopy_avx3.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_arrayCopy_avx3.cpp
@@ -111,7 +111,7 @@ void MacroAssembler::arraycopy_avx3_special_cases_conjoint(XMMRegister xmm, KReg
                                                            bool use64byteVector, Label& L_entry, Label& L_exit) {
   Label L_entry_64, L_entry_96, L_entry_128;
   Label L_entry_160, L_entry_192;
-  bool avx3 = MaxVectorSize > 32 && AVX3Threshold == 0;
+  bool avx3 = COMPILER2_OR_JVMCI_PRESENT((MaxVectorSize > 32 && AVX3Threshold == 0) ||) false;
 
   int size_mat[][6] = {
   /* T_BYTE */ {32 , 64,  96 , 128 , 160 , 192 },

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -1292,6 +1292,7 @@ class StubGenerator: public StubCodeGenerator {
     }
   }
 
+#if COMPILER2_OR_JVMCI
   // Note: Following rules apply to AVX3 optimized arraycopy stubs:-
   // - If target supports AVX3 features (BW+VL+F) then implementation uses 32 byte vectors (YMMs)
   //   for both special cases (various small block sizes) and aligned copy loop. This is the
@@ -1695,6 +1696,7 @@ class StubGenerator: public StubCodeGenerator {
     __ ret(0);
     return start;
   }
+#endif // COMPILER2_OR_JVMCI
 
 
   // Arguments:
@@ -1717,10 +1719,12 @@ class StubGenerator: public StubCodeGenerator {
   //   used by generate_conjoint_byte_copy().
   //
   address generate_disjoint_byte_copy(bool aligned, address* entry, const char *name) {
+#if COMPILER2_OR_JVMCI
     if (VM_Version::supports_avx512vlbw() && MaxVectorSize  >= 32) {
        return generate_disjoint_copy_avx3_masked(entry, "jbyte_disjoint_arraycopy_avx3", 0,
                                                  aligned, false, false);
     }
+#endif
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
@@ -1831,10 +1835,12 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_conjoint_byte_copy(bool aligned, address nooverlap_target,
                                       address* entry, const char *name) {
+#if COMPILER2_OR_JVMCI
     if (VM_Version::supports_avx512vlbw() && MaxVectorSize  >= 32) {
        return generate_conjoint_copy_avx3_masked(entry, "jbyte_conjoint_arraycopy_avx3", 0,
                                                  nooverlap_target, aligned, false, false);
     }
+#endif
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
@@ -1940,10 +1946,12 @@ class StubGenerator: public StubCodeGenerator {
   //   used by generate_conjoint_short_copy().
   //
   address generate_disjoint_short_copy(bool aligned, address *entry, const char *name) {
+#if COMPILER2_OR_JVMCI
     if (VM_Version::supports_avx512vlbw() && MaxVectorSize  >= 32) {
        return generate_disjoint_copy_avx3_masked(entry, "jshort_disjoint_arraycopy_avx3", 1,
                                                  aligned, false, false);
     }
+#endif
 
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", name);
@@ -2069,10 +2077,12 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_conjoint_short_copy(bool aligned, address nooverlap_target,
                                        address *entry, const char *name) {
+#if COMPILER2_OR_JVMCI
     if (VM_Version::supports_avx512vlbw() && MaxVectorSize  >= 32) {
        return generate_conjoint_copy_avx3_masked(entry, "jshort_conjoint_arraycopy_avx3", 1,
                                                  nooverlap_target, aligned, false, false);
     }
+#endif
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
@@ -2171,10 +2181,12 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_disjoint_int_oop_copy(bool aligned, bool is_oop, address* entry,
                                          const char *name, bool dest_uninitialized = false) {
+#if COMPILER2_OR_JVMCI
     if (VM_Version::supports_avx512vlbw() && MaxVectorSize  >= 32) {
        return generate_disjoint_copy_avx3_masked(entry, "jint_disjoint_arraycopy_avx3", 2,
                                                  aligned, is_oop, dest_uninitialized);
     }
+#endif
 
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", name);
@@ -2280,10 +2292,12 @@ class StubGenerator: public StubCodeGenerator {
   address generate_conjoint_int_oop_copy(bool aligned, bool is_oop, address nooverlap_target,
                                          address *entry, const char *name,
                                          bool dest_uninitialized = false) {
+#if COMPILER2_OR_JVMCI
     if (VM_Version::supports_avx512vlbw() && MaxVectorSize  >= 32) {
        return generate_conjoint_copy_avx3_masked(entry, "jint_conjoint_arraycopy_avx3", 2,
                                                  nooverlap_target, aligned, is_oop, dest_uninitialized);
     }
+#endif
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
@@ -2391,10 +2405,12 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_disjoint_long_oop_copy(bool aligned, bool is_oop, address *entry,
                                           const char *name, bool dest_uninitialized = false) {
+#if COMPILER2_OR_JVMCI
     if (VM_Version::supports_avx512vlbw() && MaxVectorSize  >= 32) {
        return generate_disjoint_copy_avx3_masked(entry, "jlong_disjoint_arraycopy_avx3", 3,
                                                  aligned, is_oop, dest_uninitialized);
     }
+#endif
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
@@ -2499,10 +2515,12 @@ class StubGenerator: public StubCodeGenerator {
   address generate_conjoint_long_oop_copy(bool aligned, bool is_oop,
                                           address nooverlap_target, address *entry,
                                           const char *name, bool dest_uninitialized = false) {
+#if COMPILER2_OR_JVMCI
     if (VM_Version::supports_avx512vlbw() && MaxVectorSize  >= 32) {
        return generate_conjoint_copy_avx3_masked(entry, "jlong_conjoint_arraycopy_avx3", 3,
                                                  nooverlap_target, aligned, is_oop, dest_uninitialized);
     }
+#endif
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();


### PR DESCRIPTION
To fix the bug, #if COMPILER2_OR_JVMCI was added.
Please review it. Thanks.

Testing:
  - Minimal and server-fastdebug builds on x86

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254351](https://bugs.openjdk.java.net/browse/JDK-8254351): Minimal VM build fails with undeclared identifier 'MaxVectorSize' after JDK-8252847


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/588/head:pull/588`
`$ git checkout pull/588`
