### PR TITLE
8254671: ZGC: Remove unused roots iterator types

### DIFF
--- a/src/hotspot/share/gc/z/zRootsIterator.cpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.cpp
@@ -63,18 +63,6 @@ static const ZStatSubPhase ZSubPhasePauseWeakRootsJVMTIWeakExport("Pause Weak Ro
 static const ZStatSubPhase ZSubPhaseConcurrentWeakRootsOopStorageSet("Concurrent Weak Roots OopStorageSet");
 
 template <typename T, void (T::*F)(ZRootsIteratorClosure*)>
-ZSerialOopsDo<T, F>::ZSerialOopsDo(T* iter) :
-    _iter(iter),
-    _claimed(false) {}
-
-template <typename T, void (T::*F)(ZRootsIteratorClosure*)>
-void ZSerialOopsDo<T, F>::oops_do(ZRootsIteratorClosure* cl) {
-  if (!_claimed && Atomic::cmpxchg(&_claimed, false, true) == false) {
-    (_iter->*F)(cl);
-  }
-}
-
-template <typename T, void (T::*F)(ZRootsIteratorClosure*)>
 ZParallelOopsDo<T, F>::ZParallelOopsDo(T* iter) :
     _iter(iter),
     _completed(false) {}
@@ -98,21 +86,6 @@ template <typename T, void (T::*F)(BoolObjectClosure*, ZRootsIteratorClosure*)>
 void ZSerialWeakOopsDo<T, F>::weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl) {
   if (!_claimed && Atomic::cmpxchg(&_claimed, false, true) == false) {
     (_iter->*F)(is_alive, cl);
-  }
-}
-
-template <typename T, void (T::*F)(BoolObjectClosure*, ZRootsIteratorClosure*)>
-ZParallelWeakOopsDo<T, F>::ZParallelWeakOopsDo(T* iter) :
-    _iter(iter),
-    _completed(false) {}
-
-template <typename T, void (T::*F)(BoolObjectClosure*, ZRootsIteratorClosure*)>
-void ZParallelWeakOopsDo<T, F>::weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl) {
-  if (!_completed) {
-    (_iter->*F)(is_alive, cl);
-    if (!_completed) {
-      _completed = true;
-    }
   }
 }
 

--- a/src/hotspot/share/gc/z/zRootsIterator.cpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.cpp
@@ -29,7 +29,6 @@
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetNMethod.hpp"
 #include "gc/shared/oopStorageSet.hpp"
-#include "gc/shared/oopStorageParState.inline.hpp"
 #include "gc/shared/oopStorageSetParState.inline.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
 #include "gc/z/zBarrierSetNMethod.hpp"

--- a/src/hotspot/share/gc/z/zRootsIterator.hpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.hpp
@@ -24,7 +24,6 @@
 #ifndef SHARE_GC_Z_ZROOTSITERATOR_HPP
 #define SHARE_GC_Z_ZROOTSITERATOR_HPP
 
-#include "gc/shared/oopStorageParState.hpp"
 #include "gc/shared/oopStorageSetParState.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
 #include "memory/allocation.hpp"

--- a/src/hotspot/share/gc/z/zRootsIterator.hpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.hpp
@@ -35,20 +35,8 @@
 
 class ZRootsIteratorClosure;
 
-typedef OopStorage::ParState<true /* concurrent */, false /* is_const */> ZOopStorageIterator;
 typedef OopStorageSetStrongParState<true /* concurrent */, false /* is_const */> ZOopStorageSetStrongIterator;
 typedef OopStorageSetWeakParState<true /* concurrent */, false /* is_const */> ZOopStorageSetWeakIterator;
-
-template <typename T, void (T::*F)(ZRootsIteratorClosure*)>
-class ZSerialOopsDo {
-private:
-  T* const      _iter;
-  volatile bool _claimed;
-
-public:
-  ZSerialOopsDo(T* iter);
-  void oops_do(ZRootsIteratorClosure* cl);
-};
 
 template <typename T, void (T::*F)(ZRootsIteratorClosure*)>
 class ZParallelOopsDo {
@@ -69,17 +57,6 @@ private:
 
 public:
   ZSerialWeakOopsDo(T* iter);
-  void weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl);
-};
-
-template <typename T, void (T::*F)(BoolObjectClosure*, ZRootsIteratorClosure*)>
-class ZParallelWeakOopsDo {
-private:
-  T* const      _iter;
-  volatile bool _completed;
-
-public:
-  ZParallelWeakOopsDo(T* iter);
   void weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl);
 };
 


### PR DESCRIPTION
The types ZOopStorageIterator, ZSerialOopsDo and ZParallelWeakOopsDo are no longer used and can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254671](https://bugs.openjdk.java.net/browse/JDK-8254671): ZGC: Remove unused roots iterator types


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to a27cf962069129348e5cf33334ff1f8348ebca0f


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/629/head:pull/629`
`$ git checkout pull/629`
