### PR TITLE
8254362: x86_32 builds fail after JDK-8253180

### DIFF
--- a/src/hotspot/cpu/x86/c2_safepointPollStubTable_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_safepointPollStubTable_x86.cpp
@@ -31,6 +31,7 @@
 
 #define __ masm.
 void C2SafepointPollStubTable::emit_stub_impl(MacroAssembler& masm, C2SafepointPollStub* entry) const {
+#ifdef _LP64
   assert(SharedRuntime::polling_page_return_handler_blob() != NULL,
          "polling page return stub not created yet");
   address stub = SharedRuntime::polling_page_return_handler_blob()->entry_point();
@@ -42,5 +43,8 @@ void C2SafepointPollStubTable::emit_stub_impl(MacroAssembler& masm, C2SafepointP
   __ lea(rscratch1, safepoint_pc);
   __ movptr(Address(r15_thread, JavaThread::saved_exception_pc_offset()), rscratch1);
   __ jump(callback_addr);
+#else
+  ShouldNotReachHere();
+#endif
 }
 #undef __


### PR DESCRIPTION
`r15_thread` is not available on x86_32. I noticed that JDK-8253180 introduces:

```
void C1SafepointPollStub::emit_code(LIR_Assembler* ce) {
#ifdef _LP64
...
  __ movptr(Address(r15_thread, JavaThread::saved_exception_pc_offset()), rscratch1);
...
#else
  ShouldNotReachHere();
#endif /* _LP64 */
}
```

...and we should do the same in `C2SafepointPollStubTable` to unbreak x86_32.

Testing:
 - [x] x86_32 build
 - [x] x86_32 hotspot:tier1 (lots of unrelated failures that look like JDK-8254125, never a `ShouldNotReachHere`)
 - [x] x86_64 build
 - [x] x86_64 hotspot:tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254362](https://bugs.openjdk.java.net/browse/JDK-8254362): x86_32 builds fail after JDK-8253180


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/593/head:pull/593`
`$ git checkout pull/593`
