### PR TITLE
8254695: G1: Next mark bitmap clear not cancelled after marking abort

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -594,15 +594,19 @@ private:
       HeapWord* const end = r->end();
 
       while (cur < end) {
+        // Abort iteration if necessary.
+        if (_cm != NULL) {
+          _cm->do_yield_check();
+          if (_cm->has_aborted()) {
+            return true;
+          }
+        }
+
         MemRegion mr(cur, MIN2(cur + chunk_size_in_words, end));
         _bitmap->clear_range(mr);
 
         cur += chunk_size_in_words;
 
-        // Abort iteration if after yielding the marking has been aborted.
-        if (_cm != NULL && _cm->do_yield_check() && _cm->has_aborted()) {
-          return true;
-        }
         // Repeat the asserts from before the start of the closure. We will do them
         // as asserts here to minimize their overhead on the product. However, we
         // will have them as guarantees at the beginning / end of the bitmap


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes aborting the concurrent next bitmap clear if aborted?

The problems are that we can enter the clear loop with the marking already aborted, so
- yielding does not return true any more (marking aborted while joining the STS)  and we never abort in the loop if we join all conditions together
- and G1 at least clears the first part(s) of the bitmap as the check is done afterwards

Testing: tier1-5; no more reproducable crashes with other changes (JDK-8253600)

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254695](https://bugs.openjdk.java.net/browse/JDK-8254695): G1: Next mark bitmap clear not cancelled after marking abort


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Author)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/653/head:pull/653`
`$ git checkout pull/653`
