### PR TITLE
8254966: Remove unused code from Matcher

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2608,11 +2608,6 @@ const bool Matcher::rematerialize_float_constants = false;
 // C code as the Java calling convention forces doubles to be aligned.
 const bool Matcher::misaligned_doubles_ok = true;
 
-// No-op on amd64
-void Matcher::pd_implicit_null_fixup(MachNode *node, uint idx) {
-  Unimplemented();
-}
-
 // Advertise here if the CPU requires explicit rounding operations to implement strictfp mode.
 const bool Matcher::strict_fp_requires_explicit_rounding = false;
 

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -614,7 +614,6 @@ alloc_class chunk3(RFLAGS);
 // Several register classes are automatically defined based upon information in
 // this architecture description.
 // 1) reg_class inline_cache_reg           ( /* as def'd in frame section */ )
-// 2) reg_class compiler_method_reg        ( /* as def'd in frame section */ )
 // 2) reg_class interpreter_method_reg     ( /* as def'd in frame section */ )
 // 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -614,8 +614,7 @@ alloc_class chunk3(RFLAGS);
 // Several register classes are automatically defined based upon information in
 // this architecture description.
 // 1) reg_class inline_cache_reg           ( /* as def'd in frame section */ )
-// 2) reg_class interpreter_method_reg     ( /* as def'd in frame section */ )
-// 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
+// 2) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //
 
 // Class for all 32 bit general purpose registers
@@ -4084,9 +4083,6 @@ frame %{
   // Inline Cache Register or Method for I2C.
   inline_cache_reg(R12);
 
-  // Method Register when calling interpreter.
-  interpreter_method_reg(R12);
-
   // Number of stack slots consumed by locking an object
   sync_stack_slots(2);
 
@@ -5667,16 +5663,6 @@ operand rFlagsRegU()
 operand inline_cache_RegP(iRegP reg)
 %{
   constraint(ALLOC_IN_RC(method_reg)); // inline_cache_reg
-  match(reg);
-  match(iRegPNoSp);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand interpreter_method_RegP(iRegP reg)
-%{
-  constraint(ALLOC_IN_RC(method_reg)); // interpreter_method_reg
   match(reg);
   match(iRegPNoSp);
   op_cost(0);

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -1159,10 +1159,6 @@ const bool Matcher::rematerialize_float_constants = false;
 // Java calling convention forces doubles to be aligned.
 const bool Matcher::misaligned_doubles_ok = false;
 
-// No-op on ARM.
-void Matcher::pd_implicit_null_fixup(MachNode *node, uint idx) {
-}
-
 // Advertise here if the CPU requires explicit rounding operations to implement strictfp mode.
 const bool Matcher::strict_fp_requires_explicit_rounding = false;
 

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -1663,7 +1663,6 @@ frame %{
   // These two registers define part of the calling convention
   // between compiled code and the interpreter.
   inline_cache_reg(R_Ricklass);          // Inline Cache Register or Method* for I2C
-  interpreter_method_reg(R_Rmethod);     // Method Register when calling interpreter
 
   // Optional: name the operand used by cisc-spilling to access [stack_pointer + offset]
   cisc_spilling_operand_name(indOffset);
@@ -2522,14 +2521,6 @@ operand inline_cache_regP(iRegP reg) %{
   format %{ %}
   interface(REG_INTER);
 %}
-
-operand interpreter_method_regP(iRegP reg) %{
-  constraint(ALLOC_IN_RC(Rmethod_regP));
-  match(reg);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
 
 //----------Complex Operands---------------------------------------------------
 // Indirect Memory Reference

--- a/src/hotspot/cpu/arm/arm_32.ad
+++ b/src/hotspot/cpu/arm/arm_32.ad
@@ -182,11 +182,11 @@ alloc_class chunk0(
 alloc_class chunk1(
                    R_S16, R_S17, R_S18, R_S19, R_S20, R_S21, R_S22, R_S23,
                    R_S24, R_S25, R_S26, R_S27, R_S28, R_S29, R_S30, R_S31,
-                   R_S0,  R_S1,  R_S2,  R_S3,  R_S4,  R_S5,  R_S6,  R_S7, 
+                   R_S0,  R_S1,  R_S2,  R_S3,  R_S4,  R_S5,  R_S6,  R_S7,
                    R_S8,  R_S9,  R_S10, R_S11, R_S12, R_S13, R_S14, R_S15,
-                   R_D16, R_D16x,R_D17, R_D17x,R_D18, R_D18x,R_D19, R_D19x, 
-                   R_D20, R_D20x,R_D21, R_D21x,R_D22, R_D22x,R_D23, R_D23x, 
-                   R_D24, R_D24x,R_D25, R_D25x,R_D26, R_D26x,R_D27, R_D27x, 
+                   R_D16, R_D16x,R_D17, R_D17x,R_D18, R_D18x,R_D19, R_D19x,
+                   R_D20, R_D20x,R_D21, R_D21x,R_D22, R_D22x,R_D23, R_D23x,
+                   R_D24, R_D24x,R_D25, R_D25x,R_D26, R_D26x,R_D27, R_D27x,
                    R_D28, R_D28x,R_D29, R_D29x,R_D30, R_D30x,R_D31, R_D31x
 );
 
@@ -196,8 +196,7 @@ alloc_class chunk2(APSR, FPSCR);
 // Several register classes are automatically defined based upon information in
 // this architecture description.
 // 1) reg_class inline_cache_reg           ( as defined in frame section )
-// 2) reg_class interpreter_method_reg     ( as defined in frame section )
-// 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
+// 2) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //
 
 // ----------------------------
@@ -223,7 +222,6 @@ reg_class ptr_reg(R_R0, R_R1, R_R2, R_R3, R_R4, R_R5, R_R6, R_R7, R_R8, R_R9, R_
 reg_class sp_ptr_reg(R_R0, R_R1, R_R2, R_R3, R_R4, R_R5, R_R6, R_R7, R_R8, R_R9, R_R11, R_R12, R_R14, R_R10 /* TLS*/, R_R13 /* SP*/);
 
 #define R_Ricklass R_R8
-#define R_Rmethod  R_R9
 #define R_Rthread  R_R10
 #define R_Rexception_obj R_R4
 
@@ -237,7 +235,6 @@ reg_class R9_regP(R_R9);
 reg_class R12_regP(R_R12);
 reg_class Rexception_regP(R_Rexception_obj);
 reg_class Ricklass_regP(R_Ricklass);
-reg_class Rmethod_regP(R_Rmethod);
 reg_class Rthread_regP(R_Rthread);
 reg_class IP_regP(R_R12);
 reg_class SP_regP(R_R13);
@@ -442,7 +439,7 @@ int MachCallStaticJavaNode::ret_addr_offset() {
 int MachCallDynamicJavaNode::ret_addr_offset() {
   bool far = !cache_reachable();
   // mov_oop is always 2 words
-  return (2 + (far ? 3 : 1)) * NativeInstruction::instruction_size; 
+  return (2 + (far ? 3 : 1)) * NativeInstruction::instruction_size;
 }
 
 int MachCallRuntimeNode::ret_addr_offset() {

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -535,7 +535,6 @@ alloc_class chunk4 (
 // information in this architecture description.
 
 // 1) reg_class inline_cache_reg           ( as defined in frame section )
-// 2) reg_class compiler_method_reg        ( as defined in frame section )
 // 2) reg_class interpreter_method_reg     ( as defined in frame section )
 // 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //
@@ -4760,13 +4759,6 @@ operand regF() %{
 // Method Register
 operand inline_cache_regP(iRegPdst reg) %{
   constraint(ALLOC_IN_RC(r19_bits64_reg)); // inline_cache_reg
-  match(reg);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand compiler_method_regP(iRegPdst reg) %{
-  constraint(ALLOC_IN_RC(rscratch1_bits64_reg)); // compiler_method_reg
   match(reg);
   format %{ %}
   interface(REG_INTER);

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -535,8 +535,7 @@ alloc_class chunk4 (
 // information in this architecture description.
 
 // 1) reg_class inline_cache_reg           ( as defined in frame section )
-// 2) reg_class interpreter_method_reg     ( as defined in frame section )
-// 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
+// 2) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //
 
 // ----------------------------
@@ -3854,9 +3853,6 @@ frame %{
   // Inline Cache Register or method for I2C.
   inline_cache_reg(R19); // R19_method
 
-  // Method Register when calling interpreter.
-  interpreter_method_reg(R19); // R19_method
-
   // Optional: name the operand used by cisc-spilling to access
   // [stack_pointer + offset].
   cisc_spilling_operand_name(indOffset);
@@ -4759,13 +4755,6 @@ operand regF() %{
 // Method Register
 operand inline_cache_regP(iRegPdst reg) %{
   constraint(ALLOC_IN_RC(r19_bits64_reg)); // inline_cache_reg
-  match(reg);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand interpreter_method_regP(iRegPdst reg) %{
-  constraint(ALLOC_IN_RC(r19_bits64_reg)); // interpreter_method_reg
   match(reg);
   format %{ %}
   interface(REG_INTER);

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2344,10 +2344,6 @@ const bool Matcher::rematerialize_float_constants = false;
 // Java calling convention forces doubles to be aligned.
 const bool Matcher::misaligned_doubles_ok = true;
 
-void Matcher::pd_implicit_null_fixup(MachNode *node, uint idx) {
- Unimplemented();
-}
-
 // Advertise here if the CPU requires explicit rounding operations to implement strictfp mode.
 const bool Matcher::strict_fp_requires_explicit_rounding = false;
 

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -278,8 +278,7 @@ alloc_class chunk2(
 // information in this architecture description.
 
 // 1) reg_class inline_cache_reg           (as defined in frame section)
-// 2) reg_class interpreter_method_reg     (as defined in frame section)
-// 3) reg_class stack_slots(/* one chunk of stack-based "registers" */)
+// 2) reg_class stack_slots(/* one chunk of stack-based "registers" */)
 
 // Integer Register Classes
 reg_class z_int_reg(
@@ -2465,9 +2464,6 @@ frame %{
   // Tos is loaded in run_compiled_code to Z_ARG5=Z_R6.
   // interpreter_arg_ptr_reg(Z_R6);
 
-  // Method Register when calling interpreter
-  interpreter_method_reg(Z_R9);//Z_method
-
   // Optional: name the operand used by cisc-spilling to access
   // [stack_pointer + offset].
   cisc_spilling_operand_name(indOffset12);
@@ -3526,13 +3522,6 @@ operand rscratchRegF() %{
 // Method Register
 operand inline_cache_regP(iRegP reg) %{
   constraint(ALLOC_IN_RC(z_r9_regP)); // inline_cache_reg
-  match(reg);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand interpreter_method_regP(iRegP reg) %{
-  constraint(ALLOC_IN_RC(z_r9_regP)); // interpreter_method_reg
   match(reg);
   format %{ %}
   interface(REG_INTER);

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -278,7 +278,6 @@ alloc_class chunk2(
 // information in this architecture description.
 
 // 1) reg_class inline_cache_reg           (as defined in frame section)
-// 2) reg_class compiler_method_reg        (as defined in frame section)
 // 2) reg_class interpreter_method_reg     (as defined in frame section)
 // 3) reg_class stack_slots(/* one chunk of stack-based "registers" */)
 
@@ -2466,9 +2465,6 @@ frame %{
   // Tos is loaded in run_compiled_code to Z_ARG5=Z_R6.
   // interpreter_arg_ptr_reg(Z_R6);
 
-  // Temporary in compiled entry-points
-  // compiler_method_reg(Z_R1);//Z_R1_scratch
-
   // Method Register when calling interpreter
   interpreter_method_reg(Z_R9);//Z_method
 
@@ -3530,13 +3526,6 @@ operand rscratchRegF() %{
 // Method Register
 operand inline_cache_regP(iRegP reg) %{
   constraint(ALLOC_IN_RC(z_r9_regP)); // inline_cache_reg
-  match(reg);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand compiler_method_regP(iRegP reg) %{
-  constraint(ALLOC_IN_RC(z_r1_RegP)); // compiler_method_reg
   match(reg);
   format %{ %}
   interface(REG_INTER);

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -131,8 +131,7 @@ alloc_class chunk0( ECX,   EBX,   EBP,   EDI,   EAX,   EDX,   ESI, ESP,
 // Several register classes are automatically defined based upon information in
 // this architecture description.
 // 1) reg_class inline_cache_reg           ( /* as def'd in frame section */ )
-// 2) reg_class interpreter_method_reg     ( /* as def'd in frame section */ )
-// 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
+// 2) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //
 // Class for no registers (empty set).
 reg_class no_reg();
@@ -3137,7 +3136,6 @@ frame %{
   // These three registers define part of the calling convention
   // between compiled code and the interpreter.
   inline_cache_reg(EAX);                // Inline Cache Register
-  interpreter_method_reg(EBX);          // Method Register when calling interpreter
 
   // Optional: name the operand used by cisc-spilling to access [stack_pointer + offset]
   cisc_spilling_operand_name(indOffset32);

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -131,7 +131,6 @@ alloc_class chunk0( ECX,   EBX,   EBP,   EDI,   EAX,   EDX,   ESI, ESP,
 // Several register classes are automatically defined based upon information in
 // this architecture description.
 // 1) reg_class inline_cache_reg           ( /* as def'd in frame section */ )
-// 2) reg_class compiler_method_reg        ( /* as def'd in frame section */ )
 // 2) reg_class interpreter_method_reg     ( /* as def'd in frame section */ )
 // 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -150,7 +150,6 @@ reg_class_dynamic any_reg(any_reg_no_ebp, any_reg_with_ebp, %{ PreserveFramePoin
 // Class for general registers
 reg_class int_reg_with_ebp(EAX, EDX, EBP, EDI, ESI, ECX, EBX);
 // Class for general registers (excluding EBP).
-// This register class can be used for implicit null checks on win95.
 // It is also safe for use by tailjumps (we don't want to allocate in ebp).
 // Used also if the PreserveFramePointer flag is true.
 reg_class int_reg_no_ebp(EAX, EDX, EDI, ESI, ECX, EBX);
@@ -1445,57 +1444,6 @@ const bool Matcher::rematerialize_float_constants = true;
 // piece-by-piece.  Only happens when passing doubles into C code as the
 // Java calling convention forces doubles to be aligned.
 const bool Matcher::misaligned_doubles_ok = true;
-
-
-void Matcher::pd_implicit_null_fixup(MachNode *node, uint idx) {
-  // Get the memory operand from the node
-  uint numopnds = node->num_opnds();        // Virtual call for number of operands
-  uint skipped  = node->oper_input_base();  // Sum of leaves skipped so far
-  assert( idx >= skipped, "idx too low in pd_implicit_null_fixup" );
-  uint opcnt     = 1;                 // First operand
-  uint num_edges = node->_opnds[1]->num_edges(); // leaves for first operand
-  while( idx >= skipped+num_edges ) {
-    skipped += num_edges;
-    opcnt++;                          // Bump operand count
-    assert( opcnt < numopnds, "Accessing non-existent operand" );
-    num_edges = node->_opnds[opcnt]->num_edges(); // leaves for next operand
-  }
-
-  MachOper *memory = node->_opnds[opcnt];
-  MachOper *new_memory = NULL;
-  switch (memory->opcode()) {
-  case DIRECT:
-  case INDOFFSET32X:
-    // No transformation necessary.
-    return;
-  case INDIRECT:
-    new_memory = new indirect_win95_safeOper( );
-    break;
-  case INDOFFSET8:
-    new_memory = new indOffset8_win95_safeOper(memory->disp(NULL, NULL, 0));
-    break;
-  case INDOFFSET32:
-    new_memory = new indOffset32_win95_safeOper(memory->disp(NULL, NULL, 0));
-    break;
-  case INDINDEXOFFSET:
-    new_memory = new indIndexOffset_win95_safeOper(memory->disp(NULL, NULL, 0));
-    break;
-  case INDINDEXSCALE:
-    new_memory = new indIndexScale_win95_safeOper(memory->scale());
-    break;
-  case INDINDEXSCALEOFFSET:
-    new_memory = new indIndexScaleOffset_win95_safeOper(memory->scale(), memory->disp(NULL, NULL, 0));
-    break;
-  case LOAD_LONG_INDIRECT:
-  case LOAD_LONG_INDOFFSET32:
-    // Does not use EBP as address register, use { EDX, EBX, EDI, ESI}
-    return;
-  default:
-    assert(false, "unexpected memory operand in pd_implicit_null_fixup()");
-    return;
-  }
-  node->_opnds[opcnt] = new_memory;
-}
 
 // Advertise here if the CPU requires explicit rounding operations to implement strictfp mode.
 const bool Matcher::strict_fp_requires_explicit_rounding = true;
@@ -4401,98 +4349,6 @@ operand stackSlotL(sRegL reg) %{
     index(0x4);  // No Index
     scale(0x0);  // No Scale
     disp($reg);  // Stack Offset
-  %}
-%}
-
-//----------Memory Operands - Win95 Implicit Null Variants----------------
-// Indirect Memory Operand
-operand indirect_win95_safe(eRegP_no_EBP reg)
-%{
-  constraint(ALLOC_IN_RC(int_reg));
-  match(reg);
-
-  op_cost(100);
-  format %{ "[$reg]" %}
-  interface(MEMORY_INTER) %{
-    base($reg);
-    index(0x4);
-    scale(0x0);
-    disp(0x0);
-  %}
-%}
-
-// Indirect Memory Plus Short Offset Operand
-operand indOffset8_win95_safe(eRegP_no_EBP reg, immI8 off)
-%{
-  match(AddP reg off);
-
-  op_cost(100);
-  format %{ "[$reg + $off]" %}
-  interface(MEMORY_INTER) %{
-    base($reg);
-    index(0x4);
-    scale(0x0);
-    disp($off);
-  %}
-%}
-
-// Indirect Memory Plus Long Offset Operand
-operand indOffset32_win95_safe(eRegP_no_EBP reg, immI off)
-%{
-  match(AddP reg off);
-
-  op_cost(100);
-  format %{ "[$reg + $off]" %}
-  interface(MEMORY_INTER) %{
-    base($reg);
-    index(0x4);
-    scale(0x0);
-    disp($off);
-  %}
-%}
-
-// Indirect Memory Plus Index Register Plus Offset Operand
-operand indIndexOffset_win95_safe(eRegP_no_EBP reg, rRegI ireg, immI off)
-%{
-  match(AddP (AddP reg ireg) off);
-
-  op_cost(100);
-  format %{"[$reg + $off + $ireg]" %}
-  interface(MEMORY_INTER) %{
-    base($reg);
-    index($ireg);
-    scale(0x0);
-    disp($off);
-  %}
-%}
-
-// Indirect Memory Times Scale Plus Index Register
-operand indIndexScale_win95_safe(eRegP_no_EBP reg, rRegI ireg, immI2 scale)
-%{
-  match(AddP reg (LShiftI ireg scale));
-
-  op_cost(100);
-  format %{"[$reg + $ireg << $scale]" %}
-  interface(MEMORY_INTER) %{
-    base($reg);
-    index($ireg);
-    scale($scale);
-    disp(0x0);
-  %}
-%}
-
-// Indirect Memory Times Scale Plus Index Register Plus Offset Operand
-operand indIndexScaleOffset_win95_safe(eRegP_no_EBP reg, immI off, rRegI ireg, immI2 scale)
-%{
-  match(AddP (AddP reg (LShiftI ireg scale)) off);
-
-  op_cost(100);
-  format %{"[$reg + $off + $ireg << $scale]" %}
-  interface(MEMORY_INTER) %{
-    base($reg);
-    index($ireg);
-    scale($scale);
-    disp($off);
   %}
 %}
 

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1661,9 +1661,6 @@ const bool Matcher::rematerialize_float_constants = true; // XXX
 // C code as the Java calling convention forces doubles to be aligned.
 const bool Matcher::misaligned_doubles_ok = true;
 
-// No-op on amd64
-void Matcher::pd_implicit_null_fixup(MachNode *node, uint idx) {}
-
 // Advertise here if the CPU requires explicit rounding operations to implement strictfp mode.
 const bool Matcher::strict_fp_requires_explicit_rounding = false;
 

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -161,8 +161,7 @@ alloc_class chunk0(R10,         R10_H,
 // Several register classes are automatically defined based upon information in
 // this architecture description.
 // 1) reg_class inline_cache_reg           ( /* as def'd in frame section */ )
-// 2) reg_class interpreter_method_reg     ( /* as def'd in frame section */ )
-// 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
+// 2) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //
 
 // Empty register class.
@@ -2738,8 +2737,6 @@ frame
   // These three registers define part of the calling convention
   // between compiled code and the interpreter.
   inline_cache_reg(RAX);                // Inline Cache Register
-  interpreter_method_reg(RBX);          // Method Register when
-                                        // calling interpreter
 
   // Optional: name the operand used by cisc-spilling to access
   // [stack_pointer + offset]

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -161,7 +161,6 @@ alloc_class chunk0(R10,         R10_H,
 // Several register classes are automatically defined based upon information in
 // this architecture description.
 // 1) reg_class inline_cache_reg           ( /* as def'd in frame section */ )
-// 2) reg_class compiler_method_reg        ( /* as def'd in frame section */ )
 // 2) reg_class interpreter_method_reg     ( /* as def'd in frame section */ )
 // 3) reg_class stack_slots( /* one chunk of stack-based "registers" */ )
 //

--- a/src/hotspot/share/adlc/adlparse.cpp
+++ b/src/hotspot/share/adlc/adlparse.cpp
@@ -1006,7 +1006,8 @@ void ADLParser::frame_parse(void) {
         skipws();
       }
       if (strcmp(token,"interpreter_method_reg")==0) {
-        interpreter_method_parse(frame, false);
+        parse_err(WARN, "Using obsolete Token, interpreter_method_reg");
+        skipws();
       }
       if (strcmp(token,"cisc_spilling_operand_name")==0) {
         cisc_spilling_operand_name_parse(frame, false);
@@ -1132,11 +1133,6 @@ void ADLParser::interpreter_frame_pointer_parse(FrameForm *frame, bool native) {
 //------------------------------inline_cache_parse-----------------------------
 void ADLParser::inline_cache_parse(FrameForm *frame, bool native) {
   frame->_inline_cache_reg = parse_one_arg("inline cache reg entry");
-}
-
-//------------------------------interpreter_method_parse------------------
-void ADLParser::interpreter_method_parse(FrameForm *frame, bool native) {
-  frame->_interpreter_method_reg = parse_one_arg("method reg entry");
 }
 
 //------------------------------cisc_spilling_operand_parse---------------------

--- a/src/hotspot/share/adlc/formsopt.hpp
+++ b/src/hotspot/share/adlc/formsopt.hpp
@@ -336,7 +336,6 @@ public:
   // Public Data
   char *_sync_stack_slots;
   char *_inline_cache_reg;
-  char *_interpreter_method_reg;
   char *_interpreter_frame_pointer_reg;
   char *_cisc_spilling_operand_name;
   char *_frame_pointer;

--- a/src/hotspot/share/adlc/formsopt.hpp
+++ b/src/hotspot/share/adlc/formsopt.hpp
@@ -336,6 +336,7 @@ public:
   // Public Data
   char *_sync_stack_slots;
   char *_inline_cache_reg;
+  char *_interpreter_method_reg;
   char *_interpreter_frame_pointer_reg;
   char *_cisc_spilling_operand_name;
   char *_frame_pointer;

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -4192,14 +4192,7 @@ void ArchDesc::buildFrameMethods(FILE *fp_cpp) {
   fprintf(fp_cpp,"int Matcher::inline_cache_reg_encode() {");
   fprintf(fp_cpp," return _regEncode[inline_cache_reg()]; }\n\n");
 
-  // Interpreter's Method Register, mask definition, and encoding
-  fprintf(fp_cpp,"OptoReg::Name Matcher::interpreter_method_reg() {");
-  fprintf(fp_cpp," return OptoReg::Name(%s_num); }\n\n",
-          _frame->_interpreter_method_reg);
-  fprintf(fp_cpp,"int Matcher::interpreter_method_reg_encode() {");
-  fprintf(fp_cpp," return _regEncode[interpreter_method_reg()]; }\n\n");
-
-  // Interpreter's Frame Pointer Register, mask definition, and encoding
+  // Interpreter's Frame Pointer Register
   fprintf(fp_cpp,"OptoReg::Name Matcher::interpreter_frame_pointer_reg() {");
   if (_frame->_interpreter_frame_pointer_reg == NULL)
     fprintf(fp_cpp," return OptoReg::Bad; }\n\n");

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -418,13 +418,6 @@ public:
   // The Method-klass-holder may be passed in the inline_cache_reg
   // and then expanded into the inline_cache_reg and a method_ptr register
 
-  static OptoReg::Name  interpreter_method_reg();
-  static int            interpreter_method_reg_encode();
-
-  static OptoReg::Name  compiler_method_reg();
-  static const RegMask &compiler_method_reg_mask();
-  static int            compiler_method_reg_encode();
-
   // Interpreter's Frame Pointer Register
   static OptoReg::Name  interpreter_frame_pointer_reg();
 
@@ -535,10 +528,6 @@ public:
   DEBUG_ONLY( bool verify_after_postselect_cleanup(); )
 
  public:
-  // Perform a platform dependent implicit null fixup.  This is needed
-  // on windows95 to take care of some unusual register constraints.
-  void pd_implicit_null_fixup(MachNode *load, uint idx);
-
   // Advertise here if the CPU requires explicit rounding operations to implement strictfp mode.
   static const bool strict_fp_requires_explicit_rounding;
 


### PR DESCRIPTION
These are unused:

interpreter_method_reg*
compiler_method_reg*
pd_implicit_null_fixup (only existed to workaround some Win95 issues)

Quite some code in the .ad files shook loose when removing these, so I will need some help verifying that the s390 and ppc changes are fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254966](https://bugs.openjdk.java.net/browse/JDK-8254966): Remove unused code from Matcher


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * @AzeemJiva (no known github.com user name / role)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/723/head:pull/723`
`$ git checkout pull/723`
