### PR TITLE
8253600: G1: Fully support pinned regions for full gc 

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.hpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.hpp
@@ -299,8 +299,6 @@ public:
 
   // Check if the object is in closed archive
   static inline bool is_closed_archive_object(oop object);
-  // Check if the object is in open archive
-  static inline bool is_open_archive_object(oop object);
   // Check if the object is either in closed archive or open archive
   static inline bool is_archived_object(oop object);
 
@@ -308,10 +306,8 @@ private:
   static bool _archive_check_enabled;
   static G1ArchiveRegionMap  _archive_region_map;
 
-  // Check if an object is in a closed archive region using the _closed_archive_region_map.
+  // Check if an object is in a closed archive region using the _archive_region_map.
   static inline bool in_closed_archive_range(oop object);
-  // Check if an object is in open archive region using the _open_archive_region_map.
-  static inline bool in_open_archive_range(oop object);
 
   // Check if archive object checking is enabled, to avoid calling in_open/closed_archive_range
   // unnecessarily.

--- a/src/hotspot/share/gc/g1/g1Allocator.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.inline.hpp
@@ -159,10 +159,6 @@ inline bool G1ArchiveAllocator::in_closed_archive_range(oop object) {
   return _archive_region_map.get_by_address(cast_from_oop<HeapWord*>(object)) == G1ArchiveRegionMap::ClosedArchive;
 }
 
-inline bool G1ArchiveAllocator::in_open_archive_range(oop object) {
-  return _archive_region_map.get_by_address(cast_from_oop<HeapWord*>(object)) == G1ArchiveRegionMap::OpenArchive;
-}
-
 // Check if archive object checking is enabled, to avoid calling in_open/closed_archive_range
 // unnecessarily.
 inline bool G1ArchiveAllocator::archive_check_enabled() {
@@ -171,10 +167,6 @@ inline bool G1ArchiveAllocator::archive_check_enabled() {
 
 inline bool G1ArchiveAllocator::is_closed_archive_object(oop object) {
   return (archive_check_enabled() && in_closed_archive_range(object));
-}
-
-inline bool G1ArchiveAllocator::is_open_archive_object(oop object) {
-  return (archive_check_enabled() && in_open_archive_range(object));
 }
 
 inline bool G1ArchiveAllocator::is_archived_object(oop object) {

--- a/src/hotspot/share/gc/g1/g1BiasedArray.cpp
+++ b/src/hotspot/share/gc/g1/g1BiasedArray.cpp
@@ -26,11 +26,25 @@
 #include "gc/g1/g1BiasedArray.hpp"
 #include "memory/padded.inline.hpp"
 
+G1BiasedMappedArrayBase::G1BiasedMappedArrayBase() :
+  _alloc_base(NULL),
+  _base(NULL),
+  _length(0),
+  _biased_base(NULL),
+  _bias(0),
+  _shift_by(0) { }
+
+G1BiasedMappedArrayBase::~G1BiasedMappedArrayBase() {
+  if (_alloc_base != NULL) {
+    FREE_C_HEAP_ARRAY(u_char, _alloc_base);
+  }
+}
+
 // Allocate a new array, generic version.
 address G1BiasedMappedArrayBase::create_new_base_array(size_t length, size_t elem_size) {
   assert(length > 0, "just checking");
   assert(elem_size > 0, "just checking");
-  return PaddedPrimitiveArray<u_char, mtGC>::create_unfreeable(length * elem_size);
+  return PaddedPrimitiveArray<u_char, mtGC>::create(length * elem_size, &_alloc_base);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/gc/g1/g1BiasedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1BiasedArray.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_G1_G1BIASEDARRAY_HPP
 #define SHARE_GC_G1_G1BIASEDARRAY_HPP
 
+#include "memory/allocation.hpp"
 #include "memory/memRegion.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/powerOfTwo.hpp"
@@ -32,11 +33,12 @@
 // Implements the common base functionality for arrays that contain provisions
 // for accessing its elements using a biased index.
 // The element type is defined by the instantiating the template.
-class G1BiasedMappedArrayBase {
+class G1BiasedMappedArrayBase : public CHeapObj<mtGC> {
   friend class VMStructs;
 public:
   typedef size_t idx_t;
 protected:
+  void* _alloc_base;      // the address the unpadded array has been allocated to
   address _base;          // the real base address
   size_t _length;         // the length of the array
   address _biased_base;   // base address biased by "bias" elements
@@ -45,11 +47,10 @@ protected:
 
 protected:
 
-  G1BiasedMappedArrayBase() : _base(NULL), _length(0), _biased_base(NULL),
-    _bias(0), _shift_by(0) { }
+  G1BiasedMappedArrayBase();
 
   // Allocate a new array, generic version.
-  static address create_new_base_array(size_t length, size_t elem_size);
+  address create_new_base_array(size_t length, size_t elem_size);
 
   // Initialize the members of this class. The biased start address of this array
   // is the bias (in elements) multiplied by the element size.
@@ -90,8 +91,10 @@ protected:
   void verify_biased_index_inclusive_end(idx_t biased_index) const PRODUCT_RETURN;
 
 public:
-   // Return the length of the array in elements.
-   size_t length() const { return _length; }
+  virtual ~G1BiasedMappedArrayBase();
+
+  // Return the length of the array in elements.
+  size_t length() const { return _length; }
 };
 
 // Array that provides biased access and mapping from (valid) addresses in the

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1073,17 +1073,7 @@ void G1CollectedHeap::verify_after_full_collection() {
   _hrm->verify_optional();
   _verifier->verify_region_sets_optional();
   _verifier->verify_after_gc(G1HeapVerifier::G1VerifyFull);
-  // Clear the previous marking bitmap, if needed for bitmap verification.
-  // Note we cannot do this when we clear the next marking bitmap in
-  // G1ConcurrentMark::abort() above since VerifyDuringGC verifies the
-  // objects marked during a full GC against the previous bitmap.
-  // But we need to clear it before calling check_bitmaps below since
-  // the full GC has compacted objects and updated TAMS but not updated
-  // the prev bitmap.
-  if (G1VerifyBitmaps) {
-    GCTraceTime(Debug, gc) tm("Clear Prev Bitmap for Verification");
-    _cm->clear_prev_bitmap(workers());
-  }
+
   // This call implicitly verifies that the next bitmap is clear after Full GC.
   _verifier->check_bitmaps("Full GC End");
 

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -54,7 +54,12 @@ void G1CollectionSetCandidates::verify() const {
   for (; idx < _num_regions; idx++) {
     HeapRegion *cur = _regions[idx];
     guarantee(cur != NULL, "Regions after _front_idx %u cannot be NULL but %u is", _front_idx, idx);
-    guarantee(G1CollectionSetChooser::should_add(cur), "Region %u should be eligible for addition.", cur->hrm_index());
+    // The first disjunction filters out regions with objects that were explicitly
+    // pinned after being added to the collection set candidates. Archive regions
+    // should never have been added to the collection set though.
+    guarantee((cur->is_pinned() && !cur->is_archive()) ||
+              G1CollectionSetChooser::should_add(cur),
+              "Region %u should be eligible for addition.", cur->hrm_index());
     if (prev != NULL) {
       guarantee(prev->gc_efficiency() >= cur->gc_efficiency(),
                 "GC efficiency for region %u: %1.4f smaller than for region %u: %1.4f",

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -374,8 +374,6 @@ class G1ConcurrentMark : public CHeapObj<mtGC> {
 
   void report_object_count(bool mark_completed);
 
-  void swap_mark_bitmaps();
-
   void reclaim_empty_regions();
 
   // After reclaiming empty regions, update heap sizes.
@@ -539,8 +537,8 @@ public:
   // to be called concurrently to the mutator. It will yield to safepoint requests.
   void cleanup_for_next_mark();
 
-  // Clear the previous marking bitmap during safepoint.
-  void clear_prev_bitmap(WorkGang* workers);
+  // Clear the next marking bitmap during safepoint.
+  void clear_next_bitmap(WorkGang* workers);
 
   // These two methods do the work that needs to be done at the start and end of the
   // concurrent start pause.
@@ -562,6 +560,8 @@ public:
   void preclean();
 
   void remark();
+
+  void swap_mark_bitmaps();
 
   void cleanup();
   // Mark in the previous bitmap. Caution: the prev bitmap is usually read-only, so use

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -65,7 +65,7 @@ class G1FullCollector : StackObj {
 
   protected:
     uint8_t default_value() const { return Normal; }
-    
+
   public:
     bool is_closed(HeapWord* obj) const { return get_by_address(obj) == ClosedArchive; }
     bool is_pinned(HeapWord* obj) const { return get_by_address(obj) >= Pinned; }

--- a/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
@@ -51,27 +51,26 @@ public:
 };
 
 class G1AdjustRegionClosure : public HeapRegionClosure {
+  G1FullCollector* _collector;
   G1CMBitMap* _bitmap;
   uint _worker_id;
  public:
-  G1AdjustRegionClosure(G1CMBitMap* bitmap, uint worker_id) :
+  G1AdjustRegionClosure(G1FullCollector* collector, G1CMBitMap* bitmap, uint worker_id) :
+    _collector(collector),
     _bitmap(bitmap),
     _worker_id(worker_id) { }
 
   bool do_heap_region(HeapRegion* r) {
-    G1AdjustClosure cl;
+    G1AdjustClosure cl(_collector);
     if (r->is_humongous()) {
+      // Special handling for humongous regions to get somewhat better
+      // work distribution.
       oop obj = oop(r->humongous_start_region()->bottom());
       obj->oop_iterate(&cl, MemRegion(r->bottom(), r->top()));
-    } else if (r->is_open_archive()) {
-      // Only adjust the open archive regions, the closed ones
-      // never change.
-      G1AdjustLiveClosure adjust(&cl);
-      r->apply_to_marked_objects(_bitmap, &adjust);
-      // Open archive regions will not be compacted and the marking information is
-      // no longer needed. Clear it here to avoid having to do it later.
-      _bitmap->clear_region(r);
-    } else {
+    } else if (!(r->is_closed_archive() || r->is_free())) {
+      // Closed archive regions never change references and only contain
+      // references into other closed regions and are always live. Free
+      // regions do not contain objects to iterate. So skip both.
       G1AdjustLiveClosure adjust(&cl);
       r->apply_to_marked_objects(_bitmap, &adjust);
     }
@@ -85,7 +84,7 @@ G1FullGCAdjustTask::G1FullGCAdjustTask(G1FullCollector* collector) :
     _references_done(0),
     _weak_proc_task(collector->workers()),
     _hrclaimer(collector->workers()),
-    _adjust(),
+    _adjust(collector),
     _string_dedup_cleaning_task(NULL, &_adjust, false) {
   // Need cleared claim bits for the roots processing
   ClassLoaderDataGraph::clear_claimed_marks();
@@ -116,7 +115,7 @@ void G1FullGCAdjustTask::work(uint worker_id) {
   _string_dedup_cleaning_task.work(worker_id);
 
   // Now adjust pointers region by region
-  G1AdjustRegionClosure blk(collector()->mark_bitmap(), worker_id);
+  G1AdjustRegionClosure blk(collector(), collector()->mark_bitmap(), worker_id);
   G1CollectedHeap::heap()->heap_region_par_iterate_from_worker_offset(&blk, &_hrclaimer, worker_id);
   log_task("Adjust task", worker_id, start);
 }

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -34,27 +34,19 @@
 #include "oops/oop.inline.hpp"
 #include "utilities/ticks.hpp"
 
-class G1ResetHumongousClosure : public HeapRegionClosure {
+class G1ResetPinnedClosure : public HeapRegionClosure {
   G1CMBitMap* _bitmap;
 
 public:
-  G1ResetHumongousClosure(G1CMBitMap* bitmap) :
-      _bitmap(bitmap) { }
+  G1ResetPinnedClosure(G1CMBitMap* bitmap) : _bitmap(bitmap) { }
 
-  bool do_heap_region(HeapRegion* current) {
-    if (current->is_humongous()) {
-      if (current->is_starts_humongous()) {
-        oop obj = oop(current->bottom());
-        if (_bitmap->is_marked(obj)) {
-          // Clear bitmap and fix mark word.
-          _bitmap->clear(obj);
-          obj->init_mark();
-        } else {
-          assert(current->is_empty(), "Should have been cleared in phase 2.");
-        }
-      }
-      current->reset_humongous_during_compaction();
+  bool do_heap_region(HeapRegion* r) {
+    if (!r->is_pinned()) {
+      return false;
     }
+    assert(!r->is_starts_humongous() || _bitmap->is_marked((oop)r->bottom()),
+           "must be, otherwise reclaimed earlier");
+    r->pinned_complete_compaction();
     return false;
   }
 };
@@ -78,13 +70,16 @@ size_t G1FullGCCompactTask::G1CompactRegionClosure::apply(oop obj) {
 }
 
 void G1FullGCCompactTask::compact_region(HeapRegion* hr) {
+  assert(!hr->is_pinned(), "Should be no pinned region in compaction queue");
   assert(!hr->is_humongous(), "Should be no humongous regions in compaction queue");
   G1CompactRegionClosure compact(collector()->mark_bitmap());
   hr->apply_to_marked_objects(collector()->mark_bitmap(), &compact);
-  // Once all objects have been moved the liveness information
-  // needs be cleared.
-  collector()->mark_bitmap()->clear_region(hr);
-  hr->complete_compaction();
+  // Clear the liveness information for this region if necessary i.e. if we actually look at it
+  // for bitmap verification. Otherwise it is sufficient that we move the TAMS to bottom().
+  if (G1VerifyBitmaps) {
+    collector()->mark_bitmap()->clear_region(hr);
+  }
+  hr->non_pinned_complete_compaction();
 }
 
 void G1FullGCCompactTask::work(uint worker_id) {
@@ -96,7 +91,7 @@ void G1FullGCCompactTask::work(uint worker_id) {
     compact_region(*it);
   }
 
-  G1ResetHumongousClosure hc(collector()->mark_bitmap());
+  G1ResetPinnedClosure hc(collector()->mark_bitmap());
   G1CollectedHeap::heap()->heap_region_par_iterate_from_worker_offset(&hc, &_claimer, worker_id);
   log_task("Compaction task", worker_id, start);
 }

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
@@ -30,7 +30,11 @@
 #include "gc/shared/verifyOption.hpp"
 #include "memory/iterator.inline.hpp"
 
-G1FullGCMarker::G1FullGCMarker(uint worker_id, PreservedMarks* preserved_stack, G1CMBitMap* bitmap) :
+G1FullGCMarker::G1FullGCMarker(G1FullCollector* collector,
+                               uint worker_id,
+                               PreservedMarks* preserved_stack,
+                               G1CMBitMap* bitmap) :
+    _collector(collector),
     _worker_id(worker_id),
     _bitmap(bitmap),
     _oop_stack(),

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
@@ -43,8 +43,11 @@ typedef GenericTaskQueueSet<OopQueue, mtGC>          OopQueueSet;
 typedef GenericTaskQueueSet<ObjArrayTaskQueue, mtGC> ObjArrayTaskQueueSet;
 
 class G1CMBitMap;
+class G1FullCollector;
 
 class G1FullGCMarker : public CHeapObj<mtGC> {
+  G1FullCollector*   _collector;
+
   uint               _worker_id;
   // Backing mark bitmap
   G1CMBitMap*        _bitmap;
@@ -71,7 +74,7 @@ class G1FullGCMarker : public CHeapObj<mtGC> {
   inline void follow_array(objArrayOop array);
   inline void follow_array_chunk(objArrayOop array, int index);
 public:
-  G1FullGCMarker(uint worker_id, PreservedMarks* preserved_stack, G1CMBitMap* bitmap);
+  G1FullGCMarker(G1FullCollector* collector, uint worker_id, PreservedMarks* preserved_stack, G1CMBitMap* bitmap);
   ~G1FullGCMarker();
 
   // Stack getters

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -27,6 +27,7 @@
 
 #include "gc/g1/g1Allocator.inline.hpp"
 #include "gc/g1/g1ConcurrentMarkBitMap.inline.hpp"
+#include "gc/g1/g1FullCollector.hpp"
 #include "gc/g1/g1FullGCMarker.hpp"
 #include "gc/g1/g1FullGCOopClosures.inline.hpp"
 #include "gc/g1/g1StringDedup.hpp"
@@ -39,7 +40,7 @@
 
 inline bool G1FullGCMarker::mark_object(oop obj) {
   // Not marking closed archive objects.
-  if (G1ArchiveAllocator::is_closed_archive_object(obj)) {
+  if (_collector->is_in_closed(obj)) {
     return false;
   }
 
@@ -52,7 +53,9 @@ inline bool G1FullGCMarker::mark_object(oop obj) {
   // Marked by us, preserve if needed.
   markWord mark = obj->mark();
   if (obj->mark_must_be_preserved(mark) &&
-      !G1ArchiveAllocator::is_open_archive_object(obj)) {
+      // It is not necessary to preserve marks for objects in pinned regions because
+      // we do not change their headers (i.e. forward them).
+      !_collector->is_in_pinned(obj)) {
     preserved_stack()->push(obj, mark);
   }
 

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.hpp
@@ -75,8 +75,11 @@ public:
 };
 
 class G1AdjustClosure : public BasicOopIterateClosure {
-  template <class T> static inline void adjust_pointer(T* p);
+  G1FullCollector* _collector;
+
+  template <class T> inline void adjust_pointer(T* p);
 public:
+  G1AdjustClosure(G1FullCollector* collector) : _collector(collector) { }
   template <class T> void do_oop_work(T* p) { adjust_pointer(p); }
   virtual void do_oop(oop* p);
   virtual void do_oop(narrowOop* p);

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_G1_G1FULLGCOOPCLOSURES_INLINE_HPP
 
 #include "gc/g1/g1Allocator.inline.hpp"
+#include "gc/g1/g1FullCollector.hpp"
 #include "gc/g1/g1ConcurrentMarkBitMap.inline.hpp"
 #include "gc/g1/g1FullGCMarker.inline.hpp"
 #include "gc/g1/g1FullGCOopClosures.hpp"
@@ -69,8 +70,9 @@ template <class T> inline void G1AdjustClosure::adjust_pointer(T* p) {
 
   oop obj = CompressedOops::decode_not_null(heap_oop);
   assert(Universe::heap()->is_in(obj), "should be in heap");
-  if (G1ArchiveAllocator::is_archived_object(obj)) {
-    // We never forward archive objects.
+  if (_collector->is_in_pinned(obj)) {
+    // We never forward objects in pinned regions so there is no need to
+    // process them further.
     return;
   }
 

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -40,21 +40,30 @@
 #include "utilities/ticks.hpp"
 
 bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion* hr) {
-  if (hr->is_humongous()) {
-    oop obj = oop(hr->humongous_start_region()->bottom());
-    if (_bitmap->is_marked(obj)) {
-      if (hr->is_starts_humongous()) {
-        obj->forward_to(obj);
+  if (hr->is_pinned()) {
+    // There is no need to iterate and forward objects in pinned regions ie.
+    // prepare them for compaction. The adjust pointers phase will skip
+    // work for them.
+    if (hr->is_humongous()) {
+      oop obj = oop(hr->humongous_start_region()->bottom());
+      if (!_bitmap->is_marked(obj)) {
+        free_humongous_region(hr);
       }
     } else {
-      free_humongous_region(hr);
+      bool is_empty = _bitmap->get_next_marked_addr(hr->bottom(), hr->top()) >= hr->top();
+      if (is_empty && !hr->is_archive()) { // Never free archive regions.
+        free_pinned_region(hr);
+      }
     }
-  } else if (!hr->is_pinned()) {
+  } else {
+    assert(!hr->is_humongous(), "moving humongous objects not supported.");
     prepare_for_compaction(hr);
   }
 
   // Reset data structures not valid after Full GC.
   reset_region_metadata(hr);
+
+  _collector->update_attribute_table(hr);
 
   return false;
 }
@@ -78,7 +87,7 @@ bool G1FullGCPrepareTask::has_freed_regions() {
 void G1FullGCPrepareTask::work(uint worker_id) {
   Ticks start = Ticks::now();
   G1FullGCCompactionPoint* compaction_point = collector()->compaction_point(worker_id);
-  G1CalculatePointersClosure closure(collector()->mark_bitmap(), compaction_point);
+  G1CalculatePointersClosure closure(collector(), collector()->mark_bitmap(), compaction_point);
   G1CollectedHeap::heap()->heap_region_par_iterate_from_start(&closure, &_hrclaimer);
 
   // Update humongous region sets
@@ -92,20 +101,39 @@ void G1FullGCPrepareTask::work(uint worker_id) {
   log_task("Prepare compaction task", worker_id, start);
 }
 
-G1FullGCPrepareTask::G1CalculatePointersClosure::G1CalculatePointersClosure(G1CMBitMap* bitmap,
+G1FullGCPrepareTask::G1CalculatePointersClosure::G1CalculatePointersClosure(G1FullCollector* collector,
+                                                                            G1CMBitMap* bitmap,
                                                                             G1FullGCCompactionPoint* cp) :
     _g1h(G1CollectedHeap::heap()),
+    _collector(collector),
     _bitmap(bitmap),
     _cp(cp),
-    _humongous_regions_removed(0) { }
+    _humongous_regions_removed(0),
+    _pinned_old_regions_removed(0) { }
 
 void G1FullGCPrepareTask::G1CalculatePointersClosure::free_humongous_region(HeapRegion* hr) {
-  FreeRegionList dummy_free_list("Dummy Free List for G1MarkSweep");
+  assert(hr->is_humongous(), "handled elsewhere");
+
+  FreeRegionList dummy_free_list("Humongous Dummy Free List for G1MarkSweep");
 
   hr->set_containing_set(NULL);
   _humongous_regions_removed++;
 
   _g1h->free_humongous_region(hr, &dummy_free_list);
+  prepare_for_compaction(hr);
+  dummy_free_list.remove_all();
+}
+
+void G1FullGCPrepareTask::G1CalculatePointersClosure::free_pinned_region(HeapRegion* hr) {
+  assert(hr->is_pinned(), "must be");
+  assert(!hr->is_humongous(), "handled elsewhere");
+
+  FreeRegionList dummy_free_list("Pinned Dummy Free List for G1MarkSweep");
+
+  hr->set_containing_set(NULL);
+  _pinned_old_regions_removed++;
+
+  _g1h->free_region(hr, &dummy_free_list);
   prepare_for_compaction(hr);
   dummy_free_list.remove_all();
 }
@@ -196,12 +224,17 @@ void G1FullGCPrepareTask::prepare_serial_compaction() {
 void G1FullGCPrepareTask::G1CalculatePointersClosure::update_sets() {
   // We'll recalculate total used bytes and recreate the free list
   // at the end of the GC, so no point in updating those values here.
-  _g1h->remove_from_old_sets(0, _humongous_regions_removed);
+  _g1h->remove_from_old_sets(_pinned_old_regions_removed, _humongous_regions_removed);
 }
 
 bool G1FullGCPrepareTask::G1CalculatePointersClosure::freed_regions() {
   if (_humongous_regions_removed > 0) {
     // Free regions from dead humongous regions.
+    return true;
+  }
+
+  if (_pinned_old_regions_removed > 0) {
+    // Free regions from dead pinned (non-humongous) regions.
     return true;
   }
 

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -34,6 +34,7 @@
 #include "gc/shared/referenceProcessor.hpp"
 
 class G1CMBitMap;
+class G1FullCollector;
 
 class G1FullGCPrepareTask : public G1FullGCTask {
 protected:
@@ -52,17 +53,21 @@ protected:
   class G1CalculatePointersClosure : public HeapRegionClosure {
   protected:
     G1CollectedHeap* _g1h;
+    G1FullCollector* _collector;
     G1CMBitMap* _bitmap;
     G1FullGCCompactionPoint* _cp;
     uint _humongous_regions_removed;
+    uint _pinned_old_regions_removed;
 
     virtual void prepare_for_compaction(HeapRegion* hr);
     void prepare_for_compaction_work(G1FullGCCompactionPoint* cp, HeapRegion* hr);
     void free_humongous_region(HeapRegion* hr);
+    void free_pinned_region(HeapRegion* hr);
     void reset_region_metadata(HeapRegion* hr);
 
   public:
-    G1CalculatePointersClosure(G1CMBitMap* bitmap,
+    G1CalculatePointersClosure(G1FullCollector* collector,
+                               G1CMBitMap* bitmap,
                                G1FullGCCompactionPoint* cp);
 
     void update_sets();

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -123,7 +123,7 @@ public:
   bool is_empty() const { return used() == 0; }
 
 private:
-  void reset_after_compaction() { set_top(compaction_top()); }
+  void reset_after_compaction();
 
   void clear(bool mangle_space);
 
@@ -165,16 +165,12 @@ public:
 
   HeapWord* initialize_threshold();
   HeapWord* cross_threshold(HeapWord* start, HeapWord* end);
-  // Update heap region to be consistent after Full GC compaction.
-  void reset_humongous_during_compaction() {
-    assert(is_humongous(),
-           "should only be called for humongous regions");
 
-    zero_marked_bytes();
-    init_top_at_mark_start();
-  }
-  // Update heap region to be consistent after Full GC compaction.
-  void complete_compaction();
+  // Update heap region to be consistent after Full GC compaction for non-pinned
+  // regions.
+  void non_pinned_complete_compaction();
+  void pinned_complete_compaction();
+  void complete_compaction_common();
 
   // All allocated blocks are occupied by objects in a HeapRegion
   bool block_is_obj(const HeapWord* p) const;

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -181,17 +181,43 @@ inline size_t HeapRegion::block_size(const HeapWord *addr) const {
   return block_size_using_bitmap(addr, G1CollectedHeap::heap()->concurrent_mark()->prev_mark_bitmap());
 }
 
-inline void HeapRegion::complete_compaction() {
-  // Reset space and bot after compaction is complete if needed.
+inline void HeapRegion::reset_after_compaction() {
+  set_top(compaction_top());
+  _compaction_top = bottom();
+}
+
+inline void HeapRegion::non_pinned_complete_compaction() {
+  assert(!is_pinned(), "must be");
+
   reset_after_compaction();
+  // After a compaction the mark bitmap in a non-pinned regions is invalid.
+  // We treat all objects as being above PTAMS.
+  zero_marked_bytes();
+  init_top_at_mark_start();
+
+  complete_compaction_common();
+}
+
+inline void HeapRegion::pinned_complete_compaction() {
+  assert(!is_free(), "should not have compacted free region");
+  assert(is_pinned(), "must be");
+
+  assert(compaction_top() == bottom(),
+         "region %u compaction_top " PTR_FORMAT " must not be different from bottom " PTR_FORMAT,
+         hrm_index(), p2i(compaction_top()), p2i(bottom()));
+
+  _prev_top_at_mark_start = top(); // Keep existing top and usage.
+  _prev_marked_bytes = used();
+  _next_top_at_mark_start = bottom();
+  _next_marked_bytes = 0;
+
+  complete_compaction_common();
+}
+
+inline void HeapRegion::complete_compaction_common() {
   if (is_empty()) {
     reset_bot();
   }
-
-  // After a compaction the mark bitmap is invalid, so we must
-  // treat all objects as being inside the unmarked area.
-  zero_marked_bytes();
-  init_top_at_mark_start();
 
   // Clear unused heap memory in debug builds.
   if (ZapUnusedHeapArea) {

--- a/src/hotspot/share/memory/padded.hpp
+++ b/src/hotspot/share/memory/padded.hpp
@@ -116,6 +116,7 @@ template <class T, MEMFLAGS flags, size_t alignment = DEFAULT_CACHE_LINE_SIZE>
 class PaddedPrimitiveArray {
  public:
   static T* create_unfreeable(size_t length);
+  static T* create(size_t length, void** alloc_base);
 };
 
 #endif // SHARE_MEMORY_PADDED_HPP

--- a/src/hotspot/share/memory/padded.inline.hpp
+++ b/src/hotspot/share/memory/padded.inline.hpp
@@ -82,11 +82,18 @@ T** Padded2DArray<T, flags, alignment>::create_unfreeable(uint rows, uint column
 
 template <class T, MEMFLAGS flags, size_t alignment>
 T* PaddedPrimitiveArray<T, flags, alignment>::create_unfreeable(size_t length) {
+  void* temp;
+  return create(length, &temp);
+}
+
+template <class T, MEMFLAGS flags, size_t alignment>
+T* PaddedPrimitiveArray<T, flags, alignment>::create(size_t length, void** alloc_base) {
   // Allocate a chunk of memory large enough to allow for some alignment.
   void* chunk = AllocateHeap(length * sizeof(T) + alignment, flags);
 
   memset(chunk, 0, length * sizeof(T) + alignment);
 
+  *alloc_base = chunk;
   return (T*)align_up(chunk, alignment);
 }
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that improves support for pinned regions in g1 full gc?

Currently after full gc all regions' TAMS is set to bottom, implicitly making all data in the region live, including pinned regions.

This worked fine, particular for archive regions as long as we could actually assume that all objects in such pinned regions is live. With JDK-8244778 this has changed, causing the crashes reported in JDK-8253081.

This change makes pinned regions during full gc work as intended, i.e. TAMS is set beyond the last live object and the live (prev) bitmap for these regions updated properly. This change is a pre-requisite for fixing JDK-8253081 and in general a pre-requisite for general region pinning support.

Testing: tier1-8; testing with general region pinning support prototype, and preliminary fix for JDK-8253081.

(This change does not include changes for general region pinning support)

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8253600](https://bugs.openjdk.java.net/browse/JDK-8253600): G1: Fully support pinned regions for full gc


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/699/head:pull/699`
`$ git checkout pull/699`
