### PR TITLE
8251271: C2: Compile::_for_igvn list is corrupted after RenumberLiveNodes

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2108,11 +2108,6 @@ void Compile::Optimize() {
     set_for_igvn(&new_worklist);
     igvn = PhaseIterGVN(initial_gvn());
     igvn.optimize();
-
-    // Restore the original for_igvn pointer for subsequent uses.
-    // Clear the for_igvn list because it may have irrelevant nodes
-    // from the previous PhaseRenumberLive run.
-    save_for_igvn->clear();
     set_for_igvn(save_for_igvn);
   }
 

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2104,9 +2104,16 @@ void Compile::Optimize() {
       ResourceMark rm;
       PhaseRenumberLive prl = PhaseRenumberLive(initial_gvn(), for_igvn(), &new_worklist);
     }
+    Unique_Node_List* save_for_igvn = for_igvn();
     set_for_igvn(&new_worklist);
     igvn = PhaseIterGVN(initial_gvn());
     igvn.optimize();
+
+    // Restore the original for_igvn pointer for subsequent uses.
+    // Clear the for_igvn list because it may have irrelevant nodes
+    // from the previous PhaseRenumberLive run.
+    save_for_igvn->clear();
+    set_for_igvn(save_for_igvn);
   }
 
   // Perform escape analysis

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -439,6 +439,7 @@ PhaseRemoveUseless::PhaseRemoveUseless(PhaseGVN* gvn, Unique_Node_List* worklist
 // The PhaseRenumberLive phase updates two data structures with the new node IDs.
 // (1) The worklist is used by the PhaseIterGVN phase to identify nodes that must be
 // processed. A new worklist (with the updated node IDs) is returned in 'new_worklist'.
+// 'worklist' is cleared upon returning.
 // (2) Type information (the field PhaseGVN::_types) maps type information to each
 // node ID. The mapping is updated to use the new node IDs as well. Updated type
 // information is returned in PhaseGVN::_types.
@@ -510,6 +511,9 @@ PhaseRenumberLive::PhaseRenumberLive(PhaseGVN* gvn,
 
   // Set the dead node count to 0 and reset dead node list.
   C->reset_dead_node_list();
+
+  // Clear the original worklist
+  worklist->clear();
 }
 
 int PhaseRenumberLive::new_index(int old_idx) {


### PR DESCRIPTION
I'm following up on this thread http://mail.openjdk.java.net/pipermail/hotspot-compiler-dev/2020-September/039910.html
I'm clearing `for_igvn` before restoring as suggested by Xin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8251271](https://bugs.openjdk.java.net/browse/JDK-8251271): C2: Compile::_for_igvn list is corrupted after RenumberLiveNodes


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/713/head:pull/713`
`$ git checkout pull/713`
