### PR TITLE
8249878: jfr_emergency_dump has secondary crashes

### DIFF
--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -423,7 +423,6 @@ const char* JfrEmergencyDump::chunk_path(const char* repository_path) {
 */
 static bool prepare_for_emergency_dump(Thread* thread) {
   assert(thread != NULL, "invariant");
-  DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(thread));
   if (thread->is_Watcher_thread()) {
     // need WatcherThread as a safeguard against potential deadlocks
     return false;


### PR DESCRIPTION
Hi,

Please review this small fix to remove an improperly placed assert. The assert is invalid at this location because Java threads are only a subset of all threads to enter. It was introduced by JDK-8245113 and is a debug support remnant, used for getting the new states in place.

Thanks,
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ⏳ (7/9 running) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8249878](https://bugs.openjdk.java.net/browse/JDK-8249878): jfr_emergency_dump has secondary crashes


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/682/head:pull/682`
`$ git checkout pull/682`
