### PR TITLE
8194126: Regression automated Test '/open/test/jdk/javax/swing/JColorChooser/Test7194184.java' fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -742,7 +742,6 @@ javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 802462
 javax/swing/JComboBox/8033069/bug8033069ScrollBar.java 8163367 generic-all
 javax/swing/JColorChooser/Test6827032.java 8197825 windows-all
 javax/swing/JColorChooser/Test6541987.java 8143021 windows-all,linux-all,macosx-all
-javax/swing/JColorChooser/Test7194184.java 8194126 linux-all,macosx-all
 javax/swing/JTable/4235420/bug4235420.java     8079127 generic-all
 javax/swing/JSplitPane/4201995/bug4201995.java 8079127 generic-all
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all

--- a/test/jdk/javax/swing/JColorChooser/Test7194184.java
+++ b/test/jdk/javax/swing/JColorChooser/Test7194184.java
@@ -52,17 +52,23 @@ public class Test7194184 {
     private static Robot robot;
 
     public static void main(String[] args) throws Exception {
-        robot = new Robot();
-        robot.setAutoWaitForIdle(true);
-        createUI();
-        accessRecentSwatch();
-        runRobot();
-        testColorChooser();
-        cleanUpUI();
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(100);
+            createUI();
+            robot.waitForIdle();
+            robot.delay(1000);
+            accessRecentSwatch();
+            robot.waitForIdle();
+            runRobot();
+            testColorChooser();
+        } finally {
+            cleanUpUI();
+        }
     }
 
     private static void createUI() throws Exception {
-        SwingUtilities.invokeLater(new Runnable() {
+        SwingUtilities.invokeAndWait(new Runnable() {
             @Override
             public void run() {
                 String title = getClass().getName();
@@ -71,12 +77,13 @@ public class Test7194184 {
                 frame.add(colorChooser);
                 frame.pack();
                 frame.setVisible(true);
+                frame.setLocationRelativeTo(null);
             }
         });
     }
 
     private static void accessRecentSwatch() throws Exception {
-        SwingUtilities.invokeLater(new Runnable() {
+        SwingUtilities.invokeAndWait(new Runnable() {
             @Override
             public void run() {
                 Component recentSwatchPanel = Util.findSubComponent(colorChooser, "RecentSwatchPanel");


### PR DESCRIPTION
Please review a test fix for an issue where the color is not chosen correctly. 
The issue seems to stem from the fact that keys are not processed properly so the proper color is not chosen.
Fixed by adding autoDelay during processing of key events and also made EDT change to invokeAndWait from invokeLater.
Also, move the frame to center of screen and do cleanup at finally block.
Mach5 job was run for several iteration on all 3 platforms. Link in JBS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8194126](https://bugs.openjdk.java.net/browse/JDK-8194126): Regression automated Test '/open/test/jdk/javax/swing/JColorChooser/Test7194184.java' fails


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/692/head:pull/692`
`$ git checkout pull/692`
