### PR TITLE
8251325: Miss 'L' for long value in if statement

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -132,7 +132,7 @@ final class DCmdStart extends AbstractDCmd {
         }
 
         if (delay != null) {
-            if (delay < 1000L * 1000L * 1000) {
+            if (delay < 1000L * 1000L * 1000L) {
                 // to avoid typo, delay shorter than 1s makes no sense.
                 throw new DCmdException("Could not start recording, delay must be at least 1 second.");
             }


### PR DESCRIPTION
A simple one-liner fix in DCmdStart.java.

Testing:

- tier1

- all tests under open/test/jdk/jdk/jfr locally on linux-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251325](https://bugs.openjdk.java.net/browse/JDK-8251325): Miss 'L' for long value in if statement


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/687/head:pull/687`
`$ git checkout pull/687`
