### PR TITLE
JDK-8212218: [TESTBUG] runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryErrorInMetaspace.java timed out	

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +67,19 @@ public class TestHeapDumpOnOutOfMemoryError {
     static void test(String type) throws Exception {
         String heapdumpFilename = type + ".hprof";
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+HeapDumpOnOutOfMemoryError",
-                "-XX:HeapDumpPath=" + heapdumpFilename, "-XX:MaxMetaspaceSize=64m",
+                "-XX:HeapDumpPath=" + heapdumpFilename,
+                // Note: When trying to provoke a metaspace OOM we may generate a lot of classes. In debug VMs this
+                //  can cause considerable wait times since:
+                // - Compiler Dependencies verification iterates the class tree
+                // - Before exit, the CLDG is checked.
+                // Both verifications show quadratic time or worse wrt to number of loaded classes. Therefore it
+                //  makes sense to switch one or both off and limit the metaspace size to something sensible.
+                // Example numbers on a slow ppc64 machine:
+                //  MaxMetaspaceSize=64M - ~60-70K classes - ~20min runtime with all verifications
+                //  MaxMetaspaceSize=16M - ~12-15K classes - ~12sec runtime with all verifications
+                //  MaxMetaspaceSize=16M - ~12-15K classes - VerifyDependencies off - ~3seconds on ppc
+                "-XX:MaxMetaspaceSize=16m",
+                "-XX:-VerifyDependencies",
                 TestHeapDumpOnOutOfMemoryError.class.getName(), type);
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi,

this is a very simple test fix.

TestHeapDumpOnOutOfMemoryErrorInMetaspace tests that Metaspace OOMs result in heap dumps if VM had been started with -XX:+HeapDumpOnOutOfMemoryError. 

The test fills Metaspace up to the limit (MaxMetaspaceSize) to provoke a Metaspace OOM. It sets MaxMetaspaceSize to 64m

64m gives us room for about ~62000 classes with the current VM. With JEP387, this becomes more like 68000 classes.

6x000 classes are a lot and if test runs on a debug VM they cause long verification times from compiler dependency checks as well as CLDG verification. Both verifications behave quadratic. On our slow ppc machines this often leads to timeouts (test takes about 22 minutes).

I lowered MaxMetaspaceSize to 16m which is fine for this test and reduces the number of loaded classes to ~12000 classes resp 15000 with JEP387. This eases verification costs a lot. 

I also switch off compiler dependency checks because a number of similar runtime tests do the same. 

I left it at that because that brings down test time on our ppc machine to ~30 seconds, which is fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8212218](https://bugs.openjdk.java.net/browse/JDK-8212218): [TESTBUG] runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryErrorInMetaspace.java timed out


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to f380e698d18cc2b30aaa63fe0455abe162e0cb1c
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer) ⚠️ Review applies to f380e698d18cc2b30aaa63fe0455abe162e0cb1c


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/637/head:pull/637`
`$ git checkout pull/637`
