### PR TITLE
8254913: Increase InlineSmallCode default from 2000 to 2500 for x64

### DIFF
--- a/src/hotspot/share/compiler/tieredThresholdPolicy.cpp
+++ b/src/hotspot/share/compiler/tieredThresholdPolicy.cpp
@@ -294,7 +294,7 @@ void TieredThresholdPolicy::initialize() {
   // Some inlining tuning
 #ifdef X86
   if (FLAG_IS_DEFAULT(InlineSmallCode)) {
-    FLAG_SET_DEFAULT(InlineSmallCode, 2000);
+    FLAG_SET_DEFAULT(InlineSmallCode, 2500);
   }
 #endif
 


### PR DESCRIPTION
We have seen some specific benefits to increasing InlineSmallCode to 2500 from 2000, and across the whole promo build perf test collection the change is neutral to slightly positive, where the tests are run on modern OCI systems.

Passed tier1 testing, some ad-hoc perf testing and more compiler related parts of the weekly promo performance set.

JBS: https://bugs.openjdk.java.net/browse/JDK-8254913
Thanks,
Eric

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254913](https://bugs.openjdk.java.net/browse/JDK-8254913): Increase InlineSmallCode default from 2000 to 2500 for x64


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Azeem Jiva](https://openjdk.java.net/census#azeemj) (@AzeemJiva - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/705/head:pull/705`
`$ git checkout pull/705`
