### PR TITLE
8254777: Remove unimplemented Management::get_loaded_classes

### DIFF
--- a/src/hotspot/share/services/management.hpp
+++ b/src/hotspot/share/services/management.hpp
@@ -66,8 +66,6 @@ public:
   static void* get_jmm_interface(int version);
   static void  get_optional_support(jmmOptionalSupport* support);
 
-  static void get_loaded_classes(JavaThread* cur_thread, GrowableArray<Klass*>* klass_array);
-
   static void  record_vm_startup_time(jlong begin, jlong duration)
       NOT_MANAGEMENT_RETURN;
   static void  record_vm_init_completed() {


### PR DESCRIPTION
There seems to be no definition of `Management::get_loaded_classes` anywhere in current tip or history prior the initial load. Can be removed.

Testing:
 - [x] Linux x86_64 build
 - [x] Text search for `get_loaded_classes` in `src/hotspot`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254777](https://bugs.openjdk.java.net/browse/JDK-8254777): Remove unimplemented Management::get_loaded_classes


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/660/head:pull/660`
`$ git checkout pull/660`
