### PR TITLE
8254805: compiler/debug/TestStressCM.java is still failing

### DIFF
--- a/test/hotspot/jtreg/compiler/debug/TestStressIGVN.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressIGVN.java
@@ -42,7 +42,7 @@ public class TestStressIGVN {
     static String igvnTrace(int stressSeed) throws Exception {
         String className = TestStressIGVN.class.getName();
         String[] procArgs = {
-            "-Xcomp", "-XX:-TieredCompilation",
+            "-Xcomp", "-XX:-TieredCompilation", "-XX:-Inline",
             "-XX:CompileOnly=" + className + "::sum", "-XX:+TraceIterativeGVN",
             "-XX:+StressIGVN", "-XX:StressSeed=" + stressSeed,
             className, "10"};
@@ -59,8 +59,10 @@ public class TestStressIGVN {
 
     public static void main(String[] args) throws Exception {
         if (args.length == 0) {
-            Asserts.assertEQ(igvnTrace(10), igvnTrace(10),
-                "got different IGVN traces for the same seed");
+            for (int s = 0; s < 10; s++) {
+                Asserts.assertEQ(igvnTrace(s), igvnTrace(s),
+                    "got different IGVN traces for the same seed");
+            }
         } else if (args.length > 0) {
             sum(Integer.parseInt(args[0]));
         }


### PR DESCRIPTION
Use the code motion trace produced by `TraceOptoPipelining` (excluding traces of stubs) to assert that two compilations with the same seed cause `StressLCM` and `StressGCM` to take the same randomized decisions. Previously, the entire output produced by `PrintOptoStatistics` was used instead, which has shown to be too fragile. Also, disable inlining in both `TestStressCM.java` and the similar `TestStressIGVN.java` to prevent flaky behavior, and run both tests for ten different seeds to improve coverage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254805](https://bugs.openjdk.java.net/browse/JDK-8254805): compiler/debug/TestStressCM.java is still failing


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/693/head:pull/693`
`$ git checkout pull/693`
