### PR TITLE
8254861: reformat code in vmTestbase/nsk/jdb

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002.java
@@ -60,30 +60,31 @@
 
 package nsk.jdb.caught_exception.caught_exception002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class caught_exception002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new caught_exception002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.caught_exception.caught_exception002";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".caught_exception002";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.caught_exception.caught_exception002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".caught_exception002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static final int MAX = 10;
 
@@ -91,16 +92,12 @@ public class caught_exception002 extends JdbTest {
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         for (int i = 0; i < MAX; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand._catch + " caught " + PACKAGE_NAME + ".MyException" + i);
+            jdb.receiveReplyFor(JdbCommand._catch + " caught " + PACKAGE_NAME + ".MyException" + i);
         }
 
         for (int i = 0; i < MAX; i++) {
@@ -111,11 +108,10 @@ public class caught_exception002 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private void checkCatch (String[] reply, int i) {
+    private void checkCatch(String[] reply, int i) {
         Paragrep grep;
         int count;
-        String found;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         grep = new Paragrep(reply);
         v.add("Exception occurred");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002a.java
@@ -23,32 +23,29 @@
 
 package nsk.jdb.caught_exception.caught_exception002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class caught_exception002a {
 
-    /* TEST DEPENDANT VARIABLES AND CONSTANTS */
-    static final String PACKAGE_NAME = "nsk.jdb.caught_exception.caught_exception002";
-
-    public static void main(String args[]) {
-       caught_exception002a _caught_exception002a = new caught_exception002a();
-       System.exit(caught_exception002.JCK_STATUS_BASE + _caught_exception002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        caught_exception002a _caught_exception002a = new caught_exception002a();
+        System.exit(caught_exception002.JCK_STATUS_BASE + _caught_exception002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
         lastBreak();
 
-        int  result = -1;
+        int result = -1;
         for (int i = 0; i <= 10; i++) {
             result = a(i);
         }
@@ -86,63 +83,92 @@ public class caught_exception002a {
     }
 
     public static int b(int i) throws MyException0, MyException1,
-        MyException2, MyException3, MyException4, MyException5, MyException6,
-        MyException7, MyException8, MyException9 {
+            MyException2, MyException3, MyException4, MyException5, MyException6,
+            MyException7, MyException8, MyException9 {
 
-        switch(i) {
-           case 0:
-              throw new MyException0("MyException0");
-           case 1:
-              throw new MyException1("MyException1");
-           case 2:
-              throw new MyException2("MyException2");
-           case 3:
-              throw new MyException3("MyException3");
-           case 4:
-              throw new MyException4("MyException4");
-           case 5:
-              throw new MyException5("MyException5");
-           case 6:
-              throw new MyException6("MyException6");
-           case 7:
-              throw new MyException7("MyException7");
-           case 8:
-              throw new MyException8("MyException8");
-           case 9:
-              throw new MyException9("MyException9");
-           default:
-              return i*i;
+        switch (i) {
+            case 0:
+                throw new MyException0("MyException0");
+            case 1:
+                throw new MyException1("MyException1");
+            case 2:
+                throw new MyException2("MyException2");
+            case 3:
+                throw new MyException3("MyException3");
+            case 4:
+                throw new MyException4("MyException4");
+            case 5:
+                throw new MyException5("MyException5");
+            case 6:
+                throw new MyException6("MyException6");
+            case 7:
+                throw new MyException7("MyException7");
+            case 8:
+                throw new MyException8("MyException8");
+            case 9:
+                throw new MyException9("MyException9");
+            default:
+                return i * i;
         }
     }
 }
 
 class MyException0 extends Exception {
-   public MyException0 (String s) {super(s);}
+    public MyException0(String s) {
+        super(s);
+    }
 }
+
 class MyException1 extends Exception {
-   public MyException1 (String s) {super(s);}
+    public MyException1(String s) {
+        super(s);
+    }
 }
+
 class MyException2 extends Exception {
-   public MyException2 (String s) {super(s);}
+    public MyException2(String s) {
+        super(s);
+    }
 }
+
 class MyException3 extends Exception {
-   public MyException3 (String s) {super(s);}
+    public MyException3(String s) {
+        super(s);
+    }
 }
+
 class MyException4 extends Exception {
-   public MyException4 (String s) {super(s);}
+    public MyException4(String s) {
+        super(s);
+    }
 }
+
 class MyException5 extends Exception {
-   public MyException5 (String s) {super(s);}
+    public MyException5(String s) {
+        super(s);
+    }
 }
+
 class MyException6 extends Exception {
-   public MyException6 (String s) {super(s);}
+    public MyException6(String s) {
+        super(s);
+    }
 }
+
 class MyException7 extends Exception {
-   public MyException7 (String s) {super(s);}
+    public MyException7(String s) {
+        super(s);
+    }
 }
+
 class MyException8 extends Exception {
-   public MyException8 (String s) {super(s);}
+    public MyException8(String s) {
+        super(s);
+    }
 }
+
 class MyException9 extends Exception {
-   public MyException9 (String s) {super(s);}
+    public MyException9(String s) {
+        super(s);
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001.java
@@ -51,70 +51,65 @@
 
 package nsk.jdb.classes.classes001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class classes001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new classes001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.classes.classes001";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".classes001";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final String NOT_VALID_SAMPLE   = "is not a valid";
+    static final String PACKAGE_NAME = "nsk.jdb.classes.classes001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".classes001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static String[] checkedClasses = {
-        DEBUGGEE_CLASS,
-        DEBUGGEE_CLASS + "$Inner1",
-        DEBUGGEE_CLASS + "$Inner2",
-        DEBUGGEE_CLASS + "$Inner3",
-        DEBUGGEE_CLASS + "$Inner4",
-        DEBUGGEE_CLASS + "$Inner5",
-        DEBUGGEE_CLASS + "$Inner6",
-        DEBUGGEE_CLASS + "$Inner7",
-        DEBUGGEE_CLASS + "$Inner8",
-        DEBUGGEE_CLASS + "$InnerInt1",
-        DEBUGGEE_CLASS + "$InnerInt2",
-        DEBUGGEE_CLASS + "$InnerInt3",
-        DEBUGGEE_CLASS + "$InnerInt4",
-        DEBUGGEE_CLASS + "$InnerInt5",
-        PACKAGE_NAME + ".Outer1",
-        PACKAGE_NAME + ".Outer2",
-        PACKAGE_NAME + ".Outer3",
-        PACKAGE_NAME + ".OuterInt1",
-        PACKAGE_NAME + ".OuterInt2"
-                                      };
+            DEBUGGEE_CLASS,
+            DEBUGGEE_CLASS + "$Inner1",
+            DEBUGGEE_CLASS + "$Inner2",
+            DEBUGGEE_CLASS + "$Inner3",
+            DEBUGGEE_CLASS + "$Inner4",
+            DEBUGGEE_CLASS + "$Inner5",
+            DEBUGGEE_CLASS + "$Inner6",
+            DEBUGGEE_CLASS + "$Inner7",
+            DEBUGGEE_CLASS + "$Inner8",
+            DEBUGGEE_CLASS + "$InnerInt1",
+            DEBUGGEE_CLASS + "$InnerInt2",
+            DEBUGGEE_CLASS + "$InnerInt3",
+            DEBUGGEE_CLASS + "$InnerInt4",
+            DEBUGGEE_CLASS + "$InnerInt5",
+            PACKAGE_NAME + ".Outer1",
+            PACKAGE_NAME + ".Outer2",
+            PACKAGE_NAME + ".Outer3",
+            PACKAGE_NAME + ".OuterInt1",
+            PACKAGE_NAME + ".OuterInt2"
+    };
 
     /* ------------------------------------- */
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         reply = jdb.receiveReplyFor(JdbCommand.classes);
 
-        for (int i = 0; i < checkedClasses.length; i++) {
-            if (!checkClass(checkedClasses[i], reply)) {
+        for (String checkedClass : checkedClasses) {
+            if (!checkClass(checkedClass, reply)) {
                 success = false;
             }
         }
@@ -122,7 +117,7 @@ public class classes001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkClass (String className, String[] reply) {
+    private boolean checkClass(String className, String[] reply) {
         Paragrep grep;
         String found;
         boolean result = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001a.java
@@ -23,27 +23,24 @@
 
 package nsk.jdb.classes.classes001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class classes001a {
 
-    /* TEST DEPENDANT VARIABLES AND CONSTANTS */
-    static final String PACKAGE_NAME = "nsk.jdb.classes.classes001";
-
-    public static void main(String args[]) {
-       classes001a _classes001a = new classes001a();
-       System.exit(classes001.JCK_STATUS_BASE + _classes001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        classes001a _classes001a = new classes001a();
+        System.exit(classes001.JCK_STATUS_BASE + _classes001a.runIt(args, System.out));
     }
 
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -53,27 +50,46 @@ public class classes001a {
         return classes001.PASSED;
     }
 
-    class Inner1 {}
-    interface InnerInt1 {}
+    class Inner1 {
+    }
 
-    public class Inner2 {}
-    public interface InnerInt2 {}
+    interface InnerInt1 {
+    }
 
-    private class Inner3 {}
-    private interface InnerInt3 {}
+    public class Inner2 {
+    }
 
-    protected class Inner4 {}
-    protected interface InnerInt4 {}
+    public interface InnerInt2 {
+    }
 
-    abstract class Inner5 {}
-    abstract interface InnerInt5 {}
+    private class Inner3 {
+    }
 
-    final class Inner6 extends Inner5{}
+    private interface InnerInt3 {
+    }
 
-    class Inner7 extends Outer2{}
-    class Inner8 implements OuterInt1, OuterInt2, InnerInt1, InnerInt2, InnerInt3,  InnerInt4, InnerInt5 {}
+    protected class Inner4 {
+    }
 
-    private void init () {
+    protected interface InnerInt4 {
+    }
+
+    abstract class Inner5 {
+    }
+
+    abstract interface InnerInt5 {
+    }
+
+    final class Inner6 extends Inner5 {
+    }
+
+    class Inner7 extends Outer2 {
+    }
+
+    class Inner8 implements OuterInt1, OuterInt2, InnerInt1, InnerInt2, InnerInt3, InnerInt4, InnerInt5 {
+    }
+
+    private void init() {
         Outer1 o1 = new Outer1();
         Outer3 o3 = new Outer3();
         Inner1 i1 = new Inner1();
@@ -88,10 +104,17 @@ public class classes001a {
     }
 }
 
-class Outer1 {}
-interface OuterInt1 {}
+class Outer1 {
+}
 
-abstract class Outer2 {}
-abstract interface OuterInt2 {}
+interface OuterInt1 {
+}
 
-final class Outer3 {}
+abstract class Outer2 {
+}
+
+abstract interface OuterInt2 {
+}
+
+final class Outer3 {
+}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001.java
@@ -50,20 +50,20 @@
 
 package nsk.jdb.classpath.classpath001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class classpath001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new classpath001().runTest(argv, out);
@@ -72,14 +72,12 @@ public class classpath001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.classpath.classpath001";
     static final String TEST_CLASS = PACKAGE_NAME + ".classpath001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
         String found;
 
         reply = jdb.receiveReplyFor(JdbCommand.classpath);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.classpath.classpath001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class classpath001a {
-    public static void main(String args[]) {
-       classpath001a _classpath001a = new classpath001a();
-       lastBreak();
-       System.exit(classpath001.JCK_STATUS_BASE + _classpath001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        classpath001a _classpath001a = new classpath001a();
+        lastBreak();
+        System.exit(classpath001.JCK_STATUS_BASE + _classpath001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002.java
@@ -52,41 +52,40 @@
 
 package nsk.jdb.clear.clear002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.Jdb;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class clear002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new clear002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.clear.clear002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".clear002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
-    static final String METHOD_TO_STOP   = DEBUGGEE_CLASS + ".func5";
+    static final String PACKAGE_NAME = "nsk.jdb.clear.clear002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".clear002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String METHOD_TO_STOP = DEBUGGEE_CLASS + ".func5";
     static final String METHOD1_TO_CLEAR = DEBUGGEE_CLASS + ".func4";
     static final String METHOD2_TO_CLEAR = DEBUGGEE_CLASS + "$A.func7";
-    static final String REMOVED_SAMPLE   = "Removed:";
+    static final String REMOVED_SAMPLE = "Removed:";
 
     protected void runCases() {
-        String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
         log.display("Setting breakpoint in method: " + METHOD1_TO_CLEAR);
         jdb.setBreakpointInMethod(METHOD1_TO_CLEAR);
@@ -97,11 +96,11 @@ public class clear002 extends JdbTest {
         log.display("Setting breakpoint in method: " + METHOD_TO_STOP);
         jdb.setBreakpointInMethod(METHOD_TO_STOP);
 
-        if (!checkClear (METHOD1_TO_CLEAR)) {
+        if (!checkClear(METHOD1_TO_CLEAR)) {
             success = false;
         }
 
-        if (!checkClear (METHOD2_TO_CLEAR)) {
+        if (!checkClear(METHOD2_TO_CLEAR)) {
             success = false;
         }
 
@@ -115,22 +114,21 @@ public class clear002 extends JdbTest {
             success = false;
         }
 
-        if (!checkBreakpoint (METHOD1_TO_CLEAR, grep)) {
+        if (!checkBreakpoint(METHOD1_TO_CLEAR, grep)) {
             success = false;
         }
 
-        if (!checkBreakpoint (METHOD2_TO_CLEAR, grep)) {
+        if (!checkBreakpoint(METHOD2_TO_CLEAR, grep)) {
             success = false;
         }
     }
 
-    private boolean checkBreakpoint (String methodName, Paragrep grep) {
+    private boolean checkBreakpoint(String methodName, Paragrep grep) {
         String found;
         boolean result = true;
-        int count;
-        Vector v;
+        Vector<String> v;
 
-        v = new Vector();
+        v = new Vector<>();
         v.add(Jdb.BREAKPOINT_HIT);
         v.add(methodName);
 
@@ -142,15 +140,14 @@ public class clear002 extends JdbTest {
         return result;
     }
 
-    private boolean checkClear (String methodName) {
+    private boolean checkClear(String methodName) {
         Paragrep grep;
         String found;
         String[] reply;
         boolean result = true;
-        int count;
-        Vector v;
+        Vector<String> v;
 
-        v = new Vector();
+        v = new Vector<>();
         v.add(REMOVED_SAMPLE);
         v.add(methodName);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.clear.clear002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class clear002a {
-    public static void main(String args[]) {
-       clear002a _clear002a = new clear002a();
-       lastBreak();
-       System.exit(clear002.JCK_STATUS_BASE + _clear002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        clear002a _clear002a = new clear002a();
+        lastBreak();
+        System.exit(clear002.JCK_STATUS_BASE + _clear002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -62,19 +62,19 @@ public class clear002a {
     }
 
     public int func4(int i) {
-       return func5(i) + 1;
+        return func5(i) + 1;
     }
 
     public int func5(int i) {
-       return func6(i) + 1;
+        return func6(i) + 1;
     }
 
     public int func6(int i) {
-        return i-5;
+        return i - 5;
     }
 
     static class A {
-        public static int func7 (int i) {
+        public static int func7(int i) {
             return i++;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003.java
@@ -53,20 +53,21 @@
 
 package nsk.jdb.clear.clear003;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.Jdb;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class clear003 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new clear003().runTest(argv, out);
@@ -75,8 +76,8 @@ public class clear003 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.clear.clear003";
     static final String TEST_CLASS = PACKAGE_NAME + ".clear003";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
     static final String METHOD4 = "func4";
     static final String METHOD5 = "func5";
     static final String METHOD_TO_CLEAR = DEBUGGEE_CLASS + "." + METHOD4;
@@ -85,8 +86,6 @@ public class clear003 extends JdbTest {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
         log.display("Setting breakpoint in method: " + METHOD5);
         jdb.setBreakpointInMethod(DEBUGGEE_CLASS + "." + METHOD5);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.clear.clear003;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class clear003a {
-    public static void main(String args[]) {
-       clear003a _clear003a = new clear003a();
-       lastBreak();
-       System.exit(clear003.JCK_STATUS_BASE + _clear003a.runIt(args, System.out));
+    public static void main(String[] args) {
+        clear003a _clear003a = new clear003a();
+        lastBreak();
+        System.exit(clear003.JCK_STATUS_BASE + _clear003a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -64,18 +64,18 @@ public class clear003a {
     }
 
     public int func4(int i) {
-       int value;
-       value = func5(i) + 1;
-       return value;
+        int value;
+        value = func5(i) + 1;
+        return value;
     }
 
     public int func5(int i) {
-       int value;
-       value = func6(i) + 1;
-       return value;
+        int value;
+        value = func6(i) + 1;
+        return value;
     }
 
     public int func6(int i) {
-        return i-5;
+        return i - 5;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004.java
@@ -54,49 +54,48 @@
 
 package nsk.jdb.clear.clear004;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.Jdb;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class clear004 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new clear004().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.clear.clear004";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".clear004";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
-    static final String[] BREAKPOINTS = new String[]
-        { DEBUGGEE_CLASS + ":63",
-          DEBUGGEE_CLASS + ":67",
-          DEBUGGEE_CLASS + ":71" };
-    static final String REMOVED_SAMPLE   = "Removed:";
+    static final String PACKAGE_NAME = "nsk.jdb.clear.clear004";
+    static final String TEST_CLASS = PACKAGE_NAME + ".clear004";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String[] BREAKPOINTS = new String[]{
+            DEBUGGEE_CLASS + ":63",
+            DEBUGGEE_CLASS + ":67",
+            DEBUGGEE_CLASS + ":71"};
+    static final String REMOVED_SAMPLE = "Removed:";
 
     protected void runCases() {
-        String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
-        for (int i = 0; i < BREAKPOINTS.length; i++) {
-           log.display("Setting breakpoint at " + BREAKPOINTS[i]);
-           reply = jdb.receiveReplyFor(JdbCommand.stop_at + BREAKPOINTS[i]);
+        for (String breakpoint : BREAKPOINTS) {
+            log.display("Setting breakpoint at " + breakpoint);
+            jdb.receiveReplyFor(JdbCommand.stop_at + breakpoint);
         }
 
-        if (!checkClear (BREAKPOINTS[1])) {
+        if (!checkClear(BREAKPOINTS[1])) {
             success = false;
         }
 
@@ -110,19 +109,18 @@ public class clear004 extends JdbTest {
             success = false;
         }
 
-        if (!checkBreakpoint (BREAKPOINTS[1], grep)) {
+        if (!checkBreakpoint(BREAKPOINTS[1], grep)) {
             success = false;
         }
 
     }
 
-    private boolean checkBreakpoint (String breakpoint, Paragrep grep) {
+    private boolean checkBreakpoint(String breakpoint, Paragrep grep) {
         String found;
         boolean result = true;
-        int count;
-        Vector v;
+        Vector<String> v;
 
-        v = new Vector();
+        v = new Vector<>();
         v.add(Jdb.BREAKPOINT_HIT);
         v.add(breakpoint);
 
@@ -134,15 +132,14 @@ public class clear004 extends JdbTest {
         return result;
     }
 
-    private boolean checkClear (String breakpoint) {
+    private boolean checkClear(String breakpoint) {
         Paragrep grep;
         String found;
         String[] reply;
         boolean result = true;
-        int count;
-        Vector v;
+        Vector<String> v;
 
-        v = new Vector();
+        v = new Vector<>();
         v.add(REMOVED_SAMPLE);
         v.add(breakpoint);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004a.java
@@ -25,23 +25,23 @@
 
 package nsk.jdb.clear.clear004;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class clear004a {
-    public static void main(String args[]) {
-       clear004a _clear004a = new clear004a();
-       lastBreak();
-       System.exit(clear004.JCK_STATUS_BASE + _clear004a.runIt(args, System.out));
+    public static void main(String[] args) {
+        clear004a _clear004a = new clear004a();
+        lastBreak();
+        System.exit(clear004.JCK_STATUS_BASE + _clear004a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -64,19 +64,19 @@ public class clear004a {
     }
 
     public int func4(int i) {
-       return func5(i) + 1;  // this is line for cleared breakpoint // clear004.BREAKPOINTS[1]
+        return func5(i) + 1;  // this is line for cleared breakpoint // clear004.BREAKPOINTS[1]
     }
 
     public int func5(int i) {
-       return func6(i) + 1;  // this is line for breakpoint // clear004.BREAKPOINTS[2]
+        return func6(i) + 1;  // this is line for breakpoint // clear004.BREAKPOINTS[2]
     }
 
     public int func6(int i) {
-        return i-5;
+        return i - 5;
     }
 
     static class A {
-        public static int func7 (int i) {
+        public static int func7(int i) {
             return i++;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002.java
@@ -57,56 +57,56 @@
 
 package nsk.jdb.down.down002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class down002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new down002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.down.down002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".down002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.down.down002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".down002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][] {
-        {"[1]", DEBUGGEE_CLASS + ".func5"},
-        {"[2]", DEBUGGEE_CLASS + ".func4"},
-        {"[3]", DEBUGGEE_CLASS + ".func3"},
-        {"[4]", DEBUGGEE_CLASS + ".func2"},
-        {"[5]", DEBUGGEE_CLASS + ".func1"},
-        {"[6]", DEBUGGEE_CLASS + ".runIt"},
-        {"[7]", DEBUGGEE_CLASS + ".main"}
-                                                };
+    static final String[][] FRAMES = new String[][]{
+            {"[1]", DEBUGGEE_CLASS + ".func5"},
+            {"[2]", DEBUGGEE_CLASS + ".func4"},
+            {"[3]", DEBUGGEE_CLASS + ".func3"},
+            {"[4]", DEBUGGEE_CLASS + ".func2"},
+            {"[5]", DEBUGGEE_CLASS + ".func1"},
+            {"[6]", DEBUGGEE_CLASS + ".runIt"},
+            {"[7]", DEBUGGEE_CLASS + ".main"}
+    };
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.receiveReplyFor(JdbCommand.stop_in + DEBUGGEE_CLASS + ".func5");
         jdb.receiveReplyFor(JdbCommand.cont);
 
-        for (int i = 0; i < (FRAMES.length-1); i++) {
+        for (int i = 0; i < (FRAMES.length - 1); i++) {
             jdb.receiveReplyFor(JdbCommand.up);
         }
 
-        for (int i = 0; i < (FRAMES.length-1); i++) {
+        for (int i = 0; i < (FRAMES.length - 1); i++) {
             jdb.receiveReplyFor(JdbCommand.down);
             jdb.receiveReplyFor(JdbCommand.where);
         }
@@ -116,14 +116,14 @@ public class down002 extends JdbTest {
         reply = jdb.getTotalReply();
         grep = new Paragrep(reply);
 
-        for (int i = 1; i < (FRAMES.length-1); i++) {
-            v = new Vector();
+        for (int i = 1; i < (FRAMES.length - 1); i++) {
+            v = new Vector<>();
             v.add(FRAMES[i][0]);
             v.add(FRAMES[i][1]);
             count = grep.find(v);
-            if (count != (i+1)) {
+            if (count != (i + 1)) {
                 failure("Unexpected number of the stack frame: " + FRAMES[i][1] +
-                    "\n\texpected value : " + (i+1) + ", got : " + count);
+                        "\n\texpected value : " + (i + 1) + ", got : " + count);
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.down.down002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class down002a {
-    public static void main(String args[]) {
-       down002a _down002a = new down002a();
-       lastBreak();
-       System.exit(down002.JCK_STATUS_BASE + _down002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        down002a _down002a = new down002a();
+        lastBreak();
+        System.exit(down002.JCK_STATUS_BASE + _down002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -62,14 +62,14 @@ public class down002a {
     }
 
     public int func4(int i) {
-       return func5(i) + 1;
+        return func5(i) + 1;
     }
 
     public int func5(int i) {
-       return func6(i) + 1;
+        return func6(i) + 1;
     }
 
     public int func6(int i) {
-        return i-5;
+        return i - 5;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002.java
@@ -61,20 +61,21 @@
 
 package nsk.jdb.dump.dump002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class dump002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
@@ -84,56 +85,54 @@ public class dump002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.dump.dump002";
     static final String TEST_CLASS = PACKAGE_NAME + ".dump002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
     static final String COMPOUND_PROMPT_IDENT = "main";
 
     static final String[] CHECKED_FIELDS = {
-        "_dump002a",
-        "iStatic",
-        "iPrivate",
-        "iProtect",
-        "iPublic",
-        "iFinal",
-        "iTransient",
-        "iVolatile",
-        "iArray",
-        "sStatic",
-        "sPrivate",
-        "sProtected",
-        "sPublic",
-        "sFinal",
-        "sTransient",
-        "sVolatile",
-        "sArray",
-        "fBoolean",
-        "fByte",
-        "fChar",
-        "fDouble",
-        "fFloat",
-        "fInt",
-        "fLong",
-        "fShort"
-                                         };
+            "_dump002a",
+            "iStatic",
+            "iPrivate",
+            "iProtect",
+            "iPublic",
+            "iFinal",
+            "iTransient",
+            "iVolatile",
+            "iArray",
+            "sStatic",
+            "sPrivate",
+            "sProtected",
+            "sPublic",
+            "sFinal",
+            "sTransient",
+            "sVolatile",
+            "sArray",
+            "fBoolean",
+            "fByte",
+            "fChar",
+            "fDouble",
+            "fFloat",
+            "fInt",
+            "fLong",
+            "fShort"
+    };
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v = new Vector();
-        String found;
+        Vector<String> v = new Vector<>();
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         reply = jdb.receiveReplyFor(JdbCommand.dump + DEBUGGEE_CLASS + "._dump002a");
         grep = new Paragrep(reply);
-        for (int i = 0; i < CHECKED_FIELDS.length; i++) {
+        for (String field : CHECKED_FIELDS) {
             v.setSize(0);
-            v.add(CHECKED_FIELDS[i]);
+            v.add(field);
             v.add("null");
             if (grep.find(v) > 0) {
-                failure("The field is not dumped : " + CHECKED_FIELDS[i]);
+                failure("The field is not dumped : " + field);
             }
         }
 
@@ -148,9 +147,9 @@ public class dump002 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    void checkField (String[] reply, String fieldName) {
+    void checkField(String[] reply, String fieldName) {
         Paragrep grep;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         grep = new Paragrep(reply);
         v.setSize(0);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.dump.dump002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class dump002a {
     static dump002a _dump002a = new dump002a();
 
-    public static void main(String args[]) {
-       System.exit(dump002.JCK_STATUS_BASE + _dump002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(dump002.JCK_STATUS_BASE + _dump002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -49,32 +49,32 @@ public class dump002a {
         return dump002.PASSED;
     }
 
-    static     int iStatic    = 0;
-    private    int iPrivate   = 1;
-    protected  int iProtect   = 2;
-    public     int iPublic    = 3;
-    final      int iFinal     = 4;
-    transient  int iTransient = 5;
-    volatile   int iVolatile  = 6;
+    static int iStatic = 0;
+    private int iPrivate = 1;
+    protected int iProtect = 2;
+    public int iPublic = 3;
+    final int iFinal = 4;
+    transient int iTransient = 5;
+    volatile int iVolatile = 6;
 
-    static     int [] iArray = { 7 };
+    static int[] iArray = {7};
 
-    static     String sStatic    = "zero";
-    private    String sPrivate   = "one";
-    protected  String sProtected = "two";
-    public     String sPublic    = "three";
-    final      String sFinal     = "four";
-    transient  String sTransient = "five";
-    volatile   String sVolatile  = "six";
+    static String sStatic = "zero";
+    private String sPrivate = "one";
+    protected String sProtected = "two";
+    public String sPublic = "three";
+    final String sFinal = "four";
+    transient String sTransient = "five";
+    volatile String sVolatile = "six";
 
-    static     String [] sArray = { "seven" };
+    static String[] sArray = {"seven"};
 
     boolean fBoolean = true;
-    byte    fByte    = Byte.MAX_VALUE;
-    char    fChar    = Character.MAX_VALUE;
-    double  fDouble  = Double.MAX_VALUE;
-    float   fFloat   = Float.MAX_VALUE;
-    int     fInt     = Integer.MAX_VALUE;
-    long    fLong    = Long.MAX_VALUE;
-    short   fShort   = Short.MAX_VALUE;
+    byte fByte = Byte.MAX_VALUE;
+    char fChar = Character.MAX_VALUE;
+    double fDouble = Double.MAX_VALUE;
+    float fFloat = Float.MAX_VALUE;
+    int fInt = Integer.MAX_VALUE;
+    long fLong = Long.MAX_VALUE;
+    short fShort = Short.MAX_VALUE;
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001.java
@@ -66,20 +66,20 @@
 
 package nsk.jdb.eval.eval001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class eval001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new eval001().runTest(argv, out);
@@ -88,35 +88,29 @@ public class eval001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.eval.eval001";
     static final String TEST_CLASS = PACKAGE_NAME + ".eval001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String[][] checkedExpr = {
-        { DEBUGGEE_CLASS + ".myStaticField", "-2147483648" },
-        { DEBUGGEE_CLASS + "._eval001a.myInstanceField", "9223372036854775807" },
-        { DEBUGGEE_CLASS + "._eval001a.myArrayField[0][0].toString()", "ABCDE" },
-        { DEBUGGEE_CLASS + "._eval001a.myMethod()", "2147483647" },
-        { "myClass.toString().equals(\"abcde\")", "true"},
-        { "i + j + k", "777"},
-        { "new java.lang.String(\"Hello, World\").length()", "12"},
-        { DEBUGGEE_CLASS + "._eval001a.testPrimitiveArray(test)", "1.0" }
-                                          };
+            {DEBUGGEE_CLASS + ".myStaticField", "-2147483648"},
+            {DEBUGGEE_CLASS + "._eval001a.myInstanceField", "9223372036854775807"},
+            {DEBUGGEE_CLASS + "._eval001a.myArrayField[0][0].toString()", "ABCDE"},
+            {DEBUGGEE_CLASS + "._eval001a.myMethod()", "2147483647"},
+            {"myClass.toString().equals(\"abcde\")", "true"},
+            {"i + j + k", "777"},
+            {"new java.lang.String(\"Hello, World\").length()", "12"},
+            {DEBUGGEE_CLASS + "._eval001a.testPrimitiveArray(test)", "1.0"}
+    };
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // to get out of lastBreak()
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
 
-        for (int i = 0; i < checkedExpr.length; i++) {
-            if (!checkValue(checkedExpr[i][0], checkedExpr[i][1])) {
+        for (String[] strings : checkedExpr) {
+            if (!checkValue(strings[0], strings[1])) {
                 success = false;
             }
         }
@@ -124,11 +118,10 @@ public class eval001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkValue (String expr, String value) {
+    private boolean checkValue(String expr, String value) {
         Paragrep grep;
         String[] reply;
         String found;
-        Vector v;
         boolean result = true;
 
         reply = jdb.receiveReplyFor(JdbCommand.eval + expr);
@@ -136,7 +129,7 @@ public class eval001 extends JdbTest {
         found = grep.findFirst(value);
         if (found.length() <= 0) {
             log.complain("jdb failed to report value of expression: " + expr);
-            log.complain("expected : " + value + " ;\nreported: " + (reply.length > 0? reply[0]: ""));
+            log.complain("expected : " + value + " ;\nreported: " + (reply.length > 0 ? reply[0] : ""));
             result = false;
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001a.java
@@ -23,24 +23,24 @@
 
 package nsk.jdb.eval.eval001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class eval001a {
 
     static eval001a _eval001a = new eval001a();
 
-    public static void main(String args[]) {
-       System.exit(eval001.JCK_STATUS_BASE + _eval001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(eval001.JCK_STATUS_BASE + _eval001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -62,9 +62,9 @@ public class eval001a {
     protected long myInstanceField;
     public MyClass[][] myArrayField;
 
-    private eval001a () {
-         myArrayField = new MyClass[][] {new MyClass[] {new MyClass("ABCDE")}};
-         myInstanceField = Long.MAX_VALUE;
+    private eval001a() {
+        myArrayField = new MyClass[][]{new MyClass[]{new MyClass("ABCDE")}};
+        myInstanceField = Long.MAX_VALUE;
     }
 
     synchronized private int myMethod() {
@@ -74,16 +74,16 @@ public class eval001a {
     static class MyClass {
         String line;
 
-        public MyClass (String s) {
+        public MyClass(String s) {
             line = s;
         }
 
         public String toString() {
-             return line;
+            return line;
         }
     }
 
-    public double testPrimitiveArray(double[][][] d){
+    public double testPrimitiveArray(double[][][] d) {
         return 1.0;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
@@ -73,42 +73,40 @@
 
 package nsk.jdb.exclude.exclude001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class exclude001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new exclude001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.exclude.exclude001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".exclude001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.exclude.exclude001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".exclude001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String JAVA_CORE_METHOD = "java.lang.System.currentTimeMillis";
-    static final String SUN_METHOD   = "sun.util.calendar.Gregorian";
+    static final String SUN_METHOD = "sun.util.calendar.Gregorian";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
         String[] threads;
 
         String oldExclude = "";
@@ -141,22 +139,21 @@ public class exclude001 extends JdbTest {
                         success = false;
                     } else {
 
-                        reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
+                        jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
 
                         switch (testCase) {
-                        case 0: // block all
-                                reply = jdb.receiveReplyFor(JdbCommand.exclude + "java.*,javax.*,sun.*,com.sun.*,jdk.*");
-
+                            case 0: // block all
+                                jdb.receiveReplyFor(JdbCommand.exclude + "java.*,javax.*,sun.*,com.sun.*,jdk.*");
                                 break;
-                        case 1: // allow java.*
-                                reply = jdb.receiveReplyFor(JdbCommand.exclude + "javax.*,sun.*,com.sun.*,jdk.*");
+                            case 1: // allow java.*
+                                jdb.receiveReplyFor(JdbCommand.exclude + "javax.*,sun.*,com.sun.*,jdk.*");
                                 break;
-                        case 2: // allow sun.*
-                                reply = jdb.receiveReplyFor(JdbCommand.exclude + "java.*,javax.*,com.sun.*,jdk.*");
+                            case 2: // allow sun.*
+                                jdb.receiveReplyFor(JdbCommand.exclude + "java.*,javax.*,com.sun.*,jdk.*");
                                 break;
                         }
 
-                        reply = jdb.receiveReplyFor(JdbCommand.trace + "methods " + threads[0]);
+                        jdb.receiveReplyFor(JdbCommand.trace + "methods " + threads[0]);
 
                         while (true) {
                             reply = jdb.receiveReplyForWithMessageWait(JdbCommand.cont, expectedPrompt);
@@ -184,8 +181,8 @@ public class exclude001 extends JdbTest {
                             if (count > 0) {
                                 nskTraced = true;
 
-                                reply = jdb.receiveReplyFor(JdbCommand.exclude + oldExclude);
-                                reply = jdb.receiveReplyFor(JdbCommand.untrace + "methods "+ threads[0]);
+                                jdb.receiveReplyFor(JdbCommand.exclude + oldExclude);
+                                jdb.receiveReplyFor(JdbCommand.untrace + "methods " + threads[0]);
                                 break;
                             }
                         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001a.java
@@ -23,40 +23,39 @@
 
 package nsk.jdb.exclude.exclude001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
-
-import java.util.*;
+import java.io.PrintStream;
+import java.util.GregorianCalendar;
 
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class exclude001a {
-    public static void main(String args[]) {
-       exclude001a _exclude001a = new exclude001a();
-       System.exit(exclude001.JCK_STATUS_BASE + _exclude001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        exclude001a _exclude001a = new exclude001a();
+        System.exit(exclude001.JCK_STATUS_BASE + _exclude001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    static final String MYTHREAD  = "MyThread";
-    static final int numThreads   = 3;   // number of threads.
+    static final String MYTHREAD = "MyThread";
+    static final int numThreads = 3;   // number of threads.
 
     static JdbArgumentHandler argumentHandler;
     static Log log;
 
     static Object waitnotify = new Object();
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
 
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
 
-        Thread holder [] = new Thread[numThreads];
+        Thread holder[] = new Thread[numThreads];
 
-        for (int i = 0; i < numThreads ; i++) {
+        for (int i = 0; i < numThreads; i++) {
             holder[i] = new MyThread(MYTHREAD + "-" + i);
             holder[i].start();
             try {
@@ -78,7 +77,7 @@ public class exclude001a {
 class MyThread extends Thread {
     String name;
 
-    public MyThread (String s) {
+    public MyThread(String s) {
         super(s);
         name = s;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001.java
@@ -55,68 +55,63 @@
 
 package nsk.jdb.fields.fields001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class fields001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new fields001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.fields.fields001";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".fields001";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String DEBUGGEE_CLASS1    = DEBUGGEE_CLASS + "$Inner";
-    static final String DEBUGGEE_CLASS2    = DEBUGGEE_CLASS + "$Extender";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final String NOT_VALID_SAMPLE   = "is not a valid";
+    static final String PACKAGE_NAME = "nsk.jdb.fields.fields001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".fields001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String DEBUGGEE_CLASS1 = DEBUGGEE_CLASS + "$Inner";
+    static final String DEBUGGEE_CLASS2 = DEBUGGEE_CLASS + "$Extender";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static String[] checkedFields1 = {
-        "i_st",    "o_st",
-        "i_pv",    "o_pv",
-        "i_pt",    "o_pt",
-        "i_pb",    "o_pb",
-        "i_fn",    "o_fn",
-        "i_tr",    "o_tr",
-        "i_vl",    "o_vl",
-        "i_a",     "o_a",
-        "i_aa",    "o_aa",
-        "i_aaa",   "o_aaa"
-                                      };
+            "i_st", "o_st",
+            "i_pv", "o_pv",
+            "i_pt", "o_pt",
+            "i_pb", "o_pb",
+            "i_fn", "o_fn",
+            "i_tr", "o_tr",
+            "i_vl", "o_vl",
+            "i_a", "o_a",
+            "i_aa", "o_aa",
+            "i_aaa", "o_aaa"
+    };
 
     static String[] checkedFields2 = {
-        "ii_pv",    "oi_pv",
-        "ii_pt",    "oi_pt",
-        "ii_pb",    "oi_pb",
-        "ii_fn",    "oi_fn",
-        "ii_tr",    "oi_tr",
-        "ii_vl",    "oi_vl",
-        "ii_a",     "oi_a",
-        "ii_aa",    "oi_aa",
-        "ii_aaa",   "oi_aaa"
-                                      };
+            "ii_pv", "oi_pv",
+            "ii_pt", "oi_pt",
+            "ii_pb", "oi_pb",
+            "ii_fn", "oi_fn",
+            "ii_tr", "oi_tr",
+            "ii_vl", "oi_vl",
+            "ii_a", "oi_a",
+            "ii_aa", "oi_aa",
+            "ii_aaa", "oi_aaa"
+    };
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
         if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields1)) {
@@ -136,17 +131,16 @@ public class fields001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkFields (String className, String[] reply, String[] checkedFields) {
+    private boolean checkFields(String className, String[] reply, String[] checkedFields) {
         Paragrep grep;
-        String found;
         boolean result = true;
         int count;
 
         grep = new Paragrep(reply);
-        for (int i = 0; i < checkedFields.length; i++) {
-            count = grep.find(checkedFields[i]);
+        for (String checkedField : checkedFields) {
+            count = grep.find(checkedField);
             if (count == 0) {
-                log.complain("Failed to report field " + checkedFields[i] + " for class " + className);
+                log.complain("Failed to report field " + checkedField + " for class " + className);
                 result = false;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001a.java
@@ -23,27 +23,24 @@
 
 package nsk.jdb.fields.fields001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class fields001a {
 
-    /* TEST DEPENDANT VARIABLES AND CONSTANTS */
-    static final String PACKAGE_NAME = "nsk.jdb.fields.fields001";
-
-    public static void main(String args[]) {
-       fields001a _fields001a = new fields001a();
-       System.exit(fields001.JCK_STATUS_BASE + _fields001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        fields001a _fields001a = new fields001a();
+        System.exit(fields001.JCK_STATUS_BASE + _fields001a.runIt(args, System.out));
     }
 
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -53,51 +50,54 @@ public class fields001a {
         return fields001.PASSED;
     }
 
-    static     int i_st;
-    private    int i_pv;
-    protected  int i_pt;
-    public     int i_pb;
-    final      int i_fn = 0;;
-    transient  int i_tr;
-    volatile   int i_vl;
-    int []      i_a;
-    int [][]    i_aa;
-    int [][][]  i_aaa;
+    static int i_st;
+    private int i_pv;
+    protected int i_pt;
+    public int i_pb;
+    final int i_fn = 0;
 
-    static     Object o_st;
-    private    Object o_pv;
-    protected  Object o_pt;
-    public     Object o_pb;
-    final      Object o_fn = new Object();
-    transient  Object o_tr;
-    volatile   Object o_vl;
-    Object []     o_a;
-    Object [][]   o_aa;
-    Object [][][] o_aaa;
+    transient int i_tr;
+    volatile int i_vl;
+    int[] i_a;
+    int[][] i_aa;
+    int[][][] i_aaa;
+
+    static Object o_st;
+    private Object o_pv;
+    protected Object o_pt;
+    public Object o_pb;
+    final Object o_fn = new Object();
+    transient Object o_tr;
+    volatile Object o_vl;
+    Object[] o_a;
+    Object[][] o_aa;
+    Object[][][] o_aaa;
 
     class Inner {
-        private    int ii_pv;
-        protected  int ii_pt;
-        public     int ii_pb;
-        final      int ii_fn = 0;;
-        transient  int ii_tr;
-        volatile   int ii_vl;
-        int []      ii_a;
-        int [][]    ii_aa;
-        int [][][]  ii_aaa;
+        private int ii_pv;
+        protected int ii_pt;
+        public int ii_pb;
+        final int ii_fn = 0;
 
-        private    Object oi_pv;
-        protected  Object oi_pt;
-        public     Object oi_pb;
-        final      Object oi_fn = new Object();
-        transient  Object oi_tr;
-        volatile   Object oi_vl;
-        Object []     oi_a;
-        Object [][]   oi_aa;
-        Object [][][] oi_aaa;
+        transient int ii_tr;
+        volatile int ii_vl;
+        int[] ii_a;
+        int[][] ii_aa;
+        int[][][] ii_aaa;
+
+        private Object oi_pv;
+        protected Object oi_pt;
+        public Object oi_pb;
+        final Object oi_fn = new Object();
+        transient Object oi_tr;
+        volatile Object oi_vl;
+        Object[] oi_a;
+        Object[][] oi_aa;
+        Object[][][] oi_aaa;
     }
 
-    class Extender extends Inner {};
+    class Extender extends Inner {
+    }
 
     Inner inner;
     Extender extender;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001.java
@@ -45,34 +45,33 @@
 
 package nsk.jdb.hidden_class.hc001;
 
-import java.io.*;
-import java.util.*;
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Failure;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
+
+import java.io.PrintStream;
 
 public class hc001 extends JdbTest {
-    static final String DEBUGGEE_CLASS    = hc001a.class.getTypeName();
-    static final String HC_NAME_FIELD     = DEBUGGEE_CLASS + ".hcName";
-    static final String MAIN_METHOD_NAME  = DEBUGGEE_CLASS + ".main";
+    static final String DEBUGGEE_CLASS = hc001a.class.getTypeName();
+    static final String HC_NAME_FIELD = DEBUGGEE_CLASS + ".hcName";
+    static final String MAIN_METHOD_NAME = DEBUGGEE_CLASS + ".main";
     static final String EMPTY_METHOD_NAME = DEBUGGEE_CLASS + ".emptyMethod";
-    static final String HC_METHOD_NAME    = "hcMethod";
-    static final String HC_FIELD_NAME     = "hcField";
-    static final int    MAX_SLEEP_CNT     = 3;
+    static final String HC_METHOD_NAME = "hcMethod";
+    static final String HC_FIELD_NAME = "hcField";
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
+    public static int run(String[] argv, PrintStream out) {
         debuggeeClass = DEBUGGEE_CLASS; // needed for JdbTest.runTest
         firstBreak = MAIN_METHOD_NAME;  // needed for JdbTest.runTest
         return new hc001().runTest(argv, out);
     }
 
     static boolean checkPattern(String[] arr, String pattern) {
-        for (int idx = 0; idx < arr.length; idx++) {
-            String str = arr[idx];
-            if (str.indexOf(pattern) != -1) {
+        for (String str : arr) {
+            if (str.contains(pattern)) {
                 return true;
             }
         }
@@ -90,7 +89,7 @@ public class hc001 extends JdbTest {
      *  Return the hidden class name.
      */
     private String runPrologue() {
-        String[] reply = null;
+        String[] reply;
 
         log.println("\n### Debugger: runPrologue");
 
@@ -318,18 +317,16 @@ public class hc001 extends JdbTest {
 
     /* Test the jdb commands "watch" and "eval" with various invalid class names. */
     private void testInvalidCommands() {
-        String className = null;
         String[] invClassNames = {
-            "xx.yyy/0x111/0x222",
-            "xx./0x111.0x222",
-            "xx.yyy.zzz/"
+                "xx.yyy/0x111/0x222",
+                "xx./0x111.0x222",
+                "xx.yyy.zzz/"
         };
 
         log.println("\n### Debugger: testInvalidCommands");
 
         // run jdb commands "watch" and "eval" with invalid class names
-        for (int idx = 0; idx < invClassNames.length; idx++) {
-            className = invClassNames[idx];
+        for (String className : invClassNames) {
             testInvWatchCommand(className + "." + HC_FIELD_NAME);
             testInvEvalCommand(className + "." + HC_FIELD_NAME);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001a.java
@@ -23,14 +23,14 @@
 
 package nsk.jdb.hidden_class.hc001;
 
+import nsk.share.jdb.JdbArgumentHandler;
+
 import java.io.File;
 import java.io.PrintStream;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-
-import nsk.share.jdb.*;
 
 /* Interface for tested hidden class to implement. */
 interface HCInterf {
@@ -54,10 +54,14 @@ class HiddenClass implements HCInterf {
     }
 }
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class hc001a {
     static PrintStream log = null;
-    static void logMsg(String msg) { log.println(msg); log.flush(); }
+
+    static void logMsg(String msg) {
+        log.println(msg);
+        log.flush();
+    }
 
     static final String JAVA_CP = System.getProperty("java.class.path");
     static final String HC_NAME = HiddenClass.class.getName().replace(".", File.separator) + ".class";
@@ -66,7 +70,7 @@ public class hc001a {
 
     static String getClassPath(Class<?> klass) {
         String classPath = klass.getTypeName().replace(".", File.separator) + ".class";
-        for (String path: JAVA_CP.split(File.pathSeparator)) {
+        for (String path : JAVA_CP.split(File.pathSeparator)) {
             String fullClassPath = path + File.separator + classPath;
             if (new File(fullClassPath).exists()) {
                 return fullClassPath;
@@ -75,7 +79,7 @@ public class hc001a {
         throw new RuntimeException("class path for " + klass.getName() + " not found");
     }
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
         // The Jdb framework uses stdout for commands reply,
         // so it is not usable for normal logging.
         // Use a separate log file for debuggee located in JTwork/scratch.
@@ -87,9 +91,10 @@ public class hc001a {
     }
 
     // This method is to hit a breakpoint at expected execution point.
-    void emptyMethod() {}
+    void emptyMethod() {
+    }
 
-    public int runIt(String args[]) throws Exception {
+    public int runIt(String[] args) throws Exception {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
 
         logMsg("Debuggee: runIt: started");
@@ -108,7 +113,7 @@ public class hc001a {
 
         // It is impossible to use a hidden class name to define a variable,
         // so we use the interface which the tested hidden class implements.
-        HCInterf hcObj = (HCInterf)hc.newInstance();
+        HCInterf hcObj = (HCInterf) hc.newInstance();
         logMsg("Debuggee: created an instance of a hidden class: " + hcName);
 
         // It is for debuuger to set a breakpoint at a well known execution point.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001.java
@@ -54,70 +54,69 @@
 
 package nsk.jdb.ignore.ignore001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class ignore001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new ignore001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.ignore.ignore001";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".ignore001";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String EXCEPTION_SAMPLE   = "Exception occurred:";
-    static final String REMOVED_SAMPLE     = "Removed:";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.ignore.ignore001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".ignore001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String EXCEPTION_SAMPLE = "Exception occurred:";
+    static final String REMOVED_SAMPLE = "Removed:";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
 //        jdb.setBreakpointInMethod(LAST_BREAK);
 
         log.display("Setting catch for: " + nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION);
-        reply = jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION);
+        jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION);
 
         log.display("Setting catch for: " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1);
-        reply = jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1);
+        jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1);
 
         log.display("Setting catch for: " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2);
-        reply = jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2);
+        jdb.receiveReplyFor(JdbCommand._catch + " caught " + nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2);
 
-        for (;;) {
-            if (!checkCatch(nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION)) {
-               success = false;
+        while (true) {
+            if (!checkCatch(ignore001a.JAVA_EXCEPTION)) {
+                success = false;
             }
-            if (!checkCatch(nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1)) {
-               success = false;
+            if (!checkCatch(ignore001a.USER_EXCEPTION1)) {
+                success = false;
             }
-            if (!checkCatch(nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2)) {
-               success = false;
+            if (!checkCatch(ignore001a.USER_EXCEPTION2)) {
+                success = false;
             }
 
-            if (!checkIgnore(nsk.jdb.ignore.ignore001.ignore001a.JAVA_EXCEPTION)) {
-               success = false;
+            if (!checkIgnore(ignore001a.JAVA_EXCEPTION)) {
+                success = false;
             }
-            if (!checkIgnore(nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION1)) {
-               success = false;
+            if (!checkIgnore(ignore001a.USER_EXCEPTION1)) {
+                success = false;
             }
-            if (!checkIgnore(nsk.jdb.ignore.ignore001.ignore001a.USER_EXCEPTION2)) {
-               success = false;
+            if (!checkIgnore(ignore001a.USER_EXCEPTION2)) {
+                success = false;
             }
 
             jdb.contToExit(6);
@@ -134,18 +133,17 @@ public class ignore001 extends JdbTest {
         }
     }
 
-    private boolean checkCatch (String exceptionName) {
+    private boolean checkCatch(String exceptionName) {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
+        Vector<String> v;
         String found;
         boolean result = true;
 
 //        log.display("Resuming debuggee.");
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        v = new Vector();
+        v = new Vector<>();
         v.add(EXCEPTION_SAMPLE);
         v.add(exceptionName);
 
@@ -158,18 +156,17 @@ public class ignore001 extends JdbTest {
         return result;
     }
 
-    private boolean checkIgnore (String exceptionName) {
+    private boolean checkIgnore(String exceptionName) {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
+        Vector<String> v;
         String found;
         boolean result = true;
 
         log.display("Unsetting catch for: " + exceptionName);
         reply = jdb.receiveReplyFor(JdbCommand.ignore + " caught " + exceptionName);
 
-        v = new Vector();
+        v = new Vector<>();
         v.add(REMOVED_SAMPLE);
         v.add(exceptionName);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001a.java
@@ -23,13 +23,12 @@
 
 package nsk.jdb.ignore.ignore001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class ignore001a {
 
     /* TEST DEPENDANT VARIABLES AND CONSTANTS */
@@ -41,14 +40,14 @@ public class ignore001a {
     static JdbArgumentHandler argumentHandler;
     static Log log;
 
-    public static void main(String args[]) {
-       ignore001a _ignore001a = new ignore001a();
-       System.exit(ignore001.JCK_STATUS_BASE + _ignore001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        ignore001a _ignore001a = new ignore001a();
+        System.exit(ignore001.JCK_STATUS_BASE + _ignore001a.runIt(args, System.out));
     }
 
 //    static void lastBreak () {}
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
 
@@ -60,18 +59,21 @@ public class ignore001a {
         return ignore001.PASSED;
     }
 
-    private void a (int i) {
+    private void a(int i) {
         try {
             switch (i) {
-            case 0: case 3:
-                log.display("Throwing NumberFormatException, i = " + i);
-                throw new java.lang.NumberFormatException();
-            case 1: case 4:
-                log.display("Throwing Exception1, i = " + i);
-                throw new Exception1();
-            case 2: case 5:
-                log.display("Throwing Exception2, i = " + i);
-                throw new Exception2();
+                case 0:
+                case 3:
+                    log.display("Throwing NumberFormatException, i = " + i);
+                    throw new java.lang.NumberFormatException();
+                case 1:
+                case 4:
+                    log.display("Throwing Exception1, i = " + i);
+                    throw new Exception1();
+                case 2:
+                case 5:
+                    log.display("Throwing Exception2, i = " + i);
+                    throw new Exception2();
             }
         } catch (java.lang.NumberFormatException e0) {
         } catch (Exception1 e1) {
@@ -80,7 +82,9 @@ public class ignore001a {
 //        lastBreak();
     }
 
-    class Exception1 extends Exception {}
+    class Exception1 extends Exception {
+    }
 }
 
-class Exception2 extends Exception {}
+class Exception2 extends Exception {
+}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
@@ -61,33 +61,37 @@
 
 package nsk.jdb.interrupt.interrupt001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class interrupt001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         return new interrupt001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.interrupt.interrupt001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".interrupt001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.interrupt.interrupt001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".interrupt001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = DEBUGGEE_CLASS + "$" + MYTHREAD;
     static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notInterrupted.get()";
 
@@ -108,7 +112,7 @@ public class interrupt001 extends JdbTest {
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
@@ -120,21 +124,21 @@ public class interrupt001 extends JdbTest {
 
         pauseTillAllThreadsWaiting(threads);
 
-        for (int i = 0; i < threads.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.interrupt + threads[i]);
+        for (String thread : threads) {
+            jdb.receiveReplyFor(JdbCommand.interrupt + thread);
         }
 
-        reply = jdb.receiveReplyFor(JdbCommand.threads);
-        reply = jdb.receiveReplyFor(JdbCommand.cont, true);
+        jdb.receiveReplyFor(JdbCommand.threads);
+        jdb.receiveReplyFor(JdbCommand.cont, true);
 
         reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_RESULT);
         grep = new Paragrep(reply);
-        found = grep.findFirst(DEBUGGEE_RESULT + " =" );
+        found = grep.findFirst(DEBUGGEE_RESULT + " =");
         if (found.length() > 0) {
-            if (found.indexOf(DEBUGGEE_RESULT + " = 0") < 0) {
-               log.complain("Not all " + MYTHREAD + "s were interrupted.");
-               log.complain(found);
-               success = false;
+            if (!found.contains(DEBUGGEE_RESULT + " = 0")) {
+                log.complain("Not all " + MYTHREAD + "s were interrupted.");
+                log.complain(found);
+                success = false;
             }
         } else {
             log.complain("TEST BUG: not found value for " + DEBUGGEE_RESULT);
@@ -144,34 +148,33 @@ public class interrupt001 extends JdbTest {
     }
 
     private void pauseTillAllThreadsWaiting(String[] threads) {
-        String[] reply;
         boolean tidswaiting = false;
 
         Set<String> tids = new HashSet<>(Arrays.asList(threads));
         Set<String> waitingTids = null;
 
         do {
-            String[] thrdsRply = (String[])jdb.receiveReplyFor(JdbCommand.threads);
-            waitingTids = Arrays.asList(thrdsRply).stream()
-                .filter((r)-> r.endsWith("waiting"))
-                .map((r)->{
-                    Matcher m = tidPattern.matcher(r);
-                    if (m.find()) {
-                        return m.group(1);
-                    }
-                    return null;
-                })
-                .filter((r)-> r != null)
-                .collect(Collectors.toSet());
+            String[] thrdsRply = jdb.receiveReplyFor(JdbCommand.threads);
+            waitingTids = Arrays.stream(thrdsRply)
+                    .filter((r) -> r.endsWith("waiting"))
+                    .map((r) -> {
+                        Matcher m = tidPattern.matcher(r);
+                        if (m.find()) {
+                            return m.group(1);
+                        }
+                        return null;
+                    })
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
 
             // If all Tids are waiting set allWorkersAreWaiting to true so
             // the main test thread will get out of its breakpoint loop
             // and continue with the test.
             if (waitingTids.containsAll(tids)) {
-                reply = jdb.receiveReplyFor(JdbCommand.set + DEBUGGEE_CLASS + ".allWorkersAreWaiting=true");
+                jdb.receiveReplyFor(JdbCommand.set + DEBUGGEE_CLASS + ".allWorkersAreWaiting=true");
                 tidswaiting = true;
             } else {
-                reply = jdb.receiveReplyFor(JdbCommand.cont);
+                jdb.receiveReplyFor(JdbCommand.cont);
             }
         } while (!tidswaiting);
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
@@ -23,21 +23,20 @@
 
 package nsk.jdb.interrupt.interrupt001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
-import java.util.concurrent.Semaphore;
+import java.io.PrintStream;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class interrupt001a {
     private class MyThread extends Thread {
         final Object lock;
         int ind;
         String name;
 
-        public MyThread (Object l, int i, String n) {
+        public MyThread(Object l, int i, String n) {
             lock = l;
             ind = i;
             name = n;
@@ -65,27 +64,28 @@ public class interrupt001a {
         }
     }
 
-    public static void main(String args[]) {
-       interrupt001a _interrupt001a = new interrupt001a();
-       System.exit(interrupt001.JCK_STATUS_BASE + _interrupt001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        interrupt001a _interrupt001a = new interrupt001a();
+        System.exit(interrupt001.JCK_STATUS_BASE + _interrupt001a.runIt(args, System.out));
     }
 
-    static void breakHere () {}
+    static void breakHere() {
+    }
 
-    static final String MYTHREAD        = "MyThread";
-    static final int numThreads         = 5;   // number of threads
+    static final String MYTHREAD = "MyThread";
+    static final int numThreads = 5;   // number of threads
     static volatile boolean allWorkersAreWaiting = false;
 
-    private final Object waitnotify            = new Object();
+    private final Object waitnotify = new Object();
     private volatile boolean threadRunning;
-    private volatile boolean[] flags     = new boolean[numThreads];
+    private volatile boolean[] flags = new boolean[numThreads];
 
     private JdbArgumentHandler argumentHandler;
     private Log log;
 
     public static final AtomicInteger notInterrupted = new AtomicInteger(numThreads);
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
 
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
@@ -94,19 +94,19 @@ public class interrupt001a {
         Thread[] holder = new Thread[numThreads];
         Object[] locks = new Object[numThreads];
 
-        for (i = 0; i < numThreads ; i++) {
+        for (i = 0; i < numThreads; i++) {
             locks[i] = new Object();
             holder[i] = new MyThread(locks[i], i, MYTHREAD + "-" + i);
         }
 
         synchronized (waitnotify) {
-            for (i = 0; i < numThreads ; i++) {
+            for (i = 0; i < numThreads; i++) {
                 holder[i].start();
                 try {
-                     threadRunning = false;
-                     while (!threadRunning) {
-                         waitnotify.wait();
-                     }
+                    threadRunning = false;
+                    while (!threadRunning) {
+                        waitnotify.wait();
+                    }
                 } catch (InterruptedException e) {
                     log.complain("Main thread was interrupted while waiting for start of " + MYTHREAD + "-" + i);
                     return interrupt001.FAILED;
@@ -131,7 +131,7 @@ public class interrupt001a {
                 }
             }
         }
-        for (i = 0; i < numThreads ; i++) {
+        for (i = 0; i < numThreads; i++) {
             if (holder[i].isAlive()) {
                 synchronized (locks[i]) {
                     flags[i] = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -61,30 +61,30 @@
 
 package nsk.jdb.kill.kill001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class kill001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         return new kill001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.kill.kill001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".kill001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.kill.kill001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".kill001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
     static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notKilled";
     static final String DEBUGGEE_EXCEPTIONS = DEBUGGEE_CLASS + ".exceptions";
@@ -94,8 +94,6 @@ public class kill001 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
         String found;
         String[] threads;
 
@@ -112,8 +110,8 @@ public class kill001 extends JdbTest {
 
         for (int i = 0; i < threads.length; i++) {
             reply = jdb.receiveReplyForWithMessageWait(JdbCommand.kill + threads[i] + " " +
-                                                       DEBUGGEE_EXCEPTIONS + "[" + i + "]",
-                                                       "killed");
+                            DEBUGGEE_EXCEPTIONS + "[" + i + "]",
+                    "killed");
         }
 
         for (int i = 0; i <= numThreads; i++) {
@@ -128,20 +126,20 @@ public class kill001 extends JdbTest {
         log.display("Breakpoint has been hit");
 
         reply = jdb.receiveReplyForWithMessageWait(JdbCommand.eval + DEBUGGEE_RESULT,
-                                                   DEBUGGEE_RESULT + " =");
+                DEBUGGEE_RESULT + " =");
         grep = new Paragrep(reply);
-        found = grep.findFirst(DEBUGGEE_RESULT + " =" );
+        found = grep.findFirst(DEBUGGEE_RESULT + " =");
         if (found.length() > 0) {
-            if (found.indexOf(DEBUGGEE_RESULT + " = 0") < 0) {
-               log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
-               success = false;
+            if (!found.contains(DEBUGGEE_RESULT + " = 0")) {
+                log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
+                success = false;
             }
         } else {
             log.complain("Value for " + DEBUGGEE_RESULT + " is not found.");
             success = false;
         }
 
-        reply = jdb.receiveReplyFor(JdbCommand.threads);
+        jdb.receiveReplyFor(JdbCommand.threads);
         jdb.contToExit(1);
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
@@ -23,59 +23,58 @@
 
 package nsk.jdb.kill.kill001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class kill001a {
-    public static void main(String args[]) {
-       kill001a _kill001a = new kill001a();
-       System.exit(kill001.JCK_STATUS_BASE + _kill001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        kill001a _kill001a = new kill001a();
+        System.exit(kill001.JCK_STATUS_BASE + _kill001a.runIt(args, System.out));
     }
 
-    static void breakHere () {}
+    static void breakHere() {
+    }
 
-    static final String MYTHREAD         = "MyThread";
-    static final int numThreads          = 5;   // number of threads. one lock per thread.
-    static Object lock                   = new Object();
-    static Object waitnotify             = new Object();
+    static final String MYTHREAD = "MyThread";
+    static final int numThreads = 5;   // number of threads. one lock per thread.
+    static Object lock = new Object();
+    static Object waitnotify = new Object();
     public static volatile int notKilled = 0;
-    static final String message          = "kill001a's Exception";
+    static final String message = "kill001a's Exception";
     static int waitTime;
 
     static JdbArgumentHandler argumentHandler;
     static Log log;
 
     static final Throwable[] exceptions = {
-                    new ThreadDeath(),
-                    new NullPointerException(message),
-                    new SecurityException(message),
-                    new com.sun.jdi.IncompatibleThreadStateException(message),
-                    new MyException(message)
-                                          };
+            new ThreadDeath(),
+            new NullPointerException(message),
+            new SecurityException(message),
+            new com.sun.jdi.IncompatibleThreadStateException(message),
+            new MyException(message)
+    };
 
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
 
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
         waitTime = argumentHandler.getWaitTime() * 60 * 1000;
 
         int i;
-        Thread holder [] = new Thread[numThreads];
+        Thread holder[] = new Thread[numThreads];
 
-        for (i = 0; i < numThreads ; i++) {
+        for (i = 0; i < numThreads; i++) {
             holder[i] = new MyThread(MYTHREAD + "-" + i);
         }
 
         // lock monitor to prevent threads from finishing after they started
         synchronized (lock) {
             synchronized (waitnotify) {
-                for (i = 0; i < numThreads ; i++) {
+                for (i = 0; i < numThreads; i++) {
                     holder[i].start();
                     try {
                         waitnotify.wait();
@@ -92,11 +91,11 @@ public class kill001a {
         long oldTime = System.currentTimeMillis();
         while ((System.currentTimeMillis() - oldTime) <= kill001a.waitTime) {
             boolean waited = false;
-            for (i = 0; i < numThreads ; i++) {
+            for (i = 0; i < numThreads; i++) {
                 if (holder[i].isAlive()) {
                     waited = true;
                     try {
-                        synchronized(waitnotify) {
+                        synchronized (waitnotify) {
                             waitnotify.wait(1000);
                         }
                     } catch (InterruptedException e) {
@@ -111,7 +110,7 @@ public class kill001a {
         breakHere(); // a break to check if MyThreads were killed
         log.display("notKilled == " + notKilled);
 
-        for (i = 0; i < numThreads ; i++) {
+        for (i = 0; i < numThreads; i++) {
             if (holder[i].isAlive()) {
                 log.display("Debuggee FAILED");
                 return kill001.FAILED;
@@ -123,7 +122,7 @@ public class kill001a {
     }
 
     static class MyException extends Exception {
-        MyException (String message) {
+        MyException(String message) {
             super(message);
         }
     }
@@ -133,7 +132,7 @@ public class kill001a {
 class MyThread extends Thread {
     String name;
 
-    public MyThread (String n) {
+    public MyThread(String n) {
         name = n;
     }
 
@@ -147,7 +146,8 @@ class MyThread extends Thread {
             kill001a.waitnotify.notify();
         }
         // prevent thread from early finish
-        synchronized (kill001a.lock) {}
+        synchronized (kill001a.lock) {
+        }
 
         // sleep during waitTime to give debugger a chance to kill debugee's thread
         try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002.java
@@ -57,30 +57,30 @@
 
 package nsk.jdb.kill.kill002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class kill002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         return new kill002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.kill.kill002";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".kill002";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.kill.kill002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".kill002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
     static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notKilled";
     static final String DEBUGGEE_EXCEPTIONS = DEBUGGEE_CLASS + ".exceptions";
@@ -90,13 +90,11 @@ public class kill002 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
         String found;
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
@@ -107,11 +105,11 @@ public class kill002 extends JdbTest {
         }
 
         for (int i = 0; i < threads.length; i++) {
-            reply = jdb.receiveReplyForWithMessageWait(JdbCommand.kill + threads[i] + " " +
-                                                       DEBUGGEE_EXCEPTIONS + "[" + i + "]",
-                                                       "killed");
+            jdb.receiveReplyForWithMessageWait(JdbCommand.kill + threads[i] + " " +
+                            DEBUGGEE_EXCEPTIONS + "[" + i + "]",
+                    "killed");
         }
-        reply = jdb.receiveReplyFor(JdbCommand.threads);
+        jdb.receiveReplyFor(JdbCommand.threads);
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
         // make sure the debugger is at a breakpoint
@@ -122,13 +120,13 @@ public class kill002 extends JdbTest {
         log.display("Breakpoint has been hit");
 
         reply = jdb.receiveReplyForWithMessageWait(JdbCommand.eval + DEBUGGEE_RESULT,
-                                            DEBUGGEE_RESULT + " =");
+                DEBUGGEE_RESULT + " =");
         grep = new Paragrep(reply);
-        found = grep.findFirst(DEBUGGEE_RESULT + " =" );
+        found = grep.findFirst(DEBUGGEE_RESULT + " =");
         if (found.length() > 0) {
-            if (found.indexOf(DEBUGGEE_RESULT + " = 0") < 0) {
-               log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
-               success = false;
+            if (!found.contains(DEBUGGEE_RESULT + " = 0")) {
+                log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
+                success = false;
             }
         } else {
             log.complain("Value for " + DEBUGGEE_RESULT + " is not found.");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002a.java
@@ -22,39 +22,39 @@
  */
 package nsk.jdb.kill.kill002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class kill002a {
-    public static void main(String args[]) {
-       kill002a _kill002a = new kill002a();
-       System.exit(kill002.JCK_STATUS_BASE + _kill002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        kill002a _kill002a = new kill002a();
+        System.exit(kill002.JCK_STATUS_BASE + _kill002a.runIt(args, System.out));
     }
 
-    static void breakHere () {}
+    static void breakHere() {
+    }
 
-    static final String MYTHREAD         = "MyThread";
-    static final int numThreads          = 5;   // number of threads
-    static Object waitnotify             = new Object();
+    static final String MYTHREAD = "MyThread";
+    static final int numThreads = 5;   // number of threads
+    static Object waitnotify = new Object();
     public static volatile int notKilled = 0;
-    static final String message          = "kill002a's Exception";
+    static final String message = "kill002a's Exception";
 
     static JdbArgumentHandler argumentHandler;
     static Log log;
 
     static final Exception[] exceptions = {
-                    new InterruptedException(message),
-                    new NullPointerException(message),
-                    new SecurityException(message),
-                    new com.sun.jdi.IncompatibleThreadStateException(message),
-                    new MyException(message)
-                                          };
+            new InterruptedException(message),
+            new NullPointerException(message),
+            new SecurityException(message),
+            new com.sun.jdi.IncompatibleThreadStateException(message),
+            new MyException(message)
+    };
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
 
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
@@ -63,13 +63,13 @@ public class kill002a {
         Thread[] holder = new Thread[numThreads];
         Object[] locks = new Object[numThreads];
 
-        for (i = 0; i < numThreads ; i++) {
+        for (i = 0; i < numThreads; i++) {
             locks[i] = new Object();
             holder[i] = new MyThread(locks[i], MYTHREAD + "-" + i);
         }
 
         synchronized (waitnotify) {
-            for (i = 0; i < numThreads ; i++) {
+            for (i = 0; i < numThreads; i++) {
                 holder[i].start();
                 try {
                     waitnotify.wait();
@@ -86,7 +86,7 @@ public class kill002a {
         breakHere();  // a break to get thread ids and then to kill MyThreads.
 
         // waits on all MyThreads completion in case they were not killed
-        for (i = 0; i < numThreads ; i++) {
+        for (i = 0; i < numThreads; i++) {
             synchronized (locks[i]) {
                 locks[i].notifyAll();
             }
@@ -106,7 +106,7 @@ public class kill002a {
     }
 
     static class MyException extends Exception {
-        MyException (String message) {
+        MyException(String message) {
             super(message);
         }
     }
@@ -117,7 +117,7 @@ class MyThread extends Thread {
     Object lock;
     String name;
 
-    public MyThread (Object l, String n) {
+    public MyThread(Object l, String n) {
         lock = l;
         name = n;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001.java
@@ -54,57 +54,51 @@
 
 package nsk.jdb.klass.class001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class class001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new class001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.klass.class001";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".class001";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final String NOT_VALID_SAMPLE   = "is not a valid";
+    static final String PACKAGE_NAME = "nsk.jdb.klass.class001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".class001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String NOT_VALID_SAMPLE = "is not a valid";
 
     static String[] checkedClasses = {
-        DEBUGGEE_CLASS,
-        DEBUGGEE_CLASS + "$InnerInt1",
-        DEBUGGEE_CLASS + "$Inner2",
-        DEBUGGEE_CLASS + "$Inner3",
-        DEBUGGEE_CLASS + "$Inner4",
-        DEBUGGEE_CLASS + "$Inner5",
-        DEBUGGEE_CLASS + "$Inner6",
-        PACKAGE_NAME + ".Outer1"
-                                      };
+            DEBUGGEE_CLASS,
+            DEBUGGEE_CLASS + "$InnerInt1",
+            DEBUGGEE_CLASS + "$Inner2",
+            DEBUGGEE_CLASS + "$Inner3",
+            DEBUGGEE_CLASS + "$Inner4",
+            DEBUGGEE_CLASS + "$Inner5",
+            DEBUGGEE_CLASS + "$Inner6",
+            PACKAGE_NAME + ".Outer1"
+    };
 
     /* ------------------------------------- */
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
-        for (int i = 0; i < checkedClasses.length; i++) {
-            if (!checkClass(checkedClasses[i])) {
+        for (String checkedClass : checkedClasses) {
+            if (!checkClass(checkedClass)) {
                 success = false;
             }
         }
@@ -112,10 +106,9 @@ public class class001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkClass (String className) {
+    private boolean checkClass(String className) {
         String[] reply;
         Paragrep grep;
-        int count;
         String found;
         boolean result = true;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001a.java
@@ -23,27 +23,24 @@
 
 package nsk.jdb.klass.class001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class class001a {
 
-    /* TEST DEPENDANT VARIABLES AND CONSTANTS */
-    static final String PACKAGE_NAME = "nsk.jdb.klass.class001";
-
-    public static void main(String args[]) {
-       class001a _class001a = new class001a();
-       System.exit(class001.JCK_STATUS_BASE + _class001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        class001a _class001a = new class001a();
+        System.exit(class001.JCK_STATUS_BASE + _class001a.runIt(args, System.out));
     }
 
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -53,14 +50,25 @@ public class class001a {
         return class001.PASSED;
     }
 
-    interface InnerInt1 {}
-    public class Inner2 implements InnerInt1 {}
-    private class Inner3 {}
-    protected class Inner4 {}
-    abstract class Inner5 {}
-    final class Inner6 extends Inner5{}
+    interface InnerInt1 {
+    }
 
-    private void init () {
+    public class Inner2 implements InnerInt1 {
+    }
+
+    private class Inner3 {
+    }
+
+    protected class Inner4 {
+    }
+
+    abstract class Inner5 {
+    }
+
+    final class Inner6 extends Inner5 {
+    }
+
+    private void init() {
         Outer1 o1 = new Outer1();
         Inner2 i2 = new Inner2();
         Inner3 i3 = new Inner3();
@@ -71,4 +79,5 @@ public class class001a {
     }
 }
 
-class Outer1 {}
+class Outer1 {
+}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
@@ -59,64 +59,60 @@
 
 package nsk.jdb.list.list002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class list002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new list002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.list.list002";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".list002";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".runIt";
-    static final int    LINE_NUMBER     = 38;
+    static final String PACKAGE_NAME = "nsk.jdb.list.list002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".list002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".runIt";
+    static final int LINE_NUMBER = 37;
 
-    final static String METHOD_SOURCE[] = new String[] {
-        "public int runIt(String args[], PrintStream out) {",
-        "JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);",
-        "Log log = new Log(out, argumentHandler);",
-        "log.display(\"Debuggee PASSED\");",
-        "return list002.PASSED;"
-                                                    };
+    final static String[] METHOD_SOURCE = new String[]{
+            "public int runIt(String[] args, PrintStream out) {",
+            "JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);",
+            "Log log = new Log(out, argumentHandler);",
+            "log.display(\"Debuggee PASSED\");",
+            "return list002.PASSED;"
+    };
 
     final static String LINE_SOURCE =
-        "System.exit(list002.JCK_STATUS_BASE + _list002a.runIt(args, System.out));";
+            "System.exit(list002.JCK_STATUS_BASE + _list002a.runIt(args, System.out));";
 
     final static String SOURCE_NOT_FOUND = "Source file not found";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         reply = jdb.receiveReplyFor(JdbCommand.list + "runIt");
         grep = new Paragrep(reply);
         if (grep.find(SOURCE_NOT_FOUND) > 0) {
             failure(reply[0]);
         } else {
-            for (int i = 0; i < METHOD_SOURCE.length; i++) {
-                if (grep.find(METHOD_SOURCE[i]) == 0) {
-                    failure("Line is not found in method sources:\n\t"+
-                        METHOD_SOURCE[i]);
+            for (String s : METHOD_SOURCE) {
+                if (grep.find(s) == 0) {
+                    failure("Line is not found in method sources:\n\t" + s);
                 }
             }
         }
@@ -127,8 +123,7 @@ public class list002 extends JdbTest {
             failure(reply[0]);
         } else {
             if (grep.find(LINE_SOURCE) == 0) {
-                failure("Line " + LINE_NUMBER + " is not found:\n\t"+
-                    LINE_SOURCE);
+                failure("Line " + LINE_NUMBER + " is not found:\n\t" + LINE_SOURCE);
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002a.java
@@ -23,23 +23,22 @@
 
 package nsk.jdb.list.list002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
 //    THIS TEST IS LINE NUMBER SENSITIVE
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class list002a {
     static list002a _list002a = new list002a();
 
-    public static void main(String args[]) { // list002.LINE_NUMBER
-       System.exit(list002.JCK_STATUS_BASE + _list002a.runIt(args, System.out));
+    public static void main(String[] args) { // list002.LINE_NUMBER
+        System.exit(list002.JCK_STATUS_BASE + _list002a.runIt(args, System.out));
     }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
@@ -66,20 +66,21 @@
 
 package nsk.jdb.locals.locals002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class locals002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
@@ -89,32 +90,29 @@ public class locals002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.locals.locals002";
     static final String TEST_CLASS = PACKAGE_NAME + ".locals002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
     static final String COMPOUND_PROMPT_IDENT = "main";
-    static final int    BREAKPOINT_LINE1 = 84;
-    static final int    BREAKPOINT_LINE2 = 100;
+    static final int BREAKPOINT_LINE1 = 83;
+    static final int BREAKPOINT_LINE2 = 99;
 
-    static final String LOCALS[][] = new String[][] {
-       { "boolVar"  , "true"         , "false"         },
-       { "byteVar"  , "27"           , "12"            },
-       { "charVar"  , "V"            , "A"             },
-       { "shortVar" , "767"          , "327"           },
-       { "intVar"   , "1474"         , "3647"          },
-       { "longVar"  , "21345"        , "65789"         },
-       { "floatVar" , "3.141"        , "4.852"         },
-       { "doubleVar", "2.578"        , "3.8976"        },
-       { "objVar"   , "objVarString" , "objArgString"  },
-       { "arrVar"   , "int[5]"       , "int[3]"        }
-
-                                                    };
+    static final String[][] LOCALS = new String[][]{
+            {"boolVar",     "true",         "false"},
+            {"byteVar",     "27",           "12"},
+            {"charVar",     "V",            "A"},
+            {"shortVar",    "767",          "327"},
+            {"intVar",      "1474",         "3647"},
+            {"longVar",     "21345",        "65789"},
+            {"floatVar",    "3.141",        "4.852"},
+            {"doubleVar",   "2.578",        "3.8976"},
+            {"objVar",      "objVarString", "objArgString"},
+            {"arrVar",      "int[5]",       "int[3]"}
+    };
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE1);
         jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE2);
@@ -122,39 +120,27 @@ public class locals002 extends JdbTest {
         jdb.receiveReplyFor(JdbCommand.cont);
         reply = jdb.receiveReplyFor(JdbCommand.locals);
         grep = new Paragrep(reply);
-        for (int i = 0; i < LOCALS.length; i++) {
-            v = new Vector();
-            v.add(LOCALS[i][0]);
-            v.add(LOCALS[i][2]);
+        for (String[] local : LOCALS) {
+            v = new Vector<>();
+            v.add(local[0]);
+            v.add(local[2]);
             if (grep.find(v) == 0) {
-                failure("Cannot find " + LOCALS[0][0] +
-                    " with expected value: " + LOCALS[i][2]);
+                failure("Cannot find " + LOCALS[0][0] + " with expected value: " + local[2]);
             }
         }
 
         jdb.receiveReplyFor(JdbCommand.cont);
         reply = jdb.receiveReplyFor(JdbCommand.locals);
         grep = new Paragrep(reply);
-        for (int i = 0; i < LOCALS.length; i++) {
-            v = new Vector();
-            v.add(LOCALS[i][0]);
-            v.add(LOCALS[i][1]);
+        for (String[] local : LOCALS) {
+            v = new Vector<>();
+            v.add(local[0]);
+            v.add(local[1]);
             if (grep.find(v) == 0) {
-                failure("Cannot find " + LOCALS[0][0] +
-                    " with expected value: " + LOCALS[i][1]);
+                failure("Cannot find " + LOCALS[0][0] + " with expected value: " + local[1]);
             }
         }
 
         jdb.contToExit(1);
-    }
-
-    private boolean checkStop () {
-        Paragrep grep;
-        String[] reply;
-        String found;
-        Vector v;
-        boolean result = true;
-
-        return result;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002a.java
@@ -25,42 +25,42 @@
 
 package nsk.jdb.locals.locals002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class locals002a {
     static locals002a _locals002a = new locals002a();
 
-    public static void main(String args[]) {
-       System.exit(locals002.JCK_STATUS_BASE + _locals002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(locals002.JCK_STATUS_BASE + _locals002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
         int arr[] = new int[3];
 
-        for (int i = 0 ; i < 3 ; i++) arr[i] = i*i;
+        for (int i = 0; i < 3; i++) arr[i] = i * i;
 
-        allKindsOfVars (
-            false,
-            (byte)12,
-            'A',
-            (short)327,
-            3647,
-            (long)65789,
-            (float)4.852,
-            (double)3.8976,
-            "objArgString",
-            arr
-                       );
+        allKindsOfVars(
+                false,
+                (byte) 12,
+                'A',
+                (short) 327,
+                3647,
+                (long) 65789,
+                (float) 4.852,
+                (double) 3.8976,
+                "objArgString",
+                arr
+        );
 
         allKindsOfLocals();
 
@@ -68,35 +68,34 @@ public class locals002a {
         return locals002.PASSED;
     }
 
-   public void allKindsOfVars (
-       boolean boolVar,
-       byte    byteVar,
-       char    charVar,
-       short   shortVar,
-       int     intVar,
-       long    longVar,
-       float   floatVar,
-       double  doubleVar,
-       Object  objVar,
-       int[]   arrVar
-                              )
-   {
-       int x = 3; // locals002.BREAKPOINT_LINE1
-   }
+    public void allKindsOfVars(
+            boolean boolVar,
+            byte byteVar,
+            char charVar,
+            short shortVar,
+            int intVar,
+            long longVar,
+            float floatVar,
+            double doubleVar,
+            Object objVar,
+            int[] arrVar
+    ) {
+        int x = 3; // locals002.BREAKPOINT_LINE1
+    }
 
-   static void allKindsOfLocals()  {
-       boolean boolVar   = true;
-       byte    byteVar   = 27;
-       char    charVar   = 'V';
-       short   shortVar  = (short)767;
-       int     intVar    = 1474;
-       long    longVar   = (long)21345;
-       float   floatVar  = (float)3.141;
-       double  doubleVar = (double)2.578;
-       Object  objVar    = "objVarString";
-       int[]   arrVar    = new int[5];
+    static void allKindsOfLocals() {
+        boolean boolVar = true;
+        byte byteVar = 27;
+        char charVar = 'V';
+        short shortVar = (short) 767;
+        int intVar = 1474;
+        long longVar = (long) 21345;
+        float floatVar = (float) 3.141;
+        double doubleVar = (double) 2.578;
+        Object objVar = "objVarString";
+        int[] arrVar = new int[5];
 
-       for (int j = 0; j < 5 ; j++) arrVar[j] = j;
-       int x = 4; // locals002.BREAKPOINT_LINE2
-   }
+        for (int j = 0; j < 5; j++) arrVar[j] = j;
+        int x = 4; // locals002.BREAKPOINT_LINE2
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002.java
@@ -64,20 +64,22 @@
 
 package nsk.jdb.methods.methods002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.StringTokenizer;
+import java.util.Vector;
 
 public class methods002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new methods002().runTest(argv, out);
@@ -86,110 +88,106 @@ public class methods002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.methods.methods002";
     static final String TEST_CLASS = PACKAGE_NAME + ".methods002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // Case for class with method modifiers
         String testedClass1 = TEST_CLASS + "a";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass1);
         for (int i = 1; i <= 33; i++) {
-            checkMethod( reply, "m" + intToString(i), 1, testedClass1, testedClass1 );
+            checkMethod(reply, "m" + intToString(i), 1, testedClass1, testedClass1);
         }
         for (int i = 1; i <= 3; i++) {
-            checkMethod( reply, "f" + intToString(i), 1, testedClass1, testedClass1 );
+            checkMethod(reply, "f" + intToString(i), 1, testedClass1, testedClass1);
         }
 
         // Case for class with many constructors
         String testedClass2 = TEST_CLASS + "b";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass2);
         String[] reply1 = toStringArray(reply);  // on Windows reply is single string with embedded \r\n symbols
-        checkMethod( reply1, "<init>", 4, testedClass2, testedClass2 );
+        checkMethod(reply1, "<init>", 4, testedClass2, testedClass2);
 
         // Case for class with overloaded methods
         String testedClass3 = TEST_CLASS + "c";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass3);
         reply1 = toStringArray(reply);   // // on Windows reply is single string with embedded \r\n symbols
-        checkMethod( reply1, "m01", 3, testedClass3, testedClass3 );
+        checkMethod(reply1, "m01", 3, testedClass3, testedClass3);
 
         // Case for abstract class
         String testedClass4 = TEST_CLASS + "d";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass4);
-        checkMethod( reply, "m01", 1, testedClass4, testedClass4 );
+        checkMethod(reply, "m01", 1, testedClass4, testedClass4);
 
         // Case for interface
         String testedClass5 = TEST_CLASS + "i";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass5);
-        checkMethod( reply, "i01", 1, testedClass5, testedClass5 );
+        checkMethod(reply, "i01", 1, testedClass5, testedClass5);
 
         // Case for class with implemented method
         String testedClass6 = TEST_CLASS + "e";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass6);
-        checkMethod( reply, "m01", 1, testedClass4, testedClass6 );
-        checkMethod( reply, "i01", 1, testedClass5, testedClass6 );
-        checkMethod( reply, "m01", 1, testedClass6, testedClass6 );
+        checkMethod(reply, "m01", 1, testedClass4, testedClass6);
+        checkMethod(reply, "i01", 1, testedClass5, testedClass6);
+        checkMethod(reply, "m01", 1, testedClass6, testedClass6);
 
         // Case for class with inherited methods
         String testedClass7 = TEST_CLASS + "f";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass7);
         for (int i = 1; i <= 33; i++) {
-            checkMethod( reply, "m" + intToString(i), 1, testedClass1, testedClass7 );
+            checkMethod(reply, "m" + intToString(i), 1, testedClass1, testedClass7);
         }
         for (int i = 1; i <= 3; i++) {
-            checkMethod( reply, "f" + intToString(i), 1, testedClass1, testedClass7 );
+            checkMethod(reply, "f" + intToString(i), 1, testedClass1, testedClass7);
         }
 
-        // Case for class with inherited and overrided methods
+        // Case for class with inherited and overridden methods
         String testedClass8 = TEST_CLASS + "g";
         reply = jdb.receiveReplyFor(JdbCommand.methods + testedClass8);
         for (int i = 1; i <= 33; i++) {
-            checkMethod( reply, "m" + intToString(i), 1, testedClass8, testedClass8 );
+            checkMethod(reply, "m" + intToString(i), 1, testedClass8, testedClass8);
         }
         for (int i = 1; i <= 33; i++) {
-            checkMethod( reply, "m" + intToString(i), 1, testedClass1, testedClass8 );
+            checkMethod(reply, "m" + intToString(i), 1, testedClass1, testedClass8);
         }
         for (int i = 1; i <= 3; i++) {
-            checkMethod( reply, "f" + intToString(i), 1, testedClass1, testedClass8 );
+            checkMethod(reply, "f" + intToString(i), 1, testedClass1, testedClass8);
         }
 
         jdb.contToExit(1);
     }
 
-    private void checkMethod (
-        String[] reply,       /* reply on 'methods' command */
-        String methodName,    /* method name */
-        int expOccur,         /* expected number of occurences of the method */
-        String ownerClass,    /* name of class defining method */
-        String testedClass    /* name of tested class */
-                             ) {
+    private void checkMethod(
+            String[] reply,       /* reply on 'methods' command */
+            String methodName,    /* method name */
+            int expOccur,         /* expected number of occurences of the method */
+            String ownerClass,    /* name of class defining method */
+            String testedClass    /* name of tested class */
+    ) {
 
         Paragrep grep = new Paragrep(reply);
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         v.add(ownerClass);
         v.add(methodName);
         int j = grep.find(v);
         if (j != expOccur) {
             failure("Wrong number of occurences of method " + methodName +
-                "\n\t of class " + ownerClass +
-                "\n\t in class " + testedClass +
-                "\n\t expected number: " + expOccur + " got: " + j);
+                    "\n\t of class " + ownerClass +
+                    "\n\t in class " + testedClass +
+                    "\n\t expected number: " + expOccur + " got: " + j);
         }
     }
 
-    private String[] toStringArray (String[] arr) {
-        Vector v = new Vector();
-        for (int i = 0; i < arr.length; i++) {
-            StringTokenizer st = new StringTokenizer(arr[i], "\r\n");
+    private String[] toStringArray(String[] arr) {
+        Vector<String> v = new Vector<>();
+        for (String s : arr) {
+            StringTokenizer st = new StringTokenizer(s, "\r\n");
             while (st.hasMoreTokens()) {
                 v.add(st.nextToken());
             }
@@ -197,15 +195,16 @@ public class methods002 extends JdbTest {
         Object[] objects = v.toArray();
         String[] results = new String[objects.length];
         for (int i = 0; i < objects.length; i++) {
-            results[i] = (String)objects[i];
+            results[i] = (String) objects[i];
         }
         return results;
     }
 
-    private String intToString (int i) {
+    private String intToString(int i) {
         String s = String.valueOf(i);
-        if (s.length()==1)
+        if (s.length() == 1) {
             s = "0" + s;
+        }
         return s;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.methods.methods002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class methods002a {
     static methods002a _methods002a = new methods002a();
 
-    public static void main(String args[]) {
-       System.exit(methods002.JCK_STATUS_BASE + _methods002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(methods002.JCK_STATUS_BASE + _methods002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -57,125 +57,332 @@ public class methods002a {
     static long lo;
 
     // various method modifiers
-                 void  m01 (long l) { lo = l; };
-    private      void  m02 (long l) { lo = l; };
-    protected    void  m03 (long l) { lo = l; };
-    public       void  m04 (long l) { lo = l; };
-    static       void  m05 (long l) { lo = l; };
-    synchronized void  m06 (long l) { lo = l; };
-    strictfp     void  m07 (long l) { lo = l; };
-    native       void  m08 (long l);
-    public static synchronized strictfp void m09 (long l) { lo = l; };
+    void m01(long l) {
+        lo = l;
+    }
 
-                 long  m10 (long l) { return lo + l; };
-    private      long  m11 (long l) { return lo + l; };
-    protected    long  m12 (long l) { return lo + l; };
-    public       long  m13 (long l) { return lo + l; };
-    static       long  m14 (long l) { return lo + l; };
-    synchronized long  m15 (long l) { return lo + l; };
-    strictfp     long  m16 (long l) { return lo + l; };
-    native       long  m17 (long l);
-    public static synchronized strictfp long m18 (long l) { return lo + l; };
+    private void m02(long l) {
+        lo = l;
+    }
 
-                 Object  m19 () { return new Object(); };
-    private      Object  m20 () { return new Object(); };
-    protected    Object  m21 () { return new Object(); };
-    public       Object  m22 () { return new Object(); };
-    static       Object  m23 () { return new Object(); };
-    synchronized Object  m24 () { return new Object(); };
-    strictfp     Object  m25 () { return new Object(); };
-    native       Object  m26 ();
-    public static synchronized strictfp Object m27 () { return new Object(); };
+    protected void m03(long l) {
+        lo = l;
+    }
 
+    public void m04(long l) {
+        lo = l;
+    }
+
+    static void m05(long l) {
+        lo = l;
+    }
+
+    synchronized void m06(long l) {
+        lo = l;
+    }
+
+    strictfp void m07(long l) {
+        lo = l;
+    }
+
+    native void m08(long l);
+
+    public static synchronized strictfp void m09(long l) {
+        lo = l;
+    }
+
+    long m10(long l) {
+        return lo + l;
+    }
+
+    private long m11(long l) {
+        return lo + l;
+    }
+
+    protected long m12(long l) {
+        return lo + l;
+    }
+
+    public long m13(long l) {
+        return lo + l;
+    }
+
+    static long m14(long l) {
+        return lo + l;
+    }
+
+    synchronized long m15(long l) {
+        return lo + l;
+    }
+
+    strictfp long m16(long l) {
+        return lo + l;
+    }
+
+    native long m17(long l);
+
+    public static synchronized strictfp long m18(long l) {
+        return lo + l;
+    }
+
+    Object m19() {
+        return new Object();
+    }
+
+    private Object m20() {
+        return new Object();
+    }
+
+    protected Object m21() {
+        return new Object();
+    }
+
+    public Object m22() {
+        return new Object();
+    }
+
+    static Object m23() {
+        return new Object();
+    }
+
+    synchronized Object m24() {
+        return new Object();
+    }
+
+    strictfp Object m25() {
+        return new Object();
+    }
+
+    native Object m26();
+
+    public static synchronized strictfp Object m27() {
+        return new Object();
+    }
 
     // array methods
-    double[]   m28 () { return new double[1]; };
-    double     m29 (double[] arr) {return arr[0];};
-    double[][] m30 (double[][] arr) {return arr;};
+    double[] m28() {
+        return new double[1];
+    }
 
-    String[]   m31 () { return new String[1];};
-    String     m32 (String[] arr) { return arr[0];};
-    String[][] m33 (String[][] arr) {return arr;};
+    double m29(double[] arr) {
+        return arr[0];
+    }
+
+    double[][] m30(double[][] arr) {
+        return arr;
+    }
+
+    String[] m31() {
+        return new String[1];
+    }
+
+    String m32(String[] arr) {
+        return arr[0];
+    }
+
+    String[][] m33(String[][] arr) {
+        return arr;
+    }
 
     // final methods
-    final        void    f01 (long l) { lo = l; };
-    final        long    f02 (long l) { return lo + l; };
-    final        Object  f03 () { return new Object(); };
+    final void f01(long l) {
+        lo = l;
+    }
+
+    final long f02(long l) {
+        return lo + l;
+    }
+
+    final Object f03() {
+        return new Object();
+    }
 }
 
 // Class with many constructors
 class methods002b {
     int ind;
-    methods002b (int i) { ind = i; };
 
-    private   methods002b (int i, int j) { ind = i+j; };
-    protected methods002b (int i, int j, int k) { ind = i+j+k; };
-    public    methods002b (int i, int j, int k, int l) { ind = i+j+k+l; };
+    methods002b(int i) {
+        ind = i;
+    }
+
+    private methods002b(int i, int j) {
+        ind = i + j;
+    }
+
+    protected methods002b(int i, int j, int k) {
+        ind = i + j + k;
+    }
+
+    public methods002b(int i, int j, int k, int l) {
+        ind = i + j + k + l;
+    }
 }
 
 // Class with overloaded methods
 class methods002c {
-    int m01 (int i) { return i; };
-    int m01 (int i, int j) { return i+j; };
-    int m01 (int i, short j) { return i+j; };
+    int m01(int i) {
+        return i;
+    }
+
+    int m01(int i, int j) {
+        return i + j;
+    }
+
+    int m01(int i, short j) {
+        return i + j;
+    }
 }
 
 // Class with abstract methods
 abstract class methods002d {
-    abstract void m01 ();
+    abstract void m01();
 }
 
 interface methods002i {
-    void i01 ();
+    void i01();
 }
 
 class methods002e extends methods002d implements methods002i {
-    void m01 () {};
-    public void i01 () {};
+    void m01() {
+    }
+
+    public void i01() {
+    }
 }
 
 // Class with inherited methods
-class methods002f extends methods002a {}
+class methods002f extends methods002a {
+}
 
 // Class with inherited and overrided method
 class methods002g extends methods002f {
     static long lo;
 
-                 void  m01 (long l) { lo = l; };
-    private      void  m02 (long l) { lo = l; };
-    protected    void  m03 (long l) { lo = l; };
-    public       void  m04 (long l) { lo = l; };
-    static       void  m05 (long l) { lo = l; };
-    synchronized void  m06 (long l) { lo = l; };
-    strictfp     void  m07 (long l) { lo = l; };
-    native       void  m08 (long l);
-    public static synchronized strictfp void m09 (long l) { lo = l; };
+    void m01(long l) {
+        lo = l;
+    }
 
-                 long  m10 (long l) { return lo + l; };
-    private      long  m11 (long l) { return lo + l; };
-    protected    long  m12 (long l) { return lo + l; };
-    public       long  m13 (long l) { return lo + l; };
-    static       long  m14 (long l) { return lo + l; };
-    synchronized long  m15 (long l) { return lo + l; };
-    strictfp     long  m16 (long l) { return lo + l; };
-    native       long  m17 (long l);
-    public static synchronized strictfp long m18 (long l) { return lo + l; };
+    private void m02(long l) {
+        lo = l;
+    }
 
-                 Object  m19 () { return new Object(); };
-    private      Object  m20 () { return new Object(); };
-    protected    Object  m21 () { return new Object(); };
-    public       Object  m22 () { return new Object(); };
-    static       Object  m23 () { return new Object(); };
-    synchronized Object  m24 () { return new Object(); };
-    strictfp     Object  m25 () { return new Object(); };
-    native       Object  m26 ();
-    public static synchronized strictfp Object m27 () { return new Object(); };
+    protected void m03(long l) {
+        lo = l;
+    }
 
-    double[]   m28 () { return new double[1]; };
-    double     m29 (double[] arr) {return arr[0];};
-    double[][] m30 (double[][] arr) {return arr;};
+    public void m04(long l) {
+        lo = l;
+    }
 
-    String[]   m31 () { return new String[1];};
-    String     m32 (String[] arr) { return arr[0];};
-    String[][] m33 (String[][] arr) {return arr;};
+    static void m05(long l) {
+        lo = l;
+    }
+
+    synchronized void m06(long l) {
+        lo = l;
+    }
+
+    strictfp void m07(long l) {
+        lo = l;
+    }
+
+    native void m08(long l);
+
+    public static synchronized strictfp void m09(long l) {
+        lo = l;
+    }
+
+    long m10(long l) {
+        return lo + l;
+    }
+
+    private long m11(long l) {
+        return lo + l;
+    }
+
+    protected long m12(long l) {
+        return lo + l;
+    }
+
+    public long m13(long l) {
+        return lo + l;
+    }
+
+    static long m14(long l) {
+        return lo + l;
+    }
+
+    synchronized long m15(long l) {
+        return lo + l;
+    }
+
+    strictfp long m16(long l) {
+        return lo + l;
+    }
+
+    native long m17(long l);
+
+    public static synchronized strictfp long m18(long l) {
+        return lo + l;
+    }
+
+    Object m19() {
+        return new Object();
+    }
+
+    private Object m20() {
+        return new Object();
+    }
+
+    protected Object m21() {
+        return new Object();
+    }
+
+    public Object m22() {
+        return new Object();
+    }
+
+    static Object m23() {
+        return new Object();
+    }
+
+    synchronized Object m24() {
+        return new Object();
+    }
+
+    strictfp Object m25() {
+        return new Object();
+    }
+
+    native Object m26();
+
+    public static synchronized strictfp Object m27() {
+        return new Object();
+    }
+
+    double[] m28() {
+        return new double[1];
+    }
+
+    double m29(double[] arr) {
+        return arr[0];
+    }
+
+    double[][] m30(double[][] arr) {
+        return arr;
+    }
+
+    String[] m31() {
+        return new String[1];
+    }
+
+    String m32(String[] arr) {
+        return arr[0];
+    }
+
+    String[][] m33(String[][] arr) {
+        return arr;
+    }
+
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
@@ -60,20 +60,21 @@
 
 package nsk.jdb.monitor.monitor001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class monitor001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new monitor001().runTest(argv, out);
@@ -82,32 +83,28 @@ public class monitor001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.monitor.monitor001";
     static final String TEST_CLASS = PACKAGE_NAME + ".monitor001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final int    LINE_NUMBER        = 47;
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final int LINE_NUMBER = 47;
 
     static final String[] CHECKED_COMMANDS = {
-        JdbCommand.threads,
-        JdbCommand.methods + DEBUGGEE_CLASS,
-        JdbCommand.fields  + DEBUGGEE_CLASS,
-        JdbCommand.eval + "(new java.lang.String(\"Hello, World\")).length()"
-                                             };
+            JdbCommand.threads,
+            JdbCommand.methods + DEBUGGEE_CLASS,
+            JdbCommand.fields + DEBUGGEE_CLASS,
+            JdbCommand.eval + "(new java.lang.String(\"Hello, World\")).length()"
+    };
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
-        reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
+        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
 
-        for (int i = 0; i < CHECKED_COMMANDS.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[i]);
+        for (String checkedCommand : CHECKED_COMMANDS) {
+            jdb.receiveReplyFor(JdbCommand.monitor + checkedCommand);
         }
 
         int repliesCount = CHECKED_COMMANDS.length + 1;
-        reply = jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
+        jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
 
         reply = jdb.receiveReplyFor(JdbCommand.monitor);
         if (!checkMonitors(reply)) {
@@ -124,15 +121,13 @@ public class monitor001 extends JdbTest {
 
     private boolean checkMonitors(String[] reply) {
         Paragrep grep;
-        String found;
-        Vector v;
         boolean result = true;
         int count;
 
         grep = new Paragrep(reply);
-        for (int i = 0; i < CHECKED_COMMANDS.length; i++) {
-            if ((count = grep.find(CHECKED_COMMANDS[i])) != 1) {
-                log.complain("Wrong number of monitor command: " + CHECKED_COMMANDS[i]);
+        for (String checkedCommand : CHECKED_COMMANDS) {
+            if ((count = grep.find(checkedCommand)) != 1) {
+                log.complain("Wrong number of monitor command: " + checkedCommand);
                 log.complain("    Expected: 1; found: " + count);
                 result = false;
             }
@@ -143,8 +138,7 @@ public class monitor001 extends JdbTest {
 
     private boolean checkCommands(String[] reply) {
         Paragrep grep;
-        String found;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
         boolean result = true;
         int count;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001a.java
@@ -23,25 +23,25 @@
 
 package nsk.jdb.monitor.monitor001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
 //    THIS TEST IS LINE NUMBER SENSITIVE
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class monitor001a {
     static monitor001a _monitor001a = new monitor001a();
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         System.exit(monitor001.JCK_STATUS_BASE + _monitor001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
         int localInt = 0; // monitor001.LINE_NUMBER

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002.java
@@ -56,20 +56,20 @@
 
 package nsk.jdb.monitor.monitor002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class monitor002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new monitor002().runTest(argv, out);
@@ -78,29 +78,25 @@ public class monitor002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.monitor.monitor002";
     static final String TEST_CLASS = PACKAGE_NAME + ".monitor002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final int    LINE_NUMBER        = 47;
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final int LINE_NUMBER = 47;
 
     static final String[] CHECKED_COMMANDS = {
-        JdbCommand.unmonitor + "1"
-                                             };
+            JdbCommand.unmonitor + "1"
+    };
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
-        reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
+        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
 
-        for (int i = 0; i < CHECKED_COMMANDS.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[i]);
+        for (String checkedCommand : CHECKED_COMMANDS) {
+            jdb.receiveReplyFor(JdbCommand.monitor + checkedCommand);
         }
 
         int repliesCount = CHECKED_COMMANDS.length + 1;
-        reply = jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
+        jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
 
         reply = jdb.receiveReplyFor(JdbCommand.monitor);
         if (reply.length != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002a.java
@@ -23,25 +23,25 @@
 
 package nsk.jdb.monitor.monitor002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
 //    THIS TEST IS LINE NUMBER SENSITIVE
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class monitor002a {
     static monitor002a _monitor002a = new monitor002a();
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         System.exit(monitor002.JCK_STATUS_BASE + _monitor002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
         int localInt = 0; // monitor002.LINE_NUMBER

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001.java
@@ -60,54 +60,47 @@
 
 package nsk.jdb.next.next001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class next001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new next001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.next.next001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".next001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.next.next001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".next001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String[] checkedMethods = {"func1", "func2", "func3"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-        String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
 
-        int breakCount = 0;
         int nextCount = 0;
         for (int i = 0; i < next001a.numThreads; i++) {
             reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (jdb.isAtBreakpoint(reply, LAST_BREAK)) {
-                breakCount++;
-                reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
+                jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
 
-                reply = jdb.receiveReplyFor(JdbCommand.next);
+                jdb.receiveReplyFor(JdbCommand.next);
                 if (!checkNext()) {
                     success = false;
                 } else {
@@ -126,9 +119,8 @@ public class next001 extends JdbTest {
     }
 
 
-    private boolean checkNext () {
+    private boolean checkNext() {
         Paragrep grep;
-        String found;
         int count;
         boolean result = true;
         String[] reply;
@@ -139,13 +131,13 @@ public class next001 extends JdbTest {
         count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[2]);
         if (count > 0) {
             log.complain("Debuggee is suspended in wrong method after 'next' command: " + DEBUGGEE_THREAD + "." + checkedMethods[2]);
-            result= false;
+            result = false;
         }
 
         count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[1]);
         if (count != 1) {
             log.complain("Checked method does not exist in thread stack trace: " + DEBUGGEE_THREAD + "." + checkedMethods[1]);
-            result= false;
+            result = false;
         }
 
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001a.java
@@ -23,37 +23,37 @@
 
 package nsk.jdb.next.next001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class next001a {
-    public static void main(String args[]) {
-       next001a _next001a = new next001a();
-       System.exit(next001.JCK_STATUS_BASE + _next001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        next001a _next001a = new next001a();
+        System.exit(next001.JCK_STATUS_BASE + _next001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    static final String MYTHREAD  = "MyThread";
-    static final int numThreads   = 2;   // number of threads.
+    static final String MYTHREAD = "MyThread";
+    static final int numThreads = 2;   // number of threads.
 
     static JdbArgumentHandler argumentHandler;
     static Log log;
 
     static Object waitnotify = new Object();
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
 
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
 
-        Thread holder [] = new Thread[numThreads];
+        Thread holder[] = new Thread[numThreads];
 
-        for (int i = 0; i < numThreads ; i++) {
+        for (int i = 0; i < numThreads; i++) {
             holder[i] = new MyThread();
             holder[i].start();
             try {
@@ -86,6 +86,6 @@ class MyThread extends Thread {
     }
 
     public int func3(int i) {
-        return i*i;
+        return i * i;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001.java
@@ -62,20 +62,21 @@
 
 package nsk.jdb.options.connect.connect001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class connect001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect001().runTest(argv, out);
@@ -84,8 +85,8 @@ public class connect001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect001";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.CommandLineLaunch";
@@ -99,16 +100,14 @@ public class connect001 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
             reply = jdb.getTotalReply();
             grep = new Paragrep(reply);
-            v = new Vector();
+            v = new Vector<>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.options.connect.connect001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class connect001a {
     static connect001a _connect001a = new connect001a();
 
-    public static void main(String args[]) {
-       System.exit(connect001.JCK_STATUS_BASE + _connect001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(connect001.JCK_STATUS_BASE + _connect001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002.java
@@ -62,20 +62,21 @@
 
 package nsk.jdb.options.connect.connect002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class connect002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect002().runTest(argv, out);
@@ -84,8 +85,8 @@ public class connect002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect002";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.SocketAttach";
@@ -99,16 +100,14 @@ public class connect002 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
             reply = jdb.getTotalReply();
             grep = new Paragrep(reply);
-            v = new Vector();
+            v = new Vector<>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.options.connect.connect002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class connect002a {
     static connect002a _connect002a = new connect002a();
 
-    public static void main(String args[]) {
-       System.exit(connect002.JCK_STATUS_BASE + _connect002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(connect002.JCK_STATUS_BASE + _connect002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003.java
@@ -62,20 +62,21 @@
 
 package nsk.jdb.options.connect.connect003;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class connect003 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect003().runTest(argv, out);
@@ -84,8 +85,8 @@ public class connect003 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect003";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect003";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.SharedMemoryAttach";
@@ -99,16 +100,14 @@ public class connect003 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
             reply = jdb.getTotalReply();
             grep = new Paragrep(reply);
-            v = new Vector();
+            v = new Vector<>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.options.connect.connect003;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class connect003a {
     static connect003a _connect003a = new connect003a();
 
-    public static void main(String args[]) {
-       System.exit(connect003.JCK_STATUS_BASE + _connect003a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(connect003.JCK_STATUS_BASE + _connect003a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004.java
@@ -62,20 +62,21 @@
 
 package nsk.jdb.options.connect.connect004;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class connect004 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect004().runTest(argv, out);
@@ -84,8 +85,8 @@ public class connect004 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect004";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect004";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.SocketListen";
@@ -99,16 +100,14 @@ public class connect004 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
             reply = jdb.getTotalReply();
             grep = new Paragrep(reply);
-            v = new Vector();
+            v = new Vector<>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.options.connect.connect004;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class connect004a {
     static connect004a _connect004a = new connect004a();
 
-    public static void main(String args[]) {
-       System.exit(connect004.JCK_STATUS_BASE + _connect004a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(connect004.JCK_STATUS_BASE + _connect004a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005.java
@@ -62,20 +62,21 @@
 
 package nsk.jdb.options.connect.connect005;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class connect005 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new connect005().runTest(argv, out);
@@ -84,8 +85,8 @@ public class connect005 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect005";
     static final String TEST_CLASS = PACKAGE_NAME + ".connect005";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected boolean shouldPass() {
         String feature = "com.sun.jdi.SharedMemoryListen";
@@ -99,16 +100,14 @@ public class connect005 extends JdbTest {
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
             reply = jdb.getTotalReply();
             grep = new Paragrep(reply);
-            v = new Vector();
+            v = new Vector<>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.options.connect.connect005;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class connect005a {
     static connect005a _connect005a = new connect005a();
 
-    public static void main(String args[]) {
-       System.exit(connect005.JCK_STATUS_BASE + _connect005a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(connect005.JCK_STATUS_BASE + _connect005a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/listconnectors/listconnectors001/listconnectors001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/listconnectors/listconnectors001/listconnectors001.java
@@ -66,41 +66,39 @@
 
 package nsk.jdb.options.listconnectors.listconnectors001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.Jdb;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class listconnectors001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new listconnectors001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME = "nsk.jdb.options.connect";
-    static final String TEST_CLASS = PACKAGE_NAME + ".connect001";
     static final String DEBUGGEE_CLASS = null;
-    static final String FIRST_BREAK    = null;
-    static final String LAST_BREAK     = null;
+    static final String FIRST_BREAK = null;
+    static final String LAST_BREAK = null;
 
-    static final String TESTED_OPTION = "-listconnectors";
     static final String TESTED_CONNECTORS_LIST[] = {
-        "com.sun.jdi.CommandLineLaunch", "dt_socket",
-        "com.sun.jdi.CommandLineLaunch", "dt_shmem",
-        "com.sun.jdi.RawCommandLineLaunch", "dt_socket",
-        "com.sun.jdi.RawCommandLineLaunch", "dt_shmem",
-        "com.sun.jdi.SocketAttach", "dt_socket",
-        "com.sun.jdi.SocketListen", "dt_socket",
-        "com.sun.jdi.SharedMemoryAttach", "dt_shmem",
-        "com.sun.jdi.SharedMemoryListen", "dt_shmem",
+            "com.sun.jdi.CommandLineLaunch", "dt_socket",
+            "com.sun.jdi.CommandLineLaunch", "dt_shmem",
+            "com.sun.jdi.RawCommandLineLaunch", "dt_socket",
+            "com.sun.jdi.RawCommandLineLaunch", "dt_shmem",
+            "com.sun.jdi.SocketAttach", "dt_socket",
+            "com.sun.jdi.SocketListen", "dt_socket",
+            "com.sun.jdi.SharedMemoryAttach", "dt_shmem",
+            "com.sun.jdi.SharedMemoryListen", "dt_shmem",
     };
     static final int TESTED_CONNECTORS_COUNT = TESTED_CONNECTORS_LIST.length / 2;
 /*
@@ -126,11 +124,11 @@ public class listconnectors001 extends JdbTest {
         String[] reply = jdb.getTotalReply();
 
         for (int i = 0; i < TESTED_CONNECTORS_COUNT; i++) {
-            String connector = TESTED_CONNECTORS_LIST[i*2 + 0];
-            String transport = TESTED_CONNECTORS_LIST[i*2 + 1];
+            String connector = TESTED_CONNECTORS_LIST[i * 2];
+            String transport = TESTED_CONNECTORS_LIST[i * 2 + 1];
             Paragrep grep = new Paragrep(reply);
 
-            Vector<String> v = new Vector<String>();
+            Vector<String> v = new Vector<>();
             v.add(Jdb.SUPPORTED_CONNECTOR_NAME);
             v.add(connector);
             v.add(Jdb.SUPPORTED_TRANSPORT_NAME);
@@ -150,7 +148,7 @@ public class listconnectors001 extends JdbTest {
                         + "  transport: " + transport
                         + "  found: " + found);
             } else if (argumentHandler.shouldPass(connector)
-                            || argumentHandler.shouldPass(connector, transport)) {
+                    || argumentHandler.shouldPass(connector, transport)) {
                 display("unsupported connector not found:\n"
                         + "  connector: " + connector
                         + "  transport: " + transport

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
@@ -61,20 +61,21 @@
 
 package nsk.jdb.pop.pop001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class pop001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new pop001().runTest(argv, out);
@@ -82,23 +83,19 @@ public class pop001 extends JdbTest {
 
     static final String PACKAGE_NAME = "nsk.jdb.pop.pop001";
     static final String TEST_CLASS = PACKAGE_NAME + ".pop001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String MYTHREAD        = "MyThread";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
-    static final String[] CHECKED_METHODS = {"func1", "func2", "func3", "func4", "func5"};
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         while (true) {
             String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
@@ -109,22 +106,22 @@ public class pop001 extends JdbTest {
                 break;
             }
 
-            reply = jdb.receiveReplyFor(JdbCommand.thread + threads[0]);
+            jdb.receiveReplyFor(JdbCommand.thread + threads[0]);
 
-            reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
+            jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func5", "[1]", "lastBreak", false)) {
-                 success = false;
+                success = false;
             }
-            reply = jdb.receiveReplyFor(JdbCommand.up + " 3");
+            jdb.receiveReplyFor(JdbCommand.up + " 3");
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func2", "[4]", "func3", false)) {
                 success = false;
             }
 
-            reply = jdb.receiveReplyFor(JdbCommand.pop);
+            jdb.receiveReplyFor(JdbCommand.pop);
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func1", "[1]", "func2", true)) {
@@ -135,8 +132,8 @@ public class pop001 extends JdbTest {
             grep = new Paragrep(reply);
             if (grep.find("Internal exception") > 0) {
                 log.complain("Internal exception was thrown while 'locals' command");
-                for (int i = 0; i < reply.length; i++) {
-                    log.complain(reply[i]);
+                for (String s : reply) {
+                    log.complain(s);
                 }
                 success = false;
             }
@@ -147,10 +144,9 @@ public class pop001 extends JdbTest {
         jdb.contToExit(2);
     }
 
-    private boolean checkStack (String[] reply, String shouldBe, String frameNum, String shouldNotBe, boolean pop ) {
+    private boolean checkStack(String[] reply, String shouldBe, String frameNum, String shouldNotBe, boolean pop) {
         Paragrep grep;
-        String found;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
         boolean result = true;
         int count;
 
@@ -158,14 +154,14 @@ public class pop001 extends JdbTest {
         v.add(frameNum);
         v.add(DEBUGGEE_THREAD + "." + shouldBe);
         if ((count = grep.find(v)) != 1) {
-            log.complain("Contents of stack trace is incorrect " + ( pop? "after 'pop' command": ""));
+            log.complain("Contents of stack trace is incorrect " + (pop ? "after 'pop' command" : ""));
             log.complain("Searched for: " + DEBUGGEE_THREAD + "." + shouldBe);
             log.complain("Count : " + count);
             result = false;
         }
 
         if (grep.find(DEBUGGEE_THREAD + "." + shouldNotBe) > 0) {
-            log.complain("Contents of stack trace is incorrect " + ( pop? "after 'pop' command": ""));
+            log.complain("Contents of stack trace is incorrect " + (pop ? "after 'pop' command" : ""));
             log.complain("Found wrong frame: " + DEBUGGEE_THREAD + "." + shouldNotBe);
             result = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001a.java
@@ -23,29 +23,29 @@
 
 package nsk.jdb.pop.pop001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class pop001a {
 
-    static final String MYTHREAD  = "MyThread";
+    static final String MYTHREAD = "MyThread";
 
     static JdbArgumentHandler argumentHandler;
     static Log log;
 
     static pop001a _pop001a = new pop001a();
 
-    public static void main(String args[]) {
-       System.exit(pop001.JCK_STATUS_BASE + _pop001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(pop001.JCK_STATUS_BASE + _pop001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
 
@@ -68,7 +68,7 @@ public class pop001a {
 
 class MyThread extends Thread {
 
-    public MyThread (String name) {
+    public MyThread(String name) {
         super(name);
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
@@ -48,38 +48,37 @@
 
 package nsk.jdb.pop_exception.pop_exception001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Failure;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class pop_exception001 extends JdbTest {
 
-    static final String PACKAGE_NAME    = "nsk.jdb.pop_exception.pop_exception001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".pop_exception001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.pop_exception.pop_exception001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".pop_exception001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new pop_exception001().runTest(argv, out);
     }
 
 
-
     protected void runCases() {
 
         jdb.receiveReplyFor(JdbCommand._catch + "java.lang.NullPointerException");
         jdb.receiveReplyFor(JdbCommand.cont);
-        //exception
+        // exception
         jdb.receiveReplyFor(JdbCommand.pop);
         jdb.receiveReplyFor(JdbCommand.pop);
         jdb.receiveReplyFor(JdbCommand.ignore + "java.lang.NullPointerException");
@@ -93,11 +92,11 @@ public class pop_exception001 extends JdbTest {
     }
 
     private void checkJdbReply(String[] jdbReply) {
-        String replyString = "";
-        for(String s: jdbReply) {
-            replyString += s;
-            if(s.contains("line=")){
-                if(!s.contains("line=" + pop_exception001a.expectedFinish)) {
+        StringBuilder replyString = new StringBuilder();
+        for (String s : jdbReply) {
+            replyString.append(s);
+            if (s.contains("line=")) {
+                if (!s.contains("line=" + pop_exception001a.expectedFinish)) {
                     throw new Failure("FAILED: Expected location: line=" + pop_exception001a.expectedFinish + "\n found: " + s);
                 } else {
                     return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001a.java
@@ -23,11 +23,11 @@
 
 package nsk.jdb.pop_exception.pop_exception001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Consts;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
 //    THIS TEST IS LINE NUMBER SENSITIVE
 
@@ -35,15 +35,12 @@ import java.io.*;
  * debugee application
  */
 public class pop_exception001a {
-    public static void main(String args[]) {
-       pop_exception001a _pop_exception001a = new pop_exception001a();
-       System.exit(Consts.JCK_STATUS_BASE + _pop_exception001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        pop_exception001a _pop_exception001a = new pop_exception001a();
+        System.exit(Consts.JCK_STATUS_BASE + _pop_exception001a.runIt(args, System.out));
     }
 
-    static JdbArgumentHandler argumentHandler;
-    static Log log;
-
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         int i = 0;
         Object item = null;
         try {
@@ -51,7 +48,7 @@ public class pop_exception001a {
             i = 5; // expectedFinish
             item = getItem(i);
         } finally {
-            System.out.println("item = "+item);
+            System.out.println("item = " + item);
         }
         return Consts.TEST_PASSED;
     }
@@ -64,5 +61,5 @@ public class pop_exception001a {
         }
     }
 
-    public final static String expectedFinish = "51";
+    public final static String expectedFinish = "48";
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002.java
@@ -66,20 +66,20 @@
 
 package nsk.jdb.print.print002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class print002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new print002().runTest(argv, out);
@@ -88,14 +88,14 @@ public class print002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.print.print002";
     static final String TEST_CLASS = PACKAGE_NAME + ".print002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String[][] checkedExpr = {
-        { "i + j", "8"},
-        { "j - i", "4"},
-        { "j * i", "12"},
-        { "j / i", "3"},
+            {"i + j", "8"},
+            {"j - i", "4"},
+            {"j * i", "12"},
+            {"j / i", "3"},
 //        { "j % i", "0"},
 //        { "i++",   "2"},
 //        { "++i",   "3"},
@@ -104,24 +104,18 @@ public class print002 extends JdbTest {
 //        { "!b1 ",   "false"},
 //        { "b2 && b1", "false"},
 //        { "b2 || b1", "true"},
-        { "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.s", "foo" }
-                                          };
+            {"a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.s", "foo"}
+    };
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // to get out of lastBreak()
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
 
-        for (int i = 0; i < checkedExpr.length; i++) {
-            if (!checkValue(checkedExpr[i][0], checkedExpr[i][1])) {
+        for (String[] strings : checkedExpr) {
+            if (!checkValue(strings[0], strings[1])) {
                 success = false;
             }
         }
@@ -129,11 +123,10 @@ public class print002 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkValue (String expr, String value) {
+    private boolean checkValue(String expr, String value) {
         Paragrep grep;
         String[] reply;
         String found;
-        Vector v;
         boolean result = true;
 
         reply = jdb.receiveReplyFor(JdbCommand.print + expr);
@@ -141,7 +134,7 @@ public class print002 extends JdbTest {
         found = grep.findFirst(value);
         if (found.length() <= 0) {
             log.complain("jdb failed to report value of expression: " + expr);
-            log.complain("\t expected : " + value + " ;\n\t reported: " + (reply.length > 0? reply[0]: ""));
+            log.complain("\t expected : " + value + " ;\n\t reported: " + (reply.length > 0 ? reply[0] : ""));
             result = false;
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002a.java
@@ -23,24 +23,24 @@
 
 package nsk.jdb.print.print002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class print002a {
 
     static print002a _print002a = new print002a();
 
-    public static void main(String args[]) {
-       System.exit(print002.JCK_STATUS_BASE + _print002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(print002.JCK_STATUS_BASE + _print002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -61,131 +61,209 @@ public class print002a {
 }
 
 class A {
-B b;
-A() { b = new B(); }
+    B b;
+
+    A() {
+        b = new B();
+    }
 }
 
 class B {
-C c;
-B() { c = new C(); }
+    C c;
+
+    B() {
+        c = new C();
+    }
 }
 
 class C {
-D d;
-C() { d = new D(); }
+    D d;
+
+    C() {
+        d = new D();
+    }
 }
 
 class D {
-E e;
-D() { e = new E(); }
+    E e;
+
+    D() {
+        e = new E();
+    }
 }
 
 class E {
-F f;
-E() { f = new F(); }
+    F f;
+
+    E() {
+        f = new F();
+    }
 }
 
 class F {
-G g;
-F() { g = new G(); }
+    G g;
+
+    F() {
+        g = new G();
+    }
 }
 
 class G {
-H h;
-G() { h = new H(); }
+    H h;
+
+    G() {
+        h = new H();
+    }
 }
 
 class H {
-I i;
-H() { i = new I(); }
+    I i;
+
+    H() {
+        i = new I();
+    }
 }
 
 class I {
-J j;
-I() { j = new J(); }
+    J j;
+
+    I() {
+        j = new J();
+    }
 }
 
 class J {
-K k;
-J() { k = new K(); }
+    K k;
+
+    J() {
+        k = new K();
+    }
 }
 
 class K {
-L l;
-K() { l = new L(); }
+    L l;
+
+    K() {
+        l = new L();
+    }
 }
 
 class L {
-M m;
-L() { m = new M(); }
+    M m;
+
+    L() {
+        m = new M();
+    }
 }
 
 class M {
-N n;
-M() { n = new N(); }
+    N n;
+
+    M() {
+        n = new N();
+    }
 }
 
 class N {
-O o;
-N() { o = new O(); }
+    O o;
+
+    N() {
+        o = new O();
+    }
 }
 
 class O {
-P p;
-O() { p = new P(); }
+    P p;
+
+    O() {
+        p = new P();
+    }
 }
 
 class P {
-Q q;
-P() { q = new Q(); }
+    Q q;
+
+    P() {
+        q = new Q();
+    }
 }
 
 class Q {
-R r;
-Q() { r = new R(); }
+    R r;
+
+    Q() {
+        r = new R();
+    }
 }
 
 class R {
-S s;
-R() { s = new S(); }
+    S s;
+
+    R() {
+        s = new S();
+    }
 }
 
 class S {
-T t;
-S() { t = new T(); }
+    T t;
+
+    S() {
+        t = new T();
+    }
 }
 
 class T {
-U u;
-T() { u = new U(); }
+    U u;
+
+    T() {
+        u = new U();
+    }
 }
 
 class U {
-V v;
-U() { v = new V(); }
+    V v;
+
+    U() {
+        v = new V();
+    }
 }
 
 class V {
-W w;
-V() { w = new W(); }
+    W w;
+
+    V() {
+        w = new W();
+    }
 }
 
 class W {
-X x;
-W() { x = new X(); }
+    X x;
+
+    W() {
+        x = new X();
+    }
 }
 
 class X {
-Y y;
-X() { y = new Y(); }
+    Y y;
+
+    X() {
+        y = new Y();
+    }
 }
 
 class Y {
-Z z;
-Y() { z = new Z(); }
+    Z z;
+
+    Y() {
+        z = new Z();
+    }
 }
 
 class Z {
-  String s;
-  Z() { s  = "foo";}
+    String s;
+
+    Z() {
+        s = "foo";
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
@@ -66,21 +66,22 @@
 
 package nsk.jdb.read.read001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
 import jdk.test.lib.Utils;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.PrintStream;
 
 public class read001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new read001().runTest(argv, out);
@@ -89,8 +90,8 @@ public class read001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.read.read001";
     static final String TEST_CLASS = PACKAGE_NAME + ".read001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK    = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK     = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String SCENARIO_FILE = "jdb.scenario";
     static final int SCENARIO_COMMANDS_COUNT = 5;
@@ -101,10 +102,10 @@ public class read001 extends JdbTest {
 
         // stop in lastBreak() method
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // return to testedInstanceMethod()
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
 
         String command = JdbCommand.read + srcdir + File.separator + SCENARIO_FILE;
         int count = SCENARIO_COMMANDS_COUNT + 1;
@@ -119,8 +120,6 @@ public class read001 extends JdbTest {
 
     private boolean checkCommands(String[] reply) {
         Paragrep grep;
-        String found;
-        Vector v = new Vector();
         boolean result = true;
         int count;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001a.java
@@ -23,24 +23,25 @@
 
 package nsk.jdb.read.read001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Failure;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class read001a {
 
     static boolean testedStaticFieldBoolean = true;
-    double testedInstanceFieldDouble = (double)3.1414926;
+    double testedInstanceFieldDouble = (double) 3.1414926;
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         read001a _read001a = new read001a();
         System.exit(read001.JCK_STATUS_BASE + _read001a.runIt(args, System.out));
     }
 
-    void lastBreak () {}
+    void lastBreak() {
+    }
 
     void testedInstanceMethod() {
         int testedLocalVarInt = 0;
@@ -51,7 +52,7 @@ public class read001a {
         testedLocalVarString = "bar";
     }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
         int localInt = 0;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/RedefinedClass.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/RedefinedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/RedefinedClass.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/RedefinedClass.java
@@ -26,7 +26,7 @@ package nsk.jdb.redefine.redefine001;
 public class RedefinedClass {
     public static String foo() {
         return "BEFORE_REDEFINITION"; //  This string is substituted with
-                                      //  'return "AFTER_REDEFINITION";' in
-                                      //  the newclass/RedefinedClass.java.
+        //  'return "AFTER_REDEFINITION";' in
+        //  the newclass/RedefinedClass.java.
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001.java
@@ -70,21 +70,22 @@
 
 package nsk.jdb.redefine.redefine001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
 import nsk.share.classload.ClassLoadUtils;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.PrintStream;
 
 public class redefine001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new redefine001().runTest(argv, out);
@@ -93,44 +94,41 @@ public class redefine001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.redefine.redefine001";
     static final String TEST_CLASS = PACKAGE_NAME + ".redefine001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String REDEFINED_CLASS    = PACKAGE_NAME + ".RedefinedClass";
+    static final String REDEFINED_CLASS = PACKAGE_NAME + ".RedefinedClass";
     static final String BEFORE_REDEFINITION = "BEFORE_REDEFINITION";
-    static final String FIRST_REDEFINITION  = "AFTER_REDEFINITION";
+    static final String FIRST_REDEFINITION = "AFTER_REDEFINITION";
     static final String SECOND_REDEFINITION = BEFORE_REDEFINITION;
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
-        reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
+        jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
 
         reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_CLASS + ".flag");
         grep = new Paragrep(reply);
         if (grep.find(BEFORE_REDEFINITION) == 0) {
-            log.complain("Wrong value of redefine001a.flag before redefinition: " + (reply.length > 0? reply[0]: ""));
+            log.complain("Wrong value of redefine001a.flag before redefinition: " + (reply.length > 0 ? reply[0] : ""));
             success = false;
         }
 
         String className = RedefinedClass.class.getName();
         String pathToRedefFile1 = ClassLoadUtils.getRedefineClassFileName("newclass_g", className);
         if (new File(pathToRedefFile1).exists()) {
-            reply = jdb.receiveReplyFor(JdbCommand.redefine + REDEFINED_CLASS + " " + pathToRedefFile1);
+            jdb.receiveReplyFor(JdbCommand.redefine + REDEFINED_CLASS + " " + pathToRedefFile1);
 
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            jdb.receiveReplyFor(JdbCommand.cont);
 
             reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_CLASS + ".flag");
             grep = new Paragrep(reply);
             if (grep.find(FIRST_REDEFINITION) == 0) {
-                log.complain("Wrong value of redefine001a.flag after first redefinition: " + (reply.length > 0? reply[0]: ""));
+                log.complain("Wrong value of redefine001a.flag after first redefinition: " + (reply.length > 0 ? reply[0] : ""));
                 success = false;
             }
         } else {
@@ -140,14 +138,14 @@ public class redefine001 extends JdbTest {
 
         String pathToRedefFile2 = ClassLoadUtils.getClassPathFileName(className);
         if (new File(pathToRedefFile2).exists()) {
-            reply = jdb.receiveReplyFor(JdbCommand.redefine + REDEFINED_CLASS + " " + pathToRedefFile2);
+            jdb.receiveReplyFor(JdbCommand.redefine + REDEFINED_CLASS + " " + pathToRedefFile2);
 
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            jdb.receiveReplyFor(JdbCommand.cont);
 
             reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_CLASS + ".flag");
             grep = new Paragrep(reply);
             if (grep.find(SECOND_REDEFINITION) == 0) {
-                log.complain("Wrong value of redefine001a.flag after second redefinition: " + (reply.length > 0? reply[0]: ""));
+                log.complain("Wrong value of redefine001a.flag after second redefinition: " + (reply.length > 0 ? reply[0] : ""));
                 success = false;
             }
         } else {
@@ -156,15 +154,5 @@ public class redefine001 extends JdbTest {
         }
 
         jdb.contToExit(2);
-    }
-
-    private boolean checkStop () {
-        Paragrep grep;
-        String[] reply;
-        String found;
-        Vector v;
-        boolean result = true;
-
-        return result;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.redefine.redefine001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class redefine001a {
     static redefine001a _redefine001a = new redefine001a();
 
-    public static void main(String args[]) {
-       System.exit(redefine001.JCK_STATUS_BASE + _redefine001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(redefine001.JCK_STATUS_BASE + _redefine001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
@@ -60,20 +60,21 @@
 
 package nsk.jdb.reenter.reenter001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class reenter001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new reenter001().runTest(argv, out);
@@ -81,23 +82,19 @@ public class reenter001 extends JdbTest {
 
     static final String PACKAGE_NAME = "nsk.jdb.reenter.reenter001";
     static final String TEST_CLASS = PACKAGE_NAME + ".reenter001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String MYTHREAD        = "MyThread";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
-    static final String[] CHECKED_METHODS = {"func1", "func2", "func3", "func4", "func5"};
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         while (true) {
             String[] threads = jdb.getThreadIds(DEBUGGEE_THREAD);
@@ -108,23 +105,23 @@ public class reenter001 extends JdbTest {
                 break;
             }
 
-            reply = jdb.receiveReplyFor(JdbCommand.thread + threads[0]);
+            jdb.receiveReplyFor(JdbCommand.thread + threads[0]);
 
-            reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
+            jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak()
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func5", "[1]", "lastBreak", false)) {
                 success = false;
             }
 
-            reply = jdb.receiveReplyFor(JdbCommand.up + " 3");
+            jdb.receiveReplyFor(JdbCommand.up + " 3");
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func2", "[4]", "func3", false)) {
                 success = false;
             }
 
-            reply = jdb.receiveReplyFor(JdbCommand.reenter);
+            jdb.receiveReplyFor(JdbCommand.reenter);
 
             reply = jdb.receiveReplyFor(JdbCommand.where);
             if (!checkStack(reply, "func2", "[1]", "func3", true)) {
@@ -135,8 +132,8 @@ public class reenter001 extends JdbTest {
             grep = new Paragrep(reply);
             if (grep.find("Internal exception") > 0) {
                 log.complain("Internal exception was thrown while 'locals' command");
-                for (int i = 0; i < reply.length; i++) {
-                    log.complain(reply[i]);
+                for (String s : reply) {
+                    log.complain(s);
                 }
                 success = false;
             }
@@ -147,10 +144,9 @@ public class reenter001 extends JdbTest {
         jdb.contToExit(2);
     }
 
-    private boolean checkStack (String[] reply, String shouldBe, String frameNum, String shouldNotBe, boolean reenter ) {
+    private boolean checkStack(String[] reply, String shouldBe, String frameNum, String shouldNotBe, boolean reenter) {
         Paragrep grep;
-        String found;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
         boolean result = true;
         int count;
 
@@ -158,14 +154,14 @@ public class reenter001 extends JdbTest {
         v.add(frameNum);
         v.add(DEBUGGEE_THREAD + "." + shouldBe);
         if ((count = grep.find(v)) != 1) {
-            log.complain("Contents of stack trace is incorrect " + ( reenter? "after 'reenter' command": ""));
+            log.complain("Contents of stack trace is incorrect " + (reenter ? "after 'reenter' command" : ""));
             log.complain("Searched for: " + DEBUGGEE_THREAD + "." + shouldBe);
             log.complain("Count : " + count);
             result = false;
         }
 
         if (grep.find(DEBUGGEE_THREAD + "." + shouldNotBe) > 0) {
-            log.complain("Contents of stack trace is incorrect " + ( reenter? "after 'reenter' command": ""));
+            log.complain("Contents of stack trace is incorrect " + (reenter ? "after 'reenter' command" : ""));
             log.complain("Found wrong frame: " + DEBUGGEE_THREAD + "." + shouldNotBe);
             result = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001a.java
@@ -23,29 +23,29 @@
 
 package nsk.jdb.reenter.reenter001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class reenter001a {
 
-    static final String MYTHREAD  = "MyThread";
+    static final String MYTHREAD = "MyThread";
 
     static JdbArgumentHandler argumentHandler;
     static Log log;
 
     static reenter001a _reenter001a = new reenter001a();
 
-    public static void main(String args[]) {
-       System.exit(reenter001.JCK_STATUS_BASE + _reenter001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(reenter001.JCK_STATUS_BASE + _reenter001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
 
@@ -68,7 +68,7 @@ public class reenter001a {
 
 class MyThread extends Thread {
 
-    public MyThread (String name) {
+    public MyThread(String name) {
         super(name);
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395.java
@@ -115,58 +115,59 @@
 
 package nsk.jdb.regression.b4689395;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.TestFailure;
 import nsk.share.classload.ClassLoadUtils;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.PrintStream;
 
 public class b4689395 extends JdbTest {
-        final static String TEST_CLASS     = b4689395.class.getName();
-        final static String DEBUGGEE_CLASS = TEST_CLASS + "a";
-        final static String FIRST_BREAK    = DEBUGGEE_CLASS + ".main";
-        final static String ERROR_MESSAGE  = "ERROR_M";
-        final static int    LINE_NUMBER    = 54;
-        private String classFile;
+    final static String TEST_CLASS = b4689395.class.getName();
+    final static String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    final static String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    final static String ERROR_MESSAGE = "ERROR_M";
+    final static int LINE_NUMBER = 54;
+    private String classFile;
 
-        public static void main (String argv[]) {
-                System.exit(run(argv, System.out) + JCK_STATUS_BASE);
+    public static void main(String[] argv) {
+        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
+    }
+
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
+        firstBreak = FIRST_BREAK;
+        return new b4689395().runTest(argv, out);
+    }
+
+    public b4689395() {
+        classFile = ClassLoadUtils.getRedefineClassFileName(DEBUGGEE_CLASS);
+        if (classFile == null)
+            throw new TestFailure("Unable to find redefine class file in classpath for: " + DEBUGGEE_CLASS);
+    }
+
+    protected void runCases() {
+        String[] reply;
+        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
+        jdb.receiveReplyFor(JdbCommand.cont);
+
+        if (new File(classFile).exists()) {
+            jdb.receiveReplyFor(JdbCommand.redefine + DEBUGGEE_CLASS + " " + classFile);
+            reply = jdb.receiveReplyFor(JdbCommand.next);
+
+            Paragrep grep = new Paragrep(reply);
+            if (grep.find(ERROR_MESSAGE) != 0) {
+                log.complain("'" + ERROR_MESSAGE + "' is not expected to be "
+                        + "printed after 'next' command.");
+                success = false;
+            }
+        } else {
+            log.complain("File does not exist: " + classFile);
+            success = false;
         }
 
-        public static int run(String argv[], PrintStream out) {
-                debuggeeClass =  DEBUGGEE_CLASS;
-                firstBreak = FIRST_BREAK;
-                return new b4689395().runTest(argv, out);
-        }
-
-        public b4689395() {
-                classFile = ClassLoadUtils.getRedefineClassFileName(DEBUGGEE_CLASS);
-                if (classFile == null)
-                        throw new TestFailure("Unable to find redefine class file in classpath for: " + DEBUGGEE_CLASS);
-        }
-
-        protected void runCases() {
-                String[] reply;
-                reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + LINE_NUMBER);
-                reply = jdb.receiveReplyFor(JdbCommand.cont);
-
-                if (new File(classFile).exists()) {
-                        reply = jdb.receiveReplyFor(JdbCommand.redefine + DEBUGGEE_CLASS
-                                        + " " + classFile);
-                        reply = jdb.receiveReplyFor(JdbCommand.next);
-
-                        Paragrep grep = new Paragrep(reply);
-                        if (grep.find(ERROR_MESSAGE) != 0) {
-                                log.complain("'" + ERROR_MESSAGE + "' is not expected to be "
-                                                + "printed after 'next' command.");
-                                success = false;
-                        }
-                } else {
-                        log.complain("File does not exist: " + classFile);
-                        success = false;
-                }
-
-                jdb.contToExit(1);
-        }
+        jdb.contToExit(1);
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395a.java
@@ -23,37 +23,37 @@
 
 package nsk.jdb.regression.b4689395;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Consts;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
 //    THIS TEST IS LINE NUMBER SENSITIVE
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class b4689395a {
-        static b4689395a _b4689395a = new b4689395a();
-        final static String ERROR_MESSAGE  = "ERROR_M";
+    static b4689395a _b4689395a = new b4689395a();
+    final static String ERROR_MESSAGE = "ERROR_M";
 
-        public static void main(String args[]) {
-                System.exit(Consts.JCK_STATUS_BASE + _b4689395a.runIt(args, System.out));
-        }
+    public static void main(String[] args) {
+        System.exit(Consts.JCK_STATUS_BASE + _b4689395a.runIt(args, System.out));
+    }
 
-        public int runIt(String args[], PrintStream out) {
-                JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
-                Log log = new Log(out, argumentHandler);
+    public int runIt(String[] args, PrintStream out) {
+        JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
+        Log log = new Log(out, argumentHandler);
 
-                minor();
+        minor();
 
-                log.display("Debuggee PASSED");
-                return Consts.TEST_PASSED;
-        }
+        log.display("Debuggee PASSED");
+        return Consts.TEST_PASSED;
+    }
 
-        public static void minor() {
-                System.out.println("In the top of the method minor()."); // b4689395.LINE_NUMBER
-                System.out.println("A breakpoint is here.");
-                System.out.println("In the bottom of the method minor().");
-                System.out.println(ERROR_MESSAGE);
-        }
+    public static void minor() {
+        System.out.println("In the top of the method minor()."); // b4689395.LINE_NUMBER
+        System.out.println("A breakpoint is here.");
+        System.out.println("In the bottom of the method minor().");
+        System.out.println(ERROR_MESSAGE);
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/newclass/b4689395a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/newclass/b4689395a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/newclass/b4689395a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/newclass/b4689395a.java
@@ -23,37 +23,37 @@
 
 package nsk.jdb.regression.b4689395;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Consts;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
 //    THIS TEST IS LINE NUMBER SENSITIVE
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class b4689395a {
-        static b4689395a _b4689395a = new b4689395a();
-        final static String ERROR_MESSAGE  = "ERROR_M";
+    static b4689395a _b4689395a = new b4689395a();
+    final static String ERROR_MESSAGE = "ERROR_M";
 
-        public static void main(String args[]) {
-                System.exit(Consts.JCK_STATUS_BASE + _b4689395a.runIt(args, System.out));
-        }
+    public static void main(String[] args) {
+        System.exit(Consts.JCK_STATUS_BASE + _b4689395a.runIt(args, System.out));
+    }
 
-        public int runIt(String args[], PrintStream out) {
-                JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
-                Log log = new Log(out, argumentHandler);
+    public int runIt(String[] args, PrintStream out) {
+        JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
+        Log log = new Log(out, argumentHandler);
 
-                minor();
+        minor();
 
-                log.display("Debuggee PASSED");
-                return Consts.TEST_PASSED;
-        }
+        log.display("Debuggee PASSED");
+        return Consts.TEST_PASSED;
+    }
 
-        public static void minor() {
-                System.out.println("In the top of the method minor()"); // b4689395.LINE_NUMBER
-                System.out.println("A breakpoint is here.");
-                System.out.println("In the bottom of the method minor().");
-                System.out.println(ERROR_MESSAGE);
-        }
+    public static void minor() {
+        System.out.println("In the top of the method minor()"); // b4689395.LINE_NUMBER
+        System.out.println("A breakpoint is here.");
+        System.out.println("In the bottom of the method minor().");
+        System.out.println(ERROR_MESSAGE);
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
@@ -64,39 +64,36 @@
 
 package nsk.jdb.resume.resume002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class resume002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new resume002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.resume.resume002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".resume002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.resume.resume002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".resume002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String THREAD_NAME      = "MyThread";
+    static final String THREAD_NAME = "MyThread";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002a.java
@@ -23,26 +23,28 @@
 
 package nsk.jdb.resume.resume002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Failure;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class resume002a {
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         resume002a _resume002a = new resume002a();
         System.exit(resume002.JCK_STATUS_BASE + _resume002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
+
     static int numThreads = 5;   // number of threads
-    static Thread holder [] = new Thread[numThreads];
+    static Thread holder[] = new Thread[numThreads];
 
     static Object waitnotify = new Object();
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -50,7 +52,7 @@ public class resume002a {
 
         try {
             lock.setLock();
-            for (int i = 0; i < numThreads ; i++) {
+            for (int i = 0; i < numThreads; i++) {
                 holder[i] = new MyThread(lock, "MyThread#" + i);
                 synchronized (waitnotify) {
                     holder[i].start();
@@ -59,14 +61,14 @@ public class resume002a {
             }
         } catch (Exception e) {
             System.err.println("TEST ERROR: Caught unexpected Exception while waiting in main thread: " +
-                e.getMessage());
+                    e.getMessage());
             System.exit(resume002.FAILED);
         }
 
         lastBreak();   // When jdb stops here, there should be 5 running MyThreads.
         lock.releaseLock();
 
-        for (int i = 0; i < numThreads ; i++) {
+        for (int i = 0; i < numThreads; i++) {
             if (holder[i].isAlive()) {
                 try {
                     holder[i].join(argumentHandler.getWaitTime() * 60000);
@@ -104,7 +106,7 @@ class MyThread extends Thread {
     Lock lock;
     String name;
 
-    MyThread (Lock l, String name) {
+    MyThread(Lock l, String name) {
         this.lock = l;
         this.name = name;
     }
@@ -115,9 +117,9 @@ class MyThread extends Thread {
         }
         try {
             lock.setLock();
-        } catch(Exception e) {
+        } catch (Exception e) {
             System.err.println("TEST ERROR: Caught unexpected Exception while waiting in MyThread: " +
-                e.getMessage());
+                    e.getMessage());
             System.exit(resume002.FAILED);
         }
         lock.releaseLock();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002.java
@@ -58,20 +58,21 @@
 
 package nsk.jdb.run.run002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class run002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new run002().runTest(argv, out);
@@ -80,22 +81,20 @@ public class run002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.run.run002";
     static final String TEST_CLASS = PACKAGE_NAME + ".run002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.contToExit(1);
 
         if (argumentHandler.isLaunchingConnector()) {
             reply = jdb.getTotalReply();
             grep = new Paragrep(reply);
-            v = new Vector();
+            v = new Vector<>();
             v.add(JdbCommand.run);
             v.add(DEBUGGEE_CLASS);
             if (grep.find(v) != 1) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.run.run002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class run002a {
     static run002a _run002a = new run002a();
 
-    public static void main(String args[]) {
-       System.exit(run002.JCK_STATUS_BASE + _run002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(run002.JCK_STATUS_BASE + _run002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001.java
@@ -67,20 +67,19 @@
 
 package nsk.jdb.set.set001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class set001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new set001().runTest(argv, out);
@@ -89,43 +88,39 @@ public class set001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.set.set001";
     static final String TEST_CLASS = PACKAGE_NAME + ".set001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String ERROR_MESSAGE = DEBUGGEE_CLASS + ".errorMessage";
 
     static final String[][] checkedExpr = {
-        { DEBUGGEE_CLASS + ".myStaticField", "-2147483648" },
-        { DEBUGGEE_CLASS + "._set001a.myInstanceField", "9223372036854775807" },
-                                          };
+            {DEBUGGEE_CLASS + ".myStaticField", "-2147483648"},
+            {DEBUGGEE_CLASS + "._set001a.myInstanceField", "9223372036854775807"},
+    };
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // to get out of lastBreak()
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
 
         // set values
-        for (int i = 0; i < checkedExpr.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.set + checkedExpr[i][0] + " = " + checkedExpr[i][1]);
+        for (String[] strings : checkedExpr) {
+            jdb.receiveReplyFor(JdbCommand.set + strings[0] + " = " + strings[1]);
         }
 
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
         // check value of debuggeeResult
         reply = jdb.receiveReplyFor(JdbCommand.eval + ERROR_MESSAGE);
-        //if everything is OK reply will look like this
-        //  nsk.jdb.set.set001.set001a.errorMessage = ""
+        // if everything is OK reply will look like this
+        //   nsk.jdb.set.set001.set001a.errorMessage = ""
         if (!reply[0].contains("\"\"")) {
             log.complain("jdb failed to set value for expression(s): ");
-            for (int i = 0; i < reply.length; i++) {
-                log.complain(reply[i]);
+            for (String s : reply) {
+                log.complain(s);
             }
             success = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001a.java
@@ -23,13 +23,12 @@
 
 package nsk.jdb.set.set001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class set001a {
 
     private static final String DEBUGGEE_PASSED = "Debuggee PASSED";
@@ -37,13 +36,14 @@ public class set001a {
 
     static set001a _set001a = new set001a();
 
-    public static void main(String args[]) {
-       System.exit(set001.JCK_STATUS_BASE + _set001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(set001.JCK_STATUS_BASE + _set001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
         String debuggeeResult = DEBUGGEE_PASSED;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002.java
@@ -67,20 +67,19 @@
 
 package nsk.jdb.set.set002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class set002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
 
@@ -90,44 +89,40 @@ public class set002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.set.set002";
     static final String TEST_CLASS = PACKAGE_NAME + ".set002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     static final String ERROR_MESSAGE = DEBUGGEE_CLASS + ".errorMessage";
 
     static final String[][] checkedExpr = {  //not broken, can be run safely even if 4660158 is not fixed
-        { DEBUGGEE_CLASS + "._set002a.myArrayField[0][0].line", "\"ABCDE\"" },
-        { "localInt", "java.lang.Integer.MIN_VALUE"}
-                                          };
+            {DEBUGGEE_CLASS + "._set002a.myArrayField[0][0].line", "\"ABCDE\""},
+            {"localInt", "java.lang.Integer.MIN_VALUE"}
+    };
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // to get out of lastBreak()
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
 
         // set values
-        for (int i = 0; i < checkedExpr.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.set + checkedExpr[i][0] + " = " + checkedExpr[i][1]);
+        for (String[] strings : checkedExpr) {
+            jdb.receiveReplyFor(JdbCommand.set + strings[0] + " = " + strings[1]);
         }
 
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
         // check value of debuggeeResult
         reply = jdb.receiveReplyFor(JdbCommand.eval + ERROR_MESSAGE);
 
-        //if everything is OK reply will look like this
-        //  nsk.jdb.set.set002.set002a.errorMessage = ""
+        // if everything is OK reply will look like this
+        //   nsk.jdb.set.set002.set002a.errorMessage = ""
         if (!reply[0].contains("\"\"")) {
             log.complain("jdb failed to set value for expression(s): ");
-            for (int i = 0; i < reply.length; i++) {
-                log.complain(reply[i]);
+            for (String s : reply) {
+                log.complain(s);
             }
             success = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002a.java
@@ -23,13 +23,12 @@
 
 package nsk.jdb.set.set002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class set002a {
 
     private static final String DEBUGGEE_PASSED = "Debuggee PASSED";
@@ -37,13 +36,14 @@ public class set002a {
 
     static set002a _set002a = new set002a();
 
-    public static void main(String args[]) {
-       System.exit(set002.JCK_STATUS_BASE + _set002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(set002.JCK_STATUS_BASE + _set002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
         String debuggeeResult = DEBUGGEE_PASSED;
@@ -75,19 +75,19 @@ public class set002a {
     static String errorMessage = "";
     public MyClass[][] myArrayField;
 
-    private set002a () {
-         myArrayField = new MyClass[][] {new MyClass[] {new MyClass("")}};
+    private set002a() {
+        myArrayField = new MyClass[][]{new MyClass[]{new MyClass("")}};
     }
 
     static class MyClass {
         private String line;
 
-        public MyClass (String s) {
+        public MyClass(String s) {
             line = s;
         }
 
         public String toString() {
-             return line;
+            return line;
         }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002.java
@@ -70,45 +70,41 @@
 
 package nsk.jdb.step.step002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class step002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new step002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.step.step002";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".step002";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
-    static final int    BREAKPOINT_LINE = 50;
+    static final String PACKAGE_NAME = "nsk.jdb.step.step002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".step002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final int BREAKPOINT_LINE = 49;
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-        String[] threads;
 
-        reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         // case #1 : step inside frame;
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
         reply = jdb.receiveReplyFor(JdbCommand.eval + "intVar");
         grep = new Paragrep(reply);
         if (grep.find("1234") == 0) {
@@ -116,7 +112,7 @@ public class step002 extends JdbTest {
         }
 
         // case #1 : step into called frame;
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
         reply = jdb.receiveReplyFor(JdbCommand.where);
         grep = new Paragrep(reply);
         if (grep.find("foo") == 0) {
@@ -124,7 +120,7 @@ public class step002 extends JdbTest {
         }
 
         // case #1 : step out to calling frame;
-        reply = jdb.receiveReplyFor(JdbCommand.step);
+        jdb.receiveReplyFor(JdbCommand.step);
         reply = jdb.receiveReplyFor(JdbCommand.where);
         grep = new Paragrep(reply);
         if (grep.find("foo") > 0) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002a.java
@@ -25,23 +25,22 @@
 
 package nsk.jdb.step.step002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class step002a {
-    public static void main(String args[]) {
-       step002a _step002a = new step002a();
-       System.exit(step002.JCK_STATUS_BASE + _step002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        step002a _step002a = new step002a();
+        System.exit(step002.JCK_STATUS_BASE + _step002a.runIt(args, System.out));
     }
 
     static JdbArgumentHandler argumentHandler;
     static Log log;
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
 
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
@@ -54,7 +53,7 @@ public class step002a {
         return step002.PASSED;
     }
 
-    int foo (int i) {
-        return i*i;
+    int foo(int i) {
+        return i * i;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001.java
@@ -59,54 +59,47 @@
 
 package nsk.jdb.step_up.step_up001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class step_up001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new step_up001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.step_up.step_up001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".step_up001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.step_up.step_up001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".step_up001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String[] checkedMethods = {"func1", "func2", "func3"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-        String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
 
-        int breakCount = 0;
         int stepupCount = 0;
         for (int i = 0; i < step_up001a.numThreads; i++) {
             reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (jdb.isAtBreakpoint(reply, LAST_BREAK)) {
-                breakCount++;
-                reply = jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
+                jdb.receiveReplyFor(JdbCommand.step); // to get out of lastBreak;
 
-                reply = jdb.receiveReplyFor(JdbCommand.step_up);
+                jdb.receiveReplyFor(JdbCommand.step_up);
                 if (!checkSteppedUp()) {
                     success = false;
                 } else {
@@ -125,9 +118,8 @@ public class step_up001 extends JdbTest {
     }
 
 
-    private boolean checkSteppedUp () {
+    private boolean checkSteppedUp() {
         Paragrep grep;
-        String found;
         int count;
         boolean result = true;
         String[] reply;
@@ -139,14 +131,14 @@ public class step_up001 extends JdbTest {
             count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[i]);
             if (count > 0) {
                 log.complain("Wrong method in thread stack trace: " + DEBUGGEE_THREAD + "." + checkedMethods[i]);
-                result= false;
+                result = false;
             }
         }
 
         count = grep.find(DEBUGGEE_THREAD + "." + checkedMethods[0]);
         if (count != 1) {
             log.complain("Checked method does not exist in thread stack trace: " + DEBUGGEE_THREAD + "." + checkedMethods[0]);
-            result= false;
+            result = false;
         }
 
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001a.java
@@ -23,37 +23,37 @@
 
 package nsk.jdb.step_up.step_up001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class step_up001a {
-    public static void main(String args[]) {
-       step_up001a _step_up001a = new step_up001a();
-       System.exit(step_up001.JCK_STATUS_BASE + _step_up001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        step_up001a _step_up001a = new step_up001a();
+        System.exit(step_up001.JCK_STATUS_BASE + _step_up001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    static final String MYTHREAD  = "MyThread";
-    static final int numThreads   = 2;   // number of threads.
+    static final String MYTHREAD = "MyThread";
+    static final int numThreads = 2;   // number of threads.
 
     static JdbArgumentHandler argumentHandler;
     static Log log;
 
     static Object waitnotify = new Object();
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
 
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
 
-        Thread holder [] = new Thread[numThreads];
+        Thread holder[] = new Thread[numThreads];
 
-        for (int i = 0; i < numThreads ; i++) {
+        for (int i = 0; i < numThreads; i++) {
             holder[i] = new MyThread();
             holder[i].start();
             try {
@@ -86,6 +86,6 @@ class MyThread extends Thread {
     }
 
     public int func3(int i) {
-        return i*i;
+        return i * i;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java
@@ -51,27 +51,26 @@
 
 package nsk.jdb.stop_at.stop_at002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 /*
  * Regression test for:
  * Bug ID: 4299394
  * Synopsis: TTY: Deferred breakpoints can't be set on inner classes
- *
  */
 
 public class stop_at002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new stop_at002().runTest(argv, out);
@@ -80,19 +79,13 @@ public class stop_at002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.stop_at.stop_at002";
     static final String TEST_CLASS = PACKAGE_NAME + ".stop_at002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final String DEBUGGEE_LOCATION1 = DEBUGGEE_CLASS + "$Nested$DeeperNested$DeepestNested:43";
-    static final String DEBUGGEE_LOCATION2 = DEBUGGEE_CLASS + "$Inner$MoreInner:57";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String DEBUGGEE_LOCATION1 = DEBUGGEE_CLASS + "$Nested$DeeperNested$DeepestNested:66";
+    static final String DEBUGGEE_LOCATION2 = DEBUGGEE_CLASS + "$Inner$MoreInner:81";
     static final String FAILURE_PATTERN = "Unable to set";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
-
         if (!checkStop(DEBUGGEE_LOCATION1)) {
             success = false;
         }
@@ -104,7 +97,7 @@ public class stop_at002 extends JdbTest {
         jdb.contToExit(3);
     }
 
-    private boolean checkStop (String location) {
+    private boolean checkStop(String location) {
         Paragrep grep;
         String[] reply;
         String found;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002a.java
@@ -21,25 +21,27 @@
  * questions.
  */
 
+//    THIS TEST IS LINE NUMBER SENSITIVE
+
 package nsk.jdb.stop_at.stop_at002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class stop_at002a {
-    public static void main(String args[]) {
-       stop_at002a _stop_at002a = new stop_at002a();
-       lastBreak();
-       System.exit(stop_at002.JCK_STATUS_BASE + _stop_at002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        stop_at002a _stop_at002a = new stop_at002a();
+        lastBreak();
+        System.exit(stop_at002.JCK_STATUS_BASE + _stop_at002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -53,13 +55,15 @@ public class stop_at002a {
 
     class Nested {
         boolean flag;
-        Nested (boolean b) {
+
+        Nested(boolean b) {
             flag = b;
         }
+
         class DeeperNested {
-            class  DeepestNested {
+            class DeepestNested {
                 public void foo(boolean input) {
-                    flag = input; /* <--------  This is line number 43 */
+                    flag = input; // stop_at002.DEBUGGEE_LOCATION1
                 }
             }
         }
@@ -72,8 +76,9 @@ public class stop_at002a {
             public MoreInner() {
                 content = "";
             }
+
             public void foo(String input) {
-                content += input; /* <--------  This is line number 57 */
+                content += input; // stop_at002.DEBUGGEE_LOCATION2
             }
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003.java
@@ -63,27 +63,26 @@
 
 package nsk.jdb.stop_at.stop_at003;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 /*
  * Regression test for:
  * Bug ID: 4299394
  * Synopsis: TTY: Deferred breakpoints can't be set on inner classes
- *
  */
 
 public class stop_at003 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new stop_at003().runTest(argv, out);
@@ -92,40 +91,36 @@ public class stop_at003 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.stop_at.stop_at003";
     static final String TEST_CLASS = PACKAGE_NAME + ".stop_at003";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final String[][] LOCATIONS = new String[][] {
-        { PACKAGE_NAME + ".stop_at003b:61", PACKAGE_NAME + ".stop_at003b.<clinit>()" },
-        { PACKAGE_NAME + ".stop_at003b:63", PACKAGE_NAME + ".stop_at003b.<init>()" },
-        { PACKAGE_NAME + ".stop_at003b:66", PACKAGE_NAME + ".stop_at003b.<init>()" },
-        { PACKAGE_NAME + ".stop_at003b:72", PACKAGE_NAME + ".stop_at003b.foo()" }
-                                                   };
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String[][] LOCATIONS = new String[][]{
+            {PACKAGE_NAME + ".stop_at003b:62", PACKAGE_NAME + ".stop_at003b.<clinit>()"},
+            {PACKAGE_NAME + ".stop_at003b:66", PACKAGE_NAME + ".stop_at003b.<init>()"},
+            {PACKAGE_NAME + ".stop_at003b:70", PACKAGE_NAME + ".stop_at003b.<init>()"},
+            {PACKAGE_NAME + ".stop_at003b:76", PACKAGE_NAME + ".stop_at003b.foo()"}
+    };
     static final String FAILURE_PATTERN = "Unable to set";
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
-        for (int i = 0; i < LOCATIONS.length; i++) {
-            if (!checkStop(LOCATIONS[i][0])) {
-                failure("jdb failed to set line breakpoint at : " + LOCATIONS[i][0]);
+        for (String[] location : LOCATIONS) {
+            if (!checkStop(location[0])) {
+                failure("jdb failed to set line breakpoint at : " + location[0]);
             }
         }
 
-        for (int i = 0; i < LOCATIONS.length; i++) {
+        for (String[] location : LOCATIONS) {
             reply = jdb.receiveReplyFor(JdbCommand.cont);
-            if (!jdb.isAtBreakpoint(reply, LOCATIONS[i][1])) {
-                failure("Missed breakpoint at : " + LOCATIONS[i][0]);
+            if (!jdb.isAtBreakpoint(reply, location[1])) {
+                failure("Missed breakpoint at : " + location[0]);
             }
         }
 
         jdb.contToExit(1);
     }
 
-    private boolean checkStop (String location) {
+    private boolean checkStop(String location) {
         Paragrep grep;
         String[] reply;
         String found;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003a.java
@@ -25,25 +25,25 @@
 
 package nsk.jdb.stop_at.stop_at003;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class stop_at003a {
 
 
-    public static void main(String args[]) {
-       stop_at003a _stop_at003a = new stop_at003a();
+    public static void main(String[] args) {
+        stop_at003a _stop_at003a = new stop_at003a();
 //       lastBreak();
-       System.exit(stop_at003.JCK_STATUS_BASE + _stop_at003a.runIt(args, System.out));
+        System.exit(stop_at003.JCK_STATUS_BASE + _stop_at003a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -58,18 +58,22 @@ public class stop_at003a {
 class stop_at003b {
     static int intField = 0;
 
-    static { intField = 1; }      // stop_at003.LOCATIONS[0]
-
-    { intField = 2; }             // stop_at003.LOCATIONS[1]
-
-    stop_at003b () {
-        intField++;               // stop_at003.LOCATIONS[2]
+    static {
+        intField = 1;   // stop_at003.LOCATIONS[0]
     }
 
-    void foo () {
+    {
+        intField = 2;   // stop_at003.LOCATIONS[1]
+    }
+
+    stop_at003b() {
+        intField++;     // stop_at003.LOCATIONS[2]
+    }
+
+    void foo() {
         try {
             throw new Exception("Exception in foo()");
-        } catch (Exception e) {   // stop_at003.LOCATIONS[3]
+        } catch (Exception e) { // stop_at003.LOCATIONS[3]
             System.out.println("Exception in foo() is catched.");
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002.java
@@ -64,11 +64,11 @@
 
 package nsk.jdb.stop_in.stop_in002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 /*
  * Regression test for:
@@ -79,12 +79,12 @@ import java.util.*;
 
 public class stop_in002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new stop_in002().runTest(argv, out);
@@ -93,41 +93,37 @@ public class stop_in002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.stop_in.stop_in002";
     static final String TEST_CLASS = PACKAGE_NAME + ".stop_in002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final String[] LOCATIONS = new String[] {
-        PACKAGE_NAME + ".stop_in002b.<clinit>",
-        PACKAGE_NAME + ".stop_in002b.<init>",
-        PACKAGE_NAME + ".stop_in002b$StaticNested.m1",
-        PACKAGE_NAME + ".stop_in002b$Inner.m2",
-        PACKAGE_NAME + ".stop_in002b.foo"
-                                                   };
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String[] LOCATIONS = new String[]{
+            PACKAGE_NAME + ".stop_in002b.<clinit>",
+            PACKAGE_NAME + ".stop_in002b.<init>",
+            PACKAGE_NAME + ".stop_in002b$StaticNested.m1",
+            PACKAGE_NAME + ".stop_in002b$Inner.m2",
+            PACKAGE_NAME + ".stop_in002b.foo"
+    };
     static final String FAILURE_PATTERN = "Unable to set";
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
-        for (int i = 0; i < LOCATIONS.length; i++) {
-            if (!checkStop(LOCATIONS[i])) {
-                failure("jdb failed to set line breakpoint at : " + LOCATIONS[i]);
+        for (String location : LOCATIONS) {
+            if (!checkStop(location)) {
+                failure("jdb failed to set line breakpoint at : " + location);
             }
         }
 
-        for (int i = 0; i < LOCATIONS.length; i++) {
+        for (String location : LOCATIONS) {
             reply = jdb.receiveReplyFor(JdbCommand.cont);
-            if (!jdb.isAtBreakpoint(reply, LOCATIONS[i])) {
-                failure("Missed breakpoint at : " + LOCATIONS[i]);
+            if (!jdb.isAtBreakpoint(reply, location)) {
+                failure("Missed breakpoint at : " + location);
             }
         }
 
         jdb.contToExit(1);
     }
 
-    private boolean checkStop (String location) {
+    private boolean checkStop(String location) {
         Paragrep grep;
         String[] reply;
         String found;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002a.java
@@ -23,25 +23,25 @@
 
 package nsk.jdb.stop_in.stop_in002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class stop_in002a {
 
 
-    public static void main(String args[]) {
-       stop_in002a _stop_in002a = new stop_in002a();
+    public static void main(String[] args) {
+        stop_in002a _stop_in002a = new stop_in002a();
 //       lastBreak();
-       System.exit(stop_in002.JCK_STATUS_BASE + _stop_in002a.runIt(args, System.out));
+        System.exit(stop_in002.JCK_STATUS_BASE + _stop_in002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -59,20 +59,26 @@ class stop_in002b {
     static int intField = 0;
     Inner inn = null;
 
-    static { intField = 1; }
+    static {
+        intField = 1;
+    }
 
-    stop_in002b () {
+    stop_in002b() {
         intField++;
         inn = new Inner();
     }
 
     static class StaticNested {
-        public static void m1() {}
+        public static void m1() {
+        }
     }
 
     class Inner {
-        public void m2() {}
+        public void m2() {
+        }
     }
 
-    final int foo (int i) {return i++;}
+    final int foo(int i) {
+        return i++;
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
@@ -60,20 +60,20 @@
 
 package nsk.jdb.suspend.suspend001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class suspend001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new suspend001().runTest(argv, out);
@@ -82,23 +82,21 @@ public class suspend001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.suspend.suspend001";
     static final String TEST_CLASS = PACKAGE_NAME + ".suspend001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK    = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK     = DEBUGGEE_CLASS + ".breakHere";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
 
-    static final String SUSPENDED       = "Suspended";
+    static final String SUSPENDED = "Suspended";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + SUSPENDED;
     static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notSuspended";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
         String found;
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
         while (true) {
             threads = jdb.getThreadIds(DEBUGGEE_THREAD);
             if (threads.length != 1) {
@@ -108,7 +106,7 @@ public class suspend001 extends JdbTest {
                 break;
             }
 
-            reply = jdb.receiveReplyFor(JdbCommand.suspend + threads[0]);
+            jdb.receiveReplyFor(JdbCommand.suspend + threads[0]);
 
             reply = jdb.receiveReplyFor(JdbCommand.cont);
             if (!jdb.isAtBreakpoint(reply)) {
@@ -119,12 +117,12 @@ public class suspend001 extends JdbTest {
 
             reply = jdb.receiveReplyFor(JdbCommand.eval + DEBUGGEE_RESULT);
             grep = new Paragrep(reply);
-            found = grep.findFirst(DEBUGGEE_RESULT + " =" );
-            if (found.length() > 0 && found.indexOf(DEBUGGEE_RESULT + " = null") < 0) {
-                if (found.indexOf(DEBUGGEE_RESULT + " = 1") < 0) {
-                   log.complain("Wrong value of " + DEBUGGEE_RESULT);
-                   log.complain(found);
-                   success = false;
+            found = grep.findFirst(DEBUGGEE_RESULT + " =");
+            if (found.length() > 0 && !found.contains(DEBUGGEE_RESULT + " = null")) {
+                if (!found.contains(DEBUGGEE_RESULT + " = 1")) {
+                    log.complain("Wrong value of " + DEBUGGEE_RESULT);
+                    log.complain(found);
+                    success = false;
                 }
             } else {
                 log.complain("TEST BUG: not found value for " + DEBUGGEE_RESULT);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001a.java
@@ -23,30 +23,30 @@
 
 package nsk.jdb.suspend.suspend001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class suspend001a {
     static suspend001a _suspend001a = new suspend001a();
 
     static JdbArgumentHandler argumentHandler;
     static Log log;
 
-    public static void main(String args[]) {
-       System.exit(suspend001.JCK_STATUS_BASE + _suspend001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(suspend001.JCK_STATUS_BASE + _suspend001a.runIt(args, System.out));
     }
 
-    static void breakHere () {}
+    static void breakHere() {
+    }
 
-    static Object lock                   = new Object();
-    static Object waitnotify             = new Object();
+    static Object lock = new Object();
+    static Object waitnotify = new Object();
     public static volatile int notSuspended = 0;
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
 
@@ -56,21 +56,21 @@ public class suspend001a {
         // lock monitor to prevent threads from finishing after they started
         synchronized (lock) {
             synchronized (waitnotify) {
-                    suspended.start();
-                    try {
-                        waitnotify.wait();
-                    } catch (InterruptedException e) {
-                        log.complain("Main thread was interrupted while waiting for start of Suspended thread");
-                        return suspend001.FAILED;
-                    }
+                suspended.start();
+                try {
+                    waitnotify.wait();
+                } catch (InterruptedException e) {
+                    log.complain("Main thread was interrupted while waiting for start of Suspended thread");
+                    return suspend001.FAILED;
+                }
 
-                    myThread.start();
-                    try {
-                        waitnotify.wait();
-                    } catch (InterruptedException e) {
-                        log.complain("Main thread was interrupted while waiting for start of MyThread thread");
-                        return suspend001.FAILED;
-                    }
+                myThread.start();
+                try {
+                    waitnotify.wait();
+                } catch (InterruptedException e) {
+                    log.complain("Main thread was interrupted while waiting for start of MyThread thread");
+                    return suspend001.FAILED;
+                }
             }
             breakHere();  // a break to get thread ids and then to suspend Suspended thread.
         }
@@ -106,7 +106,7 @@ public class suspend001a {
 class Suspended extends Thread {
     String name;
 
-    public Suspended (String n) {
+    public Suspended(String n) {
         name = n;
     }
 
@@ -119,7 +119,8 @@ class Suspended extends Thread {
             suspend001a.waitnotify.notify();
         }
         // prevent thread from early finish
-        synchronized (suspend001a.lock) {}
+        synchronized (suspend001a.lock) {
+        }
 
         suspend001a.notSuspended++;
 
@@ -130,7 +131,7 @@ class Suspended extends Thread {
 class MyThread extends Thread {
     String name;
 
-    public MyThread (String n) {
+    public MyThread(String n) {
         name = n;
     }
 
@@ -143,7 +144,8 @@ class MyThread extends Thread {
             suspend001a.waitnotify.notify();
         }
         // prevent thread from early finish
-        synchronized (suspend001a.lock) {}
+        synchronized (suspend001a.lock) {
+        }
 
         suspend001a.notSuspended++;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
@@ -57,39 +57,37 @@
 
 package nsk.jdb.thread.thread002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class thread002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new thread002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.thread.thread002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".thread002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.thread.thread002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".thread002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String THREAD_NAME      = "MyThread";
+    static final String THREAD_NAME = "MyThread";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
@@ -108,7 +106,7 @@ public class thread002 extends JdbTest {
         for (int i = 0; i < threadIds.length; i++) {
             count = grep.find(THREAD_NAME + "#" + i);
             if (count != 1) {
-                 failure("jdb failed to switch to thread: " + threadIds[i]);
+                failure("jdb failed to switch to thread: " + threadIds[i]);
             }
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002a.java
@@ -23,26 +23,28 @@
 
 package nsk.jdb.thread.thread002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Failure;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class thread002a {
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         thread002a _thread002a = new thread002a();
         System.exit(thread002.JCK_STATUS_BASE + _thread002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
+
     static int numThreads = 5;   // number of threads
-    static Thread holder [] = new Thread[numThreads];
+    static Thread holder[] = new Thread[numThreads];
 
     static Object waitnotify = new Object();
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -50,7 +52,7 @@ public class thread002a {
 
         try {
             lock.setLock();
-            for (int i = 0; i < numThreads ; i++) {
+            for (int i = 0; i < numThreads; i++) {
                 holder[i] = new MyThread(lock, "MyThread#" + i);
                 synchronized (waitnotify) {
                     holder[i].start();
@@ -59,14 +61,14 @@ public class thread002a {
             }
         } catch (Exception e) {
             System.err.println("TEST ERROR: Caught unexpected Exception while waiting in main thread: " +
-                e.getMessage());
+                    e.getMessage());
             System.exit(thread002.FAILED);
         }
 
         lastBreak();   // When jdb stops here, there should be 5 running MyThreads.
         lock.releaseLock();
 
-        for (int i = 0; i < numThreads ; i++) {
+        for (int i = 0; i < numThreads; i++) {
             if (holder[i].isAlive()) {
                 try {
                     holder[i].join(argumentHandler.getWaitTime() * 60000);
@@ -104,7 +106,7 @@ class MyThread extends Thread {
     Lock lock;
     String name;
 
-    MyThread (Lock l, String name) {
+    MyThread(Lock l, String name) {
         this.lock = l;
         this.name = name;
     }
@@ -115,9 +117,9 @@ class MyThread extends Thread {
         }
         try {
             lock.setLock();
-        } catch(Exception e) {
+        } catch (Exception e) {
             System.err.println("TEST ERROR: Caught unexpected Exception while waiting in MyThread: " +
-                e.getMessage());
+                    e.getMessage());
             System.exit(thread002.FAILED);
         }
         lock.releaseLock();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
@@ -55,37 +55,35 @@
 
 package nsk.jdb.threadgroup.threadgroup002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class threadgroup002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new threadgroup002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.threadgroup.threadgroup002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".threadgroup002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.threadgroup.threadgroup002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".threadgroup002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002a.java
@@ -23,43 +23,44 @@
 
 package nsk.jdb.threadgroup.threadgroup002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Failure;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class threadgroup002a {
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         threadgroup002a _threadgroup002a = new threadgroup002a();
         System.exit(threadgroup002.JCK_STATUS_BASE + _threadgroup002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
     static int numThreadGroups = 3;
-    static int numThreads      = 15;
-    static Object waitnotify   = new Object();
+    static int numThreads = 15;
+    static Object waitnotify = new Object();
     final static String THREADGROUP_NAME = "MyThreadGroup#";
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
         ThreadGroup tgHolder[] = new ThreadGroup[numThreadGroups];
-        Thread holder [] = new Thread[numThreads];
+        Thread holder[] = new Thread[numThreads];
         Lock lock = new Lock();
 
-        for (int i = 0; i < numThreadGroups ; i++ )
+        for (int i = 0; i < numThreadGroups; i++)
             tgHolder[i] = new ThreadGroup(THREADGROUP_NAME + i);
 
         try {
             lock.setLock();
             int factor = numThreads / numThreadGroups;
             int k;
-            for (int i = 0; i < numThreadGroups ; i++) {
-                for (int j = 0; j < factor ; j++) {
+            for (int i = 0; i < numThreadGroups; i++) {
+                for (int j = 0; j < factor; j++) {
                     k = i * factor + j;
                     holder[k] = new MyThread(lock, tgHolder[i], "MyThread#");
                     synchronized (waitnotify) {
@@ -70,14 +71,14 @@ public class threadgroup002a {
             }
         } catch (Exception e) {
             System.err.println("TEST ERROR: Caught unexpected Exception while waiting in main thread: " +
-                e.getMessage());
+                    e.getMessage());
             System.exit(threadgroup002.FAILED);
         }
 
         lastBreak();   // When jdb stops here, there should be 5 running MyThreads.
         lock.releaseLock();
 
-        for (int i = 0; i < numThreads ; i++) {
+        for (int i = 0; i < numThreads; i++) {
             if (holder[i].isAlive()) {
                 try {
                     holder[i].join(argumentHandler.getWaitTime() * 60000);
@@ -113,7 +114,8 @@ class Lock {
 class MyThread extends Thread {
 
     Lock lock;
-    MyThread (Lock l, ThreadGroup group, String name) {
+
+    MyThread(Lock l, ThreadGroup group, String name) {
         super(group, name);
         this.lock = l;
     }
@@ -124,9 +126,9 @@ class MyThread extends Thread {
         }
         try {
             lock.setLock();
-        } catch(Exception e) {
+        } catch (Exception e) {
             System.err.println("TEST ERROR: Caught unexpected Exception while waiting in MyThread: " +
-                e.getMessage());
+                    e.getMessage());
             System.exit(threadgroup002.FAILED);
         }
         lock.releaseLock();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002.java
@@ -55,37 +55,35 @@
 
 package nsk.jdb.threadgroups.threadgroups002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class threadgroups002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new threadgroups002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.threadgroups.threadgroups002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".threadgroups002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.threadgroups.threadgroups002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".threadgroups002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
@@ -93,9 +91,9 @@ public class threadgroups002 extends JdbTest {
         reply = jdb.receiveReplyFor(JdbCommand.threadgroups);
         grep = new Paragrep(reply);
         count = grep.find(threadgroups002a.THREADGROUP_NAME);
-        if (count != threadgroups002a.numThreadGroups ) {
+        if (count != threadgroups002a.numThreadGroups) {
             failure("Unexpected number of " + threadgroups002a.THREADGROUP_NAME + " was listed: " + count +
-                "\n\texpected value: " + threadgroups002a.numThreadGroups);
+                    "\n\texpected value: " + threadgroups002a.numThreadGroups);
         }
 
         jdb.contToExit(1);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002a.java
@@ -23,43 +23,44 @@
 
 package nsk.jdb.threadgroups.threadgroups002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Failure;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class threadgroups002a {
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         threadgroups002a _threadgroups002a = new threadgroups002a();
         System.exit(threadgroups002.JCK_STATUS_BASE + _threadgroups002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
     static int numThreadGroups = 3;
-    static int numThreads      = 15;
-    static Object waitnotify   = new Object();
+    static int numThreads = 15;
+    static Object waitnotify = new Object();
     final static String THREADGROUP_NAME = "MyThreadGroup#";
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
         ThreadGroup tgHolder[] = new ThreadGroup[numThreadGroups];
-        Thread holder [] = new Thread[numThreads];
+        Thread holder[] = new Thread[numThreads];
         Lock lock = new Lock();
 
-        for (int i = 0; i < numThreadGroups ; i++ )
+        for (int i = 0; i < numThreadGroups; i++)
             tgHolder[i] = new ThreadGroup(THREADGROUP_NAME + i);
 
         try {
             lock.setLock();
             int factor = numThreads / numThreadGroups;
             int k;
-            for (int i = 0; i < numThreadGroups ; i++) {
-                for (int j = 0; j < factor ; j++) {
+            for (int i = 0; i < numThreadGroups; i++) {
+                for (int j = 0; j < factor; j++) {
                     k = i * factor + j;
                     holder[k] = new MyThread(lock, tgHolder[i], "MyThread#");
                     synchronized (waitnotify) {
@@ -70,14 +71,14 @@ public class threadgroups002a {
             }
         } catch (Exception e) {
             System.err.println("TEST ERROR: Caught unexpected Exception while waiting in main thread: " +
-                e.getMessage());
+                    e.getMessage());
             System.exit(threadgroups002.FAILED);
         }
 
         lastBreak();   // When jdb stops here, there should be 5 running MyThreads.
         lock.releaseLock();
 
-        for (int i = 0; i < numThreads ; i++) {
+        for (int i = 0; i < numThreads; i++) {
             if (holder[i].isAlive()) {
                 try {
                     holder[i].join(argumentHandler.getWaitTime() * 60000);
@@ -113,7 +114,8 @@ class Lock {
 class MyThread extends Thread {
 
     Lock lock;
-    MyThread (Lock l, ThreadGroup group, String name) {
+
+    MyThread(Lock l, ThreadGroup group, String name) {
         super(group, name);
         this.lock = l;
     }
@@ -124,9 +126,9 @@ class MyThread extends Thread {
         }
         try {
             lock.setLock();
-        } catch(Exception e) {
+        } catch (Exception e) {
             System.err.println("TEST ERROR: Caught unexpected Exception while waiting in MyThread: " +
-                e.getMessage());
+                    e.getMessage());
             System.exit(threadgroups002.FAILED);
         }
         lock.releaseLock();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
@@ -54,39 +54,37 @@
 
 package nsk.jdb.threads.threads002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class threads002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new threads002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.threads.threads002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".threads002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.threads.threads002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".threads002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String THREAD_NAME      = PACKAGE_NAME + ".MyThread";
+    static final String THREAD_NAME = PACKAGE_NAME + ".MyThread";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
@@ -94,9 +92,9 @@ public class threads002 extends JdbTest {
         reply = jdb.receiveReplyFor(JdbCommand.threads);
         grep = new Paragrep(reply);
         count = grep.find(THREAD_NAME);
-        if (count != threads002a.numThreads ) {
+        if (count != threads002a.numThreads) {
             failure("Unexpected number of " + THREAD_NAME + " was listed: " + count +
-                "\n\texpected value: " + threads002a.numThreads);
+                    "\n\texpected value: " + threads002a.numThreads);
         }
 
         jdb.contToExit(1);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002a.java
@@ -23,34 +23,35 @@
 
 package nsk.jdb.threads.threads002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Failure;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class threads002a {
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         threads002a _threads002a = new threads002a();
         System.exit(threads002.JCK_STATUS_BASE + _threads002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
     static int numThreads = 5;   // number of threads
     static Object waitnotify = new Object();
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
-        Thread holder [] = new Thread[numThreads];
+        Thread holder[] = new Thread[numThreads];
         Lock lock = new Lock();
 
         try {
             lock.setLock();
-            for (int i = 0; i < numThreads ; i++) {
+            for (int i = 0; i < numThreads; i++) {
                 holder[i] = new MyThread(lock);
                 synchronized (waitnotify) {
                     holder[i].start();
@@ -59,14 +60,14 @@ public class threads002a {
             }
         } catch (Exception e) {
             System.err.println("TEST ERROR: Caught unexpected Exception while waiting in main thread: " +
-                e.getMessage());
+                    e.getMessage());
             System.exit(threads002.FAILED);
         }
 
         lastBreak();   // When jdb stops here, there should be 5 running MyThreads.
         lock.releaseLock();
 
-        for (int i = 0; i < numThreads ; i++) {
+        for (int i = 0; i < numThreads; i++) {
             if (holder[i].isAlive()) {
                 try {
                     holder[i].join(argumentHandler.getWaitTime() * 60000);
@@ -102,7 +103,8 @@ class Lock {
 class MyThread extends Thread {
 
     Lock lock;
-    MyThread (Lock l) {
+
+    MyThread(Lock l) {
         this.lock = l;
     }
 
@@ -112,9 +114,9 @@ class MyThread extends Thread {
         }
         try {
             lock.setLock();
-        } catch(Exception e) {
+        } catch (Exception e) {
             System.err.println("TEST ERROR: Caught unexpected Exception while waiting in MyThread: " +
-                e.getMessage());
+                    e.getMessage());
             System.exit(threads002.FAILED);
         }
         lock.releaseLock();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
@@ -61,45 +61,42 @@
 
 package nsk.jdb.trace.trace001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class trace001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new trace001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.trace.trace001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".trace001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.trace.trace001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".trace001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String[] CHECKED_METHODS = {"func1", "func2", "func3"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
@@ -109,11 +106,11 @@ public class trace001 extends JdbTest {
             success = false;
         }
 
-        for (int i = 0; i < threads.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.trace + "methods " + threads[i]);
+        for (String thread : threads) {
+            jdb.receiveReplyFor(JdbCommand.trace + "methods " + thread);
         }
 
-        jdb.contToExit(CHECKED_METHODS.length*threads.length*2 + 3);
+        jdb.contToExit(CHECKED_METHODS.length * threads.length * 2 + 3);
 
         reply = jdb.getTotalReply();
         if (!checkTrace(CHECKED_METHODS, reply)) {
@@ -121,33 +118,32 @@ public class trace001 extends JdbTest {
         }
     }
 
-    private boolean checkTrace (String[] checkedMethods, String[] reply) {
+    private boolean checkTrace(String[] checkedMethods, String[] reply) {
         Paragrep grep;
-        String found;
         int count;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
         boolean result = true;
 
         grep = new Paragrep(reply);
-        for (int i = 0; i < checkedMethods.length; i++) {
+        for (String checkedMethod : checkedMethods) {
             v.removeAllElements();
-            v.add(DEBUGGEE_THREAD + "." + checkedMethods[i]);
+            v.add(DEBUGGEE_THREAD + "." + checkedMethod);
             v.add("Method entered");
             count = grep.find(v);
             if (count != 2) {
-                log.complain("Count of method enter is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethods[i]);
+                log.complain("Count of method enter is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethod);
                 log.complain("Should be 2 trace messages, found : " + count);
-                result= false;
+                result = false;
             }
 
             v.removeAllElements();
-            v.add(DEBUGGEE_THREAD + "." + checkedMethods[i]);
+            v.add(DEBUGGEE_THREAD + "." + checkedMethod);
             v.add("Method exited");
             count = grep.find(v);
             if (count != 2) {
-                log.complain("Count of method exit is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethods[i]);
+                log.complain("Count of method exit is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethod);
                 log.complain("Should be 2 trace messages, found : " + count);
-                result= false;
+                result = false;
             }
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001a.java
@@ -23,42 +23,42 @@
 
 package nsk.jdb.trace.trace001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class trace001a {
-    public static void main(String args[]) {
-       trace001a _trace001a = new trace001a();
-       System.exit(trace001.JCK_STATUS_BASE + _trace001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        trace001a _trace001a = new trace001a();
+        System.exit(trace001.JCK_STATUS_BASE + _trace001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    static final String MYTHREAD  = "MyThread";
-    static final int numThreads   = 2;   // number of threads.
+    static final String MYTHREAD = "MyThread";
+    static final int numThreads = 2;   // number of threads.
 
     static Object waitnotify = new Object();
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
 
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
         int i;
-        Thread holder [] = new Thread[numThreads];
+        Thread holder[] = new Thread[numThreads];
         Object[] locks = new Object[numThreads];
 
-        for (i = 0; i < numThreads ; i++) {
-            locks[i]  = new Object();
-            holder[i] = new MyThread(locks[i],MYTHREAD + "-" + i);
+        for (i = 0; i < numThreads; i++) {
+            locks[i] = new Object();
+            holder[i] = new MyThread(locks[i], MYTHREAD + "-" + i);
         }
 
         synchronized (waitnotify) {
-            for (i = 0; i < numThreads ; i++) {
+            for (i = 0; i < numThreads; i++) {
                 holder[i].start();
                 try {
                     waitnotify.wait();
@@ -75,7 +75,7 @@ public class trace001a {
         lastBreak();  // a break to get thread ids and then to turn on tracing.
 
         // waits on all MyThreads completion
-        for (i = 0; i < numThreads ; i++) {
+        for (i = 0; i < numThreads; i++) {
             synchronized (locks[i]) {
                 locks[i].notifyAll();
             }
@@ -99,7 +99,7 @@ class MyThread extends Thread {
     Object lock;
     String name;
 
-    public MyThread (Object l, String n) {
+    public MyThread(Object l, String n) {
         lock = l;
         name = n;
     }
@@ -137,6 +137,6 @@ class MyThread extends Thread {
     }
 
     public int func3(int i) {
-        return i*i;
+        return i * i;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002.java
@@ -66,20 +66,21 @@
 
 package nsk.jdb.uncaught_exception.uncaught_exception002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class uncaught_exception002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new uncaught_exception002(true).runTest(argv, out);
@@ -88,24 +89,17 @@ public class uncaught_exception002 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.uncaught_exception.uncaught_exception002";
     static final String TEST_CLASS = PACKAGE_NAME + ".uncaught_exception002";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[] FRAMES = new String[] {
-        DEBUGGEE_CLASS + ".func",
-        DEBUGGEE_CLASS + ".runIt",
-        DEBUGGEE_CLASS + ".main"                };
-
-    public uncaught_exception002 (boolean debuggeeShouldFail) {
+    public uncaught_exception002(boolean debuggeeShouldFail) {
         super(debuggeeShouldFail);
     }
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.receiveReplyFor(JdbCommand.cont);
         jdb.receiveReplyFor(JdbCommand.locals);
@@ -114,29 +108,19 @@ public class uncaught_exception002 extends JdbTest {
         reply = jdb.getTotalReply();
         grep = new Paragrep(reply);
 
-        v = new Vector();
+        v = new Vector<>();
         v.add("Exception occurred");
         v.add(PACKAGE_NAME + ".TenMultipleException");
         if (grep.find(v) == 0) {
             failure("jdb does not reported of TenMultipleException occurence");
         }
 
-        v = new Vector();
+        v = new Vector<>();
         v.add("localVar");
         v.add("1234");
         if (grep.find(v) == 0) {
             failure("Local variable of stack frame the exception was thrown " +
-                "is not accessible");
+                    "is not accessible");
         }
-    }
-
-    private boolean checkStop () {
-        Paragrep grep;
-        String[] reply;
-        String found;
-        Vector v;
-        boolean result = true;
-
-        return result;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002a.java
@@ -23,21 +23,20 @@
 
 package nsk.jdb.uncaught_exception.uncaught_exception002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class uncaught_exception002a {
     static uncaught_exception002a _uncaught_exception002a = new uncaught_exception002a();
 
-    public static void main(String args[]) throws TenMultipleException {
-       System.exit(uncaught_exception002.JCK_STATUS_BASE + _uncaught_exception002a.runIt(args, System.out));
+    public static void main(String[] args) throws TenMultipleException {
+        System.exit(uncaught_exception002.JCK_STATUS_BASE + _uncaught_exception002a.runIt(args, System.out));
     }
 
-    public int runIt(String args[], PrintStream out) throws TenMultipleException {
+    public int runIt(String[] args, PrintStream out) throws TenMultipleException {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -50,7 +49,7 @@ public class uncaught_exception002a {
     public static int func(int i) throws TenMultipleException {
         int localVar = 12345;
 
-        if ( i % 10 == 0 ) {
+        if (i % 10 == 0) {
             throw new TenMultipleException(i);
         }
         return i;
@@ -58,5 +57,7 @@ public class uncaught_exception002a {
 }
 
 class TenMultipleException extends Exception {
-     TenMultipleException (int i) { super ("received " + i ); }
+    TenMultipleException(int i) {
+        super("received " + i);
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
@@ -70,20 +70,21 @@
 
 package nsk.jdb.unmonitor.unmonitor001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class unmonitor001 extends JdbTest {
 
-    public static void main (String argv[])  {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new unmonitor001().runTest(argv, out);
@@ -92,41 +93,37 @@ public class unmonitor001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.unmonitor.unmonitor001";
     static final String TEST_CLASS = PACKAGE_NAME + ".unmonitor001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
-    static final int    BREAKPOINT_LINE    = 47;
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
+    static final int BREAKPOINT_LINE = 47;
 
     static final String[] CHECKED_COMMANDS = {
-        JdbCommand.locals,
-        JdbCommand.threads,
-        JdbCommand.methods + DEBUGGEE_CLASS,
-        JdbCommand.fields  + DEBUGGEE_CLASS,
-        JdbCommand.eval + "(new java.lang.String(\"Hello, World\")).length()"
-                                             };
+            JdbCommand.locals,
+            JdbCommand.threads,
+            JdbCommand.methods + DEBUGGEE_CLASS,
+            JdbCommand.fields + DEBUGGEE_CLASS,
+            JdbCommand.eval + "(new java.lang.String(\"Hello, World\")).length()"
+    };
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
-        reply = jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
+        jdb.receiveReplyFor(JdbCommand.stop_at + DEBUGGEE_CLASS + ":" + BREAKPOINT_LINE);
 
         // set first three monitors
-        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[0]);
-        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[1]);
-        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[2]);
+        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[0]);
+        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[1]);
+        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[2]);
 
         // delete first monitor
-        reply = jdb.receiveReplyFor(JdbCommand.unmonitor + " 1");
+        jdb.receiveReplyFor(JdbCommand.unmonitor + " 1");
 
         // set first last two monitors
-        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[3]);
-        reply = jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[4]);
+        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[3]);
+        jdb.receiveReplyFor(JdbCommand.monitor + CHECKED_COMMANDS[4]);
 
         int repliesCount = 4 + 1;
-        reply = jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
+        jdb.receiveReplyFor(JdbCommand.cont, true, repliesCount);
 
         reply = jdb.receiveReplyFor(JdbCommand.monitor);
         if (!checkMonitors(reply)) {
@@ -146,8 +143,6 @@ public class unmonitor001 extends JdbTest {
 
     private boolean checkMonitors(String[] reply) {
         Paragrep grep;
-        String found;
-        Vector v;
         boolean result = true;
         int count;
 
@@ -171,8 +166,7 @@ public class unmonitor001 extends JdbTest {
 
     private boolean checkCommands(String[] reply) {
         Paragrep grep;
-        String found;
-        Vector v = new Vector();;
+        Vector<String> v = new Vector<>();
         boolean result = true;
         int count;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001a.java
@@ -25,23 +25,23 @@
 
 package nsk.jdb.unmonitor.unmonitor001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class unmonitor001a {
     static unmonitor001a _unmonitor001a = new unmonitor001a();
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         System.exit(unmonitor001.JCK_STATUS_BASE + _unmonitor001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
         int localInt = 0; // unmonitor001.BREAKPOINT_LINE

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
@@ -68,45 +68,42 @@
 
 package nsk.jdb.untrace.untrace001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class untrace001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new untrace001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.untrace.untrace001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".untrace001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
-    static final String MYTHREAD        = "MyThread";
+    static final String PACKAGE_NAME = "nsk.jdb.untrace.untrace001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".untrace001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
+    static final String MYTHREAD = "MyThread";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + "." + MYTHREAD;
 
     static final String[] CHECKED_METHODS = {"func1", "func2", "func3"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
@@ -116,20 +113,20 @@ public class untrace001 extends JdbTest {
             success = false;
         }
 
-        for (int i = 0; i < threads.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.trace + "methods " + threads[i]);
+        for (String thread : threads) {
+            jdb.receiveReplyFor(JdbCommand.trace + "methods " + thread);
         }
 
         // resumes debuggee suspended on method enter and exit until hit of the breakpoint
-        for (int i = 0; i < (CHECKED_METHODS.length*threads.length*2 + 1); i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+        for (int i = 0; i < (CHECKED_METHODS.length * threads.length * 2 + 1); i++) {
+            jdb.receiveReplyFor(JdbCommand.cont);
         }
 
-        for (int i = 0; i < threads.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.untrace + "methods " + threads[i]);
+        for (String thread : threads) {
+            jdb.receiveReplyFor(JdbCommand.untrace + "methods " + thread);
         }
 
-        jdb.contToExit(CHECKED_METHODS.length*threads.length*2 + 2);
+        jdb.contToExit(CHECKED_METHODS.length * threads.length * 2 + 2);
 
         reply = jdb.getTotalReply();
         if (!checkTrace(CHECKED_METHODS, reply)) {
@@ -137,33 +134,32 @@ public class untrace001 extends JdbTest {
         }
     }
 
-    private boolean checkTrace (String[] checkedMethods, String[] reply) {
+    private boolean checkTrace(String[] checkedMethods, String[] reply) {
         Paragrep grep;
-        String found;
         int count;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
         boolean result = true;
 
         grep = new Paragrep(reply);
-        for (int i = 0; i < checkedMethods.length; i++) {
+        for (String checkedMethod : checkedMethods) {
             v.removeAllElements();
-            v.add(DEBUGGEE_THREAD + "." + checkedMethods[i]);
+            v.add(DEBUGGEE_THREAD + "." + checkedMethod);
             v.add("Method entered");
             count = grep.find(v);
             if (count != 1) {
-                log.complain("Count of method enter is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethods[i]);
+                log.complain("Count of method enter is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethod);
                 log.complain("Should be 1 trace messages, found : " + count);
-                result= false;
+                result = false;
             }
 
             v.removeAllElements();
-            v.add(DEBUGGEE_THREAD + "." + checkedMethods[i]);
+            v.add(DEBUGGEE_THREAD + "." + checkedMethod);
             v.add("Method exited");
             count = grep.find(v);
             if (count != 1) {
-                log.complain("Count of method exit is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethods[i]);
+                log.complain("Count of method exit is incorrect for the method : " + DEBUGGEE_THREAD + "." + checkedMethod);
                 log.complain("Should be 1 trace messages, found : " + count);
-                result= false;
+                result = false;
             }
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001a.java
@@ -23,24 +23,24 @@
 
 package nsk.jdb.untrace.untrace001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class untrace001a {
 
-    public static void main(String args[]) {
-       untrace001a _untrace001a = new untrace001a();
-       System.exit(untrace001.JCK_STATUS_BASE + _untrace001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        untrace001a _untrace001a = new untrace001a();
+        System.exit(untrace001.JCK_STATUS_BASE + _untrace001a.runIt(args, System.out));
     }
 
-    static void breakHere() {}
+    static void breakHere() {
+    }
 
-    static final String MYTHREAD  = "MyThread";
-    static final int numThreads   = 1;   // number of threads.
+    static final String MYTHREAD = "MyThread";
+    static final int numThreads = 1;   // number of threads.
 
     static JdbArgumentHandler argumentHandler;
     static Log log;
@@ -50,29 +50,29 @@ public class untrace001a {
     static volatile boolean mainThreadRunning;
     static volatile boolean[] flags = new boolean[numThreads];
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
 
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
 
         int i;
-        Thread holder [] = new Thread[numThreads];
+        Thread holder[] = new Thread[numThreads];
         Object[] locks = new Object[numThreads];
 
-        for (i = 0; i < numThreads ; i++) {
-            locks[i]  = new Object();
+        for (i = 0; i < numThreads; i++) {
+            locks[i] = new Object();
             holder[i] = new MyThread(locks[i], i, MYTHREAD + "-" + i);
         }
 
         synchronized (mainThreadLock0) {
             synchronized (mainThreadLock1) {
-                for (i = 0; i < numThreads ; i++) {
+                for (i = 0; i < numThreads; i++) {
                     holder[i].start();
                     try {
-                         mainThreadRunning = false;
-                         while (!mainThreadRunning) {
-                             mainThreadLock1.wait();
-                         }
+                        mainThreadRunning = false;
+                        while (!mainThreadRunning) {
+                            mainThreadLock1.wait();
+                        }
                     } catch (InterruptedException e) {
                         log.complain("Main thread was interrupted while waiting for start of " + MYTHREAD + "-" + i);
                         return untrace001.FAILED;
@@ -86,17 +86,17 @@ public class untrace001a {
             breakHere();  // a break to get thread ids and then to turn on tracing.
 
             // waits on all MyThreads completion
-            for (i = 0; i < numThreads ; i++) {
+            for (i = 0; i < numThreads; i++) {
                 synchronized (locks[i]) {
                     flags[i] = true;
                     locks[i].notifyAll();
                 }
 
                 try {
-                     mainThreadRunning = false;
-                     while (!mainThreadRunning) {
-                         mainThreadLock0.wait();
-                     }
+                    mainThreadRunning = false;
+                    while (!mainThreadRunning) {
+                        mainThreadLock0.wait();
+                    }
                 } catch (InterruptedException e) {
                     log.complain("Main thread was interrupted while waiting for " + MYTHREAD + "-" + i);
                     return untrace001.FAILED;
@@ -131,7 +131,7 @@ class MyThread extends Thread {
     int ind;
     String name;
 
-    public MyThread (Object l, int i, String n) {
+    public MyThread(Object l, int i, String n) {
         lock = l;
         ind = i;
         name = n;
@@ -185,6 +185,6 @@ class MyThread extends Thread {
     }
 
     public int func3(int i) {
-        return i*i;
+        return i * i;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001.java
@@ -64,105 +64,95 @@
 
 package nsk.jdb.unwatch.unwatch001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class unwatch001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new unwatch001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.unwatch.unwatch001";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".unwatch001";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String DEBUGGEE_CLASS2    = DEBUGGEE_CLASS + "$CheckedFields";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".breakHere";
+    static final String PACKAGE_NAME = "nsk.jdb.unwatch.unwatch001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".unwatch001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String DEBUGGEE_CLASS2 = DEBUGGEE_CLASS + "$CheckedFields";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
 
-    static String[] checkedFields  = { "fS1", "FS0" };
-    static String[] checkedFields2 = { "fP1", "fU1", "fR1"};
+    static String[] checkedFields = {"fS1", "FS0"};
+    static String[] checkedFields2 = {"fP1", "fU1", "fR1"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
 
-        watchFields (DEBUGGEE_CLASS, checkedFields);
-        watchFields (DEBUGGEE_CLASS2, checkedFields2);
+        watchFields(DEBUGGEE_CLASS, checkedFields);
+        watchFields(DEBUGGEE_CLASS2, checkedFields2);
 
         for (int i = 0; i < (checkedFields.length + checkedFields2.length + 2); i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            jdb.receiveReplyFor(JdbCommand.cont);
         }
 
-        unwatchFields (DEBUGGEE_CLASS, checkedFields);
-        unwatchFields (DEBUGGEE_CLASS2, checkedFields2);
+        unwatchFields(DEBUGGEE_CLASS, checkedFields);
+        unwatchFields(DEBUGGEE_CLASS2, checkedFields2);
 
         // excessive number of cont commands in case if unwatch command does not work.
         jdb.contToExit(checkedFields.length + checkedFields2.length + 1);
 
         reply = jdb.getTotalReply();
-        if (!checkFields (DEBUGGEE_CLASS, reply, checkedFields)) {
+        if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields)) {
             success = false;
         }
-        if (!checkFields (DEBUGGEE_CLASS2, reply, checkedFields2)) {
+        if (!checkFields(DEBUGGEE_CLASS2, reply, checkedFields2)) {
             success = false;
         }
     }
 
-    private void watchFields (String className, String[] checkedFields) {
-        String[] reply;
-
-        for (int i = 0; i < checkedFields.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.watch + " access " + className + "." + checkedFields[i]);
+    private void watchFields(String className, String[] checkedFields) {
+        for (String checkedField : checkedFields) {
+            jdb.receiveReplyFor(JdbCommand.watch + " access " + className + "." + checkedField);
         }
-
     }
 
-    private void unwatchFields (String className, String[] checkedFields) {
-        String[] reply;
-
-        for (int i = 0; i < checkedFields.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.unwatch + " access " + className + "." + checkedFields[i]);
+    private void unwatchFields(String className, String[] checkedFields) {
+        for (String checkedField : checkedFields) {
+            jdb.receiveReplyFor(JdbCommand.unwatch + " access " + className + "." + checkedField);
         }
-
     }
 
-    private boolean checkFields (String className, String[] reply, String[] checkedFields) {
+    private boolean checkFields(String className, String[] reply, String[] checkedFields) {
         Paragrep grep;
-        String found;
         boolean result = true;
         int count;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         grep = new Paragrep(reply);
         v.add("access encountered");
-        for (int i = 0; i < checkedFields.length; i++) {
+        for (String checkedField : checkedFields) {
             v.removeAllElements();
             v.add("access encountered");
-            v.add(className + "." + checkedFields[i]);
+            v.add(className + "." + checkedField);
 
             count = grep.find(v);
             if (count != 1) {
-                log.complain("jdb reported wrong number of access to the field " + className + "." + checkedFields[i]);
+                log.complain("jdb reported wrong number of access to the field " + className + "." + checkedField);
                 log.complain("Should be 1, reported: " + count);
                 result = false;
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001a.java
@@ -23,25 +23,23 @@
 
 package nsk.jdb.unwatch.unwatch001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class unwatch001a {
-    /* TEST DEPENDANT VARIABLES AND CONSTANTS */
-    static final String PACKAGE_NAME = "nsk.jdb.unwatch.unwatch001";
 
-    public static void main(String args[]) {
-       unwatch001a _unwatch001a = new unwatch001a();
-       System.exit(unwatch001.JCK_STATUS_BASE + _unwatch001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        unwatch001a _unwatch001a = new unwatch001a();
+        System.exit(unwatch001.JCK_STATUS_BASE + _unwatch001a.runIt(args, System.out));
     }
 
-    static void breakHere () {}
+    static void breakHere() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -57,78 +55,80 @@ public class unwatch001a {
         return unwatch001.PASSED;
     }
 
-    static    boolean fS0, fS1[], fS2[][];
-    static    Boolean FS0, FS1[], FS2[][];
+    static boolean fS0, fS1[], fS2[][];
+    static Boolean FS0, FS1[], FS2[][];
 
-    interface Inter {}
-    Inter     I0, I1[], I2[][];
+    interface Inter {
+    }
+
+    Inter I0, I1[], I2[][];
 
     // assign new values to fields
     void updateFields(boolean flag) {
 
         fS0 = flag ? fS0 : false;
-        fS1 = flag ? fS1 :  new boolean[] {fS0};
-        fS2 = flag ? fS2 :  new boolean[][] {fS1};
+        fS1 = flag ? fS1 : new boolean[]{fS0};
+        fS2 = flag ? fS2 : new boolean[][]{fS1};
 
         FS0 = flag ? FS0 : new Boolean(false);
-        FS1 = flag ? FS1 : new Boolean[] {FS0};
-        FS2 = flag ? FS2 : new Boolean[][] {FS1};
+        FS1 = flag ? FS1 : new Boolean[]{FS0};
+        FS2 = flag ? FS2 : new Boolean[][]{FS1};
 
-        I0  = flag ? I0  : new CheckedFields();
-        I1  = flag ? I1  : new CheckedFields[]   {new CheckedFields()};
-        I2  = flag ? I2  : new CheckedFields[][] {new CheckedFields[] {new CheckedFields()}};
+        I0 = flag ? I0 : new CheckedFields();
+        I1 = flag ? I1 : new CheckedFields[]{new CheckedFields()};
+        I2 = flag ? I2 : new CheckedFields[][]{new CheckedFields[]{new CheckedFields()}};
     }
 
     class CheckedFields implements Inter {
 
-        private   byte    fP0, fP1[], fP2[][];
-        public    char    fU0, fU1[], fU2[][];
-        protected double  fR0, fR1[], fR2[][];
-        transient float   fT0, fT1[], fT2[][];
-        volatile  long    fV0, fV1[], fV2[][];
+        private byte fP0, fP1[], fP2[][];
+        public char fU0, fU1[], fU2[][];
+        protected double fR0, fR1[], fR2[][];
+        transient float fT0, fT1[], fT2[][];
+        volatile long fV0, fV1[], fV2[][];
 
-        private   Byte      FP0, FP1[], FP2[][];
-        public    Character FU0, FU1[], FU2[][];
-        protected Double    FR0, FR1[], FR2[][];
-        transient Float     FT0, FT1[], FT2[][];
-        volatile  Long      FV0, FV1[], FV2[][];
+        private Byte FP0, FP1[], FP2[][];
+        public Character FU0, FU1[], FU2[][];
+        protected Double FR0, FR1[], FR2[][];
+        transient Float FT0, FT1[], FT2[][];
+        volatile Long FV0, FV1[], FV2[][];
 
         // assign new values to fields
         void updateFields(boolean flag) {
 
-            fP0 = flag ? fP0 : Byte.MIN_VALUE ;
+            fP0 = flag ? fP0 : Byte.MIN_VALUE;
             fU0 = flag ? fU0 : Character.MIN_VALUE;
             fR0 = flag ? fR0 : Double.MIN_VALUE;
             fT0 = flag ? fT0 : Float.MIN_VALUE;
             fV0 = flag ? fV0 : Integer.MIN_VALUE;
 
-            FP0 = flag ? FP0 : new Byte(Byte.MIN_VALUE) ;
+            FP0 = flag ? FP0 : new Byte(Byte.MIN_VALUE);
             FU0 = flag ? FU0 : new Character(Character.MIN_VALUE);
             FR0 = flag ? FR0 : new Double(Double.MIN_VALUE);
             FT0 = flag ? FT0 : new Float(Float.MIN_VALUE);
             FV0 = flag ? FV0 : new Long(Long.MIN_VALUE);
 
-            fP1 = flag ? fP1 : new byte[] {fP0};
-            fP2 = flag ? fP2 : new byte[][] {fP1};
-            fU1 = flag ? fU1 : new char[] {fU0};
-            fU2 = flag ? fU2 : new char[][] {fU1};
-            fR1 = flag ? fR1 : new double[] {fR0};
-            fR2 = flag ? fR2 : new double[][] {fR1};
-            fT1 = flag ? fT1 : new float[] {fT0};
-            fT2 = flag ? fT2 : new float[][] {fT1};
-            fV1 = flag ? fV1 : new long[] {fV0};
-            fV2 = flag ? fV2 : new long[][] {fV1};
+            fP1 = flag ? fP1 : new byte[]{fP0};
+            fP2 = flag ? fP2 : new byte[][]{fP1};
+            fU1 = flag ? fU1 : new char[]{fU0};
+            fU2 = flag ? fU2 : new char[][]{fU1};
+            fR1 = flag ? fR1 : new double[]{fR0};
+            fR2 = flag ? fR2 : new double[][]{fR1};
+            fT1 = flag ? fT1 : new float[]{fT0};
+            fT2 = flag ? fT2 : new float[][]{fT1};
+            fV1 = flag ? fV1 : new long[]{fV0};
+            fV2 = flag ? fV2 : new long[][]{fV1};
 
-            FP1 = flag ? FP1 : new Byte[] {FP0};
-            FP2 = flag ? FP2 : new Byte[][] {FP1};
-            FU1 = flag ? FU1 : new Character[] {FU0};
-            FU2 = flag ? FU2 : new Character[][] {FU1};
-            FR1 = flag ? FR1 : new Double[] {FR0};
-            FR2 = flag ? FR2 : new Double[][] {FR1};
-            FT1 = flag ? FT1 : new Float[] {FT0};
-            FT2 = flag ? FT2 : new Float[][] {FT1};
-            FV1 = flag ? FV1 : new Long[] {FV0};
-            FV2 = flag ? FV2 : new Long[][] {FV1};
+            FP1 = flag ? FP1 : new Byte[]{FP0};
+            FP2 = flag ? FP2 : new Byte[][]{FP1};
+            FU1 = flag ? FU1 : new Character[]{FU0};
+            FU2 = flag ? FU2 : new Character[][]{FU1};
+            FR1 = flag ? FR1 : new Double[]{FR0};
+            FR2 = flag ? FR2 : new Double[][]{FR1};
+            FT1 = flag ? FT1 : new Float[]{FT0};
+            FT2 = flag ? FT2 : new Float[][]{FT1};
+            FV1 = flag ? FV1 : new Long[]{FV0};
+            FV2 = flag ? FV2 : new Long[][]{FV1};
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java
@@ -65,118 +65,108 @@
 
 package nsk.jdb.unwatch.unwatch002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class unwatch002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new unwatch002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.unwatch.unwatch002";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".unwatch002";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String DEBUGGEE_CLASS2    = DEBUGGEE_CLASS + "$CheckedFields";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".breakHere";
-    static final String expectedPrompt     = "main[1]";
+    static final String PACKAGE_NAME = "nsk.jdb.unwatch.unwatch002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".unwatch002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String DEBUGGEE_CLASS2 = DEBUGGEE_CLASS + "$CheckedFields";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
+    static final String expectedPrompt = "main[1]";
 
-    static String[] checkedFields  = { "FS1" };
-    static String[] checkedFields2 = { "FT1", "FV1" };
+    static String[] checkedFields = {"FS1"};
+    static String[] checkedFields2 = {"FT1", "FV1"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
 
-        watchFields (DEBUGGEE_CLASS, checkedFields);
-        watchFields (DEBUGGEE_CLASS2, checkedFields2);
+        watchFields(DEBUGGEE_CLASS, checkedFields);
+        watchFields(DEBUGGEE_CLASS2, checkedFields2);
 
 //        jdb.contToExit((checkedFields.length *2)  + (checkedFields2.length *2) + 2);
-        for (int i = 0; i < (checkedFields.length *2 + checkedFields2.length*2 + 2); i++) {
-            reply = jdb.receiveReplyForWithMessageWait(JdbCommand.cont, expectedPrompt);
+        for (int i = 0; i < (checkedFields.length * 2 + checkedFields2.length * 2 + 2); i++) {
+            jdb.receiveReplyForWithMessageWait(JdbCommand.cont, expectedPrompt);
         }
 
-        unwatchFields (DEBUGGEE_CLASS, checkedFields);
-        unwatchFields (DEBUGGEE_CLASS2, checkedFields2);
+        unwatchFields(DEBUGGEE_CLASS, checkedFields);
+        unwatchFields(DEBUGGEE_CLASS2, checkedFields2);
 
         // excessive number of cont commands in case if unwatch command does not work.
-        jdb.contToExit(checkedFields.length*2 + checkedFields2.length*2 + 1);
+        jdb.contToExit(checkedFields.length * 2 + checkedFields2.length * 2 + 1);
 
         reply = jdb.getTotalReply();
-        if (!checkFields (DEBUGGEE_CLASS, reply, checkedFields)) {
+        if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields)) {
             success = false;
         }
-        if (!checkFields (DEBUGGEE_CLASS2, reply, checkedFields2)) {
+        if (!checkFields(DEBUGGEE_CLASS2, reply, checkedFields2)) {
             success = false;
         }
     }
 
-    private void watchFields (String className, String[] checkedFields) {
-        String[] reply;
-
-        for (int i = 0; i < checkedFields.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.watch + " all " + className + "." + checkedFields[i]);
+    private void watchFields(String className, String[] checkedFields) {
+        for (String checkedField : checkedFields) {
+            jdb.receiveReplyFor(JdbCommand.watch + " all " + className + "." + checkedField);
         }
-
     }
 
-    private void unwatchFields (String className, String[] checkedFields) {
-        String[] reply;
-
-        for (int i = 0; i < checkedFields.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.unwatch + " all " + className + "." + checkedFields[i]);
+    private void unwatchFields(String className, String[] checkedFields) {
+        for (String checkedField : checkedFields) {
+            jdb.receiveReplyFor(JdbCommand.unwatch + " all " + className + "." + checkedField);
         }
-
     }
 
-    private boolean checkFields (String className, String[] reply, String[] checkedFields) {
+    private boolean checkFields(String className, String[] reply, String[] checkedFields) {
         Paragrep grep;
-        String found;
         boolean result = true;
         int count;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         grep = new Paragrep(reply);
         v.add("access encountered");
-        for (int i = 0; i < checkedFields.length; i++) {
+        for (String checkedField : checkedFields) {
             v.removeAllElements();
             v.add("access encountered");
-            v.add(className + "." + checkedFields[i]);
+            v.add(className + "." + checkedField);
 
             count = grep.find(v);
             if (count != 1) {
-                log.complain("jdb reported wrong number of access to the field " + className + "." + checkedFields[i]);
+                log.complain("jdb reported wrong number of access to the field " + className + "." + checkedField);
                 log.complain("Should be 1, reported: " + count);
                 result = false;
             }
 
             v.removeAllElements();
-            v.add(className + "." + checkedFields[i]);
+            v.add(className + "." + checkedField);
             v.add("will be instance");
 
             count = grep.find(v);
             if (count != 1) {
-                log.complain("jdb reported wrong number of modification of the field " + className + "." + checkedFields[i]);
+                log.complain("jdb reported wrong number of modification of the field " + className + "." + checkedField);
                 log.complain("Should be 1, reported: " + count);
                 result = false;
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002a.java
@@ -23,25 +23,23 @@
 
 package nsk.jdb.unwatch.unwatch002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class unwatch002a {
-    /* TEST DEPENDANT VARIABLES AND CONSTANTS */
-    static final String PACKAGE_NAME = "nsk.jdb.unwatch.unwatch002";
 
-    public static void main(String args[]) {
-       unwatch002a _unwatch002a = new unwatch002a();
-       System.exit(unwatch002.JCK_STATUS_BASE + _unwatch002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        unwatch002a _unwatch002a = new unwatch002a();
+        System.exit(unwatch002.JCK_STATUS_BASE + _unwatch002a.runIt(args, System.out));
     }
 
-    static void breakHere () {}
+    static void breakHere() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -57,78 +55,80 @@ public class unwatch002a {
         return unwatch002.PASSED;
     }
 
-    static    boolean fS0, fS1[], fS2[][];
-    static    Boolean FS0, FS1[], FS2[][];
+    static boolean fS0, fS1[], fS2[][];
+    static Boolean FS0, FS1[], FS2[][];
 
-    interface Inter {}
-    Inter     I0, I1[], I2[][];
+    interface Inter {
+    }
+
+    Inter I0, I1[], I2[][];
 
     // assign new values to fields
     void updateFields(boolean flag) {
 
         fS0 = flag ? fS0 : false;
-        fS1 = flag ? fS1 : new boolean[] {fS0};
-        fS2 = flag ? fS2 : new boolean[][] {fS1};
+        fS1 = flag ? fS1 : new boolean[]{fS0};
+        fS2 = flag ? fS2 : new boolean[][]{fS1};
 
         FS0 = flag ? FS0 : new Boolean(false);
-        FS1 = flag ? FS1 : new Boolean[] {FS0};
-        FS2 = flag ? FS2 : new Boolean[][] {FS1};
+        FS1 = flag ? FS1 : new Boolean[]{FS0};
+        FS2 = flag ? FS2 : new Boolean[][]{FS1};
 
-        I0  = flag ? I0  : new CheckedFields();
-        I1  = flag ? I1  : new CheckedFields[]   {new CheckedFields()};
-        I2  = flag ? I2  : new CheckedFields[][] {new CheckedFields[] {new CheckedFields()}};
+        I0 = flag ? I0 : new CheckedFields();
+        I1 = flag ? I1 : new CheckedFields[]{new CheckedFields()};
+        I2 = flag ? I2 : new CheckedFields[][]{new CheckedFields[]{new CheckedFields()}};
     }
 
     class CheckedFields implements Inter {
 
-        private   byte    fP0, fP1[], fP2[][];
-        public    char    fU0, fU1[], fU2[][];
-        protected double  fR0, fR1[], fR2[][];
-        transient float   fT0, fT1[], fT2[][];
-        volatile  long    fV0, fV1[], fV2[][];
+        private byte fP0, fP1[], fP2[][];
+        public char fU0, fU1[], fU2[][];
+        protected double fR0, fR1[], fR2[][];
+        transient float fT0, fT1[], fT2[][];
+        volatile long fV0, fV1[], fV2[][];
 
-        private   Byte      FP0, FP1[], FP2[][];
-        public    Character FU0, FU1[], FU2[][];
-        protected Double    FR0, FR1[], FR2[][];
-        transient Float     FT0, FT1[], FT2[][];
-        volatile  Long      FV0, FV1[], FV2[][];
+        private Byte FP0, FP1[], FP2[][];
+        public Character FU0, FU1[], FU2[][];
+        protected Double FR0, FR1[], FR2[][];
+        transient Float FT0, FT1[], FT2[][];
+        volatile Long FV0, FV1[], FV2[][];
 
         // assign new values to fields
         void updateFields(boolean flag) {
 
-            fP0 = flag ? fP0 : Byte.MIN_VALUE ;
+            fP0 = flag ? fP0 : Byte.MIN_VALUE;
             fU0 = flag ? fU0 : Character.MIN_VALUE;
             fR0 = flag ? fR0 : Double.MIN_VALUE;
             fT0 = flag ? fT0 : Float.MIN_VALUE;
             fV0 = flag ? fV0 : Integer.MIN_VALUE;
 
-            FP0 = flag ? FP0 : new Byte(Byte.MIN_VALUE) ;
+            FP0 = flag ? FP0 : new Byte(Byte.MIN_VALUE);
             FU0 = flag ? FU0 : new Character(Character.MIN_VALUE);
             FR0 = flag ? FR0 : new Double(Double.MIN_VALUE);
             FT0 = flag ? FT0 : new Float(Float.MIN_VALUE);
             FV0 = flag ? FV0 : new Long(Long.MIN_VALUE);
 
-            fP1 = flag ? fP1 : new byte[] {fP0};
-            fP2 = flag ? fP2 : new byte[][] {fP1};
-            fU1 = flag ? fU1 : new char[] {fU0};
-            fU2 = flag ? fU2 : new char[][] {fU1};
-            fR1 = flag ? fR1 : new double[] {fR0};
-            fR2 = flag ? fR2 : new double[][] {fR1};
-            fT1 = flag ? fT1 : new float[] {fT0};
-            fT2 = flag ? fT2 : new float[][] {fT1};
-            fV1 = flag ? fV1 : new long[] {fV0};
-            fV2 = flag ? fV2 : new long[][] {fV1};
+            fP1 = flag ? fP1 : new byte[]{fP0};
+            fP2 = flag ? fP2 : new byte[][]{fP1};
+            fU1 = flag ? fU1 : new char[]{fU0};
+            fU2 = flag ? fU2 : new char[][]{fU1};
+            fR1 = flag ? fR1 : new double[]{fR0};
+            fR2 = flag ? fR2 : new double[][]{fR1};
+            fT1 = flag ? fT1 : new float[]{fT0};
+            fT2 = flag ? fT2 : new float[][]{fT1};
+            fV1 = flag ? fV1 : new long[]{fV0};
+            fV2 = flag ? fV2 : new long[][]{fV1};
 
-            FP1 = flag ? FP1 : new Byte[] {FP0};
-            FP2 = flag ? FP2 : new Byte[][] {FP1};
-            FU1 = flag ? FU1 : new Character[] {FU0};
-            FU2 = flag ? FU2 : new Character[][] {FU1};
-            FR1 = flag ? FR1 : new Double[] {FR0};
-            FR2 = flag ? FR2 : new Double[][] {FR1};
-            FT1 = flag ? FT1 : new Float[] {FT0};
-            FT2 = flag ? FT2 : new Float[][] {FT1};
-            FV1 = flag ? FV1 : new Long[] {FV0};
-            FV2 = flag ? FV2 : new Long[][] {FV1};
+            FP1 = flag ? FP1 : new Byte[]{FP0};
+            FP2 = flag ? FP2 : new Byte[][]{FP1};
+            FU1 = flag ? FU1 : new Character[]{FU0};
+            FU2 = flag ? FU2 : new Character[][]{FU1};
+            FR1 = flag ? FR1 : new Double[]{FR0};
+            FR2 = flag ? FR2 : new Double[][]{FR1};
+            FT1 = flag ? FT1 : new Float[]{FT0};
+            FT2 = flag ? FT2 : new Float[][]{FT1};
+            FV1 = flag ? FV1 : new Long[]{FV0};
+            FV2 = flag ? FV2 : new Long[][]{FV1};
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002.java
@@ -57,47 +57,47 @@
 
 package nsk.jdb.up.up002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class up002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new up002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.up.up002";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".up002";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.up.up002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".up002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][] {
-        {"[1]", DEBUGGEE_CLASS + ".func5"},
-        {"[2]", DEBUGGEE_CLASS + ".func4"},
-        {"[3]", DEBUGGEE_CLASS + ".func3"},
-        {"[4]", DEBUGGEE_CLASS + ".func2"},
-        {"[5]", DEBUGGEE_CLASS + ".func1"},
-        {"[6]", DEBUGGEE_CLASS + ".runIt"},
-        {"[7]", DEBUGGEE_CLASS + ".main"}
-                                                };
+    static final String[][] FRAMES = new String[][]{
+            {"[1]", DEBUGGEE_CLASS + ".func5"},
+            {"[2]", DEBUGGEE_CLASS + ".func4"},
+            {"[3]", DEBUGGEE_CLASS + ".func3"},
+            {"[4]", DEBUGGEE_CLASS + ".func2"},
+            {"[5]", DEBUGGEE_CLASS + ".func1"},
+            {"[6]", DEBUGGEE_CLASS + ".runIt"},
+            {"[7]", DEBUGGEE_CLASS + ".main"}
+    };
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.receiveReplyFor(JdbCommand.stop_in + DEBUGGEE_CLASS + ".func5");
         jdb.receiveReplyFor(JdbCommand.cont);
@@ -112,14 +112,14 @@ public class up002 extends JdbTest {
         reply = jdb.getTotalReply();
         grep = new Paragrep(reply);
 
-        for (int i = 1; i < (FRAMES.length-1); i++) {
-            v = new Vector();
+        for (int i = 1; i < (FRAMES.length - 1); i++) {
+            v = new Vector<>();
             v.add(FRAMES[i][0]);
             v.add(FRAMES[i][1]);
             count = grep.find(v);
-            if (count != (i+1)) {
+            if (count != (i + 1)) {
                 failure("Unexpected number of the stack frame: " + FRAMES[i][1] +
-                    "\n\texpected value : " + (i+1) + ", got : " + count);
+                        "\n\texpected value : " + (i + 1) + ", got : " + count);
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002a.java
@@ -23,23 +23,23 @@
 
 package nsk.jdb.up.up002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class up002a {
-    public static void main(String args[]) {
-       up002a _up002a = new up002a();
-       lastBreak();
-       System.exit(up002.JCK_STATUS_BASE + _up002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        up002a _up002a = new up002a();
+        lastBreak();
+        System.exit(up002.JCK_STATUS_BASE + _up002a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -62,14 +62,14 @@ public class up002a {
     }
 
     public int func4(int i) {
-       return func5(i) + 1;
+        return func5(i) + 1;
     }
 
     public int func5(int i) {
-       return func6(i) + 1;
+        return func6(i) + 1;
     }
 
     public int func6(int i) {
-        return i-5;
+        return i - 5;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001.java
@@ -57,21 +57,22 @@
 
 package nsk.jdb.use.use001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
 import jdk.test.lib.Utils;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.PrintStream;
 
 public class use001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new use001().runTest(argv, out);
@@ -80,15 +81,12 @@ public class use001 extends JdbTest {
     static final String PACKAGE_NAME = "nsk.jdb.use.use001";
     static final String TEST_CLASS = PACKAGE_NAME + ".use001";
     static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".lastBreak";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
     protected void runCases() {
         String[] reply;
         Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         String path = "";
         String srcdir = Utils.TEST_SRC;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001a.java
@@ -23,23 +23,22 @@
 
 package nsk.jdb.use.use001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class use001a {
     static use001a _use001a = new use001a();
 
-    public static void main(String args[]) {
-       System.exit(use001.JCK_STATUS_BASE + _use001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        System.exit(use001.JCK_STATUS_BASE + _use001a.runIt(args, System.out));
     }
 
 //    static void lastBreak () {}
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001.java
@@ -62,90 +62,84 @@
 
 package nsk.jdb.watch.watch001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class watch001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
         return new watch001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.watch.watch001";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".watch001";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String DEBUGGEE_CLASS2    = DEBUGGEE_CLASS + "$CheckedFields";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".breakHere";
+    static final String PACKAGE_NAME = "nsk.jdb.watch.watch001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".watch001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String DEBUGGEE_CLASS2 = DEBUGGEE_CLASS + "$CheckedFields";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
     static final String COMPOUND_PROMPT_IDENT = "main";
 
-    static String[] checkedFields  = { "fS0", "FS1" };
-    static String[] checkedFields2 = { "FP0", "FU1", "FR0", "FT1", "FV0" };
+    static String[] checkedFields = {"fS0", "FS1"};
+    static String[] checkedFields2 = {"FP0", "FU1", "FR0", "FT1", "FV0"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
 
-        watchFields (DEBUGGEE_CLASS, checkedFields);
-        watchFields (DEBUGGEE_CLASS2, checkedFields2);
+        watchFields(DEBUGGEE_CLASS, checkedFields);
+        watchFields(DEBUGGEE_CLASS2, checkedFields2);
 
         jdb.contToExit(checkedFields.length + checkedFields2.length + 2);
 
         reply = jdb.getTotalReply();
-        if (!checkFields (DEBUGGEE_CLASS, reply, checkedFields)) {
+        if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields)) {
             success = false;
         }
-        if (!checkFields (DEBUGGEE_CLASS2, reply, checkedFields2)) {
+        if (!checkFields(DEBUGGEE_CLASS2, reply, checkedFields2)) {
             success = false;
         }
     }
 
-    private void watchFields (String className, String[] checkedFields) {
-        String[] reply;
-
-        for (int i = 0; i < checkedFields.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.watch + " access " + className + "." + checkedFields[i]);
+    private void watchFields(String className, String[] checkedFields) {
+        for (String checkedField : checkedFields) {
+            jdb.receiveReplyFor(JdbCommand.watch + " access " + className + "." + checkedField);
         }
 
     }
 
-    private boolean checkFields (String className, String[] reply, String[] checkedFields) {
+    private boolean checkFields(String className, String[] reply, String[] checkedFields) {
         Paragrep grep;
         String found;
         boolean result = true;
-        int count;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         grep = new Paragrep(reply);
         v.add("access encountered");
-        for (int i = 0; i < checkedFields.length; i++) {
+        for (String checkedField : checkedFields) {
             v.removeAllElements();
             v.add("access encountered");
-            v.add(className + "." + checkedFields[i]);
+            v.add(className + "." + checkedField);
 
             found = grep.findFirst(v);
             if (found.length() == 0) {
-                log.complain("Failed to report access to field " + className + "." + checkedFields[i]);
+                log.complain("Failed to report access to field " + className + "." + checkedField);
                 result = false;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001a.java
@@ -23,25 +23,23 @@
 
 package nsk.jdb.watch.watch001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class watch001a {
-    /* TEST DEPENDANT VARIABLES AND CONSTANTS */
-    static final String PACKAGE_NAME = "nsk.jdb.watch.watch001";
 
-    public static void main(String args[]) {
-       watch001a _watch001a = new watch001a();
-       System.exit(watch001.JCK_STATUS_BASE + _watch001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        watch001a _watch001a = new watch001a();
+        System.exit(watch001.JCK_STATUS_BASE + _watch001a.runIt(args, System.out));
     }
 
-    static void breakHere () {}
+    static void breakHere() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -53,78 +51,80 @@ public class watch001a {
         return watch001.PASSED;
     }
 
-    static    boolean fS0, fS1[], fS2[][];
-    static    Boolean FS0, FS1[], FS2[][];
+    static boolean fS0, fS1[], fS2[][];
+    static Boolean FS0, FS1[], FS2[][];
 
-    interface Inter {}
-    Inter     I0, I1[], I2[][];
+    interface Inter {
+    }
+
+    Inter I0, I1[], I2[][];
 
     // assign new values to fields
     void updateFields(boolean flag) {
 
         fS0 = flag ? fS0 : false;
-        fS1 = flag ? fS1 :  new boolean[] {fS0};
-        fS2 = flag ? fS2 :  new boolean[][] {fS1};
+        fS1 = flag ? fS1 : new boolean[]{fS0};
+        fS2 = flag ? fS2 : new boolean[][]{fS1};
 
         FS0 = flag ? FS0 : new Boolean(false);
-        FS1 = flag ? FS1 : new Boolean[] {FS0};
-        FS2 = flag ? FS2 : new Boolean[][] {FS1};
+        FS1 = flag ? FS1 : new Boolean[]{FS0};
+        FS2 = flag ? FS2 : new Boolean[][]{FS1};
 
-        I0  = flag ? I0  : new CheckedFields();
-        I1  = flag ? I1  : new CheckedFields[]   {new CheckedFields()};
-        I2  = flag ? I2  : new CheckedFields[][] {new CheckedFields[] {new CheckedFields()}};
+        I0 = flag ? I0 : new CheckedFields();
+        I1 = flag ? I1 : new CheckedFields[]{new CheckedFields()};
+        I2 = flag ? I2 : new CheckedFields[][]{new CheckedFields[]{new CheckedFields()}};
     }
 
     class CheckedFields implements Inter {
 
-        private   byte    fP0, fP1[], fP2[][];
-        public    char    fU0, fU1[], fU2[][];
-        protected double  fR0, fR1[], fR2[][];
-        transient float   fT0, fT1[], fT2[][];
-        volatile  long    fV0, fV1[], fV2[][];
+        private byte fP0, fP1[], fP2[][];
+        public char fU0, fU1[], fU2[][];
+        protected double fR0, fR1[], fR2[][];
+        transient float fT0, fT1[], fT2[][];
+        volatile long fV0, fV1[], fV2[][];
 
-        private   Byte      FP0, FP1[], FP2[][];
-        public    Character FU0, FU1[], FU2[][];
-        protected Double    FR0, FR1[], FR2[][];
-        transient Float     FT0, FT1[], FT2[][];
-        volatile  Long      FV0, FV1[], FV2[][];
+        private Byte FP0, FP1[], FP2[][];
+        public Character FU0, FU1[], FU2[][];
+        protected Double FR0, FR1[], FR2[][];
+        transient Float FT0, FT1[], FT2[][];
+        volatile Long FV0, FV1[], FV2[][];
 
         // assign new values to fields
         void updateFields(boolean flag) {
 
-            fP0 = flag ? fP0 : Byte.MIN_VALUE ;
+            fP0 = flag ? fP0 : Byte.MIN_VALUE;
             fU0 = flag ? fU0 : Character.MIN_VALUE;
             fR0 = flag ? fR0 : Double.MIN_VALUE;
             fT0 = flag ? fT0 : Float.MIN_VALUE;
             fV0 = flag ? fV0 : Integer.MIN_VALUE;
 
-            FP0 = flag ? FP0 : new Byte(Byte.MIN_VALUE) ;
+            FP0 = flag ? FP0 : new Byte(Byte.MIN_VALUE);
             FU0 = flag ? FU0 : new Character(Character.MIN_VALUE);
             FR0 = flag ? FR0 : new Double(Double.MIN_VALUE);
             FT0 = flag ? FT0 : new Float(Float.MIN_VALUE);
             FV0 = flag ? FV0 : new Long(Long.MIN_VALUE);
 
-            fP1 = flag ? fP1 : new byte[] {fP0};
-            fP2 = flag ? fP2 : new byte[][] {fP1};
-            fU1 = flag ? fU1 : new char[] {fU0};
-            fU2 = flag ? fU2 : new char[][] {fU1};
-            fR1 = flag ? fR1 : new double[] {fR0};
-            fR2 = flag ? fR2 : new double[][] {fR1};
-            fT1 = flag ? fT1 : new float[] {fT0};
-            fT2 = flag ? fT2 : new float[][] {fT1};
-            fV1 = flag ? fV1 : new long[] {fV0};
-            fV2 = flag ? fV2 : new long[][] {fV1};
+            fP1 = flag ? fP1 : new byte[]{fP0};
+            fP2 = flag ? fP2 : new byte[][]{fP1};
+            fU1 = flag ? fU1 : new char[]{fU0};
+            fU2 = flag ? fU2 : new char[][]{fU1};
+            fR1 = flag ? fR1 : new double[]{fR0};
+            fR2 = flag ? fR2 : new double[][]{fR1};
+            fT1 = flag ? fT1 : new float[]{fT0};
+            fT2 = flag ? fT2 : new float[][]{fT1};
+            fV1 = flag ? fV1 : new long[]{fV0};
+            fV2 = flag ? fV2 : new long[][]{fV1};
 
-            FP1 = flag ? FP1 : new Byte[] {FP0};
-            FP2 = flag ? FP2 : new Byte[][] {FP1};
-            FU1 = flag ? FU1 : new Character[] {FU0};
-            FU2 = flag ? FU2 : new Character[][] {FU1};
-            FR1 = flag ? FR1 : new Double[] {FR0};
-            FR2 = flag ? FR2 : new Double[][] {FR1};
-            FT1 = flag ? FT1 : new Float[] {FT0};
-            FT2 = flag ? FT2 : new Float[][] {FT1};
-            FV1 = flag ? FV1 : new Long[] {FV0};
-            FV2 = flag ? FV2 : new Long[][] {FV1};
+            FP1 = flag ? FP1 : new Byte[]{FP0};
+            FP2 = flag ? FP2 : new Byte[][]{FP1};
+            FU1 = flag ? FU1 : new Character[]{FU0};
+            FU2 = flag ? FU2 : new Character[][]{FU1};
+            FR1 = flag ? FR1 : new Double[]{FR0};
+            FR2 = flag ? FR2 : new Double[][]{FR1};
+            FT1 = flag ? FT1 : new Float[]{FT0};
+            FT2 = flag ? FT2 : new Float[][]{FT1};
+            FV1 = flag ? FV1 : new Long[]{FV0};
+            FV2 = flag ? FV2 : new Long[][]{FV1};
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002.java
@@ -62,100 +62,94 @@
 
 package nsk.jdb.watch.watch002;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class watch002 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
         return new watch002().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME       = "nsk.jdb.watch.watch002";
-    static final String TEST_CLASS         = PACKAGE_NAME + ".watch002";
-    static final String DEBUGGEE_CLASS     = TEST_CLASS + "a";
-    static final String DEBUGGEE_CLASS2    = DEBUGGEE_CLASS + "$CheckedFields";
-    static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK         = DEBUGGEE_CLASS + ".breakHere";
+    static final String PACKAGE_NAME = "nsk.jdb.watch.watch002";
+    static final String TEST_CLASS = PACKAGE_NAME + ".watch002";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String DEBUGGEE_CLASS2 = DEBUGGEE_CLASS + "$CheckedFields";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".breakHere";
     static final String COMPOUND_PROMPT_IDENT = "main";
 
-    static String[] checkedFields  = { "FS0", "FS1" };
-    static String[] checkedFields2 = { "FP1", "FU1", "FR1", "FT1", "FV1" };
+    static String[] checkedFields = {"FS0", "FS1"};
+    static String[] checkedFields2 = {"FP1", "FU1", "FR1", "FT1", "FV1"};
 
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS);
 
-        reply = jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
+        jdb.receiveReplyFor(JdbCommand.fields + DEBUGGEE_CLASS2);
 
-        watchFields (DEBUGGEE_CLASS, checkedFields);
-        watchFields (DEBUGGEE_CLASS2, checkedFields2);
+        watchFields(DEBUGGEE_CLASS, checkedFields);
+        watchFields(DEBUGGEE_CLASS2, checkedFields2);
 
-        jdb.contToExit((checkedFields.length *2)  + (checkedFields2.length *2) + 2);
+        jdb.contToExit((checkedFields.length * 2) + (checkedFields2.length * 2) + 2);
 
         reply = jdb.getTotalReply();
-        if (!checkFields (DEBUGGEE_CLASS, reply, checkedFields)) {
+        if (!checkFields(DEBUGGEE_CLASS, reply, checkedFields)) {
             success = false;
         }
-        if (!checkFields (DEBUGGEE_CLASS2, reply, checkedFields2)) {
+        if (!checkFields(DEBUGGEE_CLASS2, reply, checkedFields2)) {
             success = false;
         }
     }
 
-    private void watchFields (String className, String[] checkedFields) {
-        String[] reply;
-
-        for (int i = 0; i < checkedFields.length; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.watch + " all " + className + "." + checkedFields[i]);
+    private void watchFields(String className, String[] checkedFields) {
+        for (String checkedField : checkedFields) {
+            jdb.receiveReplyFor(JdbCommand.watch + " all " + className + "." + checkedField);
         }
 
     }
 
-    private boolean checkFields (String className, String[] reply, String[] checkedFields) {
+    private boolean checkFields(String className, String[] reply, String[] checkedFields) {
         Paragrep grep;
         String found;
         boolean result = true;
-        int count;
-        Vector v = new Vector();
+        Vector<String> v = new Vector<>();
 
         grep = new Paragrep(reply);
         v.add("access encountered");
-        for (int i = 0; i < checkedFields.length; i++) {
+        for (String checkedField : checkedFields) {
             v.removeAllElements();
             v.add("access encountered");
-            v.add(className + "." + checkedFields[i]);
+            v.add(className + "." + checkedField);
 
             found = grep.findFirst(v);
             if (found.length() == 0) {
-                log.complain("Failed to report access to field " + className + "." + checkedFields[i]);
+                log.complain("Failed to report access to field " + className + "." + checkedField);
                 result = false;
             }
 
             v.removeAllElements();
             v.add("will be");
-            v.add(className + "." + checkedFields[i]);
+            v.add(className + "." + checkedField);
 
             found = grep.findFirst(v);
             if (found.length() == 0) {
-                log.complain("Failed to report modification of field " + className + "." + checkedFields[i]);
+                log.complain("Failed to report modification of field " + className + "." + checkedField);
                 result = false;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002a.java
@@ -23,25 +23,23 @@
 
 package nsk.jdb.watch.watch002;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class watch002a {
-    /* TEST DEPENDANT VARIABLES AND CONSTANTS */
-    static final String PACKAGE_NAME = "nsk.jdb.watch.watch002";
 
-    public static void main(String args[]) {
-       watch002a _watch002a = new watch002a();
-       System.exit(watch002.JCK_STATUS_BASE + _watch002a.runIt(args, System.out));
+    public static void main(String[] args) {
+        watch002a _watch002a = new watch002a();
+        System.exit(watch002.JCK_STATUS_BASE + _watch002a.runIt(args, System.out));
     }
 
-    static void breakHere () {}
+    static void breakHere() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -53,78 +51,80 @@ public class watch002a {
         return watch002.PASSED;
     }
 
-    static    boolean fS0, fS1[], fS2[][];
-    static    Boolean FS0, FS1[], FS2[][];
+    static boolean fS0, fS1[], fS2[][];
+    static Boolean FS0, FS1[], FS2[][];
 
-    interface Inter {}
-    Inter     I0, I1[], I2[][];
+    interface Inter {
+    }
+
+    Inter I0, I1[], I2[][];
 
     // assign new values to fields
     void updateFields(boolean flag) {
 
         fS0 = flag ? fS0 : false;
-        fS1 = flag ? fS1 : new boolean[] {fS0};
-        fS2 = flag ? fS2 : new boolean[][] {fS1};
+        fS1 = flag ? fS1 : new boolean[]{fS0};
+        fS2 = flag ? fS2 : new boolean[][]{fS1};
 
         FS0 = flag ? FS0 : new Boolean(false);
-        FS1 = flag ? FS1 : new Boolean[] {FS0};
-        FS2 = flag ? FS2 : new Boolean[][] {FS1};
+        FS1 = flag ? FS1 : new Boolean[]{FS0};
+        FS2 = flag ? FS2 : new Boolean[][]{FS1};
 
-        I0  = flag ? I0  : new CheckedFields();
-        I1  = flag ? I1  : new CheckedFields[]   {new CheckedFields()};
-        I2  = flag ? I2  : new CheckedFields[][] {new CheckedFields[] {new CheckedFields()}};
+        I0 = flag ? I0 : new CheckedFields();
+        I1 = flag ? I1 : new CheckedFields[]{new CheckedFields()};
+        I2 = flag ? I2 : new CheckedFields[][]{new CheckedFields[]{new CheckedFields()}};
     }
 
     class CheckedFields implements Inter {
 
-        private   byte    fP0, fP1[], fP2[][];
-        public    char    fU0, fU1[], fU2[][];
-        protected double  fR0, fR1[], fR2[][];
-        transient float   fT0, fT1[], fT2[][];
-        volatile  long    fV0, fV1[], fV2[][];
+        private byte fP0, fP1[], fP2[][];
+        public char fU0, fU1[], fU2[][];
+        protected double fR0, fR1[], fR2[][];
+        transient float fT0, fT1[], fT2[][];
+        volatile long fV0, fV1[], fV2[][];
 
-        private   Byte      FP0, FP1[], FP2[][];
-        public    Character FU0, FU1[], FU2[][];
-        protected Double    FR0, FR1[], FR2[][];
-        transient Float     FT0, FT1[], FT2[][];
-        volatile  Long      FV0, FV1[], FV2[][];
+        private Byte FP0, FP1[], FP2[][];
+        public Character FU0, FU1[], FU2[][];
+        protected Double FR0, FR1[], FR2[][];
+        transient Float FT0, FT1[], FT2[][];
+        volatile Long FV0, FV1[], FV2[][];
 
         // assign new values to fields
         void updateFields(boolean flag) {
 
-            fP0 = flag ? fP0 : Byte.MIN_VALUE ;
+            fP0 = flag ? fP0 : Byte.MIN_VALUE;
             fU0 = flag ? fU0 : Character.MIN_VALUE;
             fR0 = flag ? fR0 : Double.MIN_VALUE;
             fT0 = flag ? fT0 : Float.MIN_VALUE;
             fV0 = flag ? fV0 : Integer.MIN_VALUE;
 
-            FP0 = flag ? FP0 : new Byte(Byte.MIN_VALUE) ;
+            FP0 = flag ? FP0 : new Byte(Byte.MIN_VALUE);
             FU0 = flag ? FU0 : new Character(Character.MIN_VALUE);
             FR0 = flag ? FR0 : new Double(Double.MIN_VALUE);
             FT0 = flag ? FT0 : new Float(Float.MIN_VALUE);
             FV0 = flag ? FV0 : new Long(Long.MIN_VALUE);
 
-            fP1 = flag ? fP1 : new byte[] {fP0};
-            fP2 = flag ? fP2 : new byte[][] {fP1};
-            fU1 = flag ? fU1 : new char[] {fU0};
-            fU2 = flag ? fU2 : new char[][] {fU1};
-            fR1 = flag ? fR1 : new double[] {fR0};
-            fR2 = flag ? fR2 : new double[][] {fR1};
-            fT1 = flag ? fT1 : new float[] {fT0};
-            fT2 = flag ? fT2 : new float[][] {fT1};
-            fV1 = flag ? fV1 : new long[] {fV0};
-            fV2 = flag ? fV2 : new long[][] {fV1};
+            fP1 = flag ? fP1 : new byte[]{fP0};
+            fP2 = flag ? fP2 : new byte[][]{fP1};
+            fU1 = flag ? fU1 : new char[]{fU0};
+            fU2 = flag ? fU2 : new char[][]{fU1};
+            fR1 = flag ? fR1 : new double[]{fR0};
+            fR2 = flag ? fR2 : new double[][]{fR1};
+            fT1 = flag ? fT1 : new float[]{fT0};
+            fT2 = flag ? fT2 : new float[][]{fT1};
+            fV1 = flag ? fV1 : new long[]{fV0};
+            fV2 = flag ? fV2 : new long[][]{fV1};
 
-            FP1 = flag ? FP1 : new Byte[] {FP0};
-            FP2 = flag ? FP2 : new Byte[][] {FP1};
-            FU1 = flag ? FU1 : new Character[] {FU0};
-            FU2 = flag ? FU2 : new Character[][] {FU1};
-            FR1 = flag ? FR1 : new Double[] {FR0};
-            FR2 = flag ? FR2 : new Double[][] {FR1};
-            FT1 = flag ? FT1 : new Float[] {FT0};
-            FT2 = flag ? FT2 : new Float[][] {FT1};
-            FV1 = flag ? FV1 : new Long[] {FV0};
-            FV2 = flag ? FV2 : new Long[][] {FV1};
+            FP1 = flag ? FP1 : new Byte[]{FP0};
+            FP2 = flag ? FP2 : new Byte[][]{FP1};
+            FU1 = flag ? FU1 : new Character[]{FU0};
+            FU2 = flag ? FU2 : new Character[][]{FU1};
+            FR1 = flag ? FR1 : new Double[]{FR0};
+            FR2 = flag ? FR2 : new Double[][]{FR1};
+            FT1 = flag ? FT1 : new Float[]{FT0};
+            FT2 = flag ? FT2 : new Float[][]{FT1};
+            FV1 = flag ? FV1 : new Long[]{FV0};
+            FV2 = flag ? FV2 : new Long[][]{FV1};
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004.java
@@ -55,46 +55,47 @@
 
 package nsk.jdb.where.where004;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class where004 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new where004().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.where.where004";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".where004";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.where.where004";
+    static final String TEST_CLASS = PACKAGE_NAME + ".where004";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][] {
-        {DEBUGGEE_CLASS + ".func5", "71"},
-        {DEBUGGEE_CLASS + ".func4", "67"},
-        {DEBUGGEE_CLASS + ".func3", "63"},
-        {DEBUGGEE_CLASS + ".func2", "59"},
-        {DEBUGGEE_CLASS + ".func1", "55"},
-        {DEBUGGEE_CLASS + ".runIt", "48"},
-        {DEBUGGEE_CLASS + ".main",  "39"}
-                                                };
+    static final String[][] FRAMES = new String[][]{
+            {DEBUGGEE_CLASS + ".func5", "71"},
+            {DEBUGGEE_CLASS + ".func4", "67"},
+            {DEBUGGEE_CLASS + ".func3", "63"},
+            {DEBUGGEE_CLASS + ".func2", "59"},
+            {DEBUGGEE_CLASS + ".func1", "55"},
+            {DEBUGGEE_CLASS + ".runIt", "48"},
+            {DEBUGGEE_CLASS + ".main", "38"}
+    };
+
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         jdb.receiveReplyFor(JdbCommand.stop_in + DEBUGGEE_CLASS + ".func5");
         jdb.receiveReplyFor(JdbCommand.cont);
@@ -102,14 +103,14 @@ public class where004 extends JdbTest {
         reply = jdb.receiveReplyFor(JdbCommand.where);
         grep = new Paragrep(reply);
 
-        for (int i = 0; i < FRAMES.length; i++) {
-            v = new Vector();
-            v.add(FRAMES[i][0]);
-            v.add(FRAMES[i][1]);
+        for (String[] frame : FRAMES) {
+            v = new Vector<>();
+            v.add(frame[0]);
+            v.add(frame[1]);
             count = grep.find(v);
             if (count != 1) {
-                failure("Unexpected number or location of the stack frame: " + FRAMES[i][0] +
-                    "\n\texpected value : 1, got one: " + count);
+                failure("Unexpected number or location of the stack frame: " + frame[0] +
+                        "\n\texpected value : 1, got one: " + count);
             }
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004a.java
@@ -25,23 +25,23 @@
 
 package nsk.jdb.where.where004;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class where004a {
-    public static void main(String args[]) {
-       where004a _where004a = new where004a();
-       lastBreak();
-       System.exit(where004.JCK_STATUS_BASE + _where004a.runIt(args, System.out)); // where004.FRAMES[6]
+    public static void main(String[] args) {
+        where004a _where004a = new where004a();
+        lastBreak();
+        System.exit(where004.JCK_STATUS_BASE + _where004a.runIt(args, System.out)); // where004.FRAMES[6]
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -64,14 +64,14 @@ public class where004a {
     }
 
     public int func4(int i) {
-       return func5(i) + 1; // where004.FRAMES[1]
+        return func5(i) + 1; // where004.FRAMES[1]
     }
 
     public int func5(int i) {
-       return func6(i) + 1; // this is line for breakpoint // where004.FRAMES[0]
+        return func6(i) + 1; // this is line for breakpoint // where004.FRAMES[0]
     }
 
     public int func6(int i) {
-        return i-5;
+        return i - 5;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005.java
@@ -56,51 +56,52 @@
 
 package nsk.jdb.where.where005;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
+import java.util.Vector;
 
 public class where005 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new where005(true).runTest(argv, out);
     }
 
-    public where005 (boolean debuggeeShouldFail) {
+    public where005(boolean debuggeeShouldFail) {
         super(debuggeeShouldFail);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.where.where005";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".where005";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.where.where005";
+    static final String TEST_CLASS = PACKAGE_NAME + ".where005";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][] {
-        {DEBUGGEE_CLASS + ".func6", "76"},
-        {DEBUGGEE_CLASS + ".func5", "71"},
-        {DEBUGGEE_CLASS + ".func4", "67"},
-        {DEBUGGEE_CLASS + ".func3", "63"},
-        {DEBUGGEE_CLASS + ".func2", "59"},
-        {DEBUGGEE_CLASS + ".func1", "55"},
-        {DEBUGGEE_CLASS + ".runIt", "48"},
-        {DEBUGGEE_CLASS + ".main",  "39"}
-                                                };
+    static final String[][] FRAMES = new String[][]{
+            {DEBUGGEE_CLASS + ".func6", "76"},
+            {DEBUGGEE_CLASS + ".func5", "71"},
+            {DEBUGGEE_CLASS + ".func4", "67"},
+            {DEBUGGEE_CLASS + ".func3", "63"},
+            {DEBUGGEE_CLASS + ".func2", "59"},
+            {DEBUGGEE_CLASS + ".func1", "55"},
+            {DEBUGGEE_CLASS + ".runIt", "48"},
+            {DEBUGGEE_CLASS + ".main", "38"}
+    };
+
     protected void runCases() {
         String[] reply;
         Paragrep grep;
         int count;
-        Vector v;
-        String found;
+        Vector<String> v;
 
         reply = jdb.receiveReplyFor(JdbCommand.cont);
         grep = new Paragrep(reply);
@@ -111,14 +112,14 @@ public class where005 extends JdbTest {
             reply = jdb.receiveReplyFor(JdbCommand.where);
             grep = new Paragrep(reply);
 
-            for (int i = 0; i < FRAMES.length; i++) {
-                v = new Vector();
-                v.add(FRAMES[i][0]);
-                v.add(FRAMES[i][1]);
+            for (String[] frame : FRAMES) {
+                v = new Vector<>();
+                v.add(frame[0]);
+                v.add(frame[1]);
                 count = grep.find(v);
                 if (count != 1) {
-                    failure("Unexpected number or location of the stack frame: " + FRAMES[i][0] +
-                        "\n\texpected value : 1, got one: " + count);
+                    failure("Unexpected number or location of the stack frame: " + frame[0] +
+                            "\n\texpected value : 1, got one: " + count);
                 }
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005a.java
@@ -25,23 +25,23 @@
 
 package nsk.jdb.where.where005;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class where005a {
-    public static void main(String args[]) {
-       where005a _where005a = new where005a();
-       lastBreak();
-       System.exit(where005.JCK_STATUS_BASE + _where005a.runIt(args, System.out)); // where005.FRAMES[7]
+    public static void main(String[] args) {
+        where005a _where005a = new where005a();
+        lastBreak();
+        System.exit(where005.JCK_STATUS_BASE + _where005a.runIt(args, System.out)); // where005.FRAMES[7]
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
@@ -64,16 +64,16 @@ public class where005a {
     }
 
     public int func4(int i) {
-       return func5(i) + 1; // where005.FRAMES[2]
+        return func5(i) + 1; // where005.FRAMES[2]
     }
 
     public int func5(int i) {
-       return func6(i) + 1; // where005.FRAMES[1]
+        return func6(i) + 1; // where005.FRAMES[1]
     }
 
     public int func6(int i) {
         String s = null;
         s.concat("null");  // throws NullPointerException // where005.FRAMES[0]
-        return i-5;
+        return i - 5;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
@@ -56,45 +56,42 @@
 
 package nsk.jdb.where.where006;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class where006 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new where006().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME     = "nsk.jdb.where.where006";
-    static final String TEST_CLASS       = PACKAGE_NAME + ".where006";
-    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
-    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.where.where006";
+    static final String TEST_CLASS = PACKAGE_NAME + ".where006";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
 
-    static final String[][] FRAMES = new String[][] {
-        {PACKAGE_NAME + ".MyThread.func5", "111"},
-        {PACKAGE_NAME + ".MyThread.func4", "103"},
-        {PACKAGE_NAME + ".MyThread.func3", "99"},
-        {PACKAGE_NAME + ".MyThread.func2", "95"},
-        {PACKAGE_NAME + ".MyThread.func1", "91"},
-        {PACKAGE_NAME + ".MyThread.run", "85"},
-                                                };
+    static final String[][] FRAMES = new String[][]{
+            {PACKAGE_NAME + ".MyThread.func5", "111"},
+            {PACKAGE_NAME + ".MyThread.func4", "103"},
+            {PACKAGE_NAME + ".MyThread.func3", "99"},
+            {PACKAGE_NAME + ".MyThread.func2", "95"},
+            {PACKAGE_NAME + ".MyThread.func1", "91"},
+            {PACKAGE_NAME + ".MyThread.run", "85"},
+    };
+
     protected void runCases() {
         String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         jdb.receiveReplyFor(JdbCommand.cont);
@@ -113,25 +110,24 @@ public class where006 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    void checkFrames (String threadId, String[] reply, int expectedVal) {
+    void checkFrames(String threadId, String[] reply, int expectedVal) {
         Paragrep grep;
         int count;
-        Vector v;
         String found;
 
         grep = new Paragrep(reply);
-        for (int j = 0; j < FRAMES.length; j++) {
-            count = grep.find(FRAMES[j][0]);
+        for (String[] frame : FRAMES) {
+            count = grep.find(frame[0]);
             if (count != expectedVal) {
-                failure("Unexpected number of occurencies of the stack frame: " + FRAMES[j][0] +
-                    " for thread " + threadId +
-                    "\n\t Expected number of occurence: " + expectedVal +", got : " + count);
+                failure("Unexpected number of occurencies of the stack frame: " + frame[0] +
+                        " for thread " + threadId +
+                        "\n\t Expected number of occurence: " + expectedVal + ", got : " + count);
                 if (count > 0) {
-                    found = grep.findFirst(FRAMES[j][0]);
-                    if (found.indexOf(FRAMES[j][1]) < 0) {
-                        failure("Unexpected location in the stack frame: " + FRAMES[j][0] +
-                            " for thread " + threadId +
-                            "\n\t Expected location: " + FRAMES[j][1] + ", got :\n\t" + found);
+                    found = grep.findFirst(frame[0]);
+                    if (!found.contains(frame[1])) {
+                        failure("Unexpected location in the stack frame: " + frame[0] +
+                                " for thread " + threadId +
+                                "\n\t Expected location: " + frame[1] + ", got :\n\t" + found);
                     }
                 }
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006a.java
@@ -23,55 +23,56 @@
 
 package nsk.jdb.where.where006;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Failure;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class where006a {
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         where006a _where006a = new where006a();
         System.exit(where006.JCK_STATUS_BASE + _where006a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
     static int numThreads = 5;   // number of threads. one lock per thread.
 
     static Object lock = new Object();
     static Object waitnotify = new Object();
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
         JdbArgumentHandler argumentHandler = new JdbArgumentHandler(args);
         Log log = new Log(out, argumentHandler);
 
-        Thread holder [] = new Thread[numThreads];
+        Thread holder[] = new Thread[numThreads];
         Lock locks[] = new Lock[numThreads];
 
-        for (int i = 0; i < numThreads ; i++) {
-           locks[i] = new Lock();
-           holder[i] = new MyThread(locks[i],"MyThread-" + i);
+        for (int i = 0; i < numThreads; i++) {
+            locks[i] = new Lock();
+            holder[i] = new MyThread(locks[i], "MyThread-" + i);
         }
 
         // lock monitor to prevent threads from finishing after they started
         synchronized (lock) {
-           synchronized (waitnotify) {
-              for (int i = 0; i < numThreads ; i++) {
-                 holder[i].start();
-                 try {
-                     waitnotify.wait();
-                 } catch ( Exception e ) {
-                     System.err.println("TEST ERROR: caught Exception while waiting: " + e);
-                     e.printStackTrace();
-                 }
-              }
-           }
-           lastBreak();   // dummy breakpoint
+            synchronized (waitnotify) {
+                for (int i = 0; i < numThreads; i++) {
+                    holder[i].start();
+                    try {
+                        waitnotify.wait();
+                    } catch (Exception e) {
+                        System.err.println("TEST ERROR: caught Exception while waiting: " + e);
+                        e.printStackTrace();
+                    }
+                }
+            }
+            lastBreak();   // dummy breakpoint
         }
 
-        for (int i = 0; i < numThreads ; i++) {
+        for (int i = 0; i < numThreads; i++) {
             if (holder[i].isAlive()) {
                 try {
                     holder[i].join(argumentHandler.getWaitTime() * 60000);
@@ -88,57 +89,62 @@ public class where006a {
 }
 
 class Lock {
-   boolean lockSet;
+    boolean lockSet;
 
-   synchronized void setLock() throws InterruptedException {
-      while (lockSet == true )
-         wait();
-      lockSet = true;
-   }
+    synchronized void setLock() throws InterruptedException {
+        while (lockSet == true)
+            wait();
+        lockSet = true;
+    }
 
-   synchronized void releaseLock() {
-      if (lockSet == true) {
-        lockSet = false;
-        notify();
-      }
-   }
+    synchronized void releaseLock() {
+        if (lockSet == true) {
+            lockSet = false;
+            notify();
+        }
+    }
 }
 
 class MyThread extends Thread {
-   Lock lock;
-   String name;
-   MyThread(Lock l, String n) {this.lock = l; name = n;}
+    Lock lock;
+    String name;
 
-   public void run() {
-      // Concatenate strings in advance to avoid lambda calculations later
-      final String ThreadFinished = "Thread finished: " + this.name;
-      int square = func1(10);
-      lock.releaseLock();
-      System.out.println(ThreadFinished);
-   }
+    MyThread(Lock l, String n) {
+        this.lock = l;
+        name = n;
+    }
 
-   public int func1(int i) {
-      return func2(i);
-   }
+    public void run() {
+        // Concatenate strings in advance to avoid lambda calculations later
+        final String ThreadFinished = "Thread finished: " + this.name;
+        int square = func1(10);
+        lock.releaseLock();
+        System.out.println(ThreadFinished);
+    }
 
-   public int func2(int i) {
-      return func3(i);
-   }
+    public int func1(int i) {
+        return func2(i);
+    }
 
-   public int func3(int i) {
-      return func4(i);
-   }
+    public int func2(int i) {
+        return func3(i);
+    }
 
-   public int func4(int i) {
-      return func5(i);
-   }
+    public int func3(int i) {
+        return func4(i);
+    }
 
-   public int func5(int i) {
-      synchronized (where006a.waitnotify) {
-         where006a.waitnotify.notify();
-      }
-      // prevent thread for early finish
-      synchronized (where006a.lock) {}
-      return i*i;
-   }
+    public int func4(int i) {
+        return func5(i);
+    }
+
+    public int func5(int i) {
+        synchronized (where006a.waitnotify) {
+            where006a.waitnotify.notify();
+        }
+        // prevent thread for early finish
+        synchronized (where006a.lock) {
+        }
+        return i * i;
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
@@ -51,42 +51,37 @@
 
 package nsk.jdb.wherei.wherei001;
 
-import nsk.share.*;
-import nsk.share.jdb.*;
+import nsk.share.Paragrep;
+import nsk.share.jdb.JdbCommand;
+import nsk.share.jdb.JdbTest;
 
-import java.io.*;
-import java.util.*;
+import java.io.PrintStream;
 
 public class wherei001 extends JdbTest {
 
-    public static void main (String argv[]) {
+    public static void main(String[] argv) {
         System.exit(run(argv, System.out) + JCK_STATUS_BASE);
     }
 
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static int run(String[] argv, PrintStream out) {
+        debuggeeClass = DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         return new wherei001().runTest(argv, out);
     }
 
-    static final String PACKAGE_NAME    = "nsk.jdb.wherei.wherei001";
-    static final String TEST_CLASS      = PACKAGE_NAME + ".wherei001";
-    static final String DEBUGGEE_CLASS  = TEST_CLASS + "a";
-    static final String FIRST_BREAK     = DEBUGGEE_CLASS + ".main";
-    static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
+    static final String PACKAGE_NAME = "nsk.jdb.wherei.wherei001";
+    static final String TEST_CLASS = PACKAGE_NAME + ".wherei001";
+    static final String DEBUGGEE_CLASS = TEST_CLASS + "a";
+    static final String FIRST_BREAK = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK = DEBUGGEE_CLASS + ".lastBreak";
     static final String DEBUGGEE_THREAD = PACKAGE_NAME + ".MyThread";
 
     protected void runCases() {
-        String[] reply;
-        Paragrep grep;
-        int count;
-        Vector v;
-        String found;
         String[] threads;
 
         jdb.setBreakpointInMethod(LAST_BREAK);
-        reply = jdb.receiveReplyFor(JdbCommand.cont);
+        jdb.receiveReplyFor(JdbCommand.cont);
 
         threads = jdb.getThreadIds(DEBUGGEE_THREAD);
 
@@ -96,8 +91,8 @@ public class wherei001 extends JdbTest {
             success = false;
         }
 
-        for (int i = 0; i < threads.length; i++) {
-            if (!checkStack(threads[i])) {
+        for (String thread : threads) {
+            if (!checkStack(thread)) {
                 success = false;
             }
         }
@@ -105,25 +100,23 @@ public class wherei001 extends JdbTest {
         jdb.contToExit(1);
     }
 
-    private boolean checkStack (String threadId) {
+    private boolean checkStack(String threadId) {
         Paragrep grep;
         String[] reply;
-        String found;
         int count;
-        Vector v;
         boolean result = true;
-        String[] func = { "func5", "func4", "func3", "func2", "func1", "run" };
+        String[] func = {"func5", "func4", "func3", "func2", "func1", "run"};
 
         reply = jdb.receiveReplyFor(JdbCommand.wherei + threadId);
 
         grep = new Paragrep(reply);
-        for (int i = 0; i < func.length; i++) {
-            count = grep.find(DEBUGGEE_THREAD + "." + func[i]);
+        for (String s : func) {
+            count = grep.find(DEBUGGEE_THREAD + "." + s);
             if (count != 1) {
                 log.complain("Contents of stack trace is incorrect for thread " + threadId);
-                log.complain("Searched for: " + DEBUGGEE_THREAD + "." + func[i]);
+                log.complain("Searched for: " + DEBUGGEE_THREAD + "." + s);
                 log.complain("Count : " + count);
-                result= false;
+                result = false;
             }
         }
         return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001a.java
@@ -23,20 +23,20 @@
 
 package nsk.jdb.wherei.wherei001;
 
-import nsk.share.*;
-import nsk.share.jpda.*;
-import nsk.share.jdb.*;
+import nsk.share.Log;
+import nsk.share.jdb.JdbArgumentHandler;
 
-import java.io.*;
+import java.io.PrintStream;
 
-/* This is debuggee aplication */
+/* This is debuggee application */
 public class wherei001a {
-    public static void main(String args[]) {
-       wherei001a _wherei001a = new wherei001a();
-       System.exit(wherei001.JCK_STATUS_BASE + _wherei001a.runIt(args, System.out));
+    public static void main(String[] args) {
+        wherei001a _wherei001a = new wherei001a();
+        System.exit(wherei001.JCK_STATUS_BASE + _wherei001a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void lastBreak() {
+    }
 
     static int numThreads = 5;   // number of threads. one lock per thread.
     static Object lock = new Object();
@@ -45,28 +45,28 @@ public class wherei001a {
     static JdbArgumentHandler argumentHandler;
     static Log log;
 
-    public int runIt(String args[], PrintStream out) {
+    public int runIt(String[] args, PrintStream out) {
 
         argumentHandler = new JdbArgumentHandler(args);
         log = new Log(out, argumentHandler);
 
         int i;
-        Thread holder [] = new Thread[numThreads];
+        Thread holder[] = new Thread[numThreads];
         Lock locks[] = new Lock[numThreads];
 
-        for (i = 0; i < numThreads ; i++) {
+        for (i = 0; i < numThreads; i++) {
             locks[i] = new Lock();
-            holder[i] = new MyThread(locks[i],"MyThread-" + i);
+            holder[i] = new MyThread(locks[i], "MyThread-" + i);
         }
 
         // lock monitor to prevent threads from finishing after they started
         synchronized (lock) {
             synchronized (waitnotify) {
-                for (i = 0; i < numThreads ; i++) {
+                for (i = 0; i < numThreads; i++) {
                     holder[i].start();
                     try {
                         waitnotify.wait();
-                    } catch ( Exception e ) {
+                    } catch (Exception e) {
                         log.complain("TEST ERROR: caught Exception while waiting: " + e);
                         e.printStackTrace();
                     }
@@ -87,7 +87,7 @@ class MyThread extends Thread {
     // Concatenate strings in advance to avoid lambda calculations later
     final String ThreadFinished = "Thread finished: " + this.name;
 
-    public MyThread (Lock l, String n) {
+    public MyThread(Lock l, String n) {
         this.lock = l;
         name = n;
     }
@@ -132,7 +132,7 @@ class MyThread extends Thread {
         synchronized (wherei001a.lock) {
             wherei001a.log.display(ThreadFinished);
         }
-        return i*i;
+        return i * i;
     }
 }
 
@@ -140,7 +140,7 @@ class Lock {
     boolean lockSet;
 
     synchronized void setLock() throws InterruptedException {
-        while (lockSet == true ) {
+        while (lockSet == true) {
             wait();
         }
         lockSet = true;


### PR DESCRIPTION
Hi all,

could you please review this patch which reformats/cleans up the code of vmTestbase/nsk/jdb tests? 

the part of this patch is a spinoff from #350.

testing:
* [x] `vmTestbase/nsk/jdb` tests on `linux-x64-debug`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254861](https://bugs.openjdk.java.net/browse/JDK-8254861): reformat code in vmTestbase/nsk/jdb


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/689/head:pull/689`
`$ git checkout pull/689`
