### PR TITLE
8254940: AArch64: Cleanup non-product thread members

### DIFF
--- a/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.hpp
@@ -27,15 +27,6 @@
 #define OS_CPU_LINUX_AARCH64_THREAD_LINUX_AARCH64_HPP
 
  private:
-#ifdef ASSERT
-  // spill stack holds N callee-save registers at each Java call and
-  // grows downwards towards limit
-  // we need limit to check we have space for a spill and base so we
-  // can identify all live spill frames at GC (eventually)
-  address          _spill_stack;
-  address          _spill_stack_base;
-  address          _spill_stack_limit;
-#endif // ASSERT
 
   void pd_initialize() {
     _anchor.clear();

--- a/src/hotspot/os_cpu/windows_aarch64/thread_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/thread_windows_aarch64.hpp
@@ -27,16 +27,6 @@
 
  private:
 
-#ifdef ASSERT
-  // spill stack holds N callee-save registers at each Java call and
-  // grows downwards towards limit
-  // we need limit to check we have space for a spill and base so we
-  // can identify all live spill frames at GC (eventually)
-  address          _spill_stack;
-  address          _spill_stack_base;
-  address          _spill_stack_limit;
-#endif // ASSERT
-
   void pd_initialize() {
     _anchor.clear();
   }


### PR DESCRIPTION
Please review a very small clean up that deletes unused thread members in linux/aarch64 and windows/aarch64

Testing: grep, linux/aarch64 fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254940](https://bugs.openjdk.java.net/browse/JDK-8254940): AArch64: Cleanup non-product thread members


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/708/head:pull/708`
`$ git checkout pull/708`
