### PR TITLE
6606767: resexhausted00[34] fail assert(!thread->owns_locks(), "must release all locks when leaving VM")

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -131,8 +131,7 @@ vmTestbase/metaspace/gc/firstGC_99m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_default/TestDescription.java 8208250 generic-all
 
 vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java 8253916 linux-all
-vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java 6606767 generic-all
-vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004/TestDescription.java 6606767 generic-all
+vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004/TestDescription.java 8253916 linux-all
 vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java 8202971 generic-all
 vmTestbase/nsk/jvmti/scenarios/jni_interception/JI05/ji05t001/TestDescription.java 8219652 aix-ppc64
 vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/TestDescription.java 8219652 aix-ppc64

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.util.regex.Matcher;
 
 import nsk.share.Consts;
 import nsk.share.test.Stresser;
+import jtreg.SkippedException;
 
 public class resexhausted003 {
 
@@ -115,7 +116,7 @@ public class resexhausted003 {
             }
 
             System.out.println("Can't reproduce OOME due to a limit on iterations/execution time. Test was useless.");
-            return Consts.TEST_PASSED;
+            throw new SkippedException("Test did not get an OutOfMemory error");
 
         } catch (OutOfMemoryError e) {
             // that is what we are waiting for

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004.java
@@ -27,6 +27,7 @@ import java.util.Random;
 import jdk.test.lib.Utils;
 
 import nsk.share.Consts;
+import jtreg.SkippedException;
 
 public class resexhausted004 {
     public static int run(String args[], PrintStream out) {
@@ -35,23 +36,24 @@ public class resexhausted004 {
         int r;
 
         for ( int i = 4 + selector.nextInt() & 3; i > 0; i-- ) {
-            switch ( selector.nextInt() % 3 ) {
+            try {
+                switch (selector.nextInt() % 3) {
                 case 0:
                     r = resexhausted001.run(args, out);
-                    if ( r != Consts.TEST_PASSED )
-                        return r;
                     break;
                 case 1:
                     r = resexhausted002.run(args, out);
-                    if ( r != Consts.TEST_PASSED )
-                        return r;
                     break;
                 default:
                     r = resexhausted003.run(args, out);
-                    if ( r != Consts.TEST_PASSED )
-                        return r;
                     break;
-           }
+                }
+                if (r != Consts.TEST_PASSED) {
+                    return r;
+                }
+            } catch (SkippedException ex) {
+                // it's ok
+            }
        }
 
        return Consts.TEST_PASSED;


### PR DESCRIPTION
Please review the fix for JDK-6606767.
The original issue is not reproducible.
The fix:
- resexhausted003 and resexhausted004 are un-problemlisted
- resexhausted004 is problemlisted on linux due JDK-8253916 (resexhausted004 executes resexhausted001/resexhausted002/resexhausted003 randomly, and resexhausted001 fails on linux)
- resexhausted003 is updated to throw SkippedException if OOME is not thrown;
- resexhausted004 is updated to catch SkippedException from resexhausted001..003, also logic is slightly simplified

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6606767](https://bugs.openjdk.java.net/browse/JDK-6606767): resexhausted00[34] fail assert(!thread->owns_locks(), "must release all locks when leaving VM")


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/671/head:pull/671`
`$ git checkout pull/671`
