### PR TITLE
8254798: Deprecate for removal an empty finalize() methods in java.desktop module

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/AbstractMidiDevice.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AbstractMidiDevice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -478,12 +478,6 @@ abstract class AbstractMidiDevice implements MidiDevice, ReferenceCountingDevice
         final boolean isOpen() {
             return open;
         }
-
-        //$$fb is that a good idea?
-        //protected void finalize() {
-        //    close();
-        //}
-
     } // class AbstractReceiver
 
 

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -760,6 +760,7 @@ public class ICC_Profile implements Serializable {
      *         options.
      */
     @Deprecated(since = "9", forRemoval = true)
+    @SuppressWarnings("removal")
     protected void finalize () {
     }
 

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -759,7 +759,7 @@ public class ICC_Profile implements Serializable {
      *         Object#finalize()} for further information about migration
      *         options.
      */
-    @Deprecated(since="9")
+    @Deprecated(since = "9", forRemoval = true)
     protected void finalize () {
     }
 

--- a/src/java.desktop/share/classes/java/awt/image/ColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ColorModel.java
@@ -1631,6 +1631,7 @@ public abstract class ColorModel implements Transparency{
      *     information about migration options.
      */
     @Deprecated(since = "9", forRemoval = true)
+    @SuppressWarnings("removal")
     public void finalize() {
     }
 

--- a/src/java.desktop/share/classes/java/awt/image/ColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ColorModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1630,7 +1630,7 @@ public abstract class ColorModel implements Transparency{
      *     See the specification for {@link Object#finalize()} for further
      *     information about migration options.
      */
-    @Deprecated(since="9")
+    @Deprecated(since = "9", forRemoval = true)
     public void finalize() {
     }
 

--- a/src/java.desktop/share/classes/java/awt/image/IndexColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/IndexColorModel.java
@@ -1525,6 +1525,7 @@ public class IndexColorModel extends ColorModel {
      *     information about migration options.
      */
     @Deprecated(since = "9", forRemoval = true)
+    @SuppressWarnings("removal")
     public void finalize() {
     }
 

--- a/src/java.desktop/share/classes/java/awt/image/IndexColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/IndexColorModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1524,7 +1524,7 @@ public class IndexColorModel extends ColorModel {
      *     See the specification for {@link Object#finalize()} for further
      *     information about migration options.
      */
-    @Deprecated(since="9")
+    @Deprecated(since = "9", forRemoval = true)
     public void finalize() {
     }
 

--- a/src/java.desktop/share/classes/sun/java2d/pipe/RegionClipSpanIterator.java
+++ b/src/java.desktop/share/classes/sun/java2d/pipe/RegionClipSpanIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -377,15 +377,4 @@ public class RegionClipSpanIterator implements SpanIterator {
     public long getNativeIterator() {
         return 0;
     }
-
-    /*
-     * Cleans out all internal data structures.
-     */
-    //public native void dispose();
-
-    @SuppressWarnings("deprecation")
-    protected void finalize() {
-        //dispose();
-    }
-
 }

--- a/src/java.desktop/share/classes/sun/java2d/pipe/RegionSpanIterator.java
+++ b/src/java.desktop/share/classes/sun/java2d/pipe/RegionSpanIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,17 +46,6 @@ public class RegionSpanIterator implements SpanIterator {
 
     // Is the associated Region rectangular?
     boolean isrect;
-
-/*
-    REMIND: For native implementation
-    long pData;     // Private storage of rect info
-
-    static {
-        initIDs();
-    }
-
-    public static native void initIDs();
-*/
 
     /**
      * Constructs an instance based on the given Region
@@ -197,14 +186,4 @@ public class RegionSpanIterator implements SpanIterator {
     public long getNativeIterator() {
         return 0;
     }
-
-    /*
-     * Cleans out all internal data structures.
-     * REMIND: Native implementation
-    public native void dispose();
-
-    protected void finalize() {
-        dispose();
-    }
-     */
 }


### PR DESCRIPTION
The java.desktop module has a few implementations of the finalize() method which do nothing. We can remove such methods if the class is not public API, and could mark these methods in the public classes as "forRemoval = true"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254798](https://bugs.openjdk.java.net/browse/JDK-8254798): Deprecate for removal an empty finalize() methods in java.desktop module


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/675/head:pull/675`
`$ git checkout pull/675`
