### PR TITLE
8254994: [x86] C1 StubAssembler::call_RT, "call_offset might not be initialized"

### DIFF
--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -69,7 +69,7 @@ int StubAssembler::call_RT(Register oop_result1, Register metadata_result, addre
   push(thread);
 #endif // _LP64
 
-  int call_offset;
+  int call_offset = -1;
   if (!align_stack) {
     set_last_Java_frame(thread, noreg, rbp, NULL);
   } else {
@@ -133,6 +133,8 @@ int StubAssembler::call_RT(Register oop_result1, Register metadata_result, addre
   if (metadata_result->is_valid()) {
     get_vm_result_2(metadata_result, thread);
   }
+
+  assert(call_offset >= 0, "Should be set");
   return call_offset;
 }
 


### PR DESCRIPTION
Static analyzers complain `call_offset` might not be initialized in `StubAssembler::call_RT` in `c1_Runtime1_x86.cpp`. The way I see it, it depends on `align_stack` value, and it is set whether it `align_stack` is `true` or `false`. But we can probably make it cleaner so that future errors would be clearly detectable. Since it is initialized off `offset()`, it should not be negative.

Testing:
 - [x] Linux x86_64 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254994](https://bugs.openjdk.java.net/browse/JDK-8254994): [x86] C1 StubAssembler::call_RT, "call_offset might not be initialized"


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/730/head:pull/730`
`$ git checkout pull/730`
