### PR TITLE
8255022: Documentation missing for Vector API zero methods

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -423,7 +423,12 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     // comment <!--workaround--> for this.
 
     /**
-     * {@inheritDoc} <!--workaround-->
+     * Returns a vector of the given species
+     * where all lane elements are set to
+     * the default primitive value.
+     *
+     * @param species species of the desired zero vector
+     * @return a zero vector
      */
     @ForceInline
     public static ByteVector zero(VectorSpecies<Byte> species) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -425,7 +425,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     /**
      * Returns a vector of the given species
      * where all lane elements are set to
-     * the default primitive value.
+     * zero, the default primitive value.
      *
      * @param species species of the desired zero vector
      * @return a zero vector

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -423,7 +423,12 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     // comment <!--workaround--> for this.
 
     /**
-     * {@inheritDoc} <!--workaround-->
+     * Returns a vector of the given species
+     * where all lane elements are set to
+     * the default primitive value.
+     *
+     * @param species species of the desired zero vector
+     * @return a zero vector
      */
     @ForceInline
     public static DoubleVector zero(VectorSpecies<Double> species) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -425,7 +425,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     /**
      * Returns a vector of the given species
      * where all lane elements are set to
-     * the default primitive value.
+     * zero, the default primitive value.
      *
      * @param species species of the desired zero vector
      * @return a zero vector

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -425,7 +425,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     /**
      * Returns a vector of the given species
      * where all lane elements are set to
-     * the default primitive value.
+     * zero, the default primitive value.
      *
      * @param species species of the desired zero vector
      * @return a zero vector

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -423,7 +423,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
     // comment <!--workaround--> for this.
 
     /**
-     * {@inheritDoc} <!--workaround-->
+     * Returns a vector of the given species
+     * where all lane elements are set to
+     * the default primitive value.
+     *
+     * @param species species of the desired zero vector
+     * @return a zero vector
      */
     @ForceInline
     public static FloatVector zero(VectorSpecies<Float> species) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -423,7 +423,12 @@ public abstract class IntVector extends AbstractVector<Integer> {
     // comment <!--workaround--> for this.
 
     /**
-     * {@inheritDoc} <!--workaround-->
+     * Returns a vector of the given species
+     * where all lane elements are set to
+     * the default primitive value.
+     *
+     * @param species species of the desired zero vector
+     * @return a zero vector
      */
     @ForceInline
     public static IntVector zero(VectorSpecies<Integer> species) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -425,7 +425,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
     /**
      * Returns a vector of the given species
      * where all lane elements are set to
-     * the default primitive value.
+     * zero, the default primitive value.
      *
      * @param species species of the desired zero vector
      * @return a zero vector

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -425,7 +425,7 @@ public abstract class LongVector extends AbstractVector<Long> {
     /**
      * Returns a vector of the given species
      * where all lane elements are set to
-     * the default primitive value.
+     * zero, the default primitive value.
      *
      * @param species species of the desired zero vector
      * @return a zero vector

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -423,7 +423,12 @@ public abstract class LongVector extends AbstractVector<Long> {
     // comment <!--workaround--> for this.
 
     /**
-     * {@inheritDoc} <!--workaround-->
+     * Returns a vector of the given species
+     * where all lane elements are set to
+     * the default primitive value.
+     *
+     * @param species species of the desired zero vector
+     * @return a zero vector
      */
     @ForceInline
     public static LongVector zero(VectorSpecies<Long> species) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -425,7 +425,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
     /**
      * Returns a vector of the given species
      * where all lane elements are set to
-     * the default primitive value.
+     * zero, the default primitive value.
      *
      * @param species species of the desired zero vector
      * @return a zero vector

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -423,7 +423,12 @@ public abstract class ShortVector extends AbstractVector<Short> {
     // comment <!--workaround--> for this.
 
     /**
-     * {@inheritDoc} <!--workaround-->
+     * Returns a vector of the given species
+     * where all lane elements are set to
+     * the default primitive value.
+     *
+     * @param species species of the desired zero vector
+     * @return a zero vector
      */
     @ForceInline
     public static ShortVector zero(VectorSpecies<Short> species) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -429,7 +429,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     /**
      * Returns a vector of the given species
      * where all lane elements are set to
-     * the default primitive value.
+     * zero, the default primitive value.
      *
      * @param species species of the desired zero vector
      * @return a zero vector

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -427,7 +427,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     // comment <!--workaround--> for this.
 
     /**
-     * {@inheritDoc} <!--workaround-->
+     * Returns a vector of the given species
+     * where all lane elements are set to
+     * the default primitive value.
+     *
+     * @param species species of the desired zero vector
+     * @return a zero vector
      */
     @ForceInline
     public static $abstractvectortype$ zero(VectorSpecies<$Boxtype$> species) {


### PR DESCRIPTION
The zero methods on `IntVector` and all other specializations are missing documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ⏳ (1/9 running) | ⏳ (1/9 running) |

### Issue
 * [JDK-8255022](https://bugs.openjdk.java.net/browse/JDK-8255022): Documentation missing for Vector API zero methods


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to 83639200ab6fb5a8a401c241f7575d724a0a3023


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/748/head:pull/748`
`$ git checkout pull/748`
