### PR TITLE
8254012: NMT: MetaspaceSnapshot::snapshot uses wrong enum

### DIFF
--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -678,8 +678,8 @@ void MetaspaceSnapshot::snapshot(Metaspace::MetadataType type, MetaspaceSnapshot
 }
 
 void MetaspaceSnapshot::snapshot(MetaspaceSnapshot& mss) {
-  snapshot(Metaspace::ClassType, mss);
+  snapshot(Metaspace::NonClassType, mss);
   if (Metaspace::using_class_space()) {
-    snapshot(Metaspace::NonClassType, mss);
+    snapshot(Metaspace::ClassType, mss);
   }
 }


### PR DESCRIPTION
Please review this simple change.
Snapshot should be done first on NonClassType which will include ClassType allocation when Metaspace::using_class_space() is false.  _class_vsm (a VirtualSpaceManager) is set only for class type allocation when using_class_space is true. The correct order is do snapshot for NonClassType first, then for ClassType if using_class_space.

Tests: mach5 tier1-4 in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254012](https://bugs.openjdk.java.net/browse/JDK-8254012): NMT: MetaspaceSnapshot::snapshot uses wrong enum


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/645/head:pull/645`
`$ git checkout pull/645`
