### PR TITLE
8254997: Remove unimplemented OSContainer::read_memory_limit_in_bytes

### DIFF
--- a/src/hotspot/os/linux/osContainer_linux.hpp
+++ b/src/hotspot/os/linux/osContainer_linux.hpp
@@ -41,8 +41,6 @@ class OSContainer: AllStatic {
   static bool   _is_containerized;
   static int    _active_processor_count;
 
-  static jlong read_memory_limit_in_bytes();
-
  public:
   static void init();
   static inline bool is_containerized();


### PR DESCRIPTION
The definition seems to be moved to CgroupSubsystem with JDK-8230305: https://hg.openjdk.java.net/jdk/jdk/rev/931354c6323d#l7.494

The leftover declaration can be cleaned up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254997](https://bugs.openjdk.java.net/browse/JDK-8254997): Remove unimplemented OSContainer::read_memory_limit_in_bytes


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/732/head:pull/732`
`$ git checkout pull/732`
