### PR TITLE
8254965: Remove unused Matcher::_ruleName and make ruleName non-product

### DIFF
--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -3702,8 +3702,10 @@ void ArchDesc::buildReduceMaps(FILE *fp_hpp, FILE *fp_cpp) {
   OutputRightOp output_right_op(fp_hpp, fp_cpp, _globalNames, *this);
   build_map(output_right_op);
   // Construct the table of rule names
+  fprintf(fp_cpp, "\n#ifndef PRODUCT\n");
   OutputRuleName output_rule_name(fp_hpp, fp_cpp, _globalNames, *this);
   build_map(output_rule_name);
+  fprintf(fp_cpp, "\n#endif // PRODUCT\n");
   // Construct the boolean table for subsumed operands
   OutputSwallowed output_swallowed(fp_hpp, fp_cpp, _globalNames, *this);
   build_map(output_swallowed);

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -76,7 +76,6 @@ Matcher::Matcher()
   _new2old_map(C->comp_arena()),
 #endif
   _allocation_started(false),
-  _ruleName(ruleName),
   _register_save_policy(register_save_policy),
   _c_reg_save_policy(c_reg_save_policy),
   _register_save_type(register_save_type) {

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -203,8 +203,6 @@ public:
   static const char *regName[];
   // Machine register encodings
   static const unsigned char _regEncode[];
-  // Machine Node names
-  const char **_ruleName;
   // Rules that are cheaper to rematerialize than to spill
   static const uint _begin_rematerialize;
   static const uint _end_rematerialize;


### PR DESCRIPTION
- Matcher::_ruleName is unused - remove
- ruleName, defined via ad, is only used by a non-product routine. #ifdef it accordingly

This reduces the JVM size (-63Kb on linux-x64, or about 0.25%)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254965](https://bugs.openjdk.java.net/browse/JDK-8254965): Remove unused Matcher::_ruleName and make ruleName non-product


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/722/head:pull/722`
`$ git checkout pull/722`
