### PR TITLE
JDK-8255032: Conflict between recent pushes breaks the build

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
@@ -117,7 +117,7 @@ public class HtmlDoclet extends AbstractDoclet {
     }
 
     @Override // defined by AbstractDoclet
-    public void generateClassFiles(DocletEnvironment docEnv, ClassTree classTree) throws DocletException {
+    public void generateClassFiles(ClassTree classTree) throws DocletException {
 
         if (!(configuration.getOptions().noDeprecated()
                 || configuration.getOptions().noDeprecatedList())) {
@@ -128,7 +128,7 @@ public class HtmlDoclet extends AbstractDoclet {
             }
         }
 
-        super.generateClassFiles(docEnv, classTree);
+        super.generateClassFiles(classTree);
     }
 
     /**


### PR DESCRIPTION
The patch resolves a bad merge between two recent changes.

The `DocletEnvironment docEnv` parameter no longer needs to be passed around.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (2/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8255032](https://bugs.openjdk.java.net/browse/JDK-8255032): Conflict between recent pushes breaks the build


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/752/head:pull/752`
`$ git checkout pull/752`
