### PR TITLE
8254575: C2: Clean up unused TRACK_PHI_INPUTS assertion code

### DIFF
--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -610,16 +610,6 @@ Block* PhaseCFG::insert_anti_dependences(Block* LCA, Node* load, bool verify) {
   Node_List non_early_stores(area); // all relevant stores outside of early
   bool must_raise_LCA = false;
 
-#ifdef TRACK_PHI_INPUTS
-  // %%% This extra checking fails because MergeMem nodes are not GVNed.
-  // Provide "phi_inputs" to check if every input to a PhiNode is from the
-  // original memory state.  This indicates a PhiNode for which should not
-  // prevent the load from sinking.  For such a block, set_raise_LCA_mark
-  // may be overly conservative.
-  // Mechanism: count inputs seen for each Phi encountered in worklist_store.
-  DEBUG_ONLY(GrowableArray<uint> phi_inputs(area, C->unique(),0,0));
-#endif
-
   // 'load' uses some memory state; look for users of the same state.
   // Recurse through MergeMem nodes to the stores that use them.
 
@@ -761,19 +751,6 @@ Block* PhaseCFG::insert_anti_dependences(Block* LCA, Node* load, bool verify) {
         }
       }
       assert(found_match, "no worklist bug");
-#ifdef TRACK_PHI_INPUTS
-#ifdef ASSERT
-        // This assert asks about correct handling of PhiNodes, which may not
-        // have all input edges directly from 'mem'. See BugId 4621264
-        int num_mem_inputs = phi_inputs.at_grow(store->_idx,0) + 1;
-        // Increment by exactly one even if there are multiple copies of 'mem'
-        // coming into the phi, because we will run this block several times
-        // if there are several copies of 'mem'.  (That's how DU iterators work.)
-        phi_inputs.at_put(store->_idx, num_mem_inputs);
-        assert(PhiNode::Input + num_mem_inputs < store->req(),
-               "Expect at least one phi input will not be from original memory state");
-#endif //ASSERT
-#endif //TRACK_PHI_INPUTS
     } else if (store_block != early) {
       // 'store' is between the current LCA and earliest possible block.
       // Label its block, and decide later on how to raise the LCA


### PR DESCRIPTION
Remove assertion code that was disabled in all build configurations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254575](https://bugs.openjdk.java.net/browse/JDK-8254575): C2: Clean up unused TRACK_PHI_INPUTS assertion code


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Contributors
 * Vladimir Ivanov `<vlivanov@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/606/head:pull/606`
`$ git checkout pull/606`
