### PR TITLE
8254882: ZGC: Use static_assert instead of guarantee

### DIFF
--- a/src/hotspot/share/gc/z/zBitField.hpp
+++ b/src/hotspot/share/gc/z/zBitField.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zBitField.hpp
+++ b/src/hotspot/share/gc/z/zBitField.hpp
@@ -60,9 +60,9 @@ class ZBitField : public AllStatic {
 private:
   static const int ContainerBits = sizeof(ContainerType) * BitsPerByte;
 
-  static_assert(FieldBits < ContainerBits);
-  static_assert(FieldShift + FieldBits <= ContainerBits);
-  static_assert(ValueShift + FieldBits <= ContainerBits);
+  static_assert(FieldBits < ContainerBits, "Field too large");
+  static_assert(FieldShift + FieldBits <= ContainerBits, "Field too large");
+  static_assert(ValueShift + FieldBits <= ContainerBits, "Field too large");
 
   static const ContainerType FieldMask = (((ContainerType)1 << FieldBits) - 1);
 

--- a/src/hotspot/share/gc/z/zBitField.hpp
+++ b/src/hotspot/share/gc/z/zBitField.hpp
@@ -60,9 +60,9 @@ class ZBitField : public AllStatic {
 private:
   static const int ContainerBits = sizeof(ContainerType) * BitsPerByte;
 
-  STATIC_ASSERT(FieldBits < ContainerBits);
-  STATIC_ASSERT(FieldShift + FieldBits <= ContainerBits);
-  STATIC_ASSERT(ValueShift + FieldBits <= ContainerBits);
+  static_assert(FieldBits < ContainerBits);
+  static_assert(FieldShift + FieldBits <= ContainerBits);
+  static_assert(ValueShift + FieldBits <= ContainerBits);
 
   static const ContainerType FieldMask = (((ContainerType)1 << FieldBits) - 1);
 

--- a/src/hotspot/share/gc/z/zMarkStack.hpp
+++ b/src/hotspot/share/gc/z/zMarkStack.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zMarkStack.hpp
+++ b/src/hotspot/share/gc/z/zMarkStack.hpp
@@ -71,8 +71,8 @@ using ZMarkStackList = ZStackList<ZMarkStack>;
 using ZMarkStackMagazine = ZStack<ZMarkStack*, ZMarkStackMagazineSlots>;
 using ZMarkStackMagazineList = ZStackList<ZMarkStackMagazine>;
 
-static_assert(sizeof(ZMarkStack) == ZMarkStackSize);
-static_assert(sizeof(ZMarkStackMagazine) <= ZMarkStackSize);
+static_assert(sizeof(ZMarkStack) == ZMarkStackSize, "ZMarkStack size mismatch");
+static_assert(sizeof(ZMarkStackMagazine) <= ZMarkStackSize, "ZMarkStackMagazine size too large");
 
 class ZMarkStripe {
 private:

--- a/src/hotspot/share/gc/z/zMarkStack.hpp
+++ b/src/hotspot/share/gc/z/zMarkStack.hpp
@@ -66,10 +66,13 @@ public:
   T* pop();
 };
 
-typedef ZStack<ZMarkStackEntry, ZMarkStackSlots>     ZMarkStack;
-typedef ZStackList<ZMarkStack>                       ZMarkStackList;
-typedef ZStack<ZMarkStack*, ZMarkStackMagazineSlots> ZMarkStackMagazine;
-typedef ZStackList<ZMarkStackMagazine>               ZMarkStackMagazineList;
+using ZMarkStack = ZStack<ZMarkStackEntry, ZMarkStackSlots>;
+using ZMarkStackList = ZStackList<ZMarkStack>;
+using ZMarkStackMagazine = ZStack<ZMarkStack*, ZMarkStackMagazineSlots>;
+using ZMarkStackMagazineList = ZStackList<ZMarkStackMagazine>;
+
+static_assert(sizeof(ZMarkStack) == ZMarkStackSize);
+static_assert(sizeof(ZMarkStackMagazine) <= ZMarkStackSize);
 
 class ZMarkStripe {
 private:

--- a/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
@@ -128,9 +128,6 @@ uintptr_t ZMarkStackSpace::alloc(size_t size) {
 ZMarkStackAllocator::ZMarkStackAllocator() :
     _freelist(),
     _space() {
-  guarantee(sizeof(ZMarkStack) == ZMarkStackSize, "Size mismatch");
-  guarantee(sizeof(ZMarkStackMagazine) <= ZMarkStackSize, "Size mismatch");
-
   // Prime free list to avoid an immediate space
   // expansion when marking starts.
   if (_space.is_initialized()) {


### PR DESCRIPTION
The ZMarkStackAllocator uses guarantee(), which can be turned into static_assert(). I took the opportunity to also change three exsisting uses of STATIC_ASSERT to static_assert, and adjust some neighbouring "typedefs" to "using".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254882](https://bugs.openjdk.java.net/browse/JDK-8254882): ZGC: Use static_assert instead of guarantee


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 61a60d44c83d82e7a169ead72c6e8c14dda5c8f3
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to b2e1a7463616cb259395eba1a1b6ad8c607d556c


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/696/head:pull/696`
`$ git checkout pull/696`
