### PR TITLE
8254855: Clean up and remove unused code in vmIntrinsics

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -743,4 +743,4 @@ vmIntrinsics::Flags vmIntrinsics::flags_for(vmIntrinsics::ID id) {
   assert(((ID4(1021,1022,1023,15) >> shift) & mask) == 15, "");
   return Flags( (info >> shift) & mask );
 }
-#endif
+#endif // ASSERT

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -701,6 +701,7 @@ const char* vmIntrinsics::short_name_as_C_string(vmIntrinsics::ID id, char* buf,
 
 #define ID4(x, y, z, f) ((ID3(x, y, z) << vmIntrinsics::log2_FLAG_LIMIT) | (jlong) (f))
 
+#ifdef ASSERT
 static const jlong intrinsic_info_array[vmIntrinsics::ID_LIMIT+1] = {
 #define VM_INTRINSIC_INFO(ignore_id, klass, name, sig, fcode) \
   ID4(SID_ENUM(klass), SID_ENUM(name), SID_ENUM(sig), vmIntrinsics::fcode),
@@ -715,7 +716,6 @@ inline jlong intrinsic_info(vmIntrinsics::ID id) {
   return intrinsic_info_array[vmIntrinsics::ID_from((int)id)];
 }
 
-#ifdef ASSERT
 vmSymbolID vmIntrinsics::class_for(vmIntrinsics::ID id) {
   jlong info = intrinsic_info(id);
   int shift = 2*vmSymbols::log2_SID_LIMIT + log2_FLAG_LIMIT, mask = right_n_bits(vmSymbols::log2_SID_LIMIT);

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -59,53 +59,6 @@ inline bool match_F_SN(jshort flags) {
   return (flags & (req | neg)) == req;
 }
 
-inline bool match_F_RNY(jshort flags) {
-  const int req = JVM_ACC_NATIVE | JVM_ACC_SYNCHRONIZED;
-  const int neg = JVM_ACC_STATIC;
-  return (flags & (req | neg)) == req;
-}
-
-static vmIntrinsics::ID wrapper_intrinsic(BasicType type, bool unboxing) {
-#define TYPE2(type, unboxing) ((int)(type)*2 + ((unboxing) ? 1 : 0))
-  switch (TYPE2(type, unboxing)) {
-#define BASIC_TYPE_CASE(type, box, unbox) \
-    case TYPE2(type, false):  return vmIntrinsics::box; \
-    case TYPE2(type, true):   return vmIntrinsics::unbox
-    BASIC_TYPE_CASE(T_BOOLEAN, _Boolean_valueOf,   _booleanValue);
-    BASIC_TYPE_CASE(T_BYTE,    _Byte_valueOf,      _byteValue);
-    BASIC_TYPE_CASE(T_CHAR,    _Character_valueOf, _charValue);
-    BASIC_TYPE_CASE(T_SHORT,   _Short_valueOf,     _shortValue);
-    BASIC_TYPE_CASE(T_INT,     _Integer_valueOf,   _intValue);
-    BASIC_TYPE_CASE(T_LONG,    _Long_valueOf,      _longValue);
-    BASIC_TYPE_CASE(T_FLOAT,   _Float_valueOf,     _floatValue);
-    BASIC_TYPE_CASE(T_DOUBLE,  _Double_valueOf,    _doubleValue);
-#undef BASIC_TYPE_CASE
-  }
-#undef TYPE2
-  return vmIntrinsics::_none;
-}
-
-vmIntrinsics::ID vmIntrinsics::for_boxing(BasicType type) {
-  return wrapper_intrinsic(type, false);
-}
-vmIntrinsics::ID vmIntrinsics::for_unboxing(BasicType type) {
-  return wrapper_intrinsic(type, true);
-}
-
-vmIntrinsics::ID vmIntrinsics::for_raw_conversion(BasicType src, BasicType dest) {
-#define SRC_DEST(s,d) (((int)(s) << 4) + (int)(d))
-  switch (SRC_DEST(src, dest)) {
-  case SRC_DEST(T_INT, T_FLOAT):   return vmIntrinsics::_intBitsToFloat;
-  case SRC_DEST(T_FLOAT, T_INT):   return vmIntrinsics::_floatToRawIntBits;
-
-  case SRC_DEST(T_LONG, T_DOUBLE): return vmIntrinsics::_longBitsToDouble;
-  case SRC_DEST(T_DOUBLE, T_LONG): return vmIntrinsics::_doubleToRawLongBits;
-  }
-#undef SRC_DEST
-
-  return vmIntrinsics::_none;
-}
-
 bool vmIntrinsics::preserves_state(vmIntrinsics::ID id) {
   assert(id != vmIntrinsics::_none, "must be a VM intrinsic");
   switch(id) {
@@ -731,7 +684,6 @@ const char* vmIntrinsics::short_name_as_C_string(vmIntrinsics::ID id, char* buf,
   case F_RN: fname = "native ";        break;
   case F_SN: fname = "native static "; break;
   case F_S:  fname = "static ";        break;
-  case F_RNY:fname = "native synchronized "; break;
   default:   break;
   }
   const char* kptr = strrchr(kname, JVM_SIGNATURE_SLASH);
@@ -763,6 +715,7 @@ inline jlong intrinsic_info(vmIntrinsics::ID id) {
   return intrinsic_info_array[vmIntrinsics::ID_from((int)id)];
 }
 
+#ifdef ASSERT
 vmSymbolID vmIntrinsics::class_for(vmIntrinsics::ID id) {
   jlong info = intrinsic_info(id);
   int shift = 2*vmSymbols::log2_SID_LIMIT + log2_FLAG_LIMIT, mask = right_n_bits(vmSymbols::log2_SID_LIMIT);
@@ -790,66 +743,4 @@ vmIntrinsics::Flags vmIntrinsics::flags_for(vmIntrinsics::ID id) {
   assert(((ID4(1021,1022,1023,15) >> shift) & mask) == 15, "");
   return Flags( (info >> shift) & mask );
 }
-
-
-#ifndef PRODUCT
-// verify_method performs an extra check on a matched intrinsic method
-
-static bool match_method(Method* m, Symbol* n, Symbol* s) {
-  return (m->name() == n &&
-          m->signature() == s);
-}
-
-static vmIntrinsics::ID match_method_with_klass(Method* m, Symbol* mk) {
-#define VM_INTRINSIC_MATCH(id, klassname, namepart, sigpart, flags) \
-  { Symbol* k = vmSymbols::klassname(); \
-    if (mk == k) { \
-      Symbol* n = vmSymbols::namepart(); \
-      Symbol* s = vmSymbols::sigpart(); \
-      if (match_method(m, n, s)) \
-        return vmIntrinsics::id; \
-    } }
-  VM_INTRINSICS_DO(VM_INTRINSIC_MATCH,
-                   VM_SYMBOL_IGNORE, VM_SYMBOL_IGNORE, VM_SYMBOL_IGNORE, VM_ALIAS_IGNORE);
-  return vmIntrinsics::_none;
-#undef VM_INTRINSIC_MATCH
-}
-
-void vmIntrinsics::verify_method(ID actual_id, Method* m) {
-  Symbol* mk = m->method_holder()->name();
-  ID declared_id = match_method_with_klass(m, mk);
-
-  if (declared_id == actual_id)  return; // success
-
-  if (declared_id == _none && actual_id != _none && mk == vmSymbols::java_lang_StrictMath()) {
-    // Here are a few special cases in StrictMath not declared in vmSymbols.hpp.
-    switch (actual_id) {
-    case _min:
-    case _max:
-    case _dsqrt:
-      declared_id = match_method_with_klass(m, vmSymbols::java_lang_Math());
-      if (declared_id == actual_id)  return; // acceptable alias
-      break;
-    default:
-        break;
-    }
-  }
-
-  const char* declared_name = name_at(declared_id);
-  const char* actual_name   = name_at(actual_id);
-  m = NULL;
-  ttyLocker ttyl;
-  if (xtty != NULL) {
-    xtty->begin_elem("intrinsic_misdeclared actual='%s' declared='%s'",
-                     actual_name, declared_name);
-    xtty->method(m);
-    xtty->end_elem("%s", "");
-  }
-  if (PrintMiscellaneous && (WizardMode || Verbose)) {
-    tty->print_cr("*** misidentified method; %s(%d) should be %s(%d):",
-                  declared_name, declared_id, actual_name, actual_id);
-    m->print_short_name(tty);
-    tty->cr();
-  }
-}
-#endif //PRODUCT
+#endif

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -1036,12 +1036,11 @@ class vmIntrinsics : AllStatic {
     F_Y,                        // !static ?native  synchronized
     F_RN,                       // !static  native !synchronized
     F_SN,                       //  static  native !synchronized
-    F_RNY,                      // !static  native  synchronized
 
     FLAG_LIMIT
   };
   enum {
-    log2_FLAG_LIMIT = 4         // checked by an assert at start-up
+    log2_FLAG_LIMIT = 3         // checked by an assert at start-up
   };
 
 public:
@@ -1079,22 +1078,15 @@ public:
     return id;
   }
 
-  static void verify_method(ID actual_id, Method* m) PRODUCT_RETURN;
-
+#ifdef ASSERT
   // Find out the symbols behind an intrinsic:
   static vmSymbolID     class_for(ID id);
   static vmSymbolID      name_for(ID id);
   static vmSymbolID signature_for(ID id);
   static Flags              flags_for(ID id);
+#endif
 
   static const char* short_name_as_C_string(ID id, char* buf, int size);
-
-  // Wrapper object methods:
-  static ID for_boxing(BasicType type);
-  static ID for_unboxing(BasicType type);
-
-  // Raw conversion:
-  static ID for_raw_conversion(BasicType src, BasicType dest);
 
   // The methods below provide information related to compiling intrinsics.
 


### PR DESCRIPTION
- Remove unused code and constants
- Guard some code only used for assertions by ASSERT
- Adjust log2_FLAG_LIMIT (could have been 3 also before removing F_RNY)

Testing: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254855](https://bugs.openjdk.java.net/browse/JDK-8254855): Clean up and remove unused code in vmIntrinsics


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/688/head:pull/688`
`$ git checkout pull/688`
