### PR TITLE
8253905: Update sanity test suite to not place windows at (0,0)

### DIFF
--- a/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/dialog/DialogDemo.java
+++ b/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/dialog/DialogDemo.java
@@ -154,6 +154,7 @@ public class DialogDemo extends JPanel {
                 frame.add(demo);
                 frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
                 frame.pack();
+				frame.setLocationRelativeTo(null);
                 frame.setVisible(true);
                 demo.start();
             }

--- a/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/dialog/DialogDemo.java
+++ b/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/dialog/DialogDemo.java
@@ -154,7 +154,7 @@ public class DialogDemo extends JPanel {
                 frame.add(demo);
                 frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
                 frame.pack();
-		  frame.setLocationRelativeTo(null);
+                frame.setLocationRelativeTo(null);
                 frame.setVisible(true);
                 demo.start();
             }

--- a/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/dialog/DialogDemo.java
+++ b/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/dialog/DialogDemo.java
@@ -154,7 +154,7 @@ public class DialogDemo extends JPanel {
                 frame.add(demo);
                 frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
                 frame.pack();
-				frame.setLocationRelativeTo(null);
+		  frame.setLocationRelativeTo(null);
                 frame.setVisible(true);
                 demo.start();
             }

--- a/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/frame/FrameDemo.java
+++ b/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/frame/FrameDemo.java
@@ -264,6 +264,7 @@ FrameDemo demo = new FrameDemo();
 frame.add(demo);
 frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 frame.pack();
+frame.setLocationRelativeTo(null);
 frame.setVisible(true);
 demo.start();
 }

--- a/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/table/TableDemo.java
+++ b/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/table/TableDemo.java
@@ -615,6 +615,7 @@ public class TableDemo extends JPanel {
                 TableDemo demo = new TableDemo();
                 frame.add(demo);
                 frame.setSize(700, 400);
+				frame.setLocationRelativeTo(null);
                 frame.setVisible(true);
                 demo.start();
             }

--- a/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/table/TableDemo.java
+++ b/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/table/TableDemo.java
@@ -615,7 +615,7 @@ public class TableDemo extends JPanel {
                 TableDemo demo = new TableDemo();
                 frame.add(demo);
                 frame.setSize(700, 400);
-		  frame.setLocationRelativeTo(null);
+                frame.setLocationRelativeTo(null);
                 frame.setVisible(true);
                 demo.start();
             }

--- a/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/table/TableDemo.java
+++ b/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/table/TableDemo.java
@@ -615,7 +615,7 @@ public class TableDemo extends JPanel {
                 TableDemo demo = new TableDemo();
                 frame.add(demo);
                 frame.setSize(700, 400);
-				frame.setLocationRelativeTo(null);
+		  frame.setLocationRelativeTo(null);
                 frame.setVisible(true);
                 demo.start();
             }

--- a/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/window/WindowDemo.java
+++ b/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/window/WindowDemo.java
@@ -152,7 +152,7 @@ public final class WindowDemo extends JPanel {
             WindowDemo demo = new WindowDemo();
             frame.add(demo);
             frame.pack();
-			frame.setLocationRelativeTo(null);
+	    frame.setLocationRelativeTo(null);
             frame.setVisible(true);
             demo.start();
         });

--- a/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/window/WindowDemo.java
+++ b/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/window/WindowDemo.java
@@ -152,7 +152,7 @@ public final class WindowDemo extends JPanel {
             WindowDemo demo = new WindowDemo();
             frame.add(demo);
             frame.pack();
-	    frame.setLocationRelativeTo(null);
+	      frame.setLocationRelativeTo(null);
             frame.setVisible(true);
             demo.start();
         });

--- a/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/window/WindowDemo.java
+++ b/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/window/WindowDemo.java
@@ -152,7 +152,7 @@ public final class WindowDemo extends JPanel {
             WindowDemo demo = new WindowDemo();
             frame.add(demo);
             frame.pack();
-	      frame.setLocationRelativeTo(null);
+            frame.setLocationRelativeTo(null);
             frame.setVisible(true);
             demo.start();
         });

--- a/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/window/WindowDemo.java
+++ b/test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/window/WindowDemo.java
@@ -152,6 +152,7 @@ public final class WindowDemo extends JPanel {
             WindowDemo demo = new WindowDemo();
             frame.add(demo);
             frame.pack();
+			frame.setLocationRelativeTo(null);
             frame.setVisible(true);
             demo.start();
         });


### PR DESCRIPTION
Four files has been modified:
        modified:   test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/dialog/DialogDemo.java
        modified:   test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/frame/FrameDemo.java
        modified:   test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/table/TableDemo.java
        modified:   test/jdk/sanity/client/lib/SwingSet3/src/com/sun/swingset3/demos/window/WindowDemo.java

Tested on Mach5 and all tests passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253905](https://bugs.openjdk.java.net/browse/JDK-8253905): Update sanity test suite to not place windows at (0,0)


### Reviewers
 * [Alexandre Iline](https://openjdk.java.net/census#shurailine) (@shurymury - Committer)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/625/head:pull/625`
`$ git checkout pull/625`
