### PR TITLE
8227077: Test java/awt/Modal/ZOrderTest6271792/ZOrderTest.java fails

### DIFF
--- a/test/jdk/java/awt/Modal/ZOrderTest/ZOrderTest.java
+++ b/test/jdk/java/awt/Modal/ZOrderTest/ZOrderTest.java
@@ -1,0 +1,122 @@
+/*
+  @test
+  @bug 6271792 8227077
+  @key headful
+  @summary Tests that all the blocked frames stay below their modal blocker dialog.
+  @run main ZOrderTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.Dialog;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+
+public class ZOrderTest
+{
+    private static Frame f1, f2, f3;
+    private static Dialog d;
+
+    private static int width=400, height=400;
+
+    public static void main( String args[] ) throws Exception
+    {
+        try {
+            f1 = new Frame("F1");
+            f1.setBounds(0, 0, width, height);
+            f1.setBackground(Color.RED);
+            f1.setLayout(new BorderLayout());
+            Button b = new Button("Click");
+            b.addActionListener(new ActionListener() {
+                public void actionPerformed(ActionEvent e) {
+                    d.setVisible(true);
+                }
+            });
+            f1.add(b, BorderLayout.SOUTH);
+            f1.setVisible(true);
+
+            f2 = new Frame("F2");
+            f2.setBounds(width + 1, 0, width, height);
+            f2.setBackground(Color.RED);
+            f2.setVisible(true);
+
+            f3 = new Frame("F3");
+            f3.setBounds(width + 1, 0 + height + 1, width, height);
+            f3.setBackground(Color.RED);
+            f3.setVisible(true);
+
+            d = new Dialog(f1, "D", true);
+            d.setBounds(3 * width / 4, 3 * height / 4,
+                    width / 2, height / 2);
+            d.setBackground(Color.BLUE);
+
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+
+            Point bl = b.getLocationOnScreen();
+            mouseClick(robot, bl.x + b.getBounds().width / 2, bl.y + b.getBounds().height / 2);
+
+            clickFrame(robot, f1);
+            Color color = robot.getPixelColor(d.getBounds().x + 10,
+                    d.getBounds().y + d.getInsets().top + 10);
+            if (!color.equals(Color.BLUE)) {
+                System.out.println(color);
+                throw new RuntimeException("Frame F1 is above its modal blocker dialog");
+            }
+
+            clickFrame(robot, f2);
+            color = robot.getPixelColor(d.getBounds().x + d.getBounds().width - 10,
+                    d.getBounds().y + d.getInsets().top + 10);
+            if (!color.equals(Color.BLUE)) {
+                throw new RuntimeException("Frame F2 is above its modal blocker dialog");
+            }
+
+            clickFrame(robot, f3);
+            color = robot.getPixelColor(d.getBounds().x + d.getBounds().width - 10,
+                    d.getBounds().y + d.getBounds().height - 10);
+            if (!color.equals(Color.BLUE)) {
+                throw new RuntimeException("Frame F3 is above its modal blocker dialog");
+            }
+        } finally {
+            if (f1 != null) {
+                f1.dispose();
+            }
+            if (f2 != null) {
+                f2.dispose();
+            }
+            if (f3 != null) {
+                f3.dispose();
+            }
+            if (d != null) {
+                d.dispose();
+            }
+        }
+    }
+
+    private static void clickFrame(Robot robot, Frame frame) {
+        Rectangle bounds = frame.getBounds();
+        // click the title of frame
+        mouseClick(robot, bounds.x + bounds.width / 2,
+                bounds.y + frame.getInsets().top / 2 + 1);
+        // click interior of frame
+        mouseClick(robot, bounds.x + bounds.width / 2,
+                bounds.y + frame.getInsets().top + 10);
+    }
+
+    private static void mouseClick(Robot robot, int x, int y) {
+        robot.mouseMove(x, y);
+        robot.waitForIdle();
+        robot.delay(200);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        robot.delay(200);
+    }
+}
+


### PR DESCRIPTION
Test java/awt/Modal/ZOrderTest6271792/ZOrderTest.java fails on Ubuntu 19.04 and Ubuntu 20.04. The test always fail on mach5 and locally.

Issue: The test create frames and then does robot mouse clicks on frame title. The frames are of less width and on some systems, the robot clicks the minimize button on the frame while clicking the frame title. This results in test failure in further steps.
Fix: Increased the frames dimensions to remove this issue. Also, used variables to define the dimension instead of using the dimension values for all the frames individually.
Along with this change, the fix also does lot of cleanup. For example, added proper robot delays and removed Thread.sleeps. Added autoDelay on Robot, removed lot of code for test machinery and lot of unnecessary functions, disposed the frames at end.
The test is moved from closed to open repo, so looks like a new test. I have run mach5 job with multiple iterations. Link in the JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8227077](https://bugs.openjdk.java.net/browse/JDK-8227077): Test java/awt/Modal/ZOrderTest6271792/ZOrderTest.java fails


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/617/head:pull/617`
`$ git checkout pull/617`
