### PR TITLE
8254668: JVMTI process frames on thread without started processing

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1674,7 +1674,7 @@ JvmtiEnv::PopFrame(JavaThread* java_thread) {
     bool is_interpreted[2];
     intptr_t *frame_sp[2];
     // The 2-nd arg of constructor is needed to stop iterating at java entry frame.
-    for (vframeStream vfs(java_thread, true); !vfs.at_end(); vfs.next()) {
+    for (vframeStream vfs(java_thread, true, false /* process_frames */); !vfs.at_end(); vfs.next()) {
       methodHandle mh(current_thread, vfs.method());
       if (mh->is_native()) return(JVMTI_ERROR_OPAQUE_FRAME);
       is_interpreted[frame_count] = vfs.is_interpreted_frame();
@@ -1686,7 +1686,7 @@ JvmtiEnv::PopFrame(JavaThread* java_thread) {
       // There can be two situations here:
       //  1. There are no more java frames
       //  2. Two top java frames are separated by non-java native frames
-      if(vframeFor(java_thread, 1) == NULL) {
+      if(vframeForNoProcess(java_thread, 1) == NULL) {
         return JVMTI_ERROR_NO_MORE_FRAMES;
       } else {
         // Intervening non-java native or VM frames separate java frames.
@@ -1785,7 +1785,7 @@ JvmtiEnv::NotifyFramePop(JavaThread* java_thread, jint depth) {
     JvmtiSuspendControl::print();
   }
 
-  vframe *vf = vframeFor(java_thread, depth);
+  vframe *vf = vframeForNoProcess(java_thread, depth);
   if (vf == NULL) {
     return JVMTI_ERROR_NO_MORE_FRAMES;
   }

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -556,7 +556,7 @@ JvmtiEnvBase::new_jthreadGroupArray(int length, Handle *handles) {
 }
 
 // return the vframe on the specified thread and depth, NULL if no such frame
-// The thread and the oops in the returned might not have been process.
+// The thread and the oops in the returned vframe might not have been process.
 vframe*
 JvmtiEnvBase::vframeForNoProcess(JavaThread* java_thread, jint depth) {
   if (!java_thread->has_last_Java_frame()) {

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -556,12 +556,13 @@ JvmtiEnvBase::new_jthreadGroupArray(int length, Handle *handles) {
 }
 
 // return the vframe on the specified thread and depth, NULL if no such frame
+// The thread and the oops in the returned might not have been process.
 vframe*
-JvmtiEnvBase::vframeFor(JavaThread* java_thread, jint depth) {
+JvmtiEnvBase::vframeForNoProcess(JavaThread* java_thread, jint depth) {
   if (!java_thread->has_last_Java_frame()) {
     return NULL;
   }
-  RegisterMap reg_map(java_thread);
+  RegisterMap reg_map(java_thread, true /* update_map */, false /* process_frames */);
   vframe *vf = java_thread->last_java_vframe(&reg_map);
   int d = 0;
   while ((vf != NULL) && (d < depth)) {
@@ -909,7 +910,7 @@ JvmtiEnvBase::get_frame_location(JavaThread *java_thread, jint depth,
          "call by myself or at handshake");
   ResourceMark rm(current_thread);
 
-  vframe *vf = vframeFor(java_thread, depth);
+  vframe *vf = vframeForNoProcess(java_thread, depth);
   if (vf == NULL) {
     return JVMTI_ERROR_NO_MORE_FRAMES;
   }
@@ -1309,7 +1310,7 @@ JvmtiEnvBase::check_top_frame(Thread* current_thread, JavaThread* java_thread,
                               jvalue value, TosState tos, Handle* ret_ob_h) {
   ResourceMark rm(current_thread);
 
-  vframe *vf = vframeFor(java_thread, 0);
+  vframe *vf = vframeForNoProcess(java_thread, 0);
   NULL_CHECK(vf, JVMTI_ERROR_NO_MORE_FRAMES);
 
   javaVFrame *jvf = (javaVFrame*) vf;

--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -286,7 +286,7 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
                                    javaVFrame *jvf,
                                    GrowableArray<jvmtiMonitorStackDepthInfo*>* owned_monitors_list,
                                    jint depth);
-  vframe* vframeFor(JavaThread* java_thread, jint depth);
+  vframe* vframeForNoProcess(JavaThread* java_thread, jint depth);
 
  public:
   // get a field descriptor for the specified class and field


### PR DESCRIPTION
I hit the following assert in some tests runs that I've been doing:
```
# Internal Error (/home/stefank/git/alt/open/src/hotspot/share/runtime/stackWatermark.inline.hpp:67), pid=828170, tid=828734
# assert(processing_started()) failed: Processing should already have started

```
The stack traces for this has been:
```
Native frames: (J=compiled Java code, A=aot compiled Java code, j=interpreted, Vv=VM code, C=native code)
V [libjvm.so+0x1626d75] StackWatermarkSet::on_iteration(JavaThread*, frame const&)+0xd5
V [libjvm.so+0xad791a] frame::sender(RegisterMap*) const+0x7a
V [libjvm.so+0xacd3f8] frame::real_sender(RegisterMap*) const+0x18
V [libjvm.so+0x1804c4a] vframe::sender() const+0xea
V [libjvm.so+0x175f47b] JavaThread::last_java_vframe(RegisterMap*)+0x5b
V [libjvm.so+0x10e10fc] JvmtiEnvBase::vframeFor(JavaThread*, int)+0x4c
V [libjvm.so+0x10e6972] JvmtiEnvBase::check_top_frame(Thread*, JavaThread*, jvalue, TosState, Handle*)+0xe2
V [libjvm.so+0x10e759c] JvmtiEnvBase::force_early_return(JavaThread*, jvalue, TosState)+0x11c
V [libjvm.so+0x105b8f5] jvmti_ForceEarlyReturnObject+0x215
```
```
V  [libjvm.so+0x1626d75]  StackWatermarkSet::on_iteration(JavaThread*, frame const&)+0xd5
V  [libjvm.so+0xad791a]  frame::sender(RegisterMap*) const+0x7a
V  [libjvm.so+0xacd3f8]  frame::real_sender(RegisterMap*) const+0x18
V  [libjvm.so+0x1804c4a]  vframe::sender() const+0xea
V  [libjvm.so+0x1804d00]  vframe::java_sender() const+0x10
V  [libjvm.so+0x10e1115]  JvmtiEnvBase::vframeFor(JavaThread*, int)+0x65
V  [libjvm.so+0x10d475f]  JvmtiEnv::NotifyFramePop(JavaThread*, int)+0x9f
V  [libjvm.so+0x106b6aa]  jvmti_NotifyFramePop+0x23a
```
The code inspects the top frame of a suspended java thread. However, there's nothing in the code that starts the watermark processing of the thread, so the code asserts when sender calls on_iteration.

We only have to call start_processing/on_iteration when oops are being read. The failing code does *not* inspect any oops, so I turn of the on_iteration call by settings process_frame to false.

To notify the readers of the code that vframeFor doesn't process the oops, I've renamed the function to vframeForNoProcess to give a visual cue.

I found this bug when running this command line:
makec ../build/fastdebug/ test TEST=test/hotspot/jtreg/vmTestbase/nsk/jvmti JTREG="JAVA_OPTIONS=-XX:+UseZGC -Xmx2g -XX:ZCollectionInterval=1 -XX:ZFragmentationLimit=0.01" JTREG_EXTRA_PROBLEM_LISTS=ProblemList-zgc.txt 

Five tests consistently asserts with this command line. All tests pass with the proposed fix.

Recommendations of tests to run are welcome. I intend to get this run through tier1-3, but haven't yet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254668](https://bugs.openjdk.java.net/browse/JDK-8254668): JVMTI process frames on thread without started processing


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to 587fd354667f84993ae15b169c62a1ab4af3d269
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - Committer) ⚠️ Review applies to 587fd354667f84993ae15b169c62a1ab4af3d269


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/627/head:pull/627`
`$ git checkout pull/627`
