### PR TITLE
8254623: gc/g1/TestHumongousConcurrentStartUndo.java still fails sometimes 

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestHumongousConcurrentStartUndo.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousConcurrentStartUndo.java
@@ -117,12 +117,14 @@ public class TestHumongousConcurrentStartUndo {
                 Helpers.waitTillCMCFinished(WHITE_BOX, 1);
                 a = null;
 
-                // Start from an "empty" heap.
-                WHITE_BOX.fullGC();
-                // The queue only holds all elements, so all humongous object
-                // will be reachable and the concurrent operation should be a regular mark.
                 a = new ArrayBlockingQueue(humongousObjectAllocations);
                 allocateHumongous(humongousObjectAllocations, humongousObjectSize, a);
+                Helpers.waitTillCMCFinished(WHITE_BOX, 1);
+                // At this point we keep humongousObjectAllocations humongous objects live
+                // in "a" which is larger than the IHOP. We just waited for any pending
+                // marking cycles. Another dummy allocation must trigger a humongous
+                // allocation that is not an Undo Cycle.
+                allocateHumongous(1, humongousObjectSize, new ArrayBlockingQueue(1));
                 Helpers.waitTillCMCFinished(WHITE_BOX, 1);
                 a = null;
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change of the gc/g1/TestHumongousConcurrentStartUndo.java test to make it even more resilient to timing?

Previously the test tried to create a stable initial condition by performing a full gc before that test step, but the problem is about when the first concurrent mark happens while building up the large set of humongous object kept alive: if it happens too early, and the concurrent undo operation takes too long, the next concurrent start will just be another undo because the large set of humongous objects will already be unreferenced and may as well cause a concurrent undo and not a concurrent mark.

The solution I came up with is that *after* creating all the humongous objects of the large set trigger an extra concurrent mark (and wait for its completion). That one (or some before) must have been a concurrent mark because at least at that point the heap must have been occupied by more than the IHOP value.

Testing: 2k iterations on failing platform (always aarch64-linux) without issues.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254623](https://bugs.openjdk.java.net/browse/JDK-8254623): gc/g1/TestHumongousConcurrentStartUndo.java still fails sometimes


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/632/head:pull/632`
`$ git checkout pull/632`
