### PR TITLE
8254769: Remove unimplemented BCEscapeAnalyzer::{add_dependence, propagate_dependencies}

### DIFF
--- a/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
@@ -88,8 +88,6 @@ class BCEscapeAnalyzer : public ResourceObj {
   void set_modified(ArgumentMap vars, int offs, int size);
 
   bool is_recursive_call(ciMethod* callee);
-  void add_dependence(ciKlass *klass, ciMethod *meth);
-  void propagate_dependencies(ciMethod *meth);
   void invoke(StateInfo &state, Bytecodes::Code code, ciMethod* target, ciKlass* holder);
 
   void iterate_one_block(ciBlock *blk, StateInfo &state, GrowableArray<ciBlock *> &successors);


### PR DESCRIPTION
These methods are not implemented, and there were no definitions since the initial load. Can be removed.

Testing:
 - [x] Linux x86_64 build
 - [x] Text searches for `add_dependence` and `propagate_dependencies` in `src/hotspot`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254769](https://bugs.openjdk.java.net/browse/JDK-8254769): Remove unimplemented BCEscapeAnalyzer::{add_dependence, propagate_dependencies}


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/656/head:pull/656`
`$ git checkout pull/656`
