### PR TITLE
8254192: ExtraSharedClassListFile contains extra white space at end of line

### DIFF
--- a/src/hotspot/share/classfile/classListParser.cpp
+++ b/src/hotspot/share/classfile/classListParser.cpp
@@ -91,7 +91,7 @@ bool ClassListParser::parse_one_line() {
     {
       int len = (int)strlen(_line);
       int i;
-      // Replace \t\r\n with ' '
+      // Replace \t\r\n\f with ' '
       for (i=0; i<len; i++) {
         if (_line[i] == '\t' || _line[i] == '\r' || _line[i] == '\n' || _line[i] == '\f') {
           _line[i] = ' ';

--- a/src/hotspot/share/classfile/classListParser.cpp
+++ b/src/hotspot/share/classfile/classListParser.cpp
@@ -87,43 +87,46 @@ bool ClassListParser::parse_one_line() {
     if (*_line == '#') { // comment
       continue;
     }
-    // The line is output TRACE_RESOLVE
+
+    {
+      int len = (int)strlen(_line);
+      int i;
+      // Replace \t\r\n with ' '
+      for (i=0; i<len; i++) {
+        if (_line[i] == '\t' || _line[i] == '\r' || _line[i] == '\n' || _line[i] == '\f') {
+          _line[i] = ' ';
+        }
+      }
+
+      // Remove trailing newline/space
+      while (len > 0) {
+        if (_line[len-1] == ' ') {
+          _line[len-1] = '\0';
+          len --;
+        } else {
+          break;
+        }
+      }
+      _line_len = len;
+    }
+
+    // Check if the line is output TRACE_RESOLVE
     if (strncmp(_line, LambdaFormInvokers::lambda_form_invoker_tag(),
                 strlen(LambdaFormInvokers::lambda_form_invoker_tag())) == 0) {
       LambdaFormInvokers::append(os::strdup((const char*)_line, mtInternal));
       continue;
     }
+
+    // valid line
     break;
   }
 
+  _class_name = _line;
   _id = _unspecified;
   _super = _unspecified;
   _interfaces->clear();
   _source = NULL;
   _interfaces_specified = false;
-
-  {
-    int len = (int)strlen(_line);
-    int i;
-    // Replace \t\r\n with ' '
-    for (i=0; i<len; i++) {
-      if (_line[i] == '\t' || _line[i] == '\r' || _line[i] == '\n') {
-        _line[i] = ' ';
-      }
-    }
-
-    // Remove trailing newline/space
-    while (len > 0) {
-      if (_line[len-1] == ' ') {
-        _line[len-1] = '\0';
-        len --;
-      } else {
-        break;
-      }
-    }
-    _line_len = len;
-    _class_name = _line;
-  }
 
   if ((_token = strchr(_line, ' ')) == NULL) {
     // No optional arguments are specified.

--- a/src/java.base/share/classes/jdk/internal/misc/CDS.java
+++ b/src/java.base/share/classes/jdk/internal/misc/CDS.java
@@ -141,14 +141,12 @@ public class CDS {
     // Throw exception on invalid input
     private static void validateInputLines(String[] lines) {
         for (String s: lines) {
-            // There might be a trailing '\f' for line in ExtraClassListFile, do trim first.
-            String line = s.trim();
-            if (!line.startsWith("[LF_RESOLVE]") && !line.startsWith("[SPECIES_RESOLVE]")) {
-                throw new IllegalArgumentException("Wrong prefix: " + line);
+            if (!s.startsWith("[LF_RESOLVE]") && !s.startsWith("[SPECIES_RESOLVE]")) {
+                throw new IllegalArgumentException("Wrong prefix: " + s);
             }
 
-            String[] parts = line.split(" ");
-            boolean isLF = line.startsWith("[LF_RESOLVE]");
+            String[] parts = s.split(" ");
+            boolean isLF = s.startsWith("[LF_RESOLVE]");
 
             if (isLF) {
                 if (parts.length != 4) {
@@ -176,7 +174,7 @@ public class CDS {
     private static Object[] generateLambdaFormHolderClasses(String[] lines) {
         Objects.requireNonNull(lines);
         validateInputLines(lines);
-        Stream<String> lineStream = Arrays.stream(lines).map(String::trim);
+        Stream<String> lineStream = Arrays.stream(lines);
         Map<String, byte[]> result = SharedSecrets.getJavaLangInvokeAccess().generateHolderClasses(lineStream);
         int size = result.size();
         Object[] retArray = new Object[size * 2];


### PR DESCRIPTION
Hi, Please review the simple change.

  The removing of white spaces from end of line in ClassListParser should be moved to before we add lambda-form-invoker line to array.  After made such arrangement, changed CDS.java for trimming line code.

Tests: local test on runtime/cds/appcds. Mach5 tier1,4 is in progress.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254192](https://bugs.openjdk.java.net/browse/JDK-8254192): ExtraSharedClassListFile contains extra white space at end of line


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/669/head:pull/669`
`$ git checkout pull/669`
