### PR TITLE
8242220: Capture JFR stack trace and thread other than the one the event is committed on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,8 @@ test/nashorn/lib
 NashornProfile.txt
 **/JTreport/**
 **/JTwork/**
-/src/utils/LogCompilation/target/
+*.class
+# Eclipse specific folders
+.classpath
+.settings
+.project

--- a/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
@@ -56,7 +56,7 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 
-static const u2 number_of_new_methods = 5;
+static const u2 number_of_new_methods = 6;
 static const u2 number_of_new_fields = 3;
 static const int extra_stream_bytes = 0x280;
 static const u2 invalid_cp_index = 0;
@@ -73,19 +73,20 @@ static const char* utf8_constants[] = {
   "()Z",          // 8
   "end",          // 9
   "shouldCommit", // 10
-  "startTime",    // 11 // LAST_REQUIRED_UTF8
-  "Ljdk/jfr/internal/handlers/EventHandler;", // 12
-  "Ljava/lang/Object;", // 13
-  "<clinit>",     // 14
-  "jdk/jfr/FlightRecorder", // 15
-  "register",     // 16
-  "(Ljava/lang/Class;)V", // 17
-  "StackMapTable", // 18
-  "Exceptions", // 19
-  "LineNumberTable", // 20
-  "LocalVariableTable", // 21
-  "LocalVariableTypeTable", // 22
-  "RuntimeVisibleAnnotation", // 23
+  "startTime",    // 11 
+  "(Ljava/lang/Thread;)V", // 12// LAST_REQUIRED_UTF8
+  "Ljdk/jfr/internal/handlers/EventHandler;", // 13
+  "Ljava/lang/Object;", // 14
+  "<clinit>",     // 15
+  "jdk/jfr/FlightRecorder", // 16
+  "register",     // 17
+  "(Ljava/lang/Class;)V", // 18
+  "StackMapTable", // 19
+  "Exceptions", // 20
+  "LineNumberTable", // 21
+  "LocalVariableTable", // 22
+  "LocalVariableTypeTable", // 23
+  "RuntimeVisibleAnnotation", // 24
 };
 
 enum utf8_req_symbols {
@@ -101,7 +102,8 @@ enum utf8_req_symbols {
   UTF8_REQ_end,
   UTF8_REQ_shouldCommit,
   UTF8_REQ_startTime,
-  NOF_UTF8_REQ_SYMBOLS
+  UTF8_REQ_EMPTY_VOID_THREAD_METHOD_DESC,
+  NOF_UTF8_REQ_SYMBOLS,
 };
 
 enum utf8_opt_symbols {
@@ -159,6 +161,26 @@ static u1 boolean_method_code_attribute[] = {
   0x0, // ex table len
   0x0,
   0x0, // attributes_count
+};
+
+static u1 empty_void_thread_method_code_attribute[] = {
+  0x0,
+  0x0,
+  0x0,
+  0xd, // attribute len
+  0x0,
+  0x0, // max stack
+  0x0,
+  0x2, // max locals
+  0x0,
+  0x0,
+  0x0,
+  0x1, // code length
+  Bytecodes::_return,
+  0x0,
+  0x0, // ex table len
+  0x0,
+  0x0  // attributes_count
 };
 
 // annotation processing support
@@ -805,6 +827,15 @@ static u2 add_method_infos(JfrBigEndianWriter& writer, const u2* utf8_indexes) {
                   utf8_indexes[UTF8_REQ_Code],
                   empty_void_method_code_attribute,
                   sizeof(empty_void_method_code_attribute));
+
+  assert(writer.is_valid(), "invariant");
+
+  add_method_info(writer,
+                  utf8_indexes[UTF8_REQ_commit],
+                  utf8_indexes[UTF8_REQ_EMPTY_VOID_THREAD_METHOD_DESC],
+                  utf8_indexes[UTF8_REQ_Code],
+                  empty_void_thread_method_code_attribute,
+                  sizeof(empty_void_thread_method_code_attribute));
 
   assert(writer.is_valid(), "invariant");
 

--- a/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
@@ -73,7 +73,7 @@ static const char* utf8_constants[] = {
   "()Z",          // 8
   "end",          // 9
   "shouldCommit", // 10
-  "startTime",    // 11 
+  "startTime",    // 11
   "(Ljava/lang/Thread;)V", // 12// LAST_REQUIRED_UTF8
   "Ljdk/jfr/internal/handlers/EventHandler;", // 13
   "Ljava/lang/Object;", // 14

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -65,6 +65,8 @@ jstring JNICALL jfr_get_pid(JNIEnv* env, jobject jvm);
 
 jlong JNICALL jfr_stacktrace_id(JNIEnv* env, jobject jvm, jint skip);
 
+jlong JNICALL jfr_stacktrace_id_1(JNIEnv* env, jobject jvm, jlong tid, jint skip);
+
 jlong JNICALL jfr_elapsed_frequency(JNIEnv* env, jobject jvm);
 
 void JNICALL jfr_subscribe_log_level(JNIEnv* env, jobject jvm, jobject log_tag, jint id);

--- a/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
@@ -47,6 +47,7 @@ JfrJniMethodRegistration::JfrJniMethodRegistration(JNIEnv* env) {
       (char*)"getClassIdNonIntrinsic", (char*)"(Ljava/lang/Class;)J", (void*)jfr_class_id,
       (char*)"getPid", (char*)"()Ljava/lang/String;", (void*)jfr_get_pid,
       (char*)"getStackTraceId", (char*)"(I)J", (void*)jfr_stacktrace_id,
+      (char*)"getStackTraceId", (char*)"(JI)J", (void*)jfr_stacktrace_id_1,
       (char*)"getThreadId", (char*)"(Ljava/lang/Thread;)J", (void*)jfr_id_for_thread,
       (char*)"getTicksFrequency", (char*)"()J", (void*)jfr_elapsed_frequency,
       (char*)"subscribeLogLevel", (char*)"(Ljdk/jfr/internal/LogTag;I)V", (void*)jfr_subscribe_log_level,

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
@@ -153,7 +153,7 @@ traceid JfrStackTraceRepository::record_async(Thread* thread, int skip) {
     void do_thread(Thread* th) {
       Atomic::store(&_traceid, record(th, _skip));
     }
-    
+
     public:
     AsyncRecordClosure(int skip) : HandshakeClosure("JfrStackTraceRepository_async_record"), _skip(skip), _traceid(0) {}
     traceid trace_id() const { return _traceid; }

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
@@ -28,6 +28,7 @@
 #include "jfr/recorder/repository/jfrChunkWriter.hpp"
 #include "jfr/recorder/stacktrace/jfrStackTraceRepository.hpp"
 #include "jfr/support/jfrThreadLocal.hpp"
+#include "runtime/handshake.hpp"
 #include "runtime/mutexLocker.hpp"
 
 static JfrStackTraceRepository* _instance = NULL;
@@ -143,6 +144,28 @@ traceid JfrStackTraceRepository::record(Thread* thread, int skip /* 0 */) {
   assert(frames != NULL, "invariant");
   assert(tl->stackframes() == frames, "invariant");
   return instance().record_for(thread->as_Java_thread(), skip, frames, tl->stackdepth());
+}
+
+traceid JfrStackTraceRepository::record_async(Thread* thread, int skip) {
+  class AsyncRecordClosure : public HandshakeClosure {
+    int _skip;
+    traceid _traceid;
+    void do_thread(Thread* th) {
+      Atomic::store(&_traceid, record(th, _skip));
+    }
+    
+    public:
+    AsyncRecordClosure(int skip) : HandshakeClosure("JfrStackTraceRepository_async_record"), _skip(skip), _traceid(0) {}
+    traceid trace_id() const { return _traceid; }
+  };
+
+  if (!thread->is_Java_thread() || thread->is_hidden_from_external_view()) {
+    return 0;
+  }
+
+  AsyncRecordClosure callback(skip);
+  Handshake::execute(&callback, thread->as_Java_thread());
+  return callback.trace_id();
 }
 
 traceid JfrStackTraceRepository::record_for(JavaThread* thread, int skip, JfrStackFrame *frames, u4 max_frames) {

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
@@ -66,6 +66,7 @@ class JfrStackTraceRepository : public JfrCHeapObj {
 
  public:
   static traceid record(Thread* thread, int skip = 0);
+  static traceid record_async(Thread* thread, int skip = 0);
   static void record_and_cache(JavaThread* thread, int skip = 0);
 };
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/Event.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Event.java
@@ -119,6 +119,9 @@ abstract public class Event extends jdk.internal.event.Event {
     final public void commit() {
     }
 
+    final public void commit(Thread thread) {
+    }
+
     /**
      * Returns {@code true} if at least one recording is running, and the
      * enabled setting for this event is set to {@code true}, otherwise

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ASMToolkit.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ASMToolkit.java
@@ -135,11 +135,15 @@ final class ASMToolkit {
         return className.replace(".", "/");
     }
 
-    public static Method makeWriteMethod(List<FieldInfo> fields) {
+    public static Method makeWriteMethod(List<FieldInfo> fields, boolean customThread) {
         StringBuilder sb = new StringBuilder();
         sb.append("(");
+        if (customThread) {
+            // make the first argument to take the custom thread
+            sb.append("Ljava/lang/Thread;");
+        }
         for (FieldInfo v : fields) {
-            if (!v.fieldName.equals(EventInstrumentation.FIELD_EVENT_THREAD) && !v.fieldName.equals(EventInstrumentation.FIELD_STACK_TRACE)) {
+            if ((!v.fieldName.equals(EventInstrumentation.FIELD_EVENT_THREAD)) && !v.fieldName.equals(EventInstrumentation.FIELD_STACK_TRACE)) {
                 sb.append(v.fieldDescriptor);
             }
         }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
@@ -60,11 +60,6 @@ public final class EventWriter {
         return ew != null ? ew : JVM.newEventWriter();
     }
 
-    public static EventWriter getEventWriter(Thread thread) {
-        EventWriter ew = (EventWriter)JVM.getEventWriter(thread.getId());
-        return ew != null ? ew : JVM.newEventWriter(thread.getId());
-    }
-
     public void putBoolean(boolean i) {
         if (isValidForSize(Byte.BYTES)) {
             currentPosition += Bits.putBoolean(currentPosition, i);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriterMethod.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriterMethod.java
@@ -44,7 +44,9 @@ public enum EventWriterMethod {
     PUT_CLASS("(Ljava/lang/Class;)V", Type.CLASS.getName(), "putClass"),
     PUT_STRING("(Ljava/lang/String;Ljdk/jfr/internal/StringPool;)V", Type.STRING.getName(), "putString"),
     PUT_EVENT_THREAD("()V", Type.THREAD.getName(), "putEventThread"),
-    PUT_STACK_TRACE("()V", Type.TYPES_PREFIX + "StackTrace", "putStackTrace");
+    PUT_STACK_TRACE("()V", Type.TYPES_PREFIX + "StackTrace", "putStackTrace"),
+    PUT_EVENT_THREAD_1("(Ljava/lang/Thread;)V", Type.THREAD.getName(), "putEventThread"),
+    PUT_STACK_TRACE_1("(Ljava/lang/Thread;)V", Type.TYPES_PREFIX + "StackTrace", "putStackTrace");
 
     private final Method asmMethod;
     private final String typeDescriptor;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -162,6 +162,8 @@ public final class JVM {
      */
     public native long getStackTraceId(int skipCount);
 
+    public native long getStackTraceId(long tid, int skipCount);
+
     /**
      * Return identifier for thread
      *
@@ -442,11 +444,26 @@ public final class JVM {
     public static native Object getEventWriter();
 
     /**
+     * Fast path fetching the EventWriter using VM intrinsics
+     *
+     * @return thread local EventWriter
+     */
+    // @IntrinsicCandidate
+    public static native Object getEventWriter(long tid);
+
+    /**
      * Create a new EventWriter
      *
      * @return thread local EventWriter
      */
     public static native EventWriter newEventWriter();
+
+    /**
+     * Create a new EventWriter
+     *
+     * @return thread local EventWriter
+     */
+    public static native EventWriter newEventWriter(long tid);
 
     /**
      * Flushes the EventWriter for this thread.

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -444,26 +444,11 @@ public final class JVM {
     public static native Object getEventWriter();
 
     /**
-     * Fast path fetching the EventWriter using VM intrinsics
-     *
-     * @return thread local EventWriter
-     */
-    // @IntrinsicCandidate
-    public static native Object getEventWriter(long tid);
-
-    /**
      * Create a new EventWriter
      *
      * @return thread local EventWriter
      */
     public static native EventWriter newEventWriter();
-
-    /**
-     * Create a new EventWriter
-     *
-     * @return thread local EventWriter
-     */
-    public static native EventWriter newEventWriter(long tid);
 
     /**
      * Flushes the EventWriter for this thread.

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVMUpcalls.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVMUpcalls.java
@@ -67,6 +67,7 @@ final class JVMUpcalls {
             }
             return JDKEvents.retransformCallback(clazz, oldBytes);
         } catch (Throwable t) {
+            t.printStackTrace();
             Logger.log(LogTag.JFR_SYSTEM, LogLevel.WARN, "Unexpected error when adding instrumentation to event class " + clazz.getName());
         }
         return oldBytes;

--- a/test/jdk/jdk/jfr/jvm/TestCustomThreadJavaEvent.java
+++ b/test/jdk/jdk/jfr/jvm/TestCustomThreadJavaEvent.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.jvm;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.LockSupport;
+
+import jdk.jfr.AnnotationElement;
+import jdk.jfr.Event;
+import jdk.jfr.EventType;
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.Recording;
+import jdk.jfr.ValueDescriptor;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+import jdk.test.lib.Utils;
+
+/**
+ * @test TextCustomThreadJavaEvent
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @modules jdk.jfr/jdk.jfr.internal
+ * @run main/othervm jdk.jfr.jvm.TestCustomThreadJavaEvent
+ */
+public class TestCustomThreadJavaEvent {
+
+    private static final int EVENTS_PER_THREAD = 50;
+    private static final int THREAD_COUNT = 100;
+
+    public static class MyEvent extends Event {
+        
+    }
+
+    public static void main(String... args) throws IOException, InterruptedException {
+        Recording r = new Recording();
+        // for (Method m : MyEvent.class.getMethods()) {
+        //     System.err.println("===> " + m);
+        // }
+        r.enable(MyEvent.class).withThreshold(Duration.ofNanos(0)).withStackTrace();
+        r.enable("jdk.SafepointBegin").withStackTrace();
+        r.start();
+
+        LongAdder adder = new LongAdder();
+        Thread worker = new Thread(()-> {
+            while (!Thread.currentThread().isInterrupted()) {
+                adder.add(call1());
+                LockSupport.parkNanos(10_000_000L); // 10ms pause
+            }
+        }, "Worker Thread");
+        worker.setDaemon(true);
+        worker.start();
+
+        ThreadGroup rootGroup = getRootGroup();
+        for (int i = 0; i < 5000; i++) {
+            processThreadGroup(rootGroup);
+            Thread.sleep(1);
+        }
+
+        r.stop();
+        System.out.println("Worker result: " + adder.sum());
+        prettyPrint();
+        File file = Utils.createTempFile("test", ".jfr").toFile();
+        r.dump(file.toPath());
+        System.err.println("===> Dumped to: " + file);
+        int eventCount = 0;
+        for (RecordedEvent e : RecordingFile.readAllEvents(file.toPath())) {
+            if (e.getEventType().getName().equals(MyEvent.class.getName())) {
+                eventCount++;
+            }
+            System.out.println(e);
+        }
+        System.out.println("Event count was " + eventCount + ", expected " + THREAD_COUNT * EVENTS_PER_THREAD);
+        r.close();
+    }
+
+    private static ThreadGroup getRootGroup() {
+        ThreadGroup currentTG = Thread.currentThread().getThreadGroup();
+        ThreadGroup parentTG = currentTG.getParent();
+        while (parentTG != null) {
+            currentTG = parentTG;
+            parentTG = currentTG.getParent();
+        }
+        return currentTG;
+    }
+
+    private static void processThreadGroup(ThreadGroup group) {
+        ThreadGroup[] groups = new ThreadGroup[group.activeGroupCount()];
+        Thread[] threads = new Thread[group.activeCount()];
+        group.enumerate(groups);
+        group.enumerate(threads);
+        for (Thread t : threads) {
+            if (t.isAlive()) {
+                MyEvent event = new MyEvent();
+                if (event.shouldCommit()) {
+                    event.commit(t);
+                }
+            }
+        }
+        for (ThreadGroup subgroup : groups) {
+            processThreadGroup(subgroup);
+        }
+    }
+
+    static void prettyPrint() {
+        for (EventType type : FlightRecorder.getFlightRecorder().getEventTypes()) {
+            for (AnnotationElement a : type.getAnnotationElements()) {
+                printAnnotation("", a);
+            }
+            System.out.print("class " + removePackage(type.getName()));
+            System.out.print(" extends Event");
+
+            System.out.println(" {");
+            List<ValueDescriptor> values = type.getFields();
+            for (int i = 0; i < values.size(); i++) {
+                ValueDescriptor v = values.get(i);
+                for (AnnotationElement a : v.getAnnotationElements()) {
+                    printAnnotation("  ", a);
+                }
+                System.out.println("  " + removePackage(v.getTypeName() + brackets(v.isArray())) + " " + v.getName());
+                if (i != values.size() - 1) {
+                    System.out.println();
+                }
+            }
+            System.out.println("}");
+            System.out.println();
+        }
+    }
+
+    private static String brackets(boolean isArray) {
+        return isArray ? "[]" : "";
+    }
+
+    private static String removePackage(String s) {
+
+        int index = s.lastIndexOf(".");
+        return s.substring(index + 1);
+    }
+
+    private static void printAnnotation(String indent, AnnotationElement a) {
+        String name = removePackage(a.getTypeName());
+        if (a.getValues().isEmpty()) {
+            System.out.println(indent + "@" + name);
+            return;
+        }
+        System.out.print(indent + "@" + name + "(");
+        for (Object o : a.getValues()) {
+            printAnnotationValue(o);
+        }
+        System.out.println(")");
+    }
+
+    private static void printAnnotationValue(Object o) {
+        if (o instanceof String) {
+            System.out.print("\"" + o + "\"");
+        } else {
+            System.out.print(String.valueOf(o));
+        }
+    }
+
+    private static int call1() {
+        return call2() + 17;
+    }
+
+    private static int call2() {
+        return call3() % 872451;
+    }
+
+    private static int call3() {
+        return ThreadLocalRandom.current().nextInt();
+    }
+
+}

--- a/test/jdk/jdk/jfr/jvm/TestCustomThreadJavaEvent.java
+++ b/test/jdk/jdk/jfr/jvm/TestCustomThreadJavaEvent.java
@@ -58,9 +58,7 @@ public class TestCustomThreadJavaEvent {
     private static final int EVENTS_PER_THREAD = 50;
     private static final int THREAD_COUNT = 100;
 
-    public static class MyEvent extends Event {
-        
-    }
+    public static class MyEvent extends Event {}
 
     public static void main(String... args) throws IOException, InterruptedException {
         Recording r = new Recording();


### PR DESCRIPTION
This is an early prototype of an enhanced Event.commit(thread) method which allows committing a JFR event on a custom java thread. This would allow, for example, having a scheduled 'sampling' thread generating generating events and filling them up with shared aggregation data and then committing them on behalf of a 'sampled' thread.

Committing an event on the given thread means that the event will be associated with that particular thread, will receive the stack trace of that thread at that particular moment and, internally, will be written out using that thread's thread-local structures.

The change is rather trivial - extend the Event API to provide commit(Thread) method and then use thread-local handshake to fill in the stacktrace details of the indicated thread. The code changes are, however, more extensive as all the supporting classes need to be also aware of the new Event method.

As already mentioned this is a very early prototype of this particular functionality. I am aware that finalizing this will take much more work but at least for DataDog this feature is quite useful and starting the discussion about it with a concrete piece of code seems to be the right way to go.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ❌ (6/6 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (6/6 passed) | ✔️ (3/3 passed) |

**Failed test tasks**
- [Linux x64 (build debug)](https://github.com/jbachorik/jdk/runs/1459000343)
- [Linux x64 (build hotspot minimal)](https://github.com/jbachorik/jdk/runs/1459000446)
- [Linux x64 (build hotspot no-pch)](https://github.com/jbachorik/jdk/runs/1459000374)
- [Linux x64 (build hotspot optimized)](https://github.com/jbachorik/jdk/runs/1459000477)
- [Linux x64 (build hotspot zero)](https://github.com/jbachorik/jdk/runs/1459000399)
- [Linux x64 (build release)](https://github.com/jbachorik/jdk/runs/1459000317)

### Issue
 * [JDK-8242220](https://bugs.openjdk.java.net/browse/JDK-8242220): Capture JFR stack trace and thread other than the one the event is committed on


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/741/head:pull/741`
`$ git checkout pull/741`
