### PR TITLE
8255027: Problem list for Graal test gc/stress/TestStressG1Humongous.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList-graal.txt
+++ b/test/hotspot/jtreg/ProblemList-graal.txt
@@ -94,6 +94,8 @@ gc/g1/plab/TestPLABEvacuationFailure.java                       8191048   generi
 gc/g1/plab/TestPLABPromotion.java                               8191048   generic-all
 gc/g1/plab/TestPLABResize.java                                  8191048   generic-all
 
+gc/stress/TestStressG1Humongous.java                            8218176   generic-all
+
 compiler/compilercontrol/directives/LogTest.java                8181753   generic-all
 
 compiler/jvmci/compilerToVM/ReprofileTest.java                  8201333   generic-all


### PR DESCRIPTION
TestStressG1Humongous.java fails sporadically with Graal. Problem list it until JDK-8218176 is resolved.
The test was on ProblemList-graal.txt but it was removed from it by JDK-8218173.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/vnkozlov/jdk/runs/1277593014)

### Issue
 * [JDK-8255027](https://bugs.openjdk.java.net/browse/JDK-8255027): Problem list for Graal test gc/stress/TestStressG1Humongous.java


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/750/head:pull/750`
`$ git checkout pull/750`
