### PR TITLE
8254799: runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
@@ -78,6 +78,7 @@ public class TestHeapDumpOnOutOfMemoryError {
                 //  MaxMetaspaceSize=16M - ~12-15K classes - ~12sec runtime with all verifications
                 //  MaxMetaspaceSize=16M - ~12-15K classes - VerifyDependencies off - ~3seconds on ppc
                 "-XX:MaxMetaspaceSize=16m",
+                "-XX:+IgnoreUnrecognizedVMOptions",
                 "-XX:-VerifyDependencies",
                 TestHeapDumpOnOutOfMemoryError.class.getName(), type);
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
@@ -29,6 +29,7 @@
  */
 
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Platform;
 import jdk.test.lib.classloader.GeneratingClassLoader;
 import jdk.test.lib.hprof.HprofParser;
 import jdk.test.lib.process.ProcessTools;
@@ -78,8 +79,7 @@ public class TestHeapDumpOnOutOfMemoryError {
                 //  MaxMetaspaceSize=16M - ~12-15K classes - ~12sec runtime with all verifications
                 //  MaxMetaspaceSize=16M - ~12-15K classes - VerifyDependencies off - ~3seconds on ppc
                 "-XX:MaxMetaspaceSize=16m",
-                "-XX:+IgnoreUnrecognizedVMOptions",
-                "-XX:-VerifyDependencies",
+                Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-Dx",
                 TestHeapDumpOnOutOfMemoryError.class.getName(), type);
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());


### PR DESCRIPTION
runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java and runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryErrorInMetaspace.java fail with release VMs due to VerifyDependencies is develop and is available only in debug version of VM.
-XX:+IgnoreUnrecognizedVMOptions is added to fix it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254799](https://bugs.openjdk.java.net/browse/JDK-8254799): runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java fails with release VMs


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/673/head:pull/673`
`$ git checkout pull/673`
