### PR TITLE
8231454: File lock in Windows on a loaded jar due to a leak in Introspector::getBeanInfo

### DIFF
--- a/src/java.desktop/share/classes/com/sun/beans/introspect/ClassInfo.java
+++ b/src/java.desktop/share/classes/com/sun/beans/introspect/ClassInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.beans.introspect;
 
-import com.sun.beans.util.Cache;
+package com.sun.beans.introspect;
 
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+
+import com.sun.beans.util.Cache;
 
 import static sun.reflect.misc.ReflectUtil.checkPackageAccess;
 
@@ -52,6 +53,14 @@ public final class ClassInfo {
         } catch (SecurityException exception) {
             return DEFAULT;
         }
+    }
+
+    public static void clear() {
+        CACHE.clear();
+    }
+
+    public static void remove(Class<?> clz) {
+        CACHE.remove(clz);
     }
 
     private final Object mutex = new Object();

--- a/src/java.desktop/share/classes/java/beans/Introspector.java
+++ b/src/java.desktop/share/classes/java/beans/Introspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -364,6 +364,7 @@ public class Introspector {
      */
     public static void flushCaches() {
         ThreadGroupContext.getContext().clearBeanInfoCache();
+        ClassInfo.clear();
     }
 
     /**
@@ -387,6 +388,7 @@ public class Introspector {
             throw new NullPointerException();
         }
         ThreadGroupContext.getContext().removeBeanInfo(clz);
+        ClassInfo.remove(clz);
     }
 
     //======================================================================

--- a/test/jdk/java/beans/Introspector/FlushClassInfoCache.java
+++ b/test/jdk/java/beans/Introspector/FlushClassInfoCache.java
@@ -30,7 +30,7 @@ import java.net.URLClassLoader;
 
 /**
  * @test
- * @bug 8207331
+ * @bug 8231454
  * @summary Tests cache cleanup by the Introspector.flushXXX()
  */
 public final class FlushClassInfoCache {

--- a/test/jdk/java/beans/Introspector/FlushClassInfoCache.java
+++ b/test/jdk/java/beans/Introspector/FlushClassInfoCache.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * @test
+ * @bug 8207331
+ * @summary Tests cache cleanup by the Introspector.flushXXX()
+ */
+public final class FlushClassInfoCache {
+
+    public static void main(String[] args) throws Exception {
+        verify(getLoader("testClass"));
+        verify(getLoader("testAll"));
+        Reference<ClassLoader> loader = getLoader("test");
+        // Clear the cache in com.sun.beans.introspect.ClassInfo::CACHE
+        Introspector.flushCaches();
+        verify(loader);
+    }
+
+    private static void verify(Reference<?> loader) throws Exception {
+        int attempt = 0;
+        while (loader.get() != null) {
+            if (++attempt > 10) {
+                throw new RuntimeException("Too many attempts: " + attempt);
+            }
+            // Cannot generate OOM here, it will clear the CACHE as well
+            System.gc();
+            Thread.sleep(1000);
+            System.out.println("Not freed :(");
+        }
+    }
+
+    public static void test() {
+        try {
+            Introspector.getBeanInfo(FlushClassInfoCache.class);
+        } catch (IntrospectionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void testClass() {
+        try {
+            Introspector.getBeanInfo(FlushClassInfoCache.class);
+            // Clear the cache in com.sun.beans.introspect.ClassInfo::CACHE
+            Introspector.flushFromCaches(FlushClassInfoCache.class);
+        } catch (IntrospectionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void testAll() {
+        try {
+            Introspector.getBeanInfo(FlushClassInfoCache.class);
+            // Clear the cache in com.sun.beans.introspect.ClassInfo::CACHE
+            Introspector.flushCaches();
+        } catch (IntrospectionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Reference<ClassLoader> getLoader(String m) throws Exception {
+        URL url = FlushClassInfoCache.class.getProtectionDomain()
+                                     .getCodeSource().getLocation();
+        URLClassLoader loader = new URLClassLoader(new URL[]{url}, null);
+        Class<?> cls = Class.forName("FlushClassInfoCache", true, loader);
+        cls.getDeclaredMethod(m).invoke(null);
+        loader.close();
+        return new WeakReference<>(loader);
+    }
+}


### PR DESCRIPTION
java.beans.Introspector is using a new cache mechanism since Java9 in com.sun.beans.introspect.ClassInfo::CACHE which uses a SoftReference cache over the class, which makes the class "leak", unless clearing the cache manually or collecting the SoftReference by the GC.

Note that this is not a pure "leak", because the SoftReference will be collected if there is no enough memory on the system, but if the heap is big enough then all objects referenced from the cached class will be in the memory.

The class has a reference to the ClassLoader, and If the soft reference to the class is not collected by the GC, then the ClassLoader cannot be unloaded and this block the jar file removing.

The solution is to update the implementation of Introspector.flushCaches()/flushFromCaches(Class) to clear the whole cache or the cache for the specific class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8231454](https://bugs.openjdk.java.net/browse/JDK-8231454): File lock in Windows on a loaded jar due to a leak in Introspector::getBeanInfo


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/647/head:pull/647`
`$ git checkout pull/647`
