### PR TITLE
8254995: [x86] ControlWord::print(), rc/pc variables might not be initialized

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4085,8 +4085,8 @@ class ControlWord {
       case 2: rc = "round up  "; break;
       case 3: rc = "chop      "; break;
       default:
-        rc = "unknown";
-        ShouldNotReachHere();
+        rc = NULL; // silence compiler warnings
+        fatal("Unknown rounding control: %d", rounding_control());
     };
     // precision control
     const char* pc;
@@ -4096,8 +4096,8 @@ class ControlWord {
       case 2: pc = "53 bits "; break;
       case 3: pc = "64 bits "; break;
       default:
-        pc = "unknown";
-        ShouldNotReachHere();
+        pc = NULL; // silence compiler warnings
+        fatal("Unknown precision control: %d", precision_control());
     };
     // flags
     char f[9];

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4084,6 +4084,9 @@ class ControlWord {
       case 1: rc = "round down"; break;
       case 2: rc = "round up  "; break;
       case 3: rc = "chop      "; break;
+      default:
+        rc = "unknown";
+        ShouldNotReachHere();
     };
     // precision control
     const char* pc;
@@ -4092,6 +4095,9 @@ class ControlWord {
       case 1: pc = "reserved"; break;
       case 2: pc = "53 bits "; break;
       case 3: pc = "64 bits "; break;
+      default:
+        pc = "unknown";
+        ShouldNotReachHere();
     };
     // flags
     char f[9];


### PR DESCRIPTION
Static analyzers complain that in `ControlWord::print()`, `rc`/`pc` variables might not be initialized. This never happens in practice, because `rounding_control()` and `precision_control()` return the good values. We can make it cleaner to silence the compiler.

Testing:
  - [x] Linux x86_64 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254995](https://bugs.openjdk.java.net/browse/JDK-8254995): [x86] ControlWord::print(), rc/pc variables might not be initialized


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/731/head:pull/731`
`$ git checkout pull/731`
