### PR TITLE
JDK-8254796: Cleanup pervasive unnecessary parameter

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
@@ -126,13 +126,12 @@ public class HtmlDoclet extends AbstractDoclet {
      * @throws DocletException if there is a problem while writing the other files
      */
     @Override // defined by AbstractDoclet
-    protected void generateOtherFiles(DocletEnvironment docEnv, ClassTree classtree)
+    protected void generateOtherFiles(ClassTree classtree)
             throws DocletException {
-        super.generateOtherFiles(docEnv, classtree);
+        super.generateOtherFiles(classtree);
         HtmlOptions options = configuration.getOptions();
         if (options.linkSource()) {
-            SourceToHTMLConverter.convertRoot(configuration,
-                docEnv, DocPaths.SOURCE_OUTPUT);
+            SourceToHTMLConverter.convertRoot(configuration,DocPaths.SOURCE_OUTPUT);
         }
         // Modules with no documented classes may be specified on the
         // command line to specify a service provider, allow these.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SourceToHTMLConverter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SourceToHTMLConverter.java
@@ -80,8 +80,6 @@ public class SourceToHTMLConverter {
     private final Resources resources;
     private final Utils utils;
 
-    private final DocletEnvironment docEnv;
-
     private final DocPath outputdir;
 
     /**
@@ -90,14 +88,12 @@ public class SourceToHTMLConverter {
      */
     private DocPath relativePath = DocPath.empty;
 
-    private SourceToHTMLConverter(HtmlConfiguration configuration, DocletEnvironment rd,
-                                  DocPath outputdir) {
+    private SourceToHTMLConverter(HtmlConfiguration configuration, DocPath outputdir) {
         this.configuration  = configuration;
         this.options = configuration.getOptions();
         this.messages = configuration.getMessages();
         this.resources = configuration.docResources;
         this.utils = configuration.utils;
-        this.docEnv = rd;
         this.outputdir = outputdir;
     }
 
@@ -105,18 +101,17 @@ public class SourceToHTMLConverter {
      * Translate the TypeElements in the given DocletEnvironment to HTML representation.
      *
      * @param configuration the configuration.
-     * @param docEnv the DocletEnvironment to convert.
      * @param outputdir the name of the directory to output to.
      * @throws DocFileIOException if there is a problem generating an output file
      * @throws SimpleDocletException if there is a problem reading a source file
      */
-    public static void convertRoot(HtmlConfiguration configuration, DocletEnvironment docEnv,
-                                   DocPath outputdir) throws DocFileIOException, SimpleDocletException {
-        new SourceToHTMLConverter(configuration, docEnv, outputdir).generate();
+    public static void convertRoot(HtmlConfiguration configuration, DocPath outputdir)
+            throws DocFileIOException, SimpleDocletException {
+        new SourceToHTMLConverter(configuration, outputdir).generate();
     }
 
     void generate() throws DocFileIOException, SimpleDocletException {
-        if (docEnv == null || outputdir == null) {
+        if (outputdir == null) {
             return;
         }
         for (ModuleElement mdl : configuration.getSpecifiedModuleElements()) {


### PR DESCRIPTION
This is a small cleanup to remove an annoying extra parameter (docEnv) being based around when creating the doclet.

(there's a hint of the old world too, when it is referred to as "rd" in one place, short for "RootDoc": the corresponding class in the old world ;-) )

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ❌ (1/2 failed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (build release)](https://github.com/jonathan-gibbons/jdk/runs/1256141534)

### Issue
 * [JDK-8254796](https://bugs.openjdk.java.net/browse/JDK-8254796): Cleanup pervasive unnecessary parameter


### Reviewers
 * [Kumar Srinivasan](https://openjdk.java.net/census#ksrini) (@kusrinivasan - **Reviewer**)
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/672/head:pull/672`
`$ git checkout pull/672`
