### PR TITLE
8254611: x86_32: Call to IRT::at_unwind clobbers rthread after JDK-8253180

### DIFF
--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -988,7 +988,7 @@ void InterpreterMacroAssembler::remove_activation(
   const Register rmon    = LP64_ONLY(c_rarg1) NOT_LP64(rcx);
                               // monitor pointers need different register
                               // because rdx may have the result in it
-  NOT_LP64(get_thread(rcx);)
+  NOT_LP64(get_thread(rthread);)
 
   // The below poll is for the stack watermark barrier. It allows fixing up frames lazily,
   // that would normally not be safe to use. Such bad returns into unsafe territory of
@@ -1001,6 +1001,7 @@ void InterpreterMacroAssembler::remove_activation(
   push(state);
   call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::at_unwind));
   pop(state);
+  NOT_LP64(get_thread(rthread);) // call_VM clobbered it, restore
   bind(fast_path);
 
   // get the value of _do_not_unlock_if_synchronized into rdx


### PR DESCRIPTION
There are massive x86_32 tier1 failures, bisection points to JDK-8253180. I think I know why this happens: in `InterpreterMacroAssembler::remove_activation`, there is a new call_VM to `InterpreterRuntime::at_unwind`, which broke the `rthread` (`rcx`) that x86_32 needs later. x86_64 is not affected, because it carries it in `r15_thread`.

Attention @fisk.

Additional testing:
  - [x] x86_32 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254611](https://bugs.openjdk.java.net/browse/JDK-8254611): x86_32: Call to IRT::at_unwind clobbers rthread after JDK-8253180


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/615/head:pull/615`
`$ git checkout pull/615`
