### PR TITLE
8254674: G1: Improve root location reference to dead obj verification message

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -68,7 +68,8 @@ public:
       oop obj = CompressedOops::decode_not_null(heap_oop);
       if (_g1h->is_obj_dead_cond(obj, _vo)) {
         Log(gc, verify) log;
-        log.error("Root location " PTR_FORMAT " points to dead obj " PTR_FORMAT, p2i(p), p2i(obj));
+        log.error("Root location " PTR_FORMAT " points to dead obj " PTR_FORMAT " in region " HR_FORMAT,
+                  p2i(p), p2i(obj), HR_FORMAT_PARAMS(_g1h->heap_region_containing(obj)));
         ResourceMark rm;
         LogStream ls(log.error());
         obj->print_on(&ls);


### PR DESCRIPTION
Hi all,

  can I have reviews for this tiny change that augments the 

Root location 0x00007fc6497f5070 points to dead obj 0x00000000e0200000

message with region information as G1 does for other references:

points to dead obj 0x00000000e0300000 in region 3:(HS)[0x00000000e0300000,0x00000000e0400000,0x00000000e0400000]

I.e. resulting in something like

Root location 0x00007fe388b7f070 points to dead obj 0x00000000e0200000 in region 2:(HS)[0x00000000e0200000,0x00000000e0300000,0x00000000e0300000]

This saves a few seconds looking up the region for the failing address during debugging..

Testing: local compilation, local verification on failing case

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254674](https://bugs.openjdk.java.net/browse/JDK-8254674): G1: Improve root location reference to dead obj verification message


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Leo Korinth](https://openjdk.java.net/census#lkorinth) (@lkorinth - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/631/head:pull/631`
`$ git checkout pull/631`
