### PR TITLE
8254345: com/sun/jdi/JdwpAttachTest.java reports error incorrectly

### DIFF
--- a/test/jdk/com/sun/jdi/JdwpAttachTest.java
+++ b/test/jdk/com/sun/jdi/JdwpAttachTest.java
@@ -129,7 +129,7 @@ public class JdwpAttachTest {
                 if (expectedResult) {
                     log("OK: attached as expected");
                 } else {
-                    throw new RuntimeException("ERROR: LingeredApp.startApp was able to attach");
+                    throw new RuntimeException("ERROR: LingeredApp.startApp was NOT able to attach");
                 }
             } catch (Exception ex) {
                 if (expectedResult) {

--- a/test/jdk/com/sun/jdi/JdwpAttachTest.java
+++ b/test/jdk/com/sun/jdi/JdwpAttachTest.java
@@ -127,15 +127,15 @@ public class JdwpAttachTest {
                                 + (!expectedResult ? ",timeout=1000" : ""));
                 debuggee.stopApp();
                 if (expectedResult) {
-                    log("OK: attached as expected");
+                    log("OK: attach succeeded as expected");
                 } else {
-                    throw new RuntimeException("ERROR: LingeredApp.startApp was NOT able to attach");
+                    throw new RuntimeException("ERROR: attach succeeded but was expected to fail");
                 }
             } catch (Exception ex) {
                 if (expectedResult) {
-                    throw new RuntimeException("ERROR: LingeredApp.startApp was able to attach");
+                    throw new RuntimeException("ERROR: attach failed but was expected to succeed");
                 } else {
-                    log("OK: failed to attach as expected");
+                    log("OK: attach failed as expected");
                 }
             }
         } finally {


### PR DESCRIPTION
Please review a trivial fix for JdwpAttachTest

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254345](https://bugs.openjdk.java.net/browse/JDK-8254345): com/sun/jdi/JdwpAttachTest.java reports error incorrectly


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/619/head:pull/619`
`$ git checkout pull/619`
