### PR TITLE
8253877: gc/g1/TestGCLogMessages.java fails - missing "Evacuation failure" message 

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
+++ b/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
@@ -39,6 +39,7 @@ package gc.g1;
  */
 
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import sun.hotspot.code.Compiler;
 
@@ -182,7 +183,9 @@ public class TestGCLogMessages {
     public static void main(String[] args) throws Exception {
         new TestGCLogMessages().testNormalLogs();
         new TestGCLogMessages().testConcurrentRefinementLogs();
-        new TestGCLogMessages().testWithToSpaceExhaustionLogs();
+        if (Platform.isDebugBuild()) {
+          new TestGCLogMessages().testWithEvacuationFailureLogs();
+        }
         new TestGCLogMessages().testWithConcurrentStart();
         new TestGCLogMessages().testExpandHeap();
     }
@@ -240,12 +243,15 @@ public class TestGCLogMessages {
         new LogMessageWithLevel("Remove Self Forwards", Level.TRACE),
     };
 
-    private void testWithToSpaceExhaustionLogs() throws Exception {
+    private void testWithEvacuationFailureLogs() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+UseG1GC",
                                                                   "-Xmx32M",
                                                                   "-Xmn16M",
+                                                                  "-XX:+G1EvacuationFailureALot",
+                                                                  "-XX:G1EvacuationFailureALotCount=100",
+                                                                  "-XX:G1EvacuationFailureALotInterval=1",
                                                                   "-Xlog:gc+phases=debug",
-                                                                  GCTestWithToSpaceExhaustion.class.getName());
+                                                                  GCTestWithEvacuationFailure.class.getName());
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         checkMessagesAtLevel(output, exhFailureMessages, Level.DEBUG);
@@ -255,7 +261,7 @@ public class TestGCLogMessages {
                                                    "-Xmx32M",
                                                    "-Xmn16M",
                                                    "-Xlog:gc+phases=trace",
-                                                   GCTestWithToSpaceExhaustion.class.getName());
+                                                   GCTestWithEvacuationFailure.class.getName());
 
         output = new OutputAnalyzer(pb.start());
         checkMessagesAtLevel(output, exhFailureMessages, Level.TRACE);
@@ -304,16 +310,19 @@ public class TestGCLogMessages {
         }
     }
 
-    static class GCTestWithToSpaceExhaustion {
+    static class GCTestWithEvacuationFailure {
         private static byte[] garbage;
         private static byte[] largeObject;
+        private static Object[] holder = new Object[200]; // Must be larger than G1EvacuationFailureALotCount
+
         public static void main(String [] args) {
             largeObject = new byte[16*1024*1024];
             System.out.println("Creating garbage");
-            // create 128MB of garbage. This should result in at least one GC,
-            // some of them with to-space exhaustion.
-            for (int i = 0; i < 1024; i++) {
-                garbage = new byte[128 * 1024];
+            // Create 16 MB of garbage. This should result in at least one GC,
+            // (Heap size is 32M, we use 17MB for the large object above)
+            // which is larger than G1EvacuationFailureALotInterval.
+            for (int i = 0; i < 16 * 1024; i++) {
+                holder[i % holder.length] = new byte[1024];
             }
             System.out.println("Done");
         }


### PR DESCRIPTION
Hi all,

  can I have reviews for this change to gc/g1/TestGCLogMessages to hopefully make it more reliable?

One subtest tries to force evacuation failure, but apparently this does not always succeed. Particularly with upcoming young gen sizing changes, there seems to be a larger than before chance that the current mechanism does not work.

This mechanism assumes that before that test the young gen has been sized that much that the allocation of a half-heap humongous object causes an evacuation failure next time - of course that's a somewhat dodgy assumption that apparently recently started failing more.

The change employs the G1 internal evacuation failure debugging mechanism to force this kind of situation. The advantage is that this is guaranteed to work, the disadvantage is that it relies on that feature.

Additionally I did some slight renaming to the helper that used the term "ToSpaceExhaustion" instead of "EvacuationFailure" which is the name of the message that is actually checked for.

Testing: 2k+ tests of previous version without reproduction (meaning that at least for me without context of other tests, the issue has not been reproducable, at least not with the mentioned 1% failure rate), 3k tests with new version without reproduction

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253877](https://bugs.openjdk.java.net/browse/JDK-8253877): gc/g1/TestGCLogMessages.java fails - missing "Evacuation failure" message


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/624/head:pull/624`
`$ git checkout pull/624`
