### PR TITLE
8254252: Generic arraycopy stub overwrites callee-save rdi register on 64-bit Windows

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -2948,8 +2948,10 @@ class StubGenerator: public StubCodeGenerator {
     const Register dst_pos    = c_rarg3;  // destination position
 #ifndef _WIN64
     const Register length     = c_rarg4;
+    const Register rklass_tmp = r9;  // load_klass
 #else
-    const Address  length(rsp, 6 * wordSize);  // elements count is on stack on Win64
+    const Address  length(rsp, 7 * wordSize);  // elements count is on stack on Win64
+    const Register rklass_tmp = rdi;  // load_klass
 #endif
 
     { int modulus = CodeEntryAlignment;
@@ -2969,6 +2971,10 @@ class StubGenerator: public StubCodeGenerator {
     address start = __ pc();
 
     __ enter(); // required for proper stackwalking of RuntimeStub frame
+
+#ifdef _WIN64
+   __ push(rklass_tmp); // rdi is callee-save on Windows
+#endif
 
     // bump this on entry, not on exit:
     inc_counter_np(SharedRuntime::_generic_array_copy_ctr);
@@ -3014,13 +3020,15 @@ class StubGenerator: public StubCodeGenerator {
     guarantee(((j1off ^ j4off) & ~15) != 0, "I$ line of 1st & 4th jumps");
 
     // registers used as temp
+    const Register r11_length    = r11; // elements count to copy
     const Register r10_src_klass = r10; // array klass
 
     //  if (length < 0) return -1;
-    __ cmpl(length, 0);
-    __ jccb(Assembler::less, L_failed_0);
+    __ movl(r11_length, length);        // length (elements count, 32-bits value)
+    __ testl(r11_length, r11_length);
+    __ jccb(Assembler::negative, L_failed_0);
 
-    __ load_klass(r10_src_klass, src, r11);
+    __ load_klass(r10_src_klass, src, rklass_tmp);
 #ifdef ASSERT
     //  assert(src->klass() != NULL);
     {
@@ -3031,7 +3039,7 @@ class StubGenerator: public StubCodeGenerator {
       __ bind(L1);
       __ stop("broken null klass");
       __ bind(L2);
-      __ load_klass(rax, dst, r11);
+      __ load_klass(rax, dst, rklass_tmp);
       __ cmpq(rax, 0);
       __ jcc(Assembler::equal, L1);     // this would be broken also
       BLOCK_COMMENT("} assert klasses not null done");
@@ -3054,7 +3062,7 @@ class StubGenerator: public StubCodeGenerator {
     __ jcc(Assembler::equal, L_objArray);
 
     //  if (src->klass() != dst->klass()) return -1;
-    __ load_klass(rax, dst, r11);
+    __ load_klass(rax, dst, rklass_tmp);
     __ cmpq(r10_src_klass, rax);
     __ jcc(Assembler::notEqual, L_failed);
 
@@ -3078,10 +3086,8 @@ class StubGenerator: public StubCodeGenerator {
     }
 #endif
 
-    const Register length_reg = NOT_WIN64(length) WIN64_ONLY(r11); // elements count to copy
-    WIN64_ONLY(__ movl(length_reg, length);) // Load from stack
-
-    arraycopy_range_checks(src, src_pos, dst, dst_pos, length_reg, r10, L_failed);
+    arraycopy_range_checks(src, src_pos, dst, dst_pos, r11_length,
+                           r10, L_failed);
 
     // TypeArrayKlass
     //
@@ -3100,6 +3106,10 @@ class StubGenerator: public StubCodeGenerator {
     BLOCK_COMMENT("choose copy loop based on element size");
     __ andl(rax_lh, Klass::_lh_log2_element_size_mask); // rax_lh -> rax_elsize
 
+#ifdef _WIN64
+    __ pop(rklass_tmp); // Restore callee-save rdi
+#endif
+
     // next registers should be set before the jump to corresponding stub
     const Register from     = c_rarg0;  // source array address
     const Register to       = c_rarg1;  // destination array address
@@ -3112,7 +3122,7 @@ class StubGenerator: public StubCodeGenerator {
     __ jccb(Assembler::notEqual, L_copy_shorts);
     __ lea(from, Address(src, src_pos, Address::times_1, 0));// src_addr
     __ lea(to,   Address(dst, dst_pos, Address::times_1, 0));// dst_addr
-    __ movl2ptr(count, length_reg); // length
+    __ movl2ptr(count, r11_length); // length
     __ jump(RuntimeAddress(byte_copy_entry));
 
   __ BIND(L_copy_shorts);
@@ -3120,7 +3130,7 @@ class StubGenerator: public StubCodeGenerator {
     __ jccb(Assembler::notEqual, L_copy_ints);
     __ lea(from, Address(src, src_pos, Address::times_2, 0));// src_addr
     __ lea(to,   Address(dst, dst_pos, Address::times_2, 0));// dst_addr
-    __ movl2ptr(count, length_reg); // length
+    __ movl2ptr(count, r11_length); // length
     __ jump(RuntimeAddress(short_copy_entry));
 
   __ BIND(L_copy_ints);
@@ -3128,7 +3138,7 @@ class StubGenerator: public StubCodeGenerator {
     __ jccb(Assembler::notEqual, L_copy_longs);
     __ lea(from, Address(src, src_pos, Address::times_4, 0));// src_addr
     __ lea(to,   Address(dst, dst_pos, Address::times_4, 0));// dst_addr
-    __ movl2ptr(count, length_reg); // length
+    __ movl2ptr(count, r11_length); // length
     __ jump(RuntimeAddress(int_copy_entry));
 
   __ BIND(L_copy_longs);
@@ -3145,44 +3155,47 @@ class StubGenerator: public StubCodeGenerator {
 #endif
     __ lea(from, Address(src, src_pos, Address::times_8, 0));// src_addr
     __ lea(to,   Address(dst, dst_pos, Address::times_8, 0));// dst_addr
-    __ movl2ptr(count, length_reg); // length
+    __ movl2ptr(count, r11_length); // length
     __ jump(RuntimeAddress(long_copy_entry));
 
     // ObjArrayKlass
   __ BIND(L_objArray);
-    // live at this point: r10_src_klass, src[_pos], dst[_pos]
+    // live at this point:  r10_src_klass, r11_length, src[_pos], dst[_pos]
 
     Label L_plain_copy, L_checkcast_copy;
     //  test array classes for subtyping
-    __ load_klass(rax, dst, r11);
+    __ load_klass(rax, dst, rklass_tmp);
     __ cmpq(r10_src_klass, rax); // usual case is exact equality
     __ jcc(Assembler::notEqual, L_checkcast_copy);
 
     // Identically typed arrays can be copied without element-wise checks.
-    WIN64_ONLY(__ movl(length_reg, length);) // Load from stack
-    arraycopy_range_checks(src, src_pos, dst, dst_pos, length_reg, r10, L_failed);
+    arraycopy_range_checks(src, src_pos, dst, dst_pos, r11_length,
+                           r10, L_failed);
 
     __ lea(from, Address(src, src_pos, TIMES_OOP,
                  arrayOopDesc::base_offset_in_bytes(T_OBJECT))); // src_addr
     __ lea(to,   Address(dst, dst_pos, TIMES_OOP,
                  arrayOopDesc::base_offset_in_bytes(T_OBJECT))); // dst_addr
-    __ movl2ptr(count, length_reg); // length
+    __ movl2ptr(count, r11_length); // length
   __ BIND(L_plain_copy);
+#ifdef _WIN64
+    __ pop(rklass_tmp); // Restore callee-save rdi
+#endif
     __ jump(RuntimeAddress(oop_copy_entry));
 
   __ BIND(L_checkcast_copy);
-    // live at this point: r10_src_klass, rax (dst_klass)
+    // live at this point:  r10_src_klass, r11_length, rax (dst_klass)
     {
       // Before looking at dst.length, make sure dst is also an objArray.
       __ cmpl(Address(rax, lh_offset), objArray_lh);
       __ jcc(Assembler::notEqual, L_failed);
 
       // It is safe to examine both src.length and dst.length.
-      WIN64_ONLY(__ movl(length_reg, length);) // Load from stack
-      arraycopy_range_checks(src, src_pos, dst, dst_pos, length_reg, rax, L_failed);
+      arraycopy_range_checks(src, src_pos, dst, dst_pos, r11_length,
+                             rax, L_failed);
 
       const Register r11_dst_klass = r11;
-      __ load_klass(r11_dst_klass, dst, rax); // reload
+      __ load_klass(r11_dst_klass, dst, rklass_tmp); // reload
 
       // Marshal the base address arguments now, freeing registers.
       __ lea(from, Address(src, src_pos, TIMES_OOP,
@@ -3207,6 +3220,10 @@ class StubGenerator: public StubCodeGenerator {
       __ movl(  sco_temp,      Address(r11_dst_klass, sco_offset));
       assert_clean_int(sco_temp, rax);
 
+#ifdef _WIN64
+    __ pop(rklass_tmp); // Restore callee-save rdi
+#endif
+
       // the checkcast_copy loop needs two extra arguments:
       assert(c_rarg3 == sco_temp, "#3 already in place");
       // Set up arguments for checkcast_copy_entry.
@@ -3216,6 +3233,9 @@ class StubGenerator: public StubCodeGenerator {
     }
 
   __ BIND(L_failed);
+#ifdef _WIN64
+    __ pop(rklass_tmp); // Restore callee-save rdi
+#endif
     __ xorptr(rax, rax);
     __ notptr(rax); // return -1
     __ leave();   // required for proper stackwalking of RuntimeStub frame

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -2973,7 +2973,7 @@ class StubGenerator: public StubCodeGenerator {
     __ enter(); // required for proper stackwalking of RuntimeStub frame
 
 #ifdef _WIN64
-   __ push(rklass_tmp); // rdi is callee-save on Windows
+    __ push(rklass_tmp); // rdi is callee-save on Windows
 #endif
 
     // bump this on entry, not on exit:
@@ -3221,7 +3221,7 @@ class StubGenerator: public StubCodeGenerator {
       assert_clean_int(sco_temp, rax);
 
 #ifdef _WIN64
-    __ pop(rklass_tmp); // Restore callee-save rdi
+      __ pop(rklass_tmp); // Restore callee-save rdi
 #endif
 
       // the checkcast_copy loop needs two extra arguments:


### PR DESCRIPTION
Since [JDK-8241825](https://bugs.openjdk.java.net/browse/JDK-8241825), MacroAssembler::load_klass requires a temporary register to decode the klass pointer. In the generic arraycopy stub, rdi is used for that on 64-bit Windows because r9 is already used as an argument register:
https://hg.openjdk.java.net/jdk/jdk/rev/0bb101fbeb10#l17.32

The problem is that rdi is callee-save [1] but not restored when returning from the stub. This leads to register corruption and more or less random crashes in the caller.

Although JDK-8241825 is part of JDK 15, this was never a problem because we did not set the _WIN64 macro in adlc and as a result accidentally treated rdi (and rsi) as caller-save:
https://github.com/openjdk/jdk/blob/b9873e18330b7e43ca47bc1c0655e7ab20828f7a/src/hotspot/cpu/x86/x86_64.ad#L89

Now that this got fixed as part of [JDK-8248238](https://bugs.openjdk.java.net/browse/JDK-8248238) [2], we hit the bug.

Unfortunately, we are running out of caller-save registers on Windows. Since rcx, rdx, r8 and r9 are used for arguments, only rax, r10 and r11 remain which are already used as temporary registers and live throughout the stub code. I've decided to free up r11 by postponing the load of the array length which is only needed on Windows anyway (because only Windows passes the 5th argument on stack).

Thanks,
Tobias

[1] https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=vs-2019
[2] https://openjdk.github.io/cr/?repo=jdk&pr=212&range=11#sdiff-8

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254252](https://bugs.openjdk.java.net/browse/JDK-8254252): Generic arraycopy stub overwrites callee-save rdi register on 64-bit Windows


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to f52fcaece1acc17b836dc6ab8978a84ab309c439
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/603/head:pull/603`
`$ git checkout pull/603`
