### PR TITLE
8254085: javax/swing/text/Caret/TestCaretPositionJTextPane.java failed with "RuntimeException:  Wrong caret position"

### DIFF
--- a/test/jdk/javax/swing/text/Caret/TestCaretPositionJTextPane.java
+++ b/test/jdk/javax/swing/text/Caret/TestCaretPositionJTextPane.java
@@ -114,7 +114,7 @@ public class TestCaretPositionJTextPane {
 
         for (int i = 0; i < 30; i++) {
             StringBuilder row = new StringBuilder();
-            for (int j = 0; j < 50; j++) {
+            for (int j = 0; j < 30; j++) {
                 row.append(j);
                 if (j % 5 == 0) {
                     row.append(" ");

--- a/test/jdk/javax/swing/text/Caret/TestCaretPositionJTextPane.java
+++ b/test/jdk/javax/swing/text/Caret/TestCaretPositionJTextPane.java
@@ -98,7 +98,7 @@ public class TestCaretPositionJTextPane {
 
             robot.waitForIdle();
             Point p = textPane.getLocationOnScreen();
-            robot.mouseMove(p.x+ 480, p.y+6);
+            robot.mouseMove(p.x+ 380, p.y+6);
             robot.waitForIdle();
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
@@ -114,7 +114,7 @@ public class TestCaretPositionJTextPane {
 
         for (int i = 0; i < 30; i++) {
             StringBuilder row = new StringBuilder();
-            for (int j = 0; j < 30; j++) {
+            for (int j = 0; j < 50; j++) {
                 row.append(j);
                 if (j % 5 == 0) {
                     row.append(" ");


### PR DESCRIPTION
Please review fix for the test issue. This test fails on machines with low display resolution.
Limiting of the length of the line to 30 characters prevents it from wrapping the line 
for a second time which fixes the problem. I tested solution on different modes from 1024x768 to 3840x2160.

/cc swing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254085](https://bugs.openjdk.java.net/browse/JDK-8254085): javax/swing/text/Caret/TestCaretPositionJTextPane.java failed with "RuntimeException:  Wrong caret position"


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/716/head:pull/716`
`$ git checkout pull/716`
