### PR TITLE
8254364: Remove leading _ from struct/union declarations in jvmti.h

### DIFF
--- a/src/hotspot/share/prims/jvmtiH.xsl
+++ b/src/hotspot/share/prims/jvmtiH.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -406,11 +406,11 @@ typedef </xsl:text>
 </xsl:template>
 
 <xsl:template match="typedef" mode="early">
-  <xsl:text>struct _</xsl:text>
+  <xsl:text>struct </xsl:text>
   <xsl:value-of select="@id"/>
   <xsl:text>;
 </xsl:text>
-  <xsl:text>typedef struct _</xsl:text>
+  <xsl:text>typedef struct </xsl:text>
   <xsl:value-of select="@id"/>
   <xsl:text> </xsl:text>
   <xsl:value-of select="@id"/>
@@ -419,7 +419,7 @@ typedef </xsl:text>
 </xsl:template>
 
 <xsl:template match="typedef" mode="body">
-  <xsl:text>struct _</xsl:text>
+  <xsl:text>struct </xsl:text>
   <xsl:value-of select="@id"/>
   <xsl:text> {
 </xsl:text>
@@ -429,11 +429,11 @@ typedef </xsl:text>
 </xsl:template>
 
 <xsl:template match="uniontypedef" mode="early">
-  <xsl:text>union _</xsl:text>
+  <xsl:text>union </xsl:text>
   <xsl:value-of select="@id"/>
   <xsl:text>;
 </xsl:text>
-  <xsl:text>typedef union _</xsl:text>
+  <xsl:text>typedef union </xsl:text>
   <xsl:value-of select="@id"/>
   <xsl:text> </xsl:text>
   <xsl:value-of select="@id"/>
@@ -442,7 +442,7 @@ typedef </xsl:text>
 </xsl:template>
 
 <xsl:template match="uniontypedef" mode="body">
-  <xsl:text>union _</xsl:text>
+  <xsl:text>union </xsl:text>
   <xsl:value-of select="@id"/>
   <xsl:text> {
 </xsl:text>


### PR DESCRIPTION
This PR changes declarations in jvmti.h like the following from

```
struct _jvmtiTimerInfo;
typedef struct _jvmtiTimerInfo jvmtiTimerInfo;
```

to

```
struct jvmtiTimerInfo;
typedef struct jvmtiTimerInfo jvmtiTimerInfo;
```

This way, it becomes possible to make forward declaration in C++ code like this, without assuming the knowledge of the `struct _jvmtiTimerInfo` type:

```
struct jvmtiTimerInfo;
```

Please see bug report [JDK-8254364](https://bugs.openjdk.java.net/browse/JDK-8254364) for the before/after versions of jvmti.h, which is generated from XML.

Tested with build tiers 1-5 in Mach5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254364](https://bugs.openjdk.java.net/browse/JDK-8254364): Remove leading _ from struct/union declarations in jvmti.h


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/596/head:pull/596`
`$ git checkout pull/596`
