### PR TITLE
8254912: ZGC: Change ZCollectionInterval type to double

### DIFF
--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -48,7 +48,7 @@ void ZDirector::sample_allocation_rate() const {
 }
 
 bool ZDirector::rule_timer() const {
-  if (ZCollectionInterval == 0) {
+  if (ZCollectionInterval <= 0) {
     // Rule disabled
     return false;
   }
@@ -57,7 +57,7 @@ bool ZDirector::rule_timer() const {
   const double time_since_last_gc = ZStatCycle::time_since_last();
   const double time_until_gc = ZCollectionInterval - time_since_last_gc;
 
-  log_debug(gc, director)("Rule: Timer, Interval: %us, TimeUntilGC: %.3fs",
+  log_debug(gc, director)("Rule: Timer, Interval: %.3fs, TimeUntilGC: %.3fs",
                           ZCollectionInterval, time_until_gc);
 
   return time_until_gc <= 0;

--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -42,7 +42,7 @@
           "Maximum number of bytes allocated for mark stacks")              \
           range(32*M, 1024*G)                                               \
                                                                             \
-  product(uint, ZCollectionInterval, 0,                                     \
+  product(double, ZCollectionInterval, 0,                                   \
           "Force GC at a fixed time interval (in seconds)")                 \
                                                                             \
   product(bool, ZProactive, true,                                           \


### PR DESCRIPTION
ZCollectionInterval is used to trigger GCs within certain time intervals. The flag specifies how many seconds to wait, and the type is uint. That means that the user can only specify the interval as discrete seconds. This is probably fine in most cases, but during stress testing it's often beneficial to be able to set a lower value. I propose that we change the type to double, so that one can use, say, -XX:ZCollectionInterval=0.5 to trigger GC every half second.

Note 1: that there's an effective lower-bound determined by how often the code checks if it's time to start a GC. That timer is today set to 100ms.

Note 2: The change is backwards-compatible, so specifying the flag as an integer still works: -XX:ZCollectionInterval=5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254912](https://bugs.openjdk.java.net/browse/JDK-8254912): ZGC: Change ZCollectionInterval type to double


### Reviewers
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/702/head:pull/702`
`$ git checkout pull/702`
