### PR TITLE
8254761: Wrong intrinsic annotation used for StringLatin1.indexOfChar

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -71,7 +71,6 @@
 #include "opto/node.hpp"
 #endif
 
-#ifndef PRODUCT
 // Helper class for printing in CodeCache
 class CodeBlob_sizes {
  private:
@@ -137,7 +136,6 @@ class CodeBlob_sizes {
     }
   }
 };
-#endif
 
 // Iterate over all CodeHeaps
 #define FOR_ALL_HEAPS(heap) for (GrowableArrayIterator<CodeHeap*> heap = _heaps->begin(); heap != _heaps->end(); ++heap)

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -213,7 +213,7 @@ final class StringLatin1 {
         return indexOfChar(value, ch, fromIndex, max);
     }
 
-    @HotSpotIntrinsicCandidate
+    @IntrinsicCandidate
     private static int indexOfChar(byte[] value, int ch, int fromIndex, int max) {
         byte c = (byte)ch;
         for (int i = fromIndex; i < max; i++) {


### PR DESCRIPTION
Wrong intrinsic name used, causing a build breakage