### PR TITLE
8254781: Remove unimplemented ClassFieldMap::compute_field_count

### DIFF
--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -804,9 +804,6 @@ class ClassFieldMap: public CHeapObj<mtInternal> {
   // add a field
   void add(int index, char type, int offset);
 
-  // returns the field count for the given class
-  static int compute_field_count(InstanceKlass* ik);
-
  public:
   ~ClassFieldMap();
 


### PR DESCRIPTION
There is no definition of `ClassFieldMap::compute_field_count` in current tip or any history after the initial load. Can be removed.

Testing:
 - [x] Linux x86_64 build
 - [x] Text searches for `compute_field_count` in `src/hotspot`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254781](https://bugs.openjdk.java.net/browse/JDK-8254781): Remove unimplemented ClassFieldMap::compute_field_count


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/663/head:pull/663`
`$ git checkout pull/663`
