### PR TITLE
8254776: Remove unimplemented LowMemoryDetector::check_memory_usage

### DIFF
--- a/src/hotspot/share/services/lowMemoryDetector.hpp
+++ b/src/hotspot/share/services/lowMemoryDetector.hpp
@@ -220,7 +220,6 @@ private:
   // > 0 if temporary disabed
   static volatile jint _disabled_count;
 
-  static void check_memory_usage();
   static bool has_pending_requests();
   static bool temporary_disabled() { return _disabled_count > 0; }
   static void disable() { Atomic::inc(&_disabled_count); }


### PR DESCRIPTION
`LowMemoryDetector::check_memory_usage` seems declared but not implemented. Current history does not show any definitions since the initial load. Can be removed.

Testing:
 - [x] Linux x86_64 build
 - [x] Test search for `check_memory_usage` in `src/hotspot`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ❌ (1/2 failed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |    | 

**Failed test task**
- [macOS x64 (build release)](https://github.com/shipilev/jdk/runs/1273499651)

### Issue
 * [JDK-8254776](https://bugs.openjdk.java.net/browse/JDK-8254776): Remove unimplemented LowMemoryDetector::check_memory_usage


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/659/head:pull/659`
`$ git checkout pull/659`
