### PR TITLE
8254880: ZGC: Let ZList iterators be alias templates

### DIFF
--- a/src/hotspot/share/gc/z/zList.hpp
+++ b/src/hotspot/share/gc/z/zList.hpp
@@ -111,26 +111,8 @@ public:
   bool next(T** elem);
 };
 
-// Iterator types
-#define ZLIST_FORWARD        true
-#define ZLIST_REVERSE        false
-
-template <typename T>
-class ZListIterator : public ZListIteratorImpl<T, ZLIST_FORWARD> {
-public:
-  ZListIterator(const ZList<T>* list);
-};
-
-template <typename T>
-class ZListReverseIterator : public ZListIteratorImpl<T, ZLIST_REVERSE> {
-public:
-  ZListReverseIterator(const ZList<T>* list);
-};
-
-template <typename T>
-class ZListRemoveIterator : public ZListRemoveIteratorImpl<T, ZLIST_FORWARD> {
-public:
-  ZListRemoveIterator(ZList<T>* list);
-};
+template <typename T> using ZListIterator = ZListIteratorImpl<T, true /* Forward */>;
+template <typename T> using ZListReverseIterator = ZListIteratorImpl<T, false /* Forward */>;
+template <typename T> using ZListRemoveIterator = ZListRemoveIteratorImpl<T, true /* Forward */>;
 
 #endif // SHARE_GC_Z_ZLIST_HPP

--- a/src/hotspot/share/gc/z/zList.inline.hpp
+++ b/src/hotspot/share/gc/z/zList.inline.hpp
@@ -232,16 +232,4 @@ inline bool ZListRemoveIteratorImpl<T, Forward>::next(T** elem) {
   return *elem != NULL;
 }
 
-template <typename T>
-inline ZListIterator<T>::ZListIterator(const ZList<T>* list) :
-    ZListIteratorImpl<T, ZLIST_FORWARD>(list) {}
-
-template <typename T>
-inline ZListReverseIterator<T>::ZListReverseIterator(const ZList<T>* list) :
-    ZListIteratorImpl<T, ZLIST_REVERSE>(list) {}
-
-template <typename T>
-inline ZListRemoveIterator<T>::ZListRemoveIterator(ZList<T>* list) :
-    ZListRemoveIteratorImpl<T, ZLIST_FORWARD>(list) {}
-
 #endif // SHARE_GC_Z_ZLIST_INLINE_HPP


### PR DESCRIPTION
Since we can now use C++11/14 features, I propose we simplify the ZList iterators by making them alias templates.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254880](https://bugs.openjdk.java.net/browse/JDK-8254880): ZGC: Let ZList iterators be alias templates


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/695/head:pull/695`
`$ git checkout pull/695`
