### PR TITLE
8254672: ZGC: ZParallelOopsDo/ZSerialWeakOopsDo should use atomic load/store

### DIFF
--- a/src/hotspot/share/gc/z/zRootsIterator.cpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.cpp
@@ -68,10 +68,10 @@ ZParallelOopsDo<T, F>::ZParallelOopsDo(T* iter) :
 
 template <typename T, void (T::*F)(ZRootsIteratorClosure*)>
 void ZParallelOopsDo<T, F>::oops_do(ZRootsIteratorClosure* cl) {
-  if (!_completed) {
+  if (!Atomic::load(&_completed)) {
     (_iter->*F)(cl);
-    if (!_completed) {
-      _completed = true;
+    if (!Atomic::load(&_completed)) {
+      Atomic::store(&_completed, true);
     }
   }
 }
@@ -83,7 +83,7 @@ ZSerialWeakOopsDo<T, F>::ZSerialWeakOopsDo(T* iter) :
 
 template <typename T, void (T::*F)(BoolObjectClosure*, ZRootsIteratorClosure*)>
 void ZSerialWeakOopsDo<T, F>::weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl) {
-  if (!_claimed && Atomic::cmpxchg(&_claimed, false, true) == false) {
+  if (!Atomic::load(&_claimed) && Atomic::cmpxchg(&_claimed, false, true) == false) {
     (_iter->*F)(is_alive, cl);
   }
 }


### PR DESCRIPTION
ZParallelOopsDo/ZSerialWeakOopsDo should use atomic load/store. This patch builds on the JDK-8254671, which is currently out for review, so only the last commit is part of this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254672](https://bugs.openjdk.java.net/browse/JDK-8254672): ZGC: ZParallelOopsDo/ZSerialWeakOopsDo should use atomic load/store


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to 6ce9cc54250964c9dae4eb996f09fbe45c31a3b9


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/630/head:pull/630`
`$ git checkout pull/630`
