### PR TITLE
8254560: Shenandoah: Concurrent Strong Roots logging is incorrect

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -98,8 +98,8 @@ class outputStream;
   f(conc_class_unload_purge_cldg,                   "    CLDG")                        \
   f(conc_class_unload_purge_ec,                     "    Exception Caches")            \
   f(conc_strong_roots,                              "Concurrent Strong Roots")         \
-  f(conc_rendezvous_roots,                          "Rendezvous")                      \
   SHENANDOAH_PAR_PHASE_DO(conc_strong_roots_,       "  CSR: ", f)                      \
+  f(conc_rendezvous_roots,                          "Rendezvous")                      \
   f(conc_evac,                                      "Concurrent Evacuation")           \
                                                                                        \
   f(init_update_refs_gross,                         "Pause Init  Update Refs (G)")     \


### PR DESCRIPTION
Look:

```
[1382.171s][info][gc,stats] Concurrent Strong Roots            1059 us, parallelism: 2.12x
[1382.171s][info][gc,stats] Rendezvous                         2246 us
[1382.171s][info][gc,stats]   CSR: Code Cache Roots              84 us, workers (us):  14,  17,  13,  14,  10,   6,   4,   5, 
[1382.171s][info][gc,stats]   CSR: VM Weak Roots               2162 us, workers (us): ---, ---, 905, ---, ---, 388, 383, 486, 
```

There should be `CSR: <total>`, but `Rendezvous` is in its place.

Testing:
  - [x] Eyeballing `-Xlog:gc+stats` on Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254560](https://bugs.openjdk.java.net/browse/JDK-8254560): Shenandoah: Concurrent Strong Roots logging is incorrect


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/599/head:pull/599`
`$ git checkout pull/599`
