### PR TITLE
8247614: java/nio/channels/DatagramChannel/Connect.java timed out

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/Connect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Connect.java
@@ -47,21 +47,19 @@ public class Connect {
     }
 
     static void test() throws Exception {
+        ExecutorService threadPool = Executors.newCachedThreadPool();
         try (Reactor r = new Reactor();
              Actor a = new Actor(r.port())) {
-            invoke(a, r);
-        }
-    }
-
-    static void invoke(Runnable reader, Runnable writer) throws CompletionException {
-        ExecutorService threadPool = Executors.newCachedThreadPool();
-        try {
-            CompletableFuture<Void> f1 = CompletableFuture.runAsync(writer, threadPool);
-            CompletableFuture<Void> f2 = CompletableFuture.runAsync(reader, threadPool);
-            wait(f1, f2);
+            invoke(threadPool, a, r);
         } finally {
             threadPool.shutdown();
         }
+    }
+
+    static void invoke(ExecutorService e, Runnable reader, Runnable writer) throws CompletionException {
+        CompletableFuture<Void> f1 = CompletableFuture.runAsync(writer, e);
+        CompletableFuture<Void> f2 = CompletableFuture.runAsync(reader, e);
+        wait(f1, f2);
     }
 
 
@@ -126,7 +124,7 @@ public class Connect {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() throws IOException {
             dc.close();
         }
     }

--- a/test/jdk/java/nio/channels/DatagramChannel/Connect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Connect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,9 @@ import java.net.*;
 import java.nio.*;
 import java.nio.channels.*;
 import java.nio.charset.*;
-
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Stream;
 
 public class Connect {
 
@@ -48,84 +50,78 @@ public class Connect {
         invoke(a, r);
     }
 
-    static void invoke(Sprintable reader, Sprintable writer) throws Exception {
-
-        Thread writerThread = new Thread(writer);
-        writerThread.start();
-
-        Thread readerThread = new Thread(reader);
-        readerThread.start();
-
-        writerThread.join();
-        readerThread.join();
-
-        reader.throwException();
-        writer.throwException();
+    static void invoke(Runnable reader, Runnable writer) throws CompletionException {
+        CompletableFuture<Void> f1 = CompletableFuture.runAsync(writer);
+        CompletableFuture<Void> f2 = CompletableFuture.runAsync(reader);
+        wait(f1, f2);
     }
 
-    public interface Sprintable extends Runnable {
-        public void throwException() throws Exception;
+    // This method waits until one of the given CompletableFutures completes exceptionally. In which case, it stops waiting for the other futures and
+    // throws a CompletionException. Otherwise, will wait for all futures to complete successfully.
+    private static void wait(CompletableFuture<?>... futures) throws CompletionException {
+        CompletableFuture<?> future = CompletableFuture.allOf(futures);
+        Stream.of(futures)
+                .forEach(f -> {
+                    f.exceptionally(ex -> {
+                        future.completeExceptionally(ex);
+                        return null;
+                    });
+                });
+        future.join();
     }
 
-    public static class Actor implements Sprintable {
+    public static class Actor implements Runnable {
         final int port;
-        Exception e = null;
 
         Actor(int port) {
             this.port = port;
         }
 
-        public void throwException() throws Exception {
-            if (e != null)
-                throw e;
-        }
-
         public void run() {
-            try {
-                DatagramChannel dc = DatagramChannel.open();
-
-                // Send a message
+            try (DatagramChannel dc = DatagramChannel.open()) {
                 ByteBuffer bb = ByteBuffer.allocateDirect(256);
                 bb.put("hello".getBytes());
                 bb.flip();
-                InetAddress address = InetAddress.getLocalHost();
-                if (address.isLoopbackAddress()) {
-                    address = InetAddress.getLoopbackAddress();
-                }
+                InetAddress address = InetAddress.getLoopbackAddress();
                 InetSocketAddress isa = new InetSocketAddress(address, port);
                 dc.connect(isa);
+
+                // Send a message
+                log.println("Actor attempting to write to Reactor at " + isa.toString());
                 dc.write(bb);
 
                 // Try to send to some other address
-                address = InetAddress.getLocalHost();
-                InetSocketAddress bogus = new InetSocketAddress(address, 3333);
                 try {
-                    dc.send(bb, bogus);
-                    throw new RuntimeException("Allowed bogus send while connected");
+                    InetSocketAddress otherAddress = new InetSocketAddress(address, (port == 3333 ? 3332 : 3333));
+                    log.println("Testing if Actor throws already connected exception when attempting to send to " + otherAddress.toString());
+                    dc.send(bb, otherAddress);
+                    throw new RuntimeException("Actor allowed send to other address while already connected");
                 } catch (AlreadyConnectedException ace) {
                     // Correct behavior
                 }
 
                 // Read a reply
                 bb.flip();
+                log.println("Actor waiting to read");
                 dc.read(bb);
                 bb.flip();
-                CharBuffer cb = Charset.forName("US-ASCII").
-                newDecoder().decode(bb);
-                log.println("From Reactor: "+isa+ " said " +cb);
+                CharBuffer cb = StandardCharsets.US_ASCII.
+                        newDecoder().decode(bb);
+                log.println("Actor received from Reactor at " + isa + ": " + cb);
 
                 // Clean up
                 dc.disconnect();
-                dc.close();
             } catch (Exception ex) {
-                e = ex;
+                log.println("Actor threw exception: " + ex);
+                throw new RuntimeException(ex);
+            } finally {
+                log.println("Actor finished");
             }
         }
     }
 
-    public static class Reactor implements Sprintable {
+    public static class Reactor implements Runnable {
         final DatagramChannel dc;
-        Exception e = null;
 
         Reactor() throws IOException {
             dc = DatagramChannel.open().bind(new InetSocketAddress(0));
@@ -135,31 +131,31 @@ public class Connect {
             return dc.socket().getLocalPort();
         }
 
-        public void throwException() throws Exception {
-            if (e != null)
-                throw e;
-        }
-
         public void run() {
             try {
                 // Listen for a message
                 ByteBuffer bb = ByteBuffer.allocateDirect(100);
+                log.println("Reactor waiting to receive");
                 SocketAddress sa = dc.receive(bb);
                 bb.flip();
-                CharBuffer cb = Charset.forName("US-ASCII").
-                newDecoder().decode(bb);
-                log.println("From Actor: "+sa+ " said " +cb);
+                CharBuffer cb = StandardCharsets.US_ASCII.
+                        newDecoder().decode(bb);
+                log.println("Reactor received from Actor at" + sa +  ": " + cb);
 
                 // Reply to sender
                 dc.connect(sa);
                 bb.flip();
+                log.println("Reactor attempting to write: " + dc.getRemoteAddress().toString());
                 dc.write(bb);
 
                 // Clean up
                 dc.disconnect();
                 dc.close();
             } catch (Exception ex) {
-                e = ex;
+                log.println("Reactor threw exception: " + ex);
+                throw new RuntimeException(ex);
+            } finally {
+                log.println("Reactor finished");
             }
         }
     }


### PR DESCRIPTION
Occasional failures of this test have been observed. However it was unclear as to the precise nature of the failure due to minimal logging and multiple features of DatagramChannel being tested in one run. Another issue is that on failure of either a Writer or Reader thread, the thread that did not fail waits until the test itself times out. 

To attempt to mitigate these factors, the test was modified in the following manner:

- Additional logging was added to help locate future points of failure in the test.
- On L95, guards were added to make sure the test for a DatagramChannel throwing an AlreadyConnectedException does not end up using the same port as used for the connection on L86-87
- `wait(CompletableFuture<?>... futures)` was implemented to throw a CompletionException if either the Reader or Writer fails, rather than waiting for the test to time out.

Seeking review in particular on implementation of the `wait(CompletableFuture<?>... futures)` function. As it stands currently the wait function waits for one of the given futures completes exceptionally. If that doesnt happen, it will wait for _all_ futures to complete successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ❌ (1/5 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x64 (build debug)](https://github.com/ccleary-oracle/jdk/runs/1322116043)

### Issue
 * [JDK-8247614](https://bugs.openjdk.java.net/browse/JDK-8247614): java/nio/channels/DatagramChannel/Connect.java timed out


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/679/head:pull/679`
`$ git checkout pull/679`
