### PR TITLE
8254576: ZGC: Clean up timers in roots iterators

### DIFF
--- a/src/hotspot/share/gc/z/zRootsIterator.hpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.hpp
@@ -159,7 +159,6 @@ private:
 
 public:
   ZWeakRootsIterator();
-  ~ZWeakRootsIterator();
 
   void weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl);
   void oops_do(ZRootsIteratorClosure* cl);


### PR DESCRIPTION
Some of the timers in roots iterators are no longer that interesting after JDK-8253180 (concurrent thread stack scanning). I propose we remove them. This patch also adjusts the line break of a comment and moves a closure closer to the function where it's used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254576](https://bugs.openjdk.java.net/browse/JDK-8254576): ZGC: Clean up timers in roots iterators


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to bd8bf0988258ab8e0c2e0821d1802b7e73e2cda9
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to bd8bf0988258ab8e0c2e0821d1802b7e73e2cda9


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/605/head:pull/605`
`$ git checkout pull/605`
