### PR TITLE
8197981: Missing return statement in __sync_val_compare_and_swap_8

### DIFF
--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
@@ -437,6 +437,7 @@ extern "C" {
     long long unsigned int oldval,
     long long unsigned int newval) {
     ShouldNotCallThis();
+    return 0; // silence compiler warnings
   }
 };
 #endif // !_LP64

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -481,7 +481,7 @@ extern "C" {
     long long unsigned int oldval,
     long long unsigned int newval) {
     ShouldNotCallThis();
-    return 0; // silence compiler compiler warnings
+    return 0; // silence compiler warnings
   }
 };
 #endif // !_LP64


### PR DESCRIPTION
This is similar to JDK-8254144 (that only did this for `os_linux_zero.cpp`), but a fuller version that also does `os_bsd_zero.cpp`. The patch is already in 7u, and needs forward porting. It takes the shape of JDK-8254144, that is with the comment: https://github.com/openjdk/jdk/commit/8f9e4792

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8197981](https://bugs.openjdk.java.net/browse/JDK-8197981): Missing return statement in __sync_val_compare_and_swap_8


### Reviewers
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/739/head:pull/739`
`$ git checkout pull/739`
