### PR TITLE
8254862: lldb in devkit doesn't work

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -960,7 +960,7 @@ var getJibProfilesDependencies = function (input, common) {
 
     var devkit_platform_revisions = {
         linux_x64: "gcc10.2.0-OL6.4+1.0",
-        macosx_x64: "Xcode11.3.1-MacOSX10.15+1.0",
+        macosx_x64: "Xcode11.3.1-MacOSX10.15+1.1",
         windows_x64: "VS2019-16.7.2+1.0",
         linux_aarch64: "gcc10.2.0-OL7.6+1.0",
         linux_arm: "gcc8.2.0-Fedora27+1.0",

--- a/make/devkit/createMacosxDevkit.sh
+++ b/make/devkit/createMacosxDevkit.sh
@@ -91,7 +91,6 @@ EXCLUDE_DIRS=" \
     Platforms/AppleTVSimulator.platform \
     Platforms/iPhoneSimulator.platform \
     Platforms/WatchSimulator.platform \
-    Contents/SharedFrameworks/LLDB.framework \
     Contents/SharedFrameworks/ModelIO.framework \
     Contents/SharedFrameworks/XCSUI.framework \
     Contents/SharedFrameworks/SceneKit.framework \


### PR DESCRIPTION
This patch adds the lldb framework to the macosx devkit to make it possible to run the lldb debugger.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254862](https://bugs.openjdk.java.net/browse/JDK-8254862): lldb in devkit doesn't work


### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/711/head:pull/711`
`$ git checkout pull/711`
