### PR TITLE
8254161: Prevent instantiation of EnumSet subclasses through deserialization

### DIFF
--- a/src/java.base/share/classes/java/util/EnumSet.java
+++ b/src/java.base/share/classes/java/util/EnumSet.java
@@ -480,11 +480,22 @@ public abstract class EnumSet<E extends Enum<E>> extends AbstractSet<E>
     }
 
     /**
+     * Throws {@code InvalidObjectException}.
      * @param s the stream
      * @throws java.io.InvalidObjectException always
      */
     @java.io.Serial
     private void readObject(java.io.ObjectInputStream s)
+        throws java.io.InvalidObjectException {
+        throw new java.io.InvalidObjectException("Proxy required");
+    }
+
+    /**
+     * Throws {@code InvalidObjectException}.
+     * @throws java.io.InvalidObjectException always
+     */
+    @java.io.Serial
+    private void readObjectNoData()
         throws java.io.InvalidObjectException {
         throw new java.io.InvalidObjectException("Proxy required");
     }


### PR DESCRIPTION
TL;DR add EnumSet::readObjectNoData() 

EnumSet is an exemplar of the Serialization Proxy Pattern. As such, it 
should strictly implement that pattern and demonstrate how best to 
defend against inappropriate instantiation through deserialization. 

EnumSet is an extensible class. There are two subclasses in the JDK, 
RegularEnumSet and JumboEnumSet. Since the serialization of an EnumSet 
object writes a replacement object to the serial stream, a serial proxy 
object, then stream objects of type RegularEnumSet or JumboEnumSet are 
not expected in the serial stream. However, if they are present in the 
serial stream, then, during deserialization, the EnumSet::readObject 
method will be invoked. EnumSet::readObject unconditionally throws an 
exception, thus preventing further deserialization of the stream object. 
In this way, stream objects that are subclasses of EnumSet are prevented 
from being instantiated through deserialization. But this is not 
sufficient to prevent such in all scenarios. 

A stream object whose local class equivalent of the specified stream 
class descriptor is a subclasses of EnumSet, but whose specified stream 
class descriptor does not list EnumSet as a superClass, may be 
instantiated through deserialization. Since the stream class descriptor 
does not list EnumSet as a superclass, then the defensive 
EnumSet::readObject is never invoked. To prevent such objects from 
being deserialized, an EnumSet::readObjectNoData() should be added - 
whose implementation unconditionally throws an exception, similar to 
that of the existing EnumSet::readObject.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254161](https://bugs.openjdk.java.net/browse/JDK-8254161): Prevent instantiation of EnumSet subclasses through deserialization


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/611/head:pull/611`
`$ git checkout pull/611`
