### PR TITLE
JDK-8254843: Exception launching app on windows in some cases

### DIFF
--- a/src/jdk.incubator.jpackage/windows/native/applauncher/WinLauncher.cpp
+++ b/src/jdk.incubator.jpackage/windows/native/applauncher/WinLauncher.cpp
@@ -105,21 +105,11 @@ class DllWrapper {
 public:
     DllWrapper(const tstring& dllName) {
         try {
-            // Try load DLL.
-            dll = std::unique_ptr<Dll>(new Dll(dllName));
-            LOG_TRACE(tstrings::any() << "Load [" << dllName << "]: OK");
-        }
-        catch (const std::exception&) {
-            // JVM DLL load failed, though it exists in file system.
-            try {
-                // Try adjust the DLL search paths with AddDllDirectory() WINAPI CALL
-                dll = loadDllWithAddDllDirectory(dllName);
-            }
-            catch (const std::exception&) {
-                // AddDllDirectory() didn't work. Try altering PATH environment
-                // variable as the last resort.
-                dll = loadDllWithAlteredPATH(dllName);
-            }
+            // Adjust the DLL search paths with AddDllDirectory() WINAPI CALL
+            dll = loadDllWithAddDllDirectory(dllName);
+        } catch (const std::exception&) {
+            // Alter PATH environment variable as the last resort.
+            dll = loadDllWithAlteredPATH(dllName);
         }
     }
 


### PR DESCRIPTION
JDK-8254843: Exception launching app on windows in some cases
loading splashscreen.dll in WinLaunchercpp would load java.dll from path instead of runtime/bin causing jni launcher to crash.
instead we just use what used to be the fallback, using loadDllWithAddDllDirectory().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (1/9 failed) |

**Failed test task**
- [macOS x64 (hs/tier1 common)](https://github.com/andyherrick/jdk/runs/1265849327)

### Issue
 * [JDK-8254843](https://bugs.openjdk.java.net/browse/JDK-8254843): Exception launching app on windows in some cases


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/706/head:pull/706`
`$ git checkout pull/706`
