### PR TITLE
8254602: compiler/debug/TestStressCM.java failed with "RuntimeException: got the same optimization stats for different seeds: expected 45"

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -64,8 +64,6 @@ compiler/rtm/print/TestPrintPreciseRTMLockingStatistics.java 8183263 generic-x64
 
 compiler/c2/Test8004741.java 8235801 generic-all
 
-compiler/debug/TestStressCM.java 8254602 generic-all
-
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/debug/TestStressCM.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressCM.java
@@ -32,11 +32,10 @@ import jdk.test.lib.Asserts;
  * @bug 8253765
  * @requires vm.debug == true & vm.compiler2.enabled
  * @summary Tests that, when compiling with StressLCM or StressGCM, using the
- *          same seed results in the same compilation, and using different seeds
- *          results in different compilations (the latter does not necessarily
- *          hold for all pairs of seeds). The output of PrintOptoStatistics is
- *          used to compare among compilations, instead of the more intuitive
- *          TraceOptoPipelining which prints non-deterministic memory addresses.
+ *          same seed results in the same compilation. The output of
+ *          PrintOptoStatistics is used to compare among compilations, instead
+ *          of the more intuitive TraceOptoPipelining which prints
+ *          non-deterministic memory addresses.
  * @library /test/lib /
  * @run driver compiler.debug.TestStressCM StressLCM
  * @run driver compiler.debug.TestStressCM StressGCM
@@ -67,8 +66,6 @@ public class TestStressCM {
             String stressOpt = args[0];
             Asserts.assertEQ(optoStats(stressOpt, 10), optoStats(stressOpt, 10),
                 "got different optimization stats for the same seed");
-            Asserts.assertNE(optoStats(stressOpt, 10), optoStats(stressOpt, 20),
-                "got the same optimization stats for different seeds");
         } else if (args.length > 0) {
             sum(Integer.parseInt(args[0]));
         }

--- a/test/hotspot/jtreg/compiler/debug/TestStressIGVN.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressIGVN.java
@@ -32,9 +32,7 @@ import jdk.test.lib.Asserts;
  * @bug 8252219
  * @requires vm.debug == true & vm.compiler2.enabled
  * @summary Tests that compilations with the same seed yield the same IGVN
- *          trace, and compilations with different seeds yield different IGVN
- *          traces (the latter does not necessarily hold for all pairs of
- *          seeds).
+ *          trace.
  * @library /test/lib /
  * @run driver compiler.debug.TestStressIGVN
  */
@@ -63,8 +61,6 @@ public class TestStressIGVN {
         if (args.length == 0) {
             Asserts.assertEQ(igvnTrace(10), igvnTrace(10),
                 "got different IGVN traces for the same seed");
-            Asserts.assertNE(igvnTrace(10), igvnTrace(20),
-                "got the same IGVN trace for different seeds");
         } else if (args.length > 0) {
             sum(Integer.parseInt(args[0]));
         }


### PR DESCRIPTION
Remove test assertion checking that different random seeds lead to different code motion decisions. This was the case for the specific pair of random seeds, IR fed to code motion, and target platforms tested originally; but does not need to hold in general. Remove similar test assertion in IGVN randomization test case. Re-enable the test case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254602](https://bugs.openjdk.java.net/browse/JDK-8254602): compiler/debug/TestStressCM.java failed with "RuntimeException: got the same optimization stats for different seeds: expected 45"


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/626/head:pull/626`
`$ git checkout pull/626`
