### PR TITLE
8254559: Remove unimplemented JVMFlag::get_locked_message_ext

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlag.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlag.hpp
@@ -263,7 +263,6 @@ public:
   void set_product();
 
   JVMFlag::MsgType get_locked_message(char*, int) const;
-  JVMFlag::MsgType get_locked_message_ext(char*, int) const;
 
   static bool is_default(JVMFlagsEnum flag);
   static bool is_ergo(JVMFlagsEnum flag);


### PR DESCRIPTION
The definition was removed with JDK-8224599, the declaration was left behind.

Testing:
 - [x] Linux x86_64 build
 - [x] Text search for `get_locked_message_ext` in entire `src/`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254559](https://bugs.openjdk.java.net/browse/JDK-8254559): Remove unimplemented JVMFlag::get_locked_message_ext


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/598/head:pull/598`
`$ git checkout pull/598`
