### PR TITLE
8254722: bsd_zero builds broken after JDK-8253717

### DIFF
--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
@@ -172,13 +172,14 @@ JVM_handle_bsd_signal(int sig,
 
       // check if fault address is within thread stack
       if (thread->is_in_full_stack(addr)) {
+        StackOverflow* overflow_state = thread->stack_overflow_state();
         // stack overflow
-        if (thread->in_stack_yellow_reserved_zone(addr)) {
-          thread->disable_stack_yellow_reserved_zone();
+        if (overflow_state->in_stack_yellow_reserved_zone(addr)) {
+          overflow_state->disable_stack_yellow_reserved_zone();
           ShouldNotCallThis();
         }
-        else if (thread->in_stack_red_zone(addr)) {
-          thread->disable_stack_red_zone();
+        else if (overflow_state->in_stack_red_zone(addr)) {
+          overflow_state->disable_stack_red_zone();
           ShouldNotCallThis();
         }
       }


### PR DESCRIPTION
This bug was found while I'm working on JDK-8253970 [1].
JDK-8253717 updated linux_zero but forgot bsd_zero.

[1] https://github.com/openjdk/jdk/pull/496#issuecomment-708088798

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (9/9 running) |    |  ⏳ (7/9 running) |

### Issue
 * [JDK-8254722](https://bugs.openjdk.java.net/browse/JDK-8254722): bsd_zero builds broken after JDK-8253717


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/646/head:pull/646`
`$ git checkout pull/646`
