### PR TITLE
8254792: Disable intrinsic StringLatin1.indexOf until 8254790 is fixed

### DIFF
--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -496,7 +496,7 @@ bool C2Compiler::is_intrinsic_supported(const methodHandle& method, bool is_virt
   case vmIntrinsics::_indexOfIU:
   case vmIntrinsics::_indexOfIUL:
   case vmIntrinsics::_indexOfU_char:
-  case vmIntrinsics::_indexOfL_char:
+  // case vmIntrinsics::_indexOfL_char: // Disable it until found issues are fixed
   case vmIntrinsics::_toBytesStringU:
   case vmIntrinsics::_getCharsStringU:
   case vmIntrinsics::_getCharStringU:


### PR DESCRIPTION
Temporary disable new intrinsic StringLatin1.indexOf  to keep testing clean while the fix for JDK-8254790 is prepared.

Tested hs-tier1 and failed test.
Currently running tier2 and tier3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ⏳ (3/9 running) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254792](https://bugs.openjdk.java.net/browse/JDK-8254792): Disable intrinsic StringLatin1.indexOf until 8254790 is fixed


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/670/head:pull/670`
`$ git checkout pull/670`
