### PR TITLE
8254773: Remove unimplemented ciReplay::is_loaded(Klass* klass)

### DIFF
--- a/src/hotspot/share/ci/ciReplay.hpp
+++ b/src/hotspot/share/ci/ciReplay.hpp
@@ -116,7 +116,6 @@ class ciReplay {
   static void initialize(ciMethod* method);
 
   static bool is_loaded(Method* method);
-  static bool is_loaded(Klass* klass);
 
   static bool should_not_inline(ciMethod* method);
   static bool should_inline(void* data, ciMethod* method, int bci, int inline_depth);


### PR DESCRIPTION
Both overloads for Klass* and Method* were added by JDK-6830717. But Klass* overload was never implemented:
http://hg.openjdk.java.net/hsx/hsx25/hotspot/rev/bd7a7ce2e264#l32.934

Testing:
 - [x] Linux x86_64 build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254773](https://bugs.openjdk.java.net/browse/JDK-8254773): Remove unimplemented ciReplay::is_loaded(Klass* klass)


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/658/head:pull/658`
`$ git checkout pull/658`
