### PR TITLE
8254771: Remove unimplemented ciSignature::get_all_klasses

### DIFF
--- a/src/hotspot/share/ci/ciSignature.hpp
+++ b/src/hotspot/share/ci/ciSignature.hpp
@@ -50,8 +50,6 @@ private:
   ciSignature(ciKlass* accessing_klass, const constantPoolHandle& cpool, ciSymbol* signature);
   ciSignature(ciKlass* accessing_klass,                           ciSymbol* signature, ciMethodType* method_type);
 
-  void get_all_klasses();
-
   Symbol* get_symbol() const                     { return _symbol->get_symbol(); }
 
 public:


### PR DESCRIPTION
This method is not implemented, and there was no definition since the initial load. Can be removed.

Testing:
  - [x] Linux x86_64 build
  - [x] Text search for `get_all_klasses` in `src/hotspot`; there is `JdkJfrEvent::get_all_klasses` that looks unrelated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254771](https://bugs.openjdk.java.net/browse/JDK-8254771): Remove unimplemented ciSignature::get_all_klasses


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/657/head:pull/657`
`$ git checkout pull/657`
