### PR TITLE
8252407: Build failure with gcc-8+ and asan

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -227,8 +227,14 @@ AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
     # -D_FORTIFY_SOURCE=2 hardening option needs optimization (at least -O1) enabled
     # set for lower O-levels -U_FORTIFY_SOURCE to overwrite previous settings
     if test "x$OPENJDK_TARGET_OS" = xlinux -a "x$DEBUG_LEVEL" = "xfastdebug"; then
-      ENABLE_FORTIFY_CFLAGS="-D_FORTIFY_SOURCE=2"
       DISABLE_FORTIFY_CFLAGS="-U_FORTIFY_SOURCE"
+      # ASan doesn't work well with _FORTIFY_SOURCE
+      # See https://github.com/google/sanitizers/wiki/AddressSanitizer#faq
+      if test "x$ASAN_ENABLED" = xyes; then
+        ENABLE_FORTIFY_CFLAGS="${DISABLE_FORTIFY_CFLAGS}"
+      else
+        ENABLE_FORTIFY_CFLAGS="-D_FORTIFY_SOURCE=2"
+      fi
       C_O_FLAG_HIGHEST_JVM="${C_O_FLAG_HIGHEST_JVM} ${ENABLE_FORTIFY_CFLAGS}"
       C_O_FLAG_HIGHEST="${C_O_FLAG_HIGHEST} ${ENABLE_FORTIFY_CFLAGS}"
       C_O_FLAG_HI="${C_O_FLAG_HI} ${ENABLE_FORTIFY_CFLAGS}"

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -440,7 +440,10 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
         fi
       ],
       IF_ENABLED: [
-        ASAN_CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+        # ASan is simply incompatible with gcc -Wstringop-truncation. See
+        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85650
+        # It's harmless to be suppressed in clang as well.
+        ASAN_CFLAGS="-fsanitize=address -Wno-stringop-truncation -fno-omit-frame-pointer"
         ASAN_LDFLAGS="-fsanitize=address"
         JVM_CFLAGS="$JVM_CFLAGS $ASAN_CFLAGS"
         JVM_LDFLAGS="$JVM_LDFLAGS $ASAN_LDFLAGS"


### PR DESCRIPTION
Summary: Fix stringop-truncation warnings casused by gcc.

The newer gcc(gcc-8 or higher) would warn for calls to bounded string
manipulation functions such as 'strncpy' that may either truncate the
copied string or leave the destination unchanged.

The reason is that -fsanitize=address might simply incompatible with
-Wstringop-truncation. This patch disables stringop-truncation warning
when asan enabled, also disables the defining of _FORTIFY_SOURCE in
fastdebug builds for some potential risks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252407](https://bugs.openjdk.java.net/browse/JDK-8252407): Build failure with gcc-8+ and asan


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/607/head:pull/607`
`$ git checkout pull/607`
