### PR TITLE
8254878: Move last piece of ZArray to GrowableArray

### DIFF
--- a/src/hotspot/share/gc/z/zArray.hpp
+++ b/src/hotspot/share/gc/z/zArray.hpp
@@ -25,16 +25,9 @@
 #define SHARE_GC_Z_ZARRAY_HPP
 
 #include "memory/allocation.hpp"
-#include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
 
-template <typename T>
-class ZArray : public GrowableArrayCHeap<T, mtGC> {
-public:
-  ZArray();
-
-  void transfer(ZArray<T>* from);
-};
+template <typename T> using ZArray = GrowableArrayCHeap<T, mtGC>;
 
 template <typename T, bool parallel>
 class ZArrayIteratorImpl : public StackObj {

--- a/src/hotspot/share/gc/z/zArray.inline.hpp
+++ b/src/hotspot/share/gc/z/zArray.inline.hpp
@@ -25,23 +25,7 @@
 #define SHARE_GC_Z_ZARRAY_INLINE_HPP
 
 #include "gc/z/zArray.hpp"
-#include "memory/allocation.inline.hpp"
 #include "runtime/atomic.hpp"
-
-template <typename T>
-inline ZArray<T>::ZArray() :
-    GrowableArrayCHeap<T, mtGC>(0) {}
-
-template <typename T>
-inline void ZArray<T>::transfer(ZArray<T>* from) {
-  assert(this->_data == NULL, "Should be empty");
-  this->_data = from->_data;
-  this->_len = from->_len;
-  this->_max = from->_max;
-  from->_data = NULL;
-  from->_len = 0;
-  from->_max = 0;
-}
 
 template <typename T, bool parallel>
 inline ZArrayIteratorImpl<T, parallel>::ZArrayIteratorImpl(ZArray<T>* array) :

--- a/src/hotspot/share/gc/z/zSafeDelete.inline.hpp
+++ b/src/hotspot/share/gc/z/zSafeDelete.inline.hpp
@@ -69,7 +69,7 @@ void ZSafeDeleteImpl<T>::disable_deferred_delete() {
     ZLocker<ZLock> locker(_lock);
     assert(_enabled > 0, "Invalid state");
     if (--_enabled == 0) {
-      deferred.transfer(&_deferred);
+      deferred.swap(&_deferred);
     }
   }
 

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -435,6 +435,12 @@ public:
     return this->at(location);
   }
 
+  void swap(GrowableArrayWithAllocator<E, Derived>* other) {
+    ::swap(this->_data, other->_data);
+    ::swap(this->_len, other->_len);
+    ::swap(this->_max, other->_max);
+  }
+
   void clear_and_deallocate();
 };
 
@@ -687,7 +693,7 @@ class GrowableArrayCHeap : public GrowableArrayWithAllocator<E, GrowableArrayCHe
   }
 
 public:
-  GrowableArrayCHeap(int initial_max) :
+  GrowableArrayCHeap(int initial_max = 0) :
       GrowableArrayWithAllocator<E, GrowableArrayCHeap<E, F> >(
           allocate(initial_max, F),
           initial_max) {}

--- a/test/hotspot/gtest/gc/z/test_zArray.cpp
+++ b/test/hotspot/gtest/gc/z/test_zArray.cpp
@@ -35,7 +35,7 @@ TEST(ZArray, sanity) {
 
   ZArray<int> b;
 
-  b.transfer(&a);
+  b.swap(&a);
 
   // Check size
   ASSERT_EQ(a.length(), 0);


### PR DESCRIPTION
ZArray used to be a separate implementation of a dynamically allocated/growable array. It now instead inherits from GrowableCHeapArray, and extends it with a transfer() function. I propose we rename this function to swap() and move it to GrowableArrayWithAllocator, since this function could be generally useful. It would also mean that ZArray could be just a typedef/using of GrowableCHeapArray.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254878](https://bugs.openjdk.java.net/browse/JDK-8254878): Move last piece of ZArray to GrowableArray


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/694/head:pull/694`
`$ git checkout pull/694`
