### PR TITLE
8254573: Shenandoah: Streamline/inline native-LRB entry point

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
@@ -179,39 +179,6 @@ void ShenandoahBarrierSet::on_thread_detach(Thread *thread) {
   }
 }
 
-oop ShenandoahBarrierSet::load_reference_barrier_native(oop obj, oop* load_addr) {
-  return load_reference_barrier_native_impl(obj, load_addr);
-}
-
-oop ShenandoahBarrierSet::load_reference_barrier_native(oop obj, narrowOop* load_addr) {
-  return load_reference_barrier_native_impl(obj, load_addr);
-}
-
-template <class T>
-oop ShenandoahBarrierSet::load_reference_barrier_native_impl(oop obj, T* load_addr) {
-  if (CompressedOops::is_null(obj)) {
-    return NULL;
-  }
-
-  ShenandoahMarkingContext* const marking_context = _heap->marking_context();
-  if (_heap->is_concurrent_weak_root_in_progress() && !marking_context->is_marked(obj)) {
-    Thread* thr = Thread::current();
-    if (thr->is_Java_thread()) {
-      return NULL;
-    } else {
-      return obj;
-    }
-  }
-
-  oop fwd = load_reference_barrier_not_null(obj);
-  if (ShenandoahSelfFixing && load_addr != NULL && fwd != obj) {
-    // Since we are here and we know the load address, update the reference.
-    ShenandoahHeap::cas_oop(fwd, load_addr, obj);
-  }
-
-  return fwd;
-}
-
 void ShenandoahBarrierSet::clone_barrier_runtime(oop src) {
   if (_heap->has_forwarded_objects() || (ShenandoahStoreValEnqueueBarrier && _heap->is_concurrent_mark_in_progress())) {
     clone_barrier(src);

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.hpp
@@ -93,8 +93,8 @@ public:
   template <class T>
   inline oop load_reference_barrier_mutator(oop obj, T* load_addr);
 
-  oop load_reference_barrier_native(oop obj, oop* load_addr);
-  oop load_reference_barrier_native(oop obj, narrowOop* load_addr);
+  template <class T>
+  inline oop load_reference_barrier_native(oop obj, T* load_addr);
 
 private:
   template <class T>
@@ -112,9 +112,6 @@ private:
   inline void arraycopy_work(T* src, size_t count);
 
   oop load_reference_barrier_impl(oop obj);
-
-  template <class T>
-  oop load_reference_barrier_native_impl(oop obj, T* load_addr);
 
   inline bool need_bulk_update(HeapWord* dst);
 public:


### PR DESCRIPTION
We currently do several calls between the native-LRB entry point and the actual implementation, presumably to resolve the templated versions. This can be simplified.

Testing: hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (8/9 running) |    |  ⏳ (6/9 running) |

### Issue
 * [JDK-8254573](https://bugs.openjdk.java.net/browse/JDK-8254573): Shenandoah: Streamline/inline native-LRB entry point


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/604/head:pull/604`
`$ git checkout pull/604`
