### PR TITLE
8253453: SourceFileInfoTable should be allocated lazily

### DIFF
--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -208,7 +208,7 @@ class decode_env {
 
   static SourceFileInfoTable& src_table() {
     if (_src_table == NULL) {
-      _src_table = new SourceFileInfoTable();
+      _src_table = new (ResourceObj::C_HEAP, mtCode)SourceFileInfoTable();
     }
     return *_src_table;
   }

--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -202,9 +202,16 @@ class decode_env {
       15889,      // prime number
       ResourceObj::C_HEAP> SourceFileInfoTable;
 
-  static SourceFileInfoTable _src_table;
+  static SourceFileInfoTable* _src_table;
   static const char* _cached_src;
   static GrowableArray<const char*>* _cached_src_lines;
+
+  static SourceFileInfoTable& src_table() {
+    if (_src_table == NULL) {
+      _src_table = new SourceFileInfoTable();
+    }
+    return *_src_table;
+  }
 
  public:
   decode_env(CodeBuffer* code, outputStream* output);
@@ -229,7 +236,7 @@ class decode_env {
 
 bool decode_env::_optionsParsed = false;
 
-decode_env::SourceFileInfoTable decode_env::_src_table;
+decode_env::SourceFileInfoTable* decode_env::_src_table = NULL;
 const char* decode_env::_cached_src = NULL;
 GrowableArray<const char*>* decode_env::_cached_src_lines = NULL;
 
@@ -238,17 +245,17 @@ void decode_env::hook(const char* file, int line, address pc) {
   // necessary as we add to the table only when PrintInterpreter is true,
   // which means we are debugging the VM and a little bit of extra
   // memory usage doesn't matter.
-  SourceFileInfo* found = _src_table.get(pc);
+  SourceFileInfo* found = src_table().get(pc);
   if (found != NULL) {
     found->append(file, line);
   } else {
     SourceFileInfo sfi(file, line);
-    _src_table.put(pc, sfi); // sfi is copied by value
+    src_table().put(pc, sfi); // sfi is copied by value
   }
 }
 
 void decode_env::print_hook_comments(address pc, bool newline) {
-  SourceFileInfo* found = _src_table.get(pc);
+  SourceFileInfo* found = src_table().get(pc);
   outputStream* st = output();
   if (found != NULL) {
     for (SourceFileInfo::Link *link = found->head; link; link = link->next) {


### PR DESCRIPTION
Avoids allocating and clearing a 128Kb large ResourceHashTable eagerly on startup

It's only used when PrintInterpreter is enabled - which prints out the interpreter during bootstrap - so proper synchronization seems excessive.

Testing: tier1, verified source line comments retained with `-XX:+PrintInterpreter`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8253453](https://bugs.openjdk.java.net/browse/JDK-8253453): SourceFileInfoTable should be allocated lazily


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/724/head:pull/724`
`$ git checkout pull/724`
