### PR TITLE
8254775: Microbenchmark StringIndexOfChar doesn't compile

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/StringIndexOfChar.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringIndexOfChar.java
@@ -68,7 +68,7 @@ public class IndexOfBenchmark {
     private static String makeRndString(boolean isUtf16, int length) {
         StringBuilder sb = new StringBuilder(length);
         if(length > 0){
-            sb.append(isUtf16?'☺':'b');
+            sb.append(isUtf16?'\u2026':'b'); // ...
 
             for (int i = 1; i < length-1; i++) {
                 sb.append((char)('b' + rng.nextInt(26)));

--- a/test/micro/org/openjdk/bench/java/lang/StringIndexOfChar.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringIndexOfChar.java
@@ -81,7 +81,7 @@ public class StringIndexOfChar {
 
 
     @Benchmark
-    public static void latin1_mixed_char() {
+    public void latin1_mixed_char() {
         int ret = 0;
         for (String what : latn1_mixedLength) {
             ret += what.indexOf('a');
@@ -89,7 +89,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static void utf16_mixed_char() {
+    public void utf16_mixed_char() {
         int ret = 0;
         for (String what : utf16_mixedLength) {
             ret += what.indexOf('a');
@@ -97,7 +97,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static void latin1_mixed_String() {
+    public void latin1_mixed_String() {
         int ret = 0;
         for (String what : latn1_mixedLength) {
             ret += what.indexOf("a");
@@ -105,7 +105,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static void utf16_mixed_String() {
+    public void utf16_mixed_String() {
         int ret = 0;
         for (String what : utf16_mixedLength) {
             ret += what.indexOf("a");
@@ -115,7 +115,7 @@ public class StringIndexOfChar {
     ////////// more detailed code path dependent tests //////////
 
     @Benchmark
-    public static void latin1_Short_char() {
+    public void latin1_Short_char() {
         int ret = 0;
         for (String what : latn1_short) {
             ret += what.indexOf('a');
@@ -123,7 +123,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static void latin1_SSE4_char() {
+    public void latin1_SSE4_char() {
         int ret = 0;
         for (String what : latn1_sse4) {
             ret += what.indexOf('a');
@@ -131,7 +131,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static void latin1_AVX2_char() {
+    public void latin1_AVX2_char() {
         int ret = 0;
         for (String what : latn1_avx2) {
             ret += what.indexOf('a');
@@ -139,7 +139,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static int utf16_Short_char() {
+    public int utf16_Short_char() {
         int ret = 0;
         for (String what : utf16_short) {
             ret += what.indexOf('a');
@@ -148,7 +148,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static int utf16_SSE4_char() {
+    public int utf16_SSE4_char() {
         int ret = 0;
         for (String what : utf16_sse4) {
             ret += what.indexOf('a');
@@ -157,7 +157,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static int utf16_AVX2_char() {
+    public int utf16_AVX2_char() {
         int ret = 0;
         for (String what : utf16_avx2) {
             ret += what.indexOf('a');
@@ -166,7 +166,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static int latin1_Short_String() {
+    public int latin1_Short_String() {
         int ret = 0;
         for (String what : latn1_short) {
             ret += what.indexOf("a");
@@ -175,7 +175,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static int latin1_SSE4_String() {
+    public int latin1_SSE4_String() {
         int ret = 0;
         for (String what : latn1_sse4) {
             ret += what.indexOf("a");
@@ -184,7 +184,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static int latin1_AVX2_String() {
+    public int latin1_AVX2_String() {
         int ret = 0;
         for (String what : latn1_avx2) {
             ret += what.indexOf("a");
@@ -193,7 +193,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static int utf16_Short_String() {
+    public int utf16_Short_String() {
         int ret = 0;
         for (String what : utf16_short) {
             ret += what.indexOf("a");
@@ -202,7 +202,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static int utf16_SSE4_String() {
+    public int utf16_SSE4_String() {
         int ret = 0;
         for (String what : utf16_sse4) {
             ret += what.indexOf("a");
@@ -211,7 +211,7 @@ public class StringIndexOfChar {
     }
 
     @Benchmark
-    public static int utf16_AVX2_String() {
+    public int utf16_AVX2_String() {
         int ret = 0;
         for (String what : utf16_avx2) {
             ret += what.indexOf("a");

--- a/test/micro/org/openjdk/bench/java/lang/StringIndexOfChar.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringIndexOfChar.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
-public class IndexOfBenchmark {
+public class StringIndexOfChar {
     private static final int loops = 100000;
     private static final Random rng = new Random(1999);
     private static final int pathCnt = 1000;


### PR DESCRIPTION
- Illegal use of a unicode codepoint > \uFFFF as a char.
- Wrong class name.
- @Benchmark methods shouldn't be static.

Each of these breaks the build, e.g. make build-microbenchmark fails, so it seems the micro was never tested..?

This patch fixes up the micro so it compiles, but makes no guarantees the micro does anything useful.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254775](https://bugs.openjdk.java.net/browse/JDK-8254775): Microbenchmark StringIndexOfChar doesn't compile


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/661/head:pull/661`
`$ git checkout pull/661`
