### PR TITLE
JDK-8254783: jpackage fails on Windows when application name differs from installer name

### DIFF
--- a/src/jdk.incubator.jpackage/windows/classes/jdk/incubator/jpackage/internal/WinMsiBundler.java
+++ b/src/jdk.incubator.jpackage/windows/classes/jdk/incubator/jpackage/internal/WinMsiBundler.java
@@ -306,15 +306,22 @@ public class WinMsiBundler  extends AbstractBundler {
                 throws PackagerException, IOException {
         Path appImage = StandardBundlerParam.getPredefinedAppImage(params);
         Path appDir;
+        String appName;
 
         // we either have an application image or need to build one
         if (appImage != null) {
             appDir = MSI_IMAGE_DIR.fetchFrom(params).resolve(APP_NAME.fetchFrom(params));
             // copy everything from appImage dir into appDir/name
             IOUtils.copyRecursive(appImage, appDir);
+            try {
+                appName = AppImageFile.load(appDir).getLauncherName();
+            } catch (Exception e) {
+                appName = APP_NAME.fetchFrom(params);
+            }
         } else {
             appDir = appImageBundler.execute(params, MSI_IMAGE_DIR.fetchFrom(
                     params));
+            appName = APP_NAME.fetchFrom(params);
         }
 
         // Configure installer icon
@@ -331,7 +338,7 @@ public class WinMsiBundler  extends AbstractBundler {
             installerIcon = ApplicationLayout.windowsAppImage()
                     .resolveAt(appDir)
                     .launchersDirectory()
-                    .resolve(APP_NAME.fetchFrom(params) + ".exe");
+                    .resolve(appName + ".exe");
         }
         installerIcon = installerIcon.toAbsolutePath();
 


### PR DESCRIPTION
…from installer name
JDK-8254783: jpackage fails on Windows when application name differs from installer name
When using --app-image, to create MSI installer, use the application name from AppImageData instead of the Msi installer name if possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254783](https://bugs.openjdk.java.net/browse/JDK-8254783): jpackage fails on Windows when application name differs from installer name


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/720/head:pull/720`
`$ git checkout pull/720`
