### PR TITLE
8254793: [JVMCI] improve speculation encoding

### DIFF
--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -52,17 +52,10 @@ class JVMCINMethodData {
   // is appended when it causes a deoptimization.
   FailedSpeculation** _failed_speculations;
 
-  // A speculation id is an index (high 26 bits) and a length (low 5 bits).
-  // Keep in sync with HotSpotSpeculationLog.HotSpotSpeculation.
-  // Since the offset of Thread::_pending_failed_speculation is exposed via VMStructs
-  // but its type is not, JVMCI Java code assumes that it's a long. So even
-  // though it could be encoded in an int, doing this would be a breaking JVMCI
-  // API change. It's sufficient to ensure that only 31-bit encoded values (i.e. signed
-  // ints) are produced by JVMCI. This allows JVMCI compilers to emit an efficient
-  // instruction sequence to store a value to Thread::_pending_failed_speculation
-  // (e.g., on x86 a MOVESLQ can write a 32 bit value sign extended to a long
-  // into a long memory location).
+  // A speculation id is a length (low 5 bits) and an index into
+  // a jbyte array (i.e. 31 bits for a positive Java int).
   enum {
+    // Keep in sync with HotSpotSpeculationEncoding.
     SPECULATION_LENGTH_BITS = 5,
     SPECULATION_LENGTH_MASK = (1 << SPECULATION_LENGTH_BITS) - 1
   };

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -391,6 +391,7 @@
   declare_constant(HeapWordSize)                                          \
   declare_constant(InvocationEntryBci)                                    \
   declare_constant(LogKlassAlignmentInBytes)                              \
+  declare_constant(JVMCINMethodData::SPECULATION_LENGTH_BITS)             \
                                                                           \
   declare_constant(JVM_ACC_WRITTEN_FLAGS)                                 \
   declare_constant(JVM_ACC_MONITOR_MATCH)                                 \

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1166,7 +1166,8 @@ class JavaThread: public Thread {
   bool      _in_retryable_allocation;
 
   // An id of a speculation that JVMCI compiled code can use to further describe and
-  // uniquely identify the  speculative optimization guarded by the uncommon trap
+  // uniquely identify the speculative optimization guarded by an uncommon trap.
+  // See JVMCINMethodData::SPECULATION_LENGTH_BITS for further details.
   jlong     _pending_failed_speculation;
 
   // These fields are mutually exclusive in terms of live ranges.

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaFieldImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaFieldImpl.java
@@ -167,9 +167,9 @@ class HotSpotResolvedJavaFieldImpl implements HotSpotResolvedJavaField {
     }
 
     /**
-     * Checks if this field has the {@link Stable} annotation.
+     * Checks if this field has the {@code Stable} annotation.
      *
-     * @return true if field has {@link Stable} annotation, false otherwise
+     * @return true if field has {@code Stable} annotation, false otherwise
      */
     @Override
     public boolean isStable() {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotSpeculationEncoding.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotSpeculationEncoding.java
@@ -175,7 +175,7 @@ final class HotSpotSpeculationEncoding extends ByteArrayOutputStream implements 
      * time.
      */
     private static final boolean SHA1_IS_CLONEABLE;
-    private static final int SHA1_LENGTH;
+    private static final int SHA1_LENGTH = 20;
 
     static {
         MessageDigest sha1 = null;
@@ -186,13 +186,14 @@ final class HotSpotSpeculationEncoding extends ByteArrayOutputStream implements 
             sha1IsCloneable = true;
         } catch (NoSuchAlgorithmException e) {
             // Should never happen given that SHA-1 is mandated in a
-            // compliant Java platform implementation. However, be
-            // conservative and fall back to not using a digest.
+            // compliant Java platform implementation.
+            throw new JVMCIError(e);
         } catch (CloneNotSupportedException e) {
         }
         SHA1 = sha1;
         SHA1_IS_CLONEABLE = sha1IsCloneable;
-        SHA1_LENGTH = SHA1 == null ? 20 : SHA1.getDigestLength();
+        assert SHA1.getDigestLength() == SHA1_LENGTH;
+        assert SHA1_LENGTH < MAX_LENGTH;
     }
 
     /**
@@ -201,7 +202,7 @@ final class HotSpotSpeculationEncoding extends ByteArrayOutputStream implements 
      */
     byte[] getByteArray() {
         if (result == null) {
-            if (SHA1 != null && count > SHA1_LENGTH) {
+            if (count > MAX_LENGTH) {
                 try {
                     MessageDigest md = SHA1_IS_CLONEABLE ? (MessageDigest) SHA1.clone() : MessageDigest.getInstance("SHA-1");
                     md.update(buf, 0, count);

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java
@@ -119,19 +119,10 @@ public class HotSpotSpeculationLog implements SpeculationLog {
 
     public static final class HotSpotSpeculation extends Speculation {
 
-        // Also defined in JVMCINMethodData C++ class - keep in sync
-        static final int LENGTH_BITS = 5;
-        static final int INDEX_BITS = 31 - LENGTH_BITS;
-
-        static final int MAX_LENGTH = (1 << LENGTH_BITS) - 1;
-        static final int MAX_INDEX = (1 << INDEX_BITS) - 1;
-
-        static final int LENGTH_MASK = MAX_LENGTH;
-
         /**
-         * A speculation id is a long encoding a length (low 5 bits) and an index (next 26 bits).
-         * Combined, the index and length denote where the {@linkplain #encoding encoded
-         * speculation} is in a {@linkplain HotSpotSpeculationLog#getFlattenedSpeculations
+         * A speculation id is a long encoding a length (low 5 bits) and an index into a
+         * {@code byte[]}. Combined, the index and length denote where the {@linkplain #encoding
+         * encoded speculation} is in a {@linkplain HotSpotSpeculationLog#getFlattenedSpeculations
          * flattened} speculations array.
          */
         private final JavaConstant id;
@@ -243,21 +234,21 @@ public class HotSpotSpeculationLog implements SpeculationLog {
     }
 
     private static long encodeIndexAndLength(int index, int length) {
-        if (length > HotSpotSpeculation.MAX_LENGTH || length < 0) {
+        if (length > HotSpotSpeculationEncoding.MAX_LENGTH || length < 0) {
             throw new InternalError(String.format("Invalid encoded speculation length: %d (0x%x)", length, length));
         }
-        if (index > HotSpotSpeculation.MAX_INDEX || index < 0) {
-            throw new JVMCIError("Encoded speculation index is negative or too big: %d (0x%x)", index, index);
+        if (index < 0) {
+            throw new JVMCIError("Encoded speculation index is negative: %d (0x%x)", index, index);
         }
-        return (index << HotSpotSpeculation.LENGTH_BITS) | length;
+        return (index << HotSpotSpeculationEncoding.LENGTH_BITS) | length;
     }
 
     private static int decodeIndex(long indexAndLength) {
-        return (int) (indexAndLength >>> HotSpotSpeculation.LENGTH_BITS);
+        return (int) (indexAndLength >>> HotSpotSpeculationEncoding.LENGTH_BITS);
     }
 
     private static int decodeLength(long indexAndLength) {
-        return (int) (indexAndLength & HotSpotSpeculation.LENGTH_MASK);
+        return (int) (indexAndLength & HotSpotSpeculationEncoding.LENGTH_MASK);
     }
 
     @Override

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
@@ -26,7 +26,6 @@ import static jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.runtime;
 import static jdk.vm.ci.hotspot.UnsafeAccess.UNSAFE;
 
 import jdk.vm.ci.common.JVMCIError;
-import jdk.vm.ci.hotspot.HotSpotSpeculationLog.HotSpotSpeculation;
 import jdk.vm.ci.services.Services;
 import jdk.internal.misc.Unsafe;
 
@@ -50,7 +49,7 @@ class HotSpotVMConfig extends HotSpotVMConfigAccess {
         super(store);
 
         int speculationLengthBits = getConstant("JVMCINMethodData::SPECULATION_LENGTH_BITS", Integer.class);
-        JVMCIError.guarantee(HotSpotSpeculation.LENGTH_BITS == speculationLengthBits, "%d != %d", HotSpotSpeculation.LENGTH_BITS, speculationLengthBits);
+        JVMCIError.guarantee(HotSpotSpeculationEncoding.LENGTH_BITS == speculationLengthBits, "%d != %d", HotSpotSpeculationEncoding.LENGTH_BITS, speculationLengthBits);
     }
 
     /**

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
@@ -25,6 +25,8 @@ package jdk.vm.ci.hotspot;
 import static jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.runtime;
 import static jdk.vm.ci.hotspot.UnsafeAccess.UNSAFE;
 
+import jdk.vm.ci.common.JVMCIError;
+import jdk.vm.ci.hotspot.HotSpotSpeculationLog.HotSpotSpeculation;
 import jdk.vm.ci.services.Services;
 import jdk.internal.misc.Unsafe;
 
@@ -46,6 +48,9 @@ class HotSpotVMConfig extends HotSpotVMConfigAccess {
 
     HotSpotVMConfig(HotSpotVMConfigStore store) {
         super(store);
+
+        int speculationLengthBits = getConstant("JVMCINMethodData::SPECULATION_LENGTH_BITS", Integer.class);
+        JVMCIError.guarantee(HotSpotSpeculation.LENGTH_BITS == speculationLengthBits, "%d != %d", HotSpotSpeculation.LENGTH_BITS, speculationLengthBits);
     }
 
     /**


### PR DESCRIPTION
This PR changes the encoding of a `jdk.vm.ci.hotspot.HotSpotSpeculationLog.HotSpotSpeculation` from a long to an int. The `Thread::_pending_failed_speculation` field remains as a `jlong` since it is already exposed to JVMCI Java code already via VMStructs and this PR does not update its usage in Graal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254793](https://bugs.openjdk.java.net/browse/JDK-8254793): [JVMCI] improve speculation encoding


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to b0d93bdc8bbfa7edb18b4320f9cfdba8119bee2a
 * [Tom Rodriguez](https://openjdk.java.net/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to b0d93bdc8bbfa7edb18b4320f9cfdba8119bee2a


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/667/head:pull/667`
`$ git checkout pull/667`
