### PR TITLE
8028707: javax/swing/JComboBox/6236162/bug6236162.java fails on azure

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -732,7 +732,6 @@ javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 8233177 linux-all,win
 javax/swing/border/TestTitledBorderLeak.java 8213531 linux-all
 javax/swing/JComponent/7154030/bug7154030.java 7190978 generic-all
 javax/swing/JComponent/6683775/bug6683775.java 8172337 generic-all
-javax/swing/JComboBox/6236162/bug6236162.java 8028707 windows-all,macosx-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedTranslucentPerPixelTranslucentGradient.java 8233582 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedPerPixelTranslucentGradient.java 8233582 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentSwing.java 8194128 macosx-all

--- a/test/jdk/javax/swing/JComboBox/6236162/bug6236162.java
+++ b/test/jdk/javax/swing/JComboBox/6236162/bug6236162.java
@@ -28,9 +28,6 @@
  * @summary Checks that there is no an inconsistence in combo box
  *          behavior when user points an item in combo popup
  *          by mouse and then uses UP/DOWN keys.
- * @library ../../regtesthelpers
- * @build Util
- * @author Mikhail Lapshin
  * @run main bug6236162
  */
 
@@ -44,8 +41,11 @@ public class bug6236162 {
     private static JFrame frame;
     private static JComboBox combo;
     private static MyComboUI comboUI;
+    private static Robot robot;
 
     public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(100);
         try {
             UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
             SwingUtilities.invokeAndWait(new Runnable() {
@@ -53,6 +53,8 @@ public class bug6236162 {
                     createAndShowGUI();
                 }
             });
+            robot.waitForIdle();
+            robot.delay(1000);
             test();
             System.out.println("Test passed");
         } finally {
@@ -74,15 +76,14 @@ public class bug6236162 {
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
+        frame.toFront();
     }
 
     private static void test() throws AWTException {
-        Robot robot = new Robot();
-        robot.setAutoDelay(50);
 
         // Open popup menu
-        robot.waitForIdle();
-        Util.hitKeys(robot, KeyEvent.VK_DOWN);
+        robot.keyPress(KeyEvent.VK_DOWN);
+        robot.keyRelease(KeyEvent.VK_DOWN);
 
         // Move mouse to the first popup menu item
         robot.waitForIdle();
@@ -98,7 +99,8 @@ public class bug6236162 {
 
         // Select the second popup menu item
         robot.waitForIdle();
-        Util.hitKeys(robot, KeyEvent.VK_DOWN);
+        robot.keyPress(KeyEvent.VK_DOWN);
+        robot.keyRelease(KeyEvent.VK_DOWN);
 
         robot.waitForIdle();
         JList list = comboUI.getComboPopup().getList();


### PR DESCRIPTION
Please review a test fix for a test issue seen in nightly testing where the combobox selection was not happening properly. 
It seems the issue seems to stem from the fact that the test was not waiting for frame to be visible long enough before commencing robot actions.
Added robot delay and remove the dependancy on Util class. 
Mach5 job was run for several iteration on all 3 platforms. Link in JBS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8028707](https://bugs.openjdk.java.net/browse/JDK-8028707): javax/swing/JComboBox/6236162/bug6236162.java fails on azure


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/686/head:pull/686`
`$ git checkout pull/686`
