### PR TITLE
8254692: (se) Clarify the behaviour of the non-abstract SelectorProvider::inheritedChannel

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/spi/SelectorProvider.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/SelectorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -300,6 +300,9 @@ public abstract class SelectorProvider {
      * <p> The first invocation of this method creates the channel that is
      * returned. Subsequent invocations of this method return the same
      * channel. </p>
+     *
+     * @implSpec The default implementation of this method returns
+     * {@code null}.
      *
      * @return  The inherited channel, if any, otherwise {@code null}.
      *

--- a/test/jdk/java/nio/channels/etc/ProtocolFamilies.java
+++ b/test/jdk/java/nio/channels/etc/ProtocolFamilies.java
@@ -39,6 +39,7 @@ import static java.lang.Boolean.parseBoolean;
 import static java.net.StandardProtocolFamily.INET;
 import static java.net.StandardProtocolFamily.INET6;
 import static jdk.test.lib.net.IPSupport.*;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 
 /*
@@ -317,7 +318,9 @@ public class ProtocolFamilies {
 
     // Tests the specified default implementation of SelectorProvider
     @Test
-    public void testCustomProvider() {
+    public void testCustomProvider() throws IOException {
+        assertNull(customerSelectorProvider.inheritedChannel());
+
         assertThrows(NPE, () -> customerSelectorProvider.openSocketChannel(null));
         assertThrows(NPE, () -> customerSelectorProvider.openServerSocketChannel(null));
 

--- a/test/jdk/java/nio/channels/etc/ProtocolFamilies.java
+++ b/test/jdk/java/nio/channels/etc/ProtocolFamilies.java
@@ -44,6 +44,7 @@ import static org.testng.Assert.assertThrows;
 
 /*
  * @test
+ * @bug 8254692
  * @summary Test SocketChannel, ServerSocketChannel and DatagramChannel
  *          with various ProtocolFamily combinations
  * @library /test/lib

--- a/test/jdk/java/nio/channels/etc/ProtocolFamilies.java
+++ b/test/jdk/java/nio/channels/etc/ProtocolFamilies.java
@@ -22,7 +22,6 @@
  */
 
 import jdk.test.lib.NetworkConfiguration;
-import jdk.test.lib.Platform;
 import jdk.test.lib.net.IPSupport;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
@@ -31,20 +30,15 @@ import org.testng.Assert.ThrowingRunnable;
 import java.io.IOException;
 import java.net.*;
 import java.nio.channels.*;
-import java.nio.channels.spi.AbstractSelector;
 import java.nio.channels.spi.SelectorProvider;
 import static java.lang.System.out;
-import static java.lang.System.getProperty;
-import static java.lang.Boolean.parseBoolean;
 import static java.net.StandardProtocolFamily.INET;
 import static java.net.StandardProtocolFamily.INET6;
 import static jdk.test.lib.net.IPSupport.*;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 
 /*
  * @test
- * @bug 8254692
  * @summary Test SocketChannel, ServerSocketChannel and DatagramChannel
  *          with various ProtocolFamily combinations
  * @library /test/lib
@@ -305,28 +299,6 @@ public class ProtocolFamilies {
         assertThrows(UOE, () -> SelectorProvider.provider().openSocketChannel(BAD_PF));
         assertThrows(UOE, () -> SelectorProvider.provider().openServerSocketChannel(BAD_PF));
         assertThrows(UOE, () -> SelectorProvider.provider().openDatagramChannel(BAD_PF));
-    }
-
-    // A concrete subclass of SelectorProvider, in order to test implSpec
-    static final SelectorProvider customerSelectorProvider = new SelectorProvider() {
-        @Override public DatagramChannel openDatagramChannel() { return null; }
-        @Override public DatagramChannel openDatagramChannel(ProtocolFamily family) { return null; }
-        @Override public Pipe openPipe() { return null; }
-        @Override public AbstractSelector openSelector() { return null; }
-        @Override public ServerSocketChannel openServerSocketChannel() { return null; }
-        @Override public SocketChannel openSocketChannel() { return null; }
-    };
-
-    // Tests the specified default implementation of SelectorProvider
-    @Test
-    public void testCustomProvider() throws IOException {
-        assertNull(customerSelectorProvider.inheritedChannel());
-
-        assertThrows(NPE, () -> customerSelectorProvider.openSocketChannel(null));
-        assertThrows(NPE, () -> customerSelectorProvider.openServerSocketChannel(null));
-
-        assertThrows(UOE, () -> customerSelectorProvider.openSocketChannel(BAD_PF));
-        assertThrows(UOE, () -> customerSelectorProvider.openServerSocketChannel(BAD_PF));
     }
 
     // Helper methods

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/TestDefaultBehaviour.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/TestDefaultBehaviour.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8254692
+ * @summary Basic test for java.nio.channels.spi.SelectorProvider.java default behavior
+ * @run testng TestDefaultBehaviour
+ */
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.ProtocolFamily;
+import java.nio.channels.*;
+import java.nio.channels.spi.AbstractSelector;
+import java.nio.channels.spi.SelectorProvider;
+
+import static org.testng.Assert.*;
+import static org.testng.Assert.assertThrows;
+
+public class TestDefaultBehaviour {
+    static final Class<UnsupportedOperationException> UOE = UnsupportedOperationException.class;
+    static final Class<NullPointerException> NPE = NullPointerException.class;
+    static final ProtocolFamily BAD_PF = () -> "BAD_PROTOCOL_FAMILY";
+
+    @Test
+    public void testSelectorProvider() throws IOException {
+        CustomSelectorProviderImpl customSpi = new CustomSelectorProviderImpl();
+
+        assertNull(customSpi.inheritedChannel());
+
+        assertThrows(NPE, () -> customSpi.openSocketChannel(null));
+        assertThrows(NPE, () -> customSpi.openServerSocketChannel(null));
+
+        assertThrows(UOE, () -> customSpi.openSocketChannel(BAD_PF));
+        assertThrows(UOE, () -> customSpi.openServerSocketChannel(BAD_PF));
+    }
+
+    // A concrete subclass of SelectorProvider, in order to test the
+    // default java.nio.channels.spi.SelectorProvider implementation
+    static class CustomSelectorProviderImpl extends SelectorProvider {
+        @Override public DatagramChannel openDatagramChannel() { return null; }
+        @Override public DatagramChannel openDatagramChannel(ProtocolFamily family) { return null; }
+        @Override public Pipe openPipe() { return null; }
+        @Override public AbstractSelector openSelector() { return null; }
+        @Override public ServerSocketChannel openServerSocketChannel() { return null; }
+        @Override public SocketChannel openSocketChannel() { return null; }
+    }
+}

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/TestDefaultBehaviour.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/TestDefaultBehaviour.java
@@ -36,7 +36,7 @@ import java.nio.channels.*;
 import java.nio.channels.spi.AbstractSelector;
 import java.nio.channels.spi.SelectorProvider;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 
 public class TestDefaultBehaviour {

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/TestDefaultImplementation.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/TestDefaultImplementation.java
@@ -24,8 +24,8 @@
 /*
  * @test
  * @bug 8254692
- * @summary Basic test for java.nio.channels.spi.SelectorProvider.java default behavior
- * @run testng TestDefaultBehaviour
+ * @summary Basic test for java.nio.channels.spi.SelectorProvider.java default implementation
+ * @run testng TestDefaultImplementation
  */
 
 import org.testng.annotations.Test;
@@ -39,7 +39,7 @@ import java.nio.channels.spi.SelectorProvider;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 
-public class TestDefaultBehaviour {
+public class TestDefaultImplementation {
     static final Class<UnsupportedOperationException> UOE = UnsupportedOperationException.class;
     static final Class<NullPointerException> NPE = NullPointerException.class;
     static final ProtocolFamily BAD_PF = () -> "BAD_PROTOCOL_FAMILY";


### PR DESCRIPTION
Please review this fix to provide spec clarity on the default implementation of java.nio.channels.spi.SelectorProvider::inheritedChannel() method which simply returns “null”, and a test for it. 

Please review the corresponding CSR as well: https://bugs.openjdk.java.net/browse/JDK-8254848

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254692](https://bugs.openjdk.java.net/browse/JDK-8254692): (se) Clarify the behaviour of the non-abstract SelectorProvider::inheritedChannel


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to 8006f0a46e38decbf637c01f5d31d0a84e883941
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/745/head:pull/745`
`$ git checkout pull/745`
