### PR TITLE
8243962: Various JVM TI tests time out using JFR on Windows

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t001/TestDescription.java
@@ -58,7 +58,7 @@
  *          /test/lib
  * @build nsk.jvmti.scenarios.sampling.SP03.sp03t001
  * @comment see JDK-8243962 for background on requires expression
- * @requires !vm.flightRecorder | !(vm.debug & os.family == "windows")
+ * @requires !(vm.flightRecorder & vm.debug & os.family == "windows")
  * @run main/othervm/native
  *      -agentlib:sp03t001=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP03.sp03t001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t001/TestDescription.java
@@ -57,6 +57,8 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jvmti.scenarios.sampling.SP03.sp03t001
+ * @comment see JDK-8243962 for background on requires expression
+ * @requires !vm.flightRecorder | !(vm.debug & os.family == "windows")
  * @run main/othervm/native
  *      -agentlib:sp03t001=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP03.sp03t001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t002/TestDescription.java
@@ -57,6 +57,8 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jvmti.scenarios.sampling.SP03.sp03t002
+ * @comment see JDK-8243962 for background on requires expression
+ * @requires !vm.flightRecorder | !(vm.debug & os.family == "windows")
  * @run main/othervm/native
  *      -agentlib:sp03t002=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP03.sp03t002

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t002/TestDescription.java
@@ -58,7 +58,7 @@
  *          /test/lib
  * @build nsk.jvmti.scenarios.sampling.SP03.sp03t002
  * @comment see JDK-8243962 for background on requires expression
- * @requires !vm.flightRecorder | !(vm.debug & os.family == "windows")
+ * @requires !(vm.flightRecorder & vm.debug & os.family == "windows")
  * @run main/othervm/native
  *      -agentlib:sp03t002=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP03.sp03t002

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t001/TestDescription.java
@@ -57,7 +57,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @comment see JDK-8243962 for background on requires expression
- * @requires !vm.flightRecorder | !(vm.debug & os.family == "windows")
+ * @requires !(vm.flightRecorder & vm.debug & os.family == "windows")
  * @run main/othervm/native
  *      -agentlib:sp04t001=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP04.sp04t001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t001/TestDescription.java
@@ -56,6 +56,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @comment see JDK-8243962 for background on requires expression
+ * @requires !vm.flightRecorder | !(vm.debug & os.family == "windows")
  * @run main/othervm/native
  *      -agentlib:sp04t001=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP04.sp04t001

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t002/TestDescription.java
@@ -56,6 +56,8 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @comment see JDK-8243962 for background on requires expression
+ * @requires !vm.flightRecorder | !(vm.debug & os.family == "windows")
  * @run main/othervm/native
  *      -agentlib:sp04t002=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP04.sp04t002

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t002/TestDescription.java
@@ -57,7 +57,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @comment see JDK-8243962 for background on requires expression
- * @requires !vm.flightRecorder | !(vm.debug & os.family == "windows")
+ * @requires !(vm.flightRecorder & vm.debug & os.family == "windows")
  * @run main/othervm/native
  *      -agentlib:sp04t002=-waittime=5,threads=10
  *      nsk.jvmti.scenarios.sampling.SP04.sp04t002


### PR DESCRIPTION
Greetings,

JDK-8243962 has been a large effort to chase down intermittent timeouts for certain JVMTI tests when run on Windows debug builds in combination with JFR. The background is long, included in JDK-8243962.

In short, the combination of some JVMTI thread suspension tests when run together with JFR on saturated Windows 2016 debug builds can intermittently time out.

There have been two major changes made to JFR derived from JDK-8243962 (linked therein) in an attempt to reduce the poor scalability observed.

Unfortunately, the efforts have not fully resolved the situation entirely as there have still been intermittent sightings for the following tests:

vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t002/TestDescription.java
vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t001/TestDescription.java
vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t001/TestDescription.java
vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t002/TestDescription.java 

This change will add a requires expression to these tests to exclude the combination of running them with JFR on Windows debug builds.

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8243962](https://bugs.openjdk.java.net/browse/JDK-8243962): Various JVM TI tests time out using JFR on Windows


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/712/head:pull/712`
`$ git checkout pull/712`
