### PR TITLE
8254874: ZGC: JNIHandleBlock verification failure in stack watermark processing

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/cm03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/cm03t001.cpp
@@ -339,6 +339,10 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
+    /* klass is used by other threads - convert to global handle */
+    if (!NSK_JNI_VERIFY(jni, (klass = (jclass)jni->NewGlobalRef(klass)) != NULL))
+        return NSK_FALSE;
+
     /* get tested thread method 'delay' */
     if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "delay", "()V")) != NULL))
         return NSK_FALSE;
@@ -811,6 +815,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         nsk_jvmti_setFailStatus();
 
     NSK_TRACE(jni->DeleteGlobalRef(thread));
+    NSK_TRACE(jni->DeleteGlobalRef(klass));
 
     /* resume debugee and wait for sync */
     if (!nsk_jvmti_resumeSync())


### PR DESCRIPTION
The cm03t001 test creates a local JNI handle in the prepare function. It later uses that handle from a callback function, from another thread. When the callback runs, ZGC applies a load barrier to that handle and self-heals it in the other threads stack. Later when that thread verifies its stack, during the start of its stack processing, it finds that the oop is unexpectedly not "bad".

It's invalid to send a local JNI handle over to another thread:
https://docs.oracle.com/en/java/javase/15/docs/specs/jni/design.html#global-and-local-references

So, my proposed fix is to convert the local handle to a global handle.

I've tested this with the reproducer in the bug report.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254874](https://bugs.openjdk.java.net/browse/JDK-8254874): ZGC: JNIHandleBlock verification failure in stack watermark processing


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/701/head:pull/701`
`$ git checkout pull/701`
