### PR TITLE
8254562: ZGC: Remove ZMarkRootsTask

### DIFF
--- a/src/hotspot/share/gc/z/zHeapIterator.cpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.cpp
@@ -176,7 +176,6 @@ ZHeapIterator::ZHeapIterator(uint nworkers, bool visit_weaks) :
     _bitmaps_lock(),
     _queues(nworkers),
     _array_queues(nworkers),
-    _roots(),
     _concurrent_roots(),
     _weak_roots(),
     _concurrent_weak_roots(),
@@ -341,7 +340,6 @@ void ZHeapIterator::drain_and_steal(const ZHeapIteratorContext& context, ObjectC
 
 template <bool VisitWeaks>
 void ZHeapIterator::object_iterate_inner(const ZHeapIteratorContext& context, ObjectClosure* cl) {
-  push_roots<false /* Concurrent */, false /* Weak */>(context, _roots);
   push_roots<true  /* Concurrent */, false /* Weak */>(context, _concurrent_roots);
   if (VisitWeaks) {
     push_roots<false /* Concurrent */, true  /* Weak */>(context, _weak_roots);

--- a/src/hotspot/share/gc/z/zHeapIterator.hpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.hpp
@@ -52,7 +52,6 @@ private:
   ZLock                              _bitmaps_lock;
   ZHeapIteratorQueues                _queues;
   ZHeapIteratorArrayQueues           _array_queues;
-  ZRootsIterator                     _roots;
   ZConcurrentRootsIteratorClaimOther _concurrent_roots;
   ZWeakRootsIterator                 _weak_roots;
   ZConcurrentWeakRootsIterator       _concurrent_weak_roots;

--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -54,9 +54,28 @@ public:
   }
 };
 
+class ZRelocateRootsTask : public ZTask {
+private:
+  ZRelocateRootsIteratorClosure _cl;
+
+public:
+  ZRelocateRootsTask() :
+      ZTask("ZRelocateRootsTask") {}
+
+  virtual void work() {
+    // Allocation path assumes that relocating GC threads are ZWorkers
+    assert(ZThread::is_worker(), "Relocation code needs to be run as a worker");
+    assert(ZThread::worker_id() == 0, "No multi-thread support");
+
+    // During relocation we need to visit the JVMTI
+    // export weak roots to rehash the JVMTI tag map
+    ZRelocateRoots::oops_do(&_cl);
+  }
+};
+
 void ZRelocate::start() {
-  ZRelocateRootsIteratorClosure cl;
-  ZRelocateRoots::oops_do(&cl);
+  ZRelocateRootsTask task;
+  _workers->run_serial(&task);
 }
 
 uintptr_t ZRelocate::relocate_object_inner(ZForwarding* forwarding, uintptr_t from_index, uintptr_t from_offset) const {

--- a/src/hotspot/share/gc/z/zRootsIterator.cpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.cpp
@@ -54,7 +54,6 @@
 #include "runtime/vmThread.hpp"
 #include "utilities/debug.hpp"
 
-static const ZStatSubPhase ZSubPhasePauseRoots("Pause Roots");
 static const ZStatSubPhase ZSubPhasePauseRootsJVMTIWeakExport("Pause Roots JVMTIWeakExport");
 
 static const ZStatSubPhase ZSubPhaseConcurrentRootsSetup("Concurrent Roots Setup");
@@ -141,23 +140,10 @@ void ZJavaThreadsIterator::threads_do(ThreadClosure* cl) {
   }
 }
 
-ZRootsIterator::ZRootsIterator(bool visit_jvmti_weak_export) :
-    _visit_jvmti_weak_export(visit_jvmti_weak_export),
-    _jvmti_weak_export(this) {
-  assert(SafepointSynchronize::is_at_safepoint(), "Should be at safepoint");
-}
-
-void ZRootsIterator::do_jvmti_weak_export(ZRootsIteratorClosure* cl) {
+void ZRelocateRoots::oops_do(OopClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsJVMTIWeakExport);
   AlwaysTrueClosure always_alive;
   JvmtiExport::weak_oops_do(&always_alive, cl);
-}
-
-void ZRootsIterator::oops_do(ZRootsIteratorClosure* cl) {
-  ZStatTimer timer(ZSubPhasePauseRoots);
-  if (_visit_jvmti_weak_export) {
-    _jvmti_weak_export.oops_do(cl);
-  }
 }
 
 ZConcurrentRootsIterator::ZConcurrentRootsIterator(int cld_claim) :

--- a/src/hotspot/share/gc/z/zRootsIterator.hpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.hpp
@@ -105,18 +105,9 @@ public:
   void threads_do(ThreadClosure* cl);
 };
 
-class ZRootsIterator {
-private:
-  const bool _visit_jvmti_weak_export;
-
-  void do_jvmti_weak_export(ZRootsIteratorClosure* cl);
-
-  ZSerialOopsDo<ZRootsIterator, &ZRootsIterator::do_jvmti_weak_export>   _jvmti_weak_export;
-
+class ZRelocateRoots : public AllStatic {
 public:
-  ZRootsIterator(bool visit_jvmti_weak_export = false);
-
-  void oops_do(ZRootsIteratorClosure* cl);
+  static void oops_do(OopClosure* cl);
 };
 
 class ZConcurrentRootsIterator {

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -229,10 +229,6 @@ void ZVerify::roots(bool verify_fixed) {
   }
 }
 
-void ZVerify::roots_strong() {
-  roots<ZRootsIterator>(true /* verify_fixed */);
-}
-
 void ZVerify::roots_weak() {
   roots<ZWeakRootsIterator>(true /* verify_fixed */);
 }
@@ -246,7 +242,6 @@ void ZVerify::roots_concurrent_weak() {
 }
 
 void ZVerify::roots(bool verify_concurrent_strong, bool verify_weaks) {
-  roots_strong();
   roots_concurrent_strong(verify_concurrent_strong);
   if (verify_weaks) {
     roots_weak();

--- a/src/hotspot/share/gc/z/zVerify.hpp
+++ b/src/hotspot/share/gc/z/zVerify.hpp
@@ -33,7 +33,6 @@ class ZVerify : public AllStatic {
 private:
   template <typename RootsIterator> static void roots(bool verify_fixed);
 
-  static void roots_strong();
   static void roots_weak();
   static void roots_concurrent_strong(bool verify_fixed);
   static void roots_concurrent_weak();

--- a/src/hotspot/share/gc/z/zWorkers.cpp
+++ b/src/hotspot/share/gc/z/zWorkers.cpp
@@ -101,6 +101,10 @@ void ZWorkers::run(ZTask* task, uint nworkers) {
   _workers.run_task(task->gang_task());
 }
 
+void ZWorkers::run_serial(ZTask* task) {
+  run(task, 1  /* nworkers */);
+}
+
 void ZWorkers::run_parallel(ZTask* task) {
   run(task, nparallel());
 }

--- a/src/hotspot/share/gc/z/zWorkers.hpp
+++ b/src/hotspot/share/gc/z/zWorkers.hpp
@@ -48,6 +48,7 @@ public:
 
   void set_boost(bool boost);
 
+  void run_serial(ZTask* task);
   void run_parallel(ZTask* task);
   void run_concurrent(ZTask* task);
 


### PR DESCRIPTION
After introducing concurrent stack scanning, we don't need to mark through any roots during the mark start pause. Remove the code.

Note that the old code passed in `false` to `_roots(false /* visit_jvmti_weak_export */)`. This has the effect that no roots are visited by the iterator:
```
void ZRootsIterator::oops_do(ZRootsIteratorClosure* cl) {
  ZStatTimer timer(ZSubPhasePauseRoots);
  if (_visit_jvmti_weak_export) {
    _jvmti_weak_export.oops_do(cl);
  }
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254562](https://bugs.openjdk.java.net/browse/JDK-8254562): ZGC: Remove ZMarkRootsTask


### Reviewers
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/601/head:pull/601`
`$ git checkout pull/601`
