### PR TITLE
8254780: EnterInterpOnlyModeClosure::completed() always returns true

### DIFF
--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -224,7 +224,7 @@ class EnterInterpOnlyModeClosure : public HandshakeClosure {
     _completed = true;
   }
   bool completed() {
-    return _completed = true;
+    return _completed;
   }
 };
 


### PR DESCRIPTION
JDK-8238761 introduced this funky code:

```
class EnterInterpOnlyModeClosure : public HandshakeClosure {
 private:
  bool _completed;
 public:
  EnterInterpOnlyModeClosure() : HandshakeClosure("EnterInterpOnlyMode"), _completed(false) { }
  void do_thread(Thread* th) {
     ...
     _completed = true;
  }
  bool completed() {
    return _completed = true;
  }
};
```

It seems the flag is there to communicate that target thread indeed executed the handshake. But `completed()` sets the bool unconditionally and always returns true. And it is used in one and only place here:

```
     guarantee(hs.completed(), "Handshake failed: Target thread is not alive?");
```

...which means that guarantee always passes.

Attention @robehn :)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254780](https://bugs.openjdk.java.net/browse/JDK-8254780): EnterInterpOnlyModeClosure::completed() always returns true


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/662/head:pull/662`
`$ git checkout pull/662`
