### PR TITLE
8254967: com.sun.net.HttpsServer spins on TLS session close

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/SSLStreams.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/SSLStreams.java
@@ -430,11 +430,16 @@ class SSLStreams {
             handshaking.lock();
             ByteBuffer tmp = allocate(BufType.APPLICATION);
             WrapperResult r;
+            Status st;
+            HandshakeStatus hs;
             do {
                 tmp.clear();
                 tmp.flip ();
                 r = wrapper.wrapAndSendX (tmp, true);
-            } while (r.result.getStatus() != Status.CLOSED);
+                hs = r.result.getHandshakeStatus();
+                st = r.result.getStatus();
+            } while (st != Status.CLOSED &&
+                        !(st == Status.OK && hs == HandshakeStatus.NOT_HANDSHAKING));
         } finally {
             handshaking.unlock();
         }


### PR DESCRIPTION
This fixes a busy loop bug in the Http server which happens sometimes when an SSL connection is closed by the client.

There is no regression test as it is not easy to reproduce and the only effect is that one executor thread gets tied up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (2/9 running) | ⏳ (9/9 running) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254967](https://bugs.openjdk.java.net/browse/JDK-8254967): com.sun.net.HttpsServer spins on TLS session close


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/742/head:pull/742`
`$ git checkout pull/742`
