### PR TITLE
8255004: [JVMCI] expose JVM_ACC_FIELD_INITIALIZED_FINAL_UPDATE

### DIFF
--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -407,6 +407,7 @@
   declare_preprocessor_constant("JVM_ACC_ENUM", JVM_ACC_ENUM)             \
   declare_preprocessor_constant("JVM_ACC_SYNTHETIC", JVM_ACC_SYNTHETIC)   \
   declare_preprocessor_constant("JVM_ACC_INTERFACE", JVM_ACC_INTERFACE)   \
+  declare_preprocessor_constant("JVM_ACC_FIELD_INITIALIZED_FINAL_UPDATE", JVM_ACC_FIELD_INITIALIZED_FINAL_UPDATE) \
                                                                           \
   declare_constant(JVM_CONSTANT_Utf8)                                     \
   declare_constant(JVM_CONSTANT_Unicode)                                  \


### PR DESCRIPTION
This PR exposes to Graal the JVM_ACC_FIELD_INITIALIZED_FINAL_UPDATE access flag added in https://bugs.openjdk.java.net/browse/JDK-8157181. This allows Graal to take the correct action for final fields that are updated outside of `<init>` and `<clinit>` methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255004](https://bugs.openjdk.java.net/browse/JDK-8255004): [JVMCI] expose JVM_ACC_FIELD_INITIALIZED_FINAL_UPDATE


### Reviewers
 * [Tom Rodriguez](https://openjdk.java.net/census#never) (@tkrodriguez - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/737/head:pull/737`
`$ git checkout pull/737`
