### PR TITLE
8254557: Compiler crashes with java.lang.AssertionError: isSubtype UNKNOWN

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2108,6 +2108,26 @@ public class Attr extends JCTree.Visitor {
                     }
                     super.scan(tree);
                 }
+
+                @Override
+                public void visitClassDef(JCClassDecl that) {
+                    if (that.sym != null) {
+                        // Method preFlow can't visit class definitions
+                        // that have not been entered and attributed.
+                        // See JDK-8254557 and JDK-8203277 for more details.
+                        super.visitClassDef(that);
+                    }
+                }
+
+                @Override
+                public void visitLambda(JCLambda that) {
+                    if (that.type != null) {
+                        // Method preFlow can't visit lambda expressions
+                        // that have not been entered and attributed.
+                        // See JDK-8254557 and JDK-8203277 for more details.
+                        super.visitLambda(that);
+                    }
+                }
             }.scan(tree);
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2112,7 +2112,7 @@ public class Attr extends JCTree.Visitor {
                 @Override
                 public void visitClassDef(JCClassDecl that) {
                     if (that.sym != null) {
-                        // Method preFlow can't visit class definitions
+                        // Method preFlow shouldn't visit class definitions
                         // that have not been entered and attributed.
                         // See JDK-8254557 and JDK-8203277 for more details.
                         super.visitClassDef(that);
@@ -2122,7 +2122,7 @@ public class Attr extends JCTree.Visitor {
                 @Override
                 public void visitLambda(JCLambda that) {
                     if (that.type != null) {
-                        // Method preFlow can't visit lambda expressions
+                        // Method preFlow shouldn't visit lambda expressions
                         // that have not been entered and attributed.
                         // See JDK-8254557 and JDK-8203277 for more details.
                         super.visitLambda(that);

--- a/test/langtools/tools/javac/T8254557/T8254557.java
+++ b/test/langtools/tools/javac/T8254557/T8254557.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8254557
- * @summary Method Attr.preFlow can't visit class definitions that have not yet been entered and attributed.
+ * @summary Method Attr.preFlow shouldn't visit class definitions that have not yet been entered and attributed.
  * @compile T8254557.java
  */
 

--- a/test/langtools/tools/javac/T8254557/T8254557.java
+++ b/test/langtools/tools/javac/T8254557/T8254557.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8254557
+ * @summary Method Attr.preFlow can't visit class definitions that have not yet been entered and attributed.
+ * @compile T8254557.java
+ */
+
+import java.util.Iterator;
+import java.util.function.Function;
+
+public class T8254557 {
+    // test anonymous class in if statement
+    public <T> void testIf(boolean b) {
+        test(rs -> {
+            if (b) {
+                return new Iterator<>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+
+                    @Override
+                    public T next() {
+                        return null;
+                    }
+                };
+            } else {
+                return new Iterator<>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+
+                    @Override
+                    public T next() {
+                        return null;
+                    }
+                };
+            }
+        });
+    }
+
+    // test anonymous class in while statement
+    public <T> void testWhile(boolean b) {
+        test(rs -> {
+            while (b) {
+                return new Iterator<>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+
+                    @Override
+                    public T next() {
+                        return null;
+                    }
+                };
+            }
+            return null;
+        });
+    }
+
+    // test anonymous class in do while statement
+    public <T> void testDoWhileLoop(boolean b) {
+        test(rs -> {
+            do {
+                return new Iterator<>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+
+                    @Override
+                    public T next() {
+                        return null;
+                    }
+                };
+            } while (b);
+        });
+    }
+
+    // test anonymous class in for statement
+    public <T> void testForLoop(boolean b) {
+        test(rs -> {
+            for ( ; ; ) {
+                return new Iterator<>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+
+                    @Override
+                    public T next() {
+                        return null;
+                    }
+                };
+            }
+        });
+    }
+
+    private void test(Function function) { }
+}


### PR DESCRIPTION
Hi all,

[JDK-8254557](https://bugs.openjdk.java.net/browse/JDK-8254557) is similar to [JDK-8203277](https://bugs.openjdk.java.net/browse/JDK-8203277). The method `Attr.preFlow` shouldn't visit 
class definitions and lambda expressions that have not yet been entered and attributed.

The  [JDK-8181287](https://bugs.openjdk.java.net/browse/JDK-8231826) submitted some code that uses `Attr.preFlow`  which 
causes this bug.
Thank you for taking the time to review.

Best Regards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254557](https://bugs.openjdk.java.net/browse/JDK-8254557): Compiler crashes with java.lang.AssertionError: isSubtype UNKNOWN


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/718/head:pull/718`
`$ git checkout pull/718`
