### PR TITLE
Add proper signatures to module and package pages

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
@@ -213,7 +213,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
             pre.add(span);
         }
         if (utils.isRecord(typeElement)) {
-            pre.add(getRecordComponents(typeElement));
+            pre.add(getRecordComponents());
         }
         if (!utils.isAnnotationType(typeElement)) {
             if (!utils.isInterface(typeElement)) {
@@ -279,7 +279,7 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
     }
 
     @SuppressWarnings("preview")
-    private Content getRecordComponents(TypeElement typeElem) {
+    private Content getRecordComponents() {
         Content content = new ContentBuilder();
         content.add("(");
         String sep = "";

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
@@ -196,9 +196,6 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
         headerContent.add(navBar.getContent(Navigation.Position.TOP));
         HtmlTree div = new HtmlTree(TagName.DIV);
         div.setStyle(HtmlStyle.header);
-        Content annotationContent = new HtmlTree(TagName.P);
-        addAnnotationInfo(mdle, annotationContent);
-        div.add(annotationContent);
         Content label = mdle.isOpen() && (configuration.docEnv.getModuleMode() == ModuleMode.ALL)
                 ? contents.openModuleLabel : contents.moduleLabel;
         Content tHeading = HtmlTree.HEADING_TITLE(Headings.PAGE_TITLE_HEADING,
@@ -830,6 +827,19 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
             addTagsInfo(mdle, tree);
             moduleContentTree.add(tree);
         }
+    }
+
+    @Override
+    public void addModuleSignature(Content moduleContentTree) {
+        moduleContentTree.add(new HtmlTree(TagName.HR));
+        Content pre = new HtmlTree(TagName.PRE);
+        addAnnotationInfo(mdle, pre);
+        String label = mdle.isOpen() && (configuration.docEnv.getModuleMode() == ModuleMode.ALL)
+                ? "open module" : "module";
+        pre.add(label);
+        pre.add(" ");
+        pre.add(mdle.getQualifiedName().toString());
+        moduleContentTree.add(pre);
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
@@ -117,9 +117,6 @@ public class PackageWriterImpl extends HtmlDocletWriter
                     new StringContent(mdle.getQualifiedName().toString())));
             div.add(moduleNameDiv);
         }
-        Content annotationContent = new HtmlTree(TagName.P);
-        addAnnotationInfo(packageElement, annotationContent);
-        div.add(annotationContent);
         Content tHeading = HtmlTree.HEADING_TITLE(Headings.PAGE_TITLE_HEADING,
                 HtmlStyle.title, contents.packageLabel);
         tHeading.add(Entity.NO_BREAK_SPACE);
@@ -251,6 +248,16 @@ public class PackageWriterImpl extends HtmlDocletWriter
         Content htmlTree = sectionTree;
         addTagsInfo(packageElement, htmlTree);
         packageContentTree.add(sectionTree);
+    }
+
+    @Override
+    public void addPackageSignature(Content packageContentTree) {
+        packageContentTree.add(new HtmlTree(TagName.HR));
+        Content pre = new HtmlTree(TagName.PRE);
+        addAnnotationInfo(packageElement, pre);
+        pre.add("package ");
+        pre.add(packageElement.getQualifiedName().toString());
+        packageContentTree.add(pre);
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ModuleSummaryWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ModuleSummaryWriter.java
@@ -77,6 +77,14 @@ public interface ModuleSummaryWriter {
     void addModuleDescription(Content moduleContentTree);
 
     /**
+     * Adds the module signature.
+     *
+     * @param moduleContentTree the content tree to which the module signature
+     *                           will be added
+     */
+    void addModuleSignature(Content moduleContentTree);
+
+    /**
      * Adds the summary of modules to the list of summaries.
      *
      * @param summariesList the list of summaries

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/PackageSummaryWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/PackageSummaryWriter.java
@@ -139,6 +139,14 @@ public interface PackageSummaryWriter {
     void addPackageTags(Content packageContentTree);
 
     /**
+     * Adds the package signature.
+     *
+     * @param packageContentTree the content tree to which the package signature
+     *                           will be added
+     */
+    void addPackageSignature(Content packageContentTree);
+
+    /**
      * Adds the tag information from the "packages.html" or "package-info.java" file to the
      * documentation tree.
      *

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ModuleSummaryBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ModuleSummaryBuilder.java
@@ -121,6 +121,7 @@ public class ModuleSummaryBuilder extends AbstractBuilder {
     protected void buildContent() throws DocletException {
         Content moduleContentTree = moduleWriter.getContentHeader();
 
+        moduleWriter.addModuleSignature(moduleContentTree);
         buildModuleDescription(moduleContentTree);
         buildSummary(moduleContentTree);
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/PackageSummaryBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/PackageSummaryBuilder.java
@@ -128,6 +128,7 @@ public class PackageSummaryBuilder extends AbstractBuilder {
     protected void buildContent() throws DocletException {
         Content packageContentTree = packageWriter.getContentHeader();
 
+        packageWriter.addPackageSignature(packageContentTree);
         buildPackageDescription(packageContentTree);
         buildPackageTags(packageContentTree);
         buildSummary(packageContentTree);

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -27,7 +27,7 @@
  *      8168766 8168688 8162674 8160196 8175799 8174974 8176778 8177562 8175218
  *      8175823 8166306 8178043 8181622 8183511 8169819 8074407 8183037 8191464
  *      8164407 8192007 8182765 8196200 8196201 8196202 8196202 8205593 8202462
- *      8184205 8219060 8223378 8234746 8239804 8239816 8253117
+ *      8184205 8219060 8223378 8234746 8239804 8239816 8253117 8245058
  * @summary Test modules support in javadoc.
  * @library ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -497,27 +497,6 @@ public class TestModules extends JavadocTester {
                     <caption><span>Modules</span><span class="tab-end">&nbsp;</span></caption>""");
     }
 
-    void checkNoDescription(boolean found) {
-        checkOutput("moduleA/module-summary.html", found,
-                """
-                    <div class="header">
-                    <p>@Deprecated(forRemoval=true)
-                    </p>
-                    <h1 title="Module" class="title">Module&nbsp;moduleA</h1>
-                    </div><ul class="block-list">
-                    <li>
-                    <ul class="block-list">
-                    <li>
-                    <!-- ============ PACKAGES SUMMARY =========== -->""");
-        checkOutput("moduleB/module-summary.html", found,
-                """
-                    <ul class="block-list">
-                    <li>
-                    <ul class="block-list">
-                    <li>
-                    <!-- ============ PACKAGES SUMMARY =========== -->""");
-    }
-
     void checkHtml5Description(boolean found) {
         checkOutput("moduleA/module-summary.html", found,
                 """
@@ -563,10 +542,11 @@ public class TestModules extends JavadocTester {
         checkOutput("moduleA/module-summary.html", found,
                 """
                     <div class="header">
-                    <p>@Deprecated(forRemoval=true)
-                    </p>
                     <h1 title="Module" class="title">Module&nbsp;moduleA</h1>
                     </div>
+                    <hr>
+                    <pre>@Deprecated(forRemoval=true)
+                    module moduleA</pre>
                     <section class="summary">
                     <ul class="summary-list">
                     <li>
@@ -574,13 +554,15 @@ public class TestModules extends JavadocTester {
                     <!-- ============ PACKAGES SUMMARY =========== -->""");
         checkOutput("moduleB/module-summary.html", found,
                 """
-                    <p><a href="testpkgmdlB/AnnotationType.html" title="annotation in testpkgmdlB">@\
-                    AnnotationType</a>(<a href="testpkgmdlB/AnnotationType.html#optional()">optional\
-                    </a>="Module Annotation",
-                                    <a href="testpkgmdlB/AnnotationType.html#required()">required</a>=2016)
-                    </p>
+                    <div class="header">
                     <h1 title="Module" class="title">Module&nbsp;moduleB</h1>
                     </div>
+                    <hr>
+                    <pre><a href="testpkgmdlB/AnnotationType.html" title="annotation in testpkgmdlB"\
+                    >@AnnotationType</a>(<a href="testpkgmdlB/AnnotationType.html#optional()">option\
+                    al</a>="Module Annotation",
+                                    <a href="testpkgmdlB/AnnotationType.html#required()">required</a>=2016)
+                    module moduleB</pre>
                     <section class="summary">
                     <ul class="summary-list">
                     <li>
@@ -1119,8 +1101,12 @@ public class TestModules extends JavadocTester {
                     """);
         checkOutput("moduletags/module-summary.html", found,
                 """
-                    <p>@Deprecated
-                    </p>""",
+                    <div class="header">
+                    <h1 title="Module" class="title">Module&nbsp;moduletags</h1>
+                    </div>
+                    <hr>
+                    <pre>@Deprecated
+                    module moduletags</pre>""",
                 """
                     <div class="deprecation-block"><span class="deprecated-label">Deprecated.</span></div>""");
     }
@@ -1128,11 +1114,15 @@ public class TestModules extends JavadocTester {
     void checkModuleAnnotation() {
         checkOutput("moduleB/module-summary.html", true,
                 """
-                    <p><a href="testpkgmdlB/AnnotationType.html" title="annotation in testpkgmdlB">@\
-                    AnnotationType</a>(<a href="testpkgmdlB/AnnotationType.html#optional()">optional\
-                    </a>="Module Annotation",
+                    <div class="header">
+                    <h1 title="Module" class="title">Module&nbsp;moduleB</h1>
+                    </div>
+                    <hr>
+                    <pre><a href="testpkgmdlB/AnnotationType.html" title="annotation in testpkgmdlB"\
+                    >@AnnotationType</a>(<a href="testpkgmdlB/AnnotationType.html#optional()">option\
+                    al</a>="Module Annotation",
                                     <a href="testpkgmdlB/AnnotationType.html#required()">required</a>=2016)
-                    </p>""");
+                    module moduleB</pre>""");
         checkOutput("moduleB/module-summary.html", false,
                 "@AnnotationTypeUndocumented");
     }

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug  8222091
+ * @bug  8222091 8245058
  * @summary  Javadoc does not handle package annotations correctly on package-info.java
  * @library  ../../lib/
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -52,10 +52,11 @@ public class TestPackageAnnotation extends JavadocTester {
                 """
                     <main role="main">
                     <div class="header">
-                    <p>@Deprecated(since="1&lt;2&gt;3")
-                    </p>
                     <h1 title="Package" class="title">Package&nbsp;pkg1</h1>
                     </div>
+                    <hr>
+                    <pre>@Deprecated(since="1&lt;2&gt;3")
+                    package pkg1</pre>
                     """);
     }
 
@@ -87,10 +88,11 @@ public class TestPackageAnnotation extends JavadocTester {
                 """
                     <main role="main">
                     <div class="header">
-                    <p>@Deprecated(since="1&lt;2&gt;3")
-                    </p>
                     <h1 title="Package" class="title">Package&nbsp;pkg3</h1>
                     </div>
+                    <hr>
+                    <pre>@Deprecated(since="1&lt;2&gt;3")
+                    package pkg3</pre>
                     """);
     }
 }


### PR DESCRIPTION
This adds a dedicated signature `<pre>` element to module and package summary pages. 

The changes are very straightforward. The module and package writer interfaces and classes get a new method called `addModuleSignature` and `addPackageSignature` respecively, and it is invoked after the header instead. I tried to refactor the signature generating code to a single `Signatures` class but the outcome was not an improvement. Type and member signatures are very different and share very little common code, and module and package signatures are very simple anyway. The refactoring just added a layer of indirection and a rather confusing collection of signature generating code.

One question I was uncertain about is whether we should add a `<hr>` (horizontal rule) between the page heading and the signature like it is done for type pages. I opted to add it for consistency even though module and package pages are usually less cluttered than type pages and therefore less in need of visual structure.  

Example module page: http://cr.openjdk.java.net/~hannesw/8245058/api.00/java.base/module-summary.html
Example package page: http://cr.openjdk.java.net/~hannesw/8245058/api.00/java.base/java/lang/package-summary.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/683/head:pull/683`
`$ git checkout pull/683`
