### PR TITLE
8255016: ConstantDescs.FALSE claims it represents TRUE

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
@@ -276,7 +276,7 @@ public final class ConstantDescs {
                                           "TRUE", CD_Boolean, CD_Boolean);
 
     /**
-     * Nominal descriptor representing the constant {@linkplain Boolean#TRUE}
+     * Nominal descriptor representing the constant {@linkplain Boolean#FALSE}
      * @since 15
      */
     public static final DynamicConstantDesc<Boolean> FALSE


### PR DESCRIPTION
This is a fix for "just a typo" or copy/paste error, but it probably requires a CSR since it changes a normative portion of the spec.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255016](https://bugs.openjdk.java.net/browse/JDK-8255016): ConstantDescs.FALSE claims it represents TRUE


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/744/head:pull/744`
`$ git checkout pull/744`
