### PR TITLE
8240709: Enable javax/swing/UI/UnninstallUIMemoryLeaks/UnninstallUIMemoryLeaks.java on all L&F

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/motif/MotifComboBoxUI.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/motif/MotifComboBoxUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,16 +22,34 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package com.sun.java.swing.plaf.motif;
 
-import java.awt.*;
-import javax.swing.*;
-import javax.swing.plaf.*;
-import javax.swing.border.*;
-import javax.swing.plaf.basic.*;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.LayoutManager;
+import java.awt.Rectangle;
+import java.awt.event.KeyListener;
+import java.awt.event.MouseMotionAdapter;
+import java.awt.event.MouseMotionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.Serializable;
-import java.awt.event.*;
-import java.beans.*;
+
+import javax.swing.Icon;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.ListCellRenderer;
+import javax.swing.UIManager;
+import javax.swing.border.Border;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.basic.BasicComboBoxUI;
+import javax.swing.plaf.basic.BasicComboPopup;
+import javax.swing.plaf.basic.ComboPopup;
 
 /**
  * ComboBox motif look and feel
@@ -59,16 +77,6 @@ public class MotifComboBoxUI extends BasicComboBoxUI implements Serializable {
         arrowIcon = new MotifComboBoxArrowIcon(UIManager.getColor("controlHighlight"),
                                                UIManager.getColor("controlShadow"),
                                                UIManager.getColor("control"));
-
-        Runnable initCode = new Runnable() {
-            public void run(){
-                if ( motifGetEditor() != null ) {
-                    motifGetEditor().setBackground( UIManager.getColor( "text" ) );
-                }
-            }
-        };
-
-        SwingUtilities.invokeLater( initCode );
     }
 
     public Dimension getMinimumSize( JComponent c ) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthComboBoxUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthComboBoxUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,37 @@
 
 package javax.swing.plaf.synth;
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
-import javax.swing.plaf.*;
-import javax.swing.event.*;
-import javax.swing.plaf.basic.*;
-import java.beans.PropertyChangeListener;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
 import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import javax.swing.ComboBoxEditor;
+import javax.swing.DefaultButtonModel;
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.ListCellRenderer;
+import javax.swing.SwingConstants;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.UIResource;
+import javax.swing.plaf.basic.BasicComboBoxEditor;
+import javax.swing.plaf.basic.BasicComboBoxUI;
+import javax.swing.plaf.basic.ComboPopup;
 
 /**
  * Provides the Synth L&amp;F UI delegate for
@@ -730,9 +753,9 @@ public class SynthComboBoxUI extends BasicComboBoxUI implements
             comboBox.addPropertyChangeListener("editor",this);
         }
 
-        public void unregister(){
-            comboBox.removePropertyChangeListener(this);
-            if (editorComponent!=null){
+        public void unregister() {
+            comboBox.removePropertyChangeListener("editor", this);
+            if (editorComponent != null) {
                 editorComponent.removeFocusListener(this);
             }
         }

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthDesktopIconUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthDesktopIconUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,23 @@
 
 package javax.swing.plaf.synth;
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
-import javax.swing.plaf.*;
-import javax.swing.plaf.basic.BasicDesktopIconUI;
-import java.beans.*;
+import java.awt.BorderLayout;
+import java.awt.Graphics;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyVetoException;
 
+import javax.swing.Icon;
+import javax.swing.JComponent;
+import javax.swing.JInternalFrame;
+import javax.swing.JPopupMenu;
+import javax.swing.JToggleButton;
+import javax.swing.ToolTipManager;
+import javax.swing.UIManager;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.basic.BasicDesktopIconUI;
 
 /**
  * Provides the Synth L&amp;F UI delegate for a minimized internal frame on a desktop.
@@ -89,6 +99,20 @@ public class SynthDesktopIconUI extends BasicDesktopIconUI
         desktopIcon.add(iconPane, BorderLayout.CENTER);
     }
 
+    @Override
+    protected void uninstallComponents() {
+        // Uninstall the listeners here because the iconPane will be set to null
+        // in the super.uninstallComponents()
+        if (iconPane instanceof JToggleButton) {
+            ((JToggleButton) iconPane).removeActionListener(handler);
+            frame.removePropertyChangeListener(this);
+        } else if (iconPane instanceof SynthInternalFrameTitlePane) {
+            // Uninstall the listeners added by the  SynthInternalFrameTitlePane
+            ((SynthInternalFrameTitlePane) iconPane).uninstallListeners();
+        }
+        super.uninstallComponents();
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -108,10 +132,6 @@ public class SynthDesktopIconUI extends BasicDesktopIconUI
      */
     @Override
     protected void uninstallListeners() {
-        if (iconPane instanceof JToggleButton) {
-            ((JToggleButton)iconPane).removeActionListener(handler);
-            frame.removePropertyChangeListener(this);
-        }
         desktopIcon.removePropertyChangeListener(this);
         super.uninstallListeners();
     }

--- a/test/jdk/javax/swing/UI/UnninstallUIMemoryLeaks/UnninstallUIMemoryLeaks.java
+++ b/test/jdk/javax/swing/UI/UnninstallUIMemoryLeaks/UnninstallUIMemoryLeaks.java
@@ -76,7 +76,7 @@ import static javax.swing.UIManager.getInstalledLookAndFeels;
 /**
  * @test
  * @key headful
- * @bug 8134947 8253977
+ * @bug 8134947 8253977 8240709
  * @library /test/lib
  * @run main/timeout=450/othervm UnninstallUIMemoryLeaks
  */
@@ -91,9 +91,7 @@ public final class UnninstallUIMemoryLeaks {
             List<Process> tasks = new ArrayList<>();
             for (LookAndFeelInfo laf : getInstalledLookAndFeels()) {
                 String name = laf.getName();
-                if (name.contains("OS X") || name.contains("Metal")) {
-                    tasks.add(runProcess(laf));
-                }
+                tasks.add(runProcess(laf));
             }
             for (Process p : tasks) {
                 if (!p.waitFor(end - System.nanoTime(), TimeUnit.NANOSECONDS)) {


### PR DESCRIPTION
Fix for various memory leaks in Nimbus and Motif L&Fs, see comments inline.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8240709](https://bugs.openjdk.java.net/browse/JDK-8240709): Enable javax/swing/UI/UnninstallUIMemoryLeaks/UnninstallUIMemoryLeaks.java on all L&F


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/595/head:pull/595`
`$ git checkout pull/595`
