### PR TITLE
8254369: Node::disconnect_inputs may skip precedences

### DIFF
--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -895,6 +895,14 @@ int Node::replace_edges_in_range(Node* old, Node* neww, int start, int end) {
 //-------------------------disconnect_inputs-----------------------------------
 // NULL out all inputs to eliminate incoming Def-Use edges.
 void Node::disconnect_inputs(Compile* C) {
+  // the layout of Node::_in
+  // r: a required input, null is allowed
+  // p: a precedence, null values are all at the end
+  // -----------------------------------
+  // |r|...|r|p|...|p|null|...|null|
+  //         |                     |
+  //         req()                 len()
+  // -----------------------------------
   for (uint i = 0; i < req(); ++i) {
     if (in(i) != nullptr) {
       set_req(i, nullptr);
@@ -903,9 +911,16 @@ void Node::disconnect_inputs(Compile* C) {
 
   // Remove precedence edges if any exist
   // Note: Safepoints may have precedence edges, even during parsing
-  for (uint i = req(); i < len(); ++i) {
-    set_prec(i, nullptr);
+  for (uint i = len() - 1; i < len() && i >= req(); --i) {
+    rm_prec(i);                // no-op if _in[i] is nullptr
   }
+
+#ifndef PRODUCT
+  // sanity check
+  for (uint i = 0; i < len(); ++i) {
+    assert(_in[i] == nullptr, "disconnect_inputs() failed!");
+  }
+#endif
 
   // Node::destruct requires all out edges be deleted first
   // debug_only(destruct();)   // no reuse benefit expected

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -915,7 +915,7 @@ void Node::disconnect_inputs(Compile* C) {
     rm_prec(i);                // no-op if _in[i] is nullptr
   }
 
-#ifndef PRODUCT
+#ifdef ASSERT
   // sanity check
   for (uint i = 0; i < len(); ++i) {
     assert(_in[i] == nullptr, "disconnect_inputs() failed!");

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -911,8 +911,8 @@ void Node::disconnect_inputs(Compile* C) {
 
   // Remove precedence edges if any exist
   // Note: Safepoints may have precedence edges, even during parsing
-  for (uint i = len() - 1; i < len() && i >= req(); --i) {
-    rm_prec(i);                // no-op if _in[i] is nullptr
+  for (uint i = len(); i > req(); ) {
+    rm_prec(--i);  // no-op if _in[i] is nullptr
   }
 
 #ifdef ASSERT

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -538,7 +538,7 @@ public:
     }
     if (_in[i] != NULL) _in[i]->del_out((Node *)this);
     _in[i] = n;
-    if (n != NULL) n->add_out((Node *)this);
+    n->add_out((Node *)this);
   }
 
   // Set this node's index, used by cisc_version to replace current node


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254369](https://bugs.openjdk.java.net/browse/JDK-8254369): Node::disconnect_inputs may skip precedences


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/664/head:pull/664`
`$ git checkout pull/664`
