### PR TITLE
8254696: safepointMechanism_aix needs adaptation for JDK-8253180

### DIFF
--- a/src/hotspot/os/aix/safepointMechanism_aix.cpp
+++ b/src/hotspot/os/aix/safepointMechanism_aix.cpp
@@ -37,6 +37,10 @@ void SafepointMechanism::pd_initialize() {
     return;
   }
 
+  // Poll bit values
+  _poll_word_armed_value    = poll_bit();
+  _poll_word_disarmed_value = ~_poll_word_armed_value;
+
   // Allocate one protected page
   char* map_address = (char*)MAP_FAILED;
   const size_t page_size = os::vm_page_size();
@@ -104,8 +108,8 @@ void SafepointMechanism::pd_initialize() {
   if (!os::guard_memory((char*)_polling_page, page_size)) {
     fatal("Could not protect polling page");
   }
-  intptr_t bad_page_val  = reinterpret_cast<intptr_t>(map_address),
-           good_page_val = bad_page_val + os::vm_page_size();
-  _poll_armed_value    = reinterpret_cast<void*>(bad_page_val  + poll_bit());
-  _poll_disarmed_value = reinterpret_cast<void*>(good_page_val);
+  uintptr_t bad_page_val  = reinterpret_cast<uintptr_t>(map_address),
+            good_page_val = bad_page_val + os::vm_page_size();
+  _poll_page_armed_value    = bad_page_val  + poll_bit();
+  _poll_page_disarmed_value = good_page_val;
 }


### PR DESCRIPTION
JDK-8253180 changed SafepointMechanism::default_initialize(). SafepointMechanism::pd_initialize() in safepointMechanism_aix.cpp needs the same changes in order to fix build and initialization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254696](https://bugs.openjdk.java.net/browse/JDK-8254696): safepointMechanism_aix needs adaptation for JDK-8253180


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/635/head:pull/635`
`$ git checkout pull/635`
