### PR TITLE
8196090: javax/swing/JComboBox/6559152/bug6559152.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -750,7 +750,6 @@ javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all
 javax/swing/JFileChooser/8041694/bug8041694.java 8196302 windows-all,macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
 javax/swing/Action/8133039/bug8133039.java 8196089 windows-all,macosx-all
-javax/swing/JComboBox/6559152/bug6559152.java 8196090 windows-all,macosx-all
 javax/swing/JComboBox/8032878/bug8032878.java 8196092,8196439 windows-all,macosx-all,linux-all
 javax/swing/JComboBox/8072767/bug8072767.java 8196093 windows-all,macosx-all
 javax/swing/JFileChooser/4524490/bug4524490.java 8042380 generic-all

--- a/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
+++ b/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
@@ -41,9 +41,11 @@ import java.awt.event.KeyEvent;
 public class bug6559152 {
     private JFrame frame;
     private JComboBox cb;
-    private ExtendedRobot robot;
+    private static Robot robot;
 
     public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(100);
         final bug6559152 test = new bug6559152();
         try {
             SwingUtilities.invokeAndWait(new Runnable() {
@@ -51,6 +53,8 @@ public class bug6559152 {
                     test.setupUI();
                 }
             });
+            robot.waitForIdle();
+            robot.delay(1000);
             test.test();
         } finally {
             if (test.frame != null) {
@@ -77,19 +81,20 @@ public class bug6559152 {
     }
 
     private void test() throws Exception {
-        robot = new ExtendedRobot();
-        robot.waitForIdle();
         testImpl();
         robot.waitForIdle();
         checkResult();
     }
 
     private void testImpl() throws Exception {
-        robot.type(KeyEvent.VK_DOWN);
+        robot.keyPress(KeyEvent.VK_DOWN);
+        robot.keyRelease(KeyEvent.VK_DOWN);
         robot.waitForIdle();
-        robot.type(KeyEvent.VK_DOWN);
+        robot.keyPress(KeyEvent.VK_DOWN);
+        robot.keyRelease(KeyEvent.VK_DOWN);
         robot.waitForIdle();
-        robot.type(KeyEvent.VK_ENTER);
+        robot.keyPress(KeyEvent.VK_ENTER);
+        robot.keyRelease(KeyEvent.VK_ENTER);
     }
 
     private void checkResult() {


### PR DESCRIPTION
Please review a test fix for a test issue seen where correct item of combobox is not selected.
The issue seems to stem from the fact the key events was processed without waiting for the frame to show up and also delay between key events was less as it used ExtendedRobot which by default sets delay between events to 20ms so key event was not processed correctly in mach5 system.
Added robot delay to allow frame to show up and also replaced ExtendedRobot to awt Robot and sets delay to 100ms to be consistent as it is used for other tests.
Mach5 job was run for several iteration on all 3 platforms. Link in JBS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8196090](https://bugs.openjdk.java.net/browse/JDK-8196090): javax/swing/JComboBox/6559152/bug6559152.java fails


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/700/head:pull/700`
`$ git checkout pull/700`
