### PR TITLE
8254842: [JVMCI] copy thread name when attaching libgraal thread to HotSpot

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -2349,13 +2349,23 @@ C2V_VMENTRY_PREFIX(jlong, getCurrentJavaThread, (JNIEnv* env, jobject c2vm))
   return (jlong) p2i(thread);
 C2V_END
 
-C2V_VMENTRY_PREFIX(jboolean, attachCurrentThread, (JNIEnv* env, jobject c2vm, jboolean as_daemon))
+C2V_VMENTRY_PREFIX(jboolean, attachCurrentThread, (JNIEnv* env, jobject c2vm, jbyteArray name, jboolean as_daemon))
   if (thread == NULL) {
     // Called from unattached JVMCI shared library thread
     extern struct JavaVM_ main_vm;
     JNIEnv* hotspotEnv;
-    jint res = as_daemon ? main_vm.AttachCurrentThreadAsDaemon((void**) &hotspotEnv, NULL) :
-                           main_vm.AttachCurrentThread((void**) &hotspotEnv, NULL);
+
+    int name_len = env->GetArrayLength(name);
+    char name_buf[64]; // Cannot use Resource heap as it requires a current thread
+    int to_copy = MIN2(name_len, (int) sizeof(name_buf) - 1);
+    env->GetByteArrayRegion(name, 0, to_copy, (jbyte*) name_buf);
+    name_buf[to_copy] = '\0';
+    JavaVMAttachArgs attach_args;
+    attach_args.version = JNI_VERSION_1_2;
+    attach_args.name = name_buf;
+    attach_args.group = NULL;
+    jint res = as_daemon ? main_vm.AttachCurrentThreadAsDaemon((void**) &hotspotEnv, &attach_args) :
+                           main_vm.AttachCurrentThread((void**) &hotspotEnv, &attach_args);
     if (res != JNI_OK) {
       JNI_THROW_("attachCurrentThread", InternalError, err_msg("Trying to attach thread returned %d", res), false);
     }
@@ -2803,7 +2813,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "registerNativeMethods",                        CC "(" CLASS ")[J",                                                                   FN_PTR(registerNativeMethods)},
   {CC "isCurrentThreadAttached",                      CC "()Z",                                                                             FN_PTR(isCurrentThreadAttached)},
   {CC "getCurrentJavaThread",                         CC "()J",                                                                             FN_PTR(getCurrentJavaThread)},
-  {CC "attachCurrentThread",                          CC "(Z)Z",                                                                            FN_PTR(attachCurrentThread)},
+  {CC "attachCurrentThread",                          CC "([BZ)Z",                                                                          FN_PTR(attachCurrentThread)},
   {CC "detachCurrentThread",                          CC "()V",                                                                             FN_PTR(detachCurrentThread)},
   {CC "translate",                                    CC "(" OBJECT ")J",                                                                   FN_PTR(translate)},
   {CC "unhand",                                       CC "(J)" OBJECT,                                                                      FN_PTR(unhand)},

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -2352,6 +2352,8 @@ C2V_END
 C2V_VMENTRY_PREFIX(jboolean, attachCurrentThread, (JNIEnv* env, jobject c2vm, jbyteArray name, jboolean as_daemon))
   if (thread == NULL) {
     // Called from unattached JVMCI shared library thread
+	guarantee(name != NULL, "libjvmci caller must pass non-null name");
+
     extern struct JavaVM_ main_vm;
     JNIEnv* hotspotEnv;
 

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -2352,7 +2352,7 @@ C2V_END
 C2V_VMENTRY_PREFIX(jboolean, attachCurrentThread, (JNIEnv* env, jobject c2vm, jbyteArray name, jboolean as_daemon))
   if (thread == NULL) {
     // Called from unattached JVMCI shared library thread
-	guarantee(name != NULL, "libjvmci caller must pass non-null name");
+    guarantee(name != NULL, "libjvmci caller must pass non-null name");
 
     extern struct JavaVM_ main_vm;
     JNIEnv* hotspotEnv;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -977,9 +977,10 @@ final class CompilerToVM {
     native long getCurrentJavaThread();
 
     /**
+     * @param name name of current thread if in a native image otherwise {@code null}
      * @see HotSpotJVMCIRuntime#attachCurrentThread
      */
-    native boolean attachCurrentThread(boolean asDaemon);
+    native boolean attachCurrentThread(byte[] name, boolean asDaemon);
 
     /**
      * @see HotSpotJVMCIRuntime#detachCurrentThread()

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -1117,7 +1117,8 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
      *             the length of the array returned by {@link #registerNativeMethods}
      */
     public boolean attachCurrentThread(boolean asDaemon) {
-        return compilerToVm.attachCurrentThread(asDaemon);
+        byte[] name = IS_IN_NATIVE_IMAGE ? Thread.currentThread().getName().getBytes() : null;
+        return compilerToVm.attachCurrentThread(name, asDaemon);
     }
 
     /**


### PR DESCRIPTION
This PR modifies `HotSpotJVMCIRuntime.attachCurrentThread` when it is called from within libgraal so that the name of the thread in the libgraal heap is used as the name of the peer thread created in HotSpot.

This useful when viewing output such as `-XX:JVMCITraceLevel=1`. For example, here's sample output without this PR:
```
JVMCITrace-1[Thread-0]: initializing JVMCI runtime -1
JVMCITrace-1[Thread-0]: initialized JVMCI runtime -1
```
and then with:
```
JVMCITrace-1[LibGraalHotSpotGraalManagementInitialization]: initializing JVMCI runtime -1
JVMCITrace-1[LibGraalHotSpotGraalManagementInitialization]: initialized JVMCI runtime -1
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254842](https://bugs.openjdk.java.net/browse/JDK-8254842): [JVMCI] copy thread name when attaching libgraal thread to HotSpot


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 726faca57b53dc7e47381bbcfb196f9ff21db2b4
 * [Tom Rodriguez](https://openjdk.java.net/census#never) (@tkrodriguez - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/684/head:pull/684`
`$ git checkout pull/684`
