### PR TITLE
8254825: Monitoring available clipboard formats should be done via new Windows APIs

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
@@ -42,9 +42,7 @@ jobject AwtClipboard::theCurrentClipboard;
 BOOL AwtClipboard::isGettingOwnership = FALSE;
 
 volatile jmethodID AwtClipboard::handleContentsChangedMID;
-volatile BOOL AwtClipboard::skipInitialWmDrawClipboardMsg = TRUE;
 volatile BOOL AwtClipboard::isClipboardViewerRegistered = FALSE;
-volatile HWND AwtClipboard::hwndNextViewer = NULL;
 
 #define GALLOCFLG (GMEM_DDESHARE | GMEM_MOVEABLE | GMEM_ZEROINIT)
 
@@ -59,27 +57,11 @@ void AwtClipboard::LostOwnership(JNIEnv *env) {
     }
 }
 
-void AwtClipboard::WmChangeCbChain(WPARAM wParam, LPARAM lParam) {
-    if ((HWND)wParam == hwndNextViewer) {
-        hwndNextViewer = (HWND)lParam;
-    } else if (hwndNextViewer != NULL) {
-        ::SendMessage(hwndNextViewer, WM_CHANGECBCHAIN, wParam, lParam);
-    }
-}
-
-void AwtClipboard::WmDrawClipboard(JNIEnv *env, WPARAM wParam, LPARAM lParam) {
-    if (skipInitialWmDrawClipboardMsg) {
-        // skipping the first contents change notification as it comes
-        // immediately after registering the clipboard viewer window
-        // and it is not caused by an actual contents change.
-        skipInitialWmDrawClipboardMsg = FALSE;
-        return;
-    }
+void AwtClipboard::WmClipboardUpdate(JNIEnv *env) {
     if (theCurrentClipboard != NULL) {
         env->CallVoidMethod(theCurrentClipboard, handleContentsChangedMID);
         DASSERT(!safe_ExceptionOccurred(env));
     }
-    ::SendMessage(hwndNextViewer, WM_DRAWCLIPBOARD, wParam, lParam);
 }
 
 void AwtClipboard::RegisterClipboardViewer(JNIEnv *env, jobject jclipboard) {
@@ -96,7 +78,7 @@ void AwtClipboard::RegisterClipboardViewer(JNIEnv *env, jobject jclipboard) {
             env->GetMethodID(cls, "handleContentsChanged", "()V");
     DASSERT(AwtClipboard::handleContentsChangedMID != NULL);
 
-    hwndNextViewer = ::SetClipboardViewer(AwtToolkit::GetInstance().GetHWnd());
+    ::AddClipboardFormatListener(AwtToolkit::GetInstance().GetHWnd());
     isClipboardViewerRegistered = TRUE;
 }
 
@@ -104,10 +86,8 @@ void AwtClipboard::UnregisterClipboardViewer(JNIEnv *env) {
     TRY;
 
     if (isClipboardViewerRegistered) {
-        ::ChangeClipboardChain(AwtToolkit::GetInstance().GetHWnd(), AwtClipboard::hwndNextViewer);
-        AwtClipboard::hwndNextViewer = NULL;
+        ::RemoveClipboardFormatListener(AwtToolkit::GetInstance().GetHWnd());
         isClipboardViewerRegistered = FALSE;
-        skipInitialWmDrawClipboardMsg = TRUE;
     }
 
     CATCH_BAD_ALLOC;

--- a/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.h
@@ -36,10 +36,7 @@
 class AwtClipboard {
 private:
     static BOOL isGettingOwnership;
-    // handle to the next window in the clipboard viewer chain
-    static volatile HWND hwndNextViewer;
     static volatile BOOL isClipboardViewerRegistered;
-    static volatile BOOL skipInitialWmDrawClipboardMsg;
     static volatile jmethodID handleContentsChangedMID;
 
 public:
@@ -57,8 +54,7 @@ public:
     }
 
     static void LostOwnership(JNIEnv *env);
-    static void WmChangeCbChain(WPARAM wparam, LPARAM lparam);
-    static void WmDrawClipboard(JNIEnv *env, WPARAM wparam, LPARAM lparam);
+    static void WmClipboardUpdate(JNIEnv *env);
     static void RegisterClipboardViewer(JNIEnv *env, jobject jclipboard);
     static void UnregisterClipboardViewer(JNIEnv *env);
 };

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -1067,12 +1067,8 @@ LRESULT CALLBACK AwtToolkit::WndProc(HWND hWnd, UINT message,
               AwtClipboard::LostOwnership((JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2));
           return 0;
       }
-      case WM_CHANGECBCHAIN: {
-          AwtClipboard::WmChangeCbChain(wParam, lParam);
-          return 0;
-      }
-      case WM_DRAWCLIPBOARD: {
-          AwtClipboard::WmDrawClipboard((JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2), wParam, lParam);
+      case WM_CLIPBOARDUPDATE: {
+          AwtClipboard::WmClipboardUpdate((JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2));
           return 0;
       }
       case WM_AWT_LIST_SETMULTISELECT: {

--- a/test/jdk/java/awt/datatransfer/ClipboardInterVMTest/ClipboardInterVMTest.java
+++ b/test/jdk/java/awt/datatransfer/ClipboardInterVMTest/ClipboardInterVMTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/datatransfer/ClipboardInterVMTest/ClipboardInterVMTest.java
+++ b/test/jdk/java/awt/datatransfer/ClipboardInterVMTest/ClipboardInterVMTest.java
@@ -83,7 +83,7 @@ public class ClipboardInterVMTest {
             }
         });
 
-        System.out.println("Starting external clipborad modifier...");
+        System.out.println("Starting external clipboard modifier...");
         new Thread(() -> runTest(ClipboardInterVMTest.class.getCanonicalName(), "pong")).start();
 
         String content = "";
@@ -106,7 +106,7 @@ public class ClipboardInterVMTest {
         };
 
         if (!flavorChangedMonitor.await(10, TimeUnit.SECONDS)) {
-            throw new RuntimeException("No LostOwnership event received.");
+            throw new RuntimeException("No FlavorsChanged event received.");
         };
 
         if (!content.equals("pong")) {


### PR DESCRIPTION
This change replaces the usage of SetClipboardViewer with Add/RemoveClipboardFormatListener, introduced in Windows Vista. This makes OpenJDK immune to external applications failing to process clipboard messages properly.
I have put this proposal forward in the [mailing list](https://mail.openjdk.java.net/pipermail/awt-dev/2020-July/015990.html), which was tentatively accepted by Mr. Sergey Bylokhov.

The deficiencies of the old APIs are well known and might result in some subscribed applications not receiving notifications from the operating system, as they rely on all the applications in the current clipboard chain processing clipboard messages properly. Porting the code to use the new APIs not only makes OpenJDK immune to these issues, but also results in slightly less code needed to support clipboard-related functionality.

As this is a change that's very platform-specific, I don't think providing a unit test is practical, as it would also require providing a native application that runs alongside the test and deliberately breaks the keyboard chain, resulting in OpenJDK not being able to receive clipboard format change notifications. This is a bug/limitation of the old Windows API, not OpenJDK itself. Anyhow, the already existing ClipboardInterVMTest passes, which shows that already existing functionality is not impacted by this change.

I have prepared a proof-of-concept test which illustrates the deficiencies of the old API, however it is not integrated with the test suite, as it requires compiling a native WinAPI application. I will gladly share the source if needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254825](https://bugs.openjdk.java.net/browse/JDK-8254825): Monitoring available clipboard formats should be done via new Windows APIs


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/594/head:pull/594`
`$ git checkout pull/594`
