### PR TITLE
8254788: Dead code in the sun.java2d.xr.XRPMBlitLoops$XrSwToPMBlit

### DIFF
--- a/src/java.desktop/unix/classes/sun/java2d/xr/XRPMBlitLoops.java
+++ b/src/java.desktop/unix/classes/sun/java2d/xr/XRPMBlitLoops.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,12 +34,12 @@ import java.awt.*;
 import java.awt.geom.*;
 import java.lang.ref.*;
 
-public class XRPMBlitLoops {
+public final class XRPMBlitLoops {
 
     static WeakReference<SunVolatileImage> argbTmpPM = new WeakReference<SunVolatileImage>(null);
     static WeakReference<SunVolatileImage> rgbTmpPM = new WeakReference<SunVolatileImage>(null);
 
-    public XRPMBlitLoops() {
+    private XRPMBlitLoops() {
     }
 
     public static void register() {
@@ -355,19 +355,13 @@ class XrSwToPMBlit extends Blit {
     }
 
     public void Blit(SurfaceData src, SurfaceData dst, Composite comp, Region clip, int sx, int sy, int dx, int dy, int w, int h) {
-        // If the blit is write-only (putimge), no need for a temporary VI.
-        if (CompositeType.SrcOverNoEa.equals(comp) && (src.getTransparency() == Transparency.OPAQUE)) {
-            Blit opaqueSwToSurfaceBlit = Blit.getFromCache(src.getSurfaceType(), CompositeType.SrcNoEa, dst.getSurfaceType());
-            opaqueSwToSurfaceBlit.Blit(src, dst, comp, clip, sx, sy, dx, dy, w, h);
-        } else {
-            try {
-                SunToolkit.awtLock();
+        try {
+            SunToolkit.awtLock();
 
-                XRSurfaceData vImgSurface = XRPMBlitLoops.cacheToTmpSurface(src, (XRSurfaceData) dst, w, h, sx, sy);
-                pmToSurfaceBlit.Blit(vImgSurface, dst, comp, clip, 0, 0, dx, dy, w, h);
-            } finally {
-                SunToolkit.awtUnlock();
-            }
+            XRSurfaceData vImgSurface = XRPMBlitLoops.cacheToTmpSurface(src, (XRSurfaceData) dst, w, h, sx, sy);
+            pmToSurfaceBlit.Blit(vImgSurface, dst, comp, clip, 0, 0, dx, dy, w, h);
+        } finally {
+            SunToolkit.awtUnlock();
         }
     }
 }


### PR DESCRIPTION
The XrSwToPMBlit is a blit which is used as a direct(unscaled) blit of the image in the memory to the pixmap. It tries to optimize the SrcOver composite in case of an opaque source image and use Src instead:

        if (CompositeType.SrcOverNoEa.equals(comp) && (src.getTransparency() == Transparency.OPAQUE)) {
            Blit opaqueSwToSurfaceBlit = Blit.getFromCache(src.getSurfaceType(), CompositeType.SrcNoEa, dst.getSurfaceType());
            opaqueSwToSurfaceBlit.Blit(src, dst, comp, clip, sx, sy, dx, dy, w, h);
        } else {

The code above does not work for two reasons:
- The check "CompositeType.SrcOverNoEa.equals(comp)" always fails because the comp is of type Composite(AlphaComposite/XORComposite/etc) not a CompositeType
 - This optimisation is applied already in the sun.java2d.pipe.DrawImage#blitSurfaceData:
https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/sun/java2d/pipe/DrawImage.java#L933

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254788](https://bugs.openjdk.java.net/browse/JDK-8254788): Dead code in the sun.java2d.xr.XRPMBlitLoops$XrSwToPMBlit


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/665/head:pull/665`
`$ git checkout pull/665`
