### PR TITLE
8198400: Test javax/swing/SwingUtilities/6797139/bug6797139.java fails in mach5

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -781,7 +781,6 @@ javax/swing/plaf/basic/BasicComboBoxEditor/Test8015336.java 8198394 generic-all
 javax/swing/plaf/metal/MetalLookAndFeel/Test8039750.java 8198395 generic-all
 javax/swing/text/DevanagariEditor.java 8198397 generic-all
 javax/swing/SpringLayout/4726194/bug4726194.java 8198399 generic-all
-javax/swing/SwingUtilities/6797139/bug6797139.java 8198400 generic-all
 javax/swing/text/html/parser/Parser/6836089/bug6836089.java 8198401 generic-all
 javax/swing/JTable/8133919/DrawGridLinesTest.java 8198407 generic-all
 javax/swing/text/html/StyleSheet/BackgroundImage/BackgroundImagePosition.java 8198409 generic-all

--- a/test/jdk/javax/swing/SwingUtilities/6797139/bug6797139.java
+++ b/test/jdk/javax/swing/SwingUtilities/6797139/bug6797139.java
@@ -22,9 +22,8 @@
  */
 
 /* @test
- *
+ * @key headful
  * @bug 6797139
- * @author Alexander Potochkin
  * @summary tests that JButton's text is not incorrectly truncated
  */
 import javax.swing.*;

--- a/test/jdk/javax/swing/SwingUtilities/6797139/bug6797139.java
+++ b/test/jdk/javax/swing/SwingUtilities/6797139/bug6797139.java
@@ -22,7 +22,6 @@
  */
 
 /* @test
- * @key headful
  * @bug 6797139
  * @summary tests that JButton's text is not incorrectly truncated
  */


### PR DESCRIPTION
Please review a test fix for an issue seen failing in mach5 testing although it is not reproducible locally.
The issue seems to stem from the fact that the test was been run as headless test although it requires to create UI class like ComponentUI which is needed for painting, layout calculations etc and therefore it fails citing

_no ComponentUI class for: javax.swing.JButton[,0,0,0x0,invalid,alignmentX=0.0,alignmentY=0.0,border=,flags=0,maximumSize=,minimumSize=,preferredSize=,defaultIcon=,disabledIcon=,disabledSelectedIcon=,margin=null,paintBorder=true,paintFocus=true,pressedIcon=,rolloverEnabled=false,rolloverIcon=,rolloverSelectedIcon=,selectedIcon=,text=Probably,defaultCapable=true]_ 

Modified the test to mark it as headful.
Mach5 job was run for several iteration on all 3 platforms. Link in JBS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8198400](https://bugs.openjdk.java.net/browse/JDK-8198400): Test javax/swing/SwingUtilities/6797139/bug6797139.java fails in mach5


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/719/head:pull/719`
`$ git checkout pull/719`
