### PR TITLE
8254811: JDK-8254158 broke ppc64, s390 builds

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -965,8 +965,12 @@ bool os::Posix::handle_stack_overflow(JavaThread* thread, address addr, address 
           if (activation.sp() != NULL) {
             overflow_state->disable_stack_reserved_zone();
             if (activation.is_interpreted_frame()) {
-              overflow_state->set_reserved_stack_activation((address)(
-                activation.fp() + frame::interpreter_frame_initial_sp_offset));
+              overflow_state->set_reserved_stack_activation((address)(activation.fp()
+                // Some platforms use frame pointers for interpreter frames, others use initial sp.
+#if !defined(PPC64) && !defined(S390)
+                + frame::interpreter_frame_initial_sp_offset
+#endif
+                ));
             } else {
               overflow_state->set_reserved_stack_activation((address)activation.unextended_sp());
             }

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -146,7 +146,7 @@ frame os::fetch_compiled_frame_from_context(const void* ucVoid) {
   const ucontext_t* uc = (const ucontext_t*)ucVoid;
   intptr_t* sp = os::Aix::ucontext_get_sp(uc);
   address lr = ucontext_get_lr(uc);
-  *fr = frame(sp, lr);
+  return frame(sp, lr);
 }
 
 frame os::get_sender_for_C_frame(frame* fr) {


### PR DESCRIPTION
"frame::interpreter_frame_initial_sp_offset" is currently used in shared POSIX code, but doesn't exist on ppc64 and s390.
These platforms use frame pointers instead of initial sp for reserved zone checks. See comments in InterpreterMacroAssembler::remove_activation on these platforms. So we must not add any offset.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ❌ (1/9 failed) | ⏳ (1/9 running) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x64 (langtools/tier1)](https://github.com/TheRealMDoerr/jdk/runs/1259035336)

### Issue
 * [JDK-8254811](https://bugs.openjdk.java.net/browse/JDK-8254811): JDK-8254158 broke ppc64, s390 builds


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/680/head:pull/680`
`$ git checkout pull/680`
