### PR TITLE
8254863: Delete code leftover from old fixes

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -1842,17 +1842,6 @@ public class ICC_Profile implements Serializable {
         }
     }
 
-    /**
-     * Checks whether built-in profile specified by fileName exists.
-     */
-    private static boolean standardProfileExists(final String fileName) {
-        return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-                public Boolean run() {
-                    return PCMM.class.getResource("profiles/"+fileName) != null;
-                }
-            });
-    }
-
     /*
      * Serialization support.
      *

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -830,8 +830,6 @@ public class ICC_Profile implements Serializable {
      */
     public static ICC_Profile getInstance (int cspace) {
         ICC_Profile thisProfile = null;
-        String fileName;
-
         switch (cspace) {
         case ColorSpace.CS_sRGB:
             synchronized(ICC_Profile.class) {
@@ -869,17 +867,11 @@ public class ICC_Profile implements Serializable {
         case ColorSpace.CS_PYCC:
             synchronized(ICC_Profile.class) {
                 if (PYCCprofile == null) {
-                    if (standardProfileExists("PYCC.pf"))
-                    {
-                        ProfileDeferralInfo pInfo =
-                            new ProfileDeferralInfo("PYCC.pf",
-                                                    ColorSpace.TYPE_3CLR, 3,
-                                                    CLASS_DISPLAY);
-                        PYCCprofile = getDeferredInstance(pInfo);
-                    } else {
-                        throw new IllegalArgumentException(
-                                "Can't load standard profile: PYCC.pf");
-                    }
+                    ProfileDeferralInfo pInfo =
+                        new ProfileDeferralInfo("PYCC.pf",
+                                                ColorSpace.TYPE_3CLR, 3,
+                                                CLASS_DISPLAY);
+                    PYCCprofile = getDeferredInstance(pInfo);
                 }
                 thisProfile = PYCCprofile;
             }

--- a/src/java.desktop/share/classes/sun/java2d/cmm/CMSManager.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/CMSManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,11 @@
 
 package sun.java2d.cmm;
 
+import java.awt.color.CMMException;
 import java.awt.color.ColorSpace;
 import java.awt.color.ICC_Profile;
-import java.awt.color.CMMException;
-import java.awt.image.BufferedImage;
-import java.awt.image.Raster;
-import java.awt.image.WritableRaster;
 import java.security.AccessController;
-import java.security.PrivilegedAction;
+
 import sun.security.action.GetPropertyAction;
 
 public class CMSManager {
@@ -101,11 +98,6 @@ public class CMSManager {
             Profile p = tcmm.loadProfile(data);
             System.err.printf("(ID=%s)\n", p.toString());
             return p;
-        }
-
-        public void freeProfile(Profile p) {
-            System.err.printf(cName + ".freeProfile(ID=%s)\n", p.toString());
-            tcmm.freeProfile(p);
         }
 
         public int getProfileSize(Profile p) {

--- a/src/java.desktop/share/classes/sun/java2d/cmm/PCMM.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/PCMM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ public interface PCMM {
 
     /* methods invoked from ICC_Profile */
     public Profile loadProfile(byte[] data);
-    public void freeProfile(Profile p);
     public int  getProfileSize(Profile p);
     public void getProfileData(Profile p, byte[] data);
     public void getTagData(Profile p, int tagSignature, byte[] data);

--- a/src/java.desktop/share/classes/sun/java2d/cmm/ProfileDeferralMgr.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/ProfileDeferralMgr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,23 +58,6 @@ public class ProfileDeferralMgr {
         return;
     }
 
-
-    /**
-     * Removes a ProfileActivator object from the vector of ProfileActivator
-     * objects whose activate method will be called if the CMM needs to be
-     * activated.
-     */
-    public static void unregisterDeferral(ProfileActivator pa) {
-
-        if (!deferring) {
-            return;
-        }
-        if (aVector == null) {
-            return;
-        }
-        aVector.removeElement(pa);
-        return;
-    }
 
     /**
      * Removes a ProfileActivator object from the vector of ProfileActivator

--- a/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMS.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package sun.java2d.cmm.lcms;
 
 import java.awt.color.CMMException;
 import java.awt.color.ICC_Profile;
+
 import sun.java2d.cmm.ColorTransform;
 import sun.java2d.cmm.PCMM;
 import sun.java2d.cmm.Profile;
@@ -54,12 +55,6 @@ public class LCMS implements PCMM {
             return (LCMSProfile)p;
         }
         throw new CMMException("Invalid profile: " + p);
-    }
-
-
-    @Override
-    public void freeProfile(Profile p) {
-        // we use disposer, so this method does nothing
     }
 
     @Override


### PR DESCRIPTION
The fix for JDK-4893408 adds a special code to handle the "PYCC.pf" color profile for the "kernel java":
https://bugs.openjdk.java.net/browse/JDK-4893408?focusedCommentId=12284308&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-12284308
The "kernel java" support was removed in jdk7 in JDK-7016724 but the special code in the ICC_Profile.java still exists.

After the fix for JDK-8175984 a few methods became unused:
 - CMSManager#freeProfile()
 - ProfileDeferralMgr#unregisterDeferral()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254863](https://bugs.openjdk.java.net/browse/JDK-8254863): Delete code leftover from old fixes


### Reviewers
 * [Azeem Jiva](https://openjdk.java.net/census#azeemj) (@AzeemJiva - Author)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/691/head:pull/691`
`$ git checkout pull/691`
