### PR TITLE
8254998: C2: assert(!n->as_Loop()->is_transformed_long_loop()) failure with -XX:StressLongCountedLoop=1

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3426,7 +3426,7 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
     }
     break;
   case Op_Loop:
-    assert(!n->as_Loop()->is_transformed_long_loop(), "should have been turned into a counted loop");
+    assert(!n->as_Loop()->is_transformed_long_loop() || _loop_opts_cnt == 0, "should have been turned into a counted loop");
   case Op_CountedLoop:
   case Op_OuterStripMinedLoop:
     if (n->as_Loop()->is_inner_loop()) {

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestTooManyLoopOpts.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestTooManyLoopOpts.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug JDK-8254998
+ * @summary C2: assert(!n->as_Loop()->is_transformed_long_loop()) failure with -XX:StressLongCountedLoop=1
+ * @requires vm.compiler2.enabled & vm.gc.Parallel
+ *
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:MaxRecursiveInlineLevel=26 -XX:MaxInlineLevel=26 -XX:LoopOptsCount=41 -XX:+UseParallelGC TestTooManyLoopOpts
+ *
+ */
+
+public class TestTooManyLoopOpts {
+    private static volatile int field;
+
+    public static void main(String[] args) {
+        test(0);
+    }
+
+    private static void test(int stop) {
+        for (long l = 0; l < 10; l++) {
+            test_helper(stop, 26);
+            field = 0x42;
+        }
+    }
+    private static void test_helper(int stop, int rec) {
+        if (rec <= 0) {
+            return;
+        }
+        for (int i = 0; i < stop; i++) {
+            test_helper(stop, rec - 1);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestTooManyLoopOpts.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestTooManyLoopOpts.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug JDK-8254998
+ * @bug 8254998
  * @summary C2: assert(!n->as_Loop()->is_transformed_long_loop()) failure with -XX:StressLongCountedLoop=1
  * @requires vm.compiler2.enabled & vm.gc.Parallel
  *


### PR DESCRIPTION
Transformation of a long counted loop into a loop nest with a counted
loop inner loop happens in 2 passes of loop opts: first the loop nest
is created and then the inner loop is transformed into a counted
loop. The assert fires because the second step doesn't have a chance
to run given the first step was executed as the last loop opts pass
before running out of allowed loop opts passes. The fix I propose for
this corner case is to relax the assert to account for this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254998](https://bugs.openjdk.java.net/browse/JDK-8254998): C2: assert(!n->as_Loop()->is_transformed_long_loop()) failure with -XX:StressLongCountedLoop=1


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to 3e6d02699fa831c416c3012e712605a153f225c1
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 3e6d02699fa831c416c3012e712605a153f225c1
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/735/head:pull/735`
`$ git checkout pull/735`
