### PR TITLE
8254352: 3 compiler tests failed with "assert(allocates2(pc)) failed: not in CodeBuffer memory"

### DIFF
--- a/src/hotspot/cpu/x86/stubRoutines_x86.hpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.hpp
@@ -33,7 +33,7 @@ static bool returns_to_call_stub(address return_pc) { return return_pc == _call_
 
 enum platform_dependent_constants {
   code_size1 = 20000 LP64_ONLY(+10000),         // simply increase if too small (assembler will crash if too small)
-  code_size2 = 35300 LP64_ONLY(+21400)          // simply increase if too small (assembler will crash if too small)
+  code_size2 = 35300 LP64_ONLY(+25000)          // simply increase if too small (assembler will crash if too small)
 };
 
 class x86 {


### PR DESCRIPTION
JDK-8252847 changes added new AVX3 specific stubs for arraycopy and increased code buffer size but it was not enough.
On Windows we need 3500 bytes more because additional code is used to preserve registers.

Tested hs tier1-3 and ran bug's tests on machine where they failed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254352](https://bugs.openjdk.java.net/browse/JDK-8254352): 3 compiler tests failed with "assert(allocates2(pc)) failed: not in CodeBuffer memory"


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/592/head:pull/592`
`$ git checkout pull/592`
