### PR TITLE
7110890: reg test TranslucentShapedFrameTest fails to create non-opaque frame

### DIFF
--- a/test/jdk/java/awt/Window/TranslucentShapedFrameTest/TSFrame.java
+++ b/test/jdk/java/awt/Window/TranslucentShapedFrameTest/TSFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,27 +22,24 @@
  */
 
 import java.awt.BorderLayout;
+import java.awt.Canvas;
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Frame;
+import java.awt.GradientPaint;
 import java.awt.Graphics;
-import java.awt.GraphicsConfiguration;
+import java.awt.Graphics2D;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsDevice.WindowTranslucency;
-import java.awt.GraphicsEnvironment;
 import java.awt.RenderingHints;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.awt.Canvas;
-import java.awt.Component;
-import java.awt.GradientPaint;
-import java.awt.Graphics2D;
-import java.awt.Paint;
-import java.util.Random;
 import java.awt.geom.Ellipse2D;
-import javax.swing.JApplet;
+import java.util.Random;
+
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
@@ -107,31 +104,6 @@ public class TSFrame {
             setUndecorated(true);
         }
     }
-    private static class NonOpaqueJAppletFrame extends JFrame {
-        JPanel p;
-        NonOpaqueJAppletFrame() {
-            super("NonOpaque Swing JAppletFrame");
-            JApplet ja = new JApplet() {
-                public void paint(Graphics g) {
-                    super.paint(g);
-                    System.err.println("JAppletFrame paint called");
-                }
-            };
-            p = new JPanel() {
-                public void paintComponent(Graphics g) {
-                    super.paintComponent(g);
-                    render(g, getWidth(), getHeight(), true);
-                    g.setColor(Color.red);
-                    g.drawString("Non-Opaque Swing JFrame", 10, 15);
-                }
-            };
-            p.setDoubleBuffered(false);
-            p.setOpaque(false);
-            ja.add(p);
-            add(ja);
-            setUndecorated(true);
-        }
-    }
     private static class NonOpaqueFrame extends Frame {
         NonOpaqueFrame() {
             super("NonOpaque AWT Frame");
@@ -177,7 +149,6 @@ public class TSFrame {
         if (useNonOpaque) {
             if (useSwing) {
                 frame = new NonOpaqueJFrame();
-//                frame = new NonOpaqueJAppletFrame(gc);
             } else {
                 frame = new NonOpaqueFrame();
             }
@@ -224,11 +195,7 @@ public class TSFrame {
             }
         });
         frame.setPreferredSize(new Dimension(800, 600));
-
-        if (useShape) {
-            frame.setUndecorated(true);
-        }
-
+        frame.setUndecorated(true);
         frame.setLocation(450, 10);
         frame.pack();
 

--- a/test/jdk/java/awt/Window/TranslucentShapedFrameTest/TranslucentShapedFrameTest.java
+++ b/test/jdk/java/awt/Window/TranslucentShapedFrameTest/TranslucentShapedFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,19 +31,19 @@
  * @run main/manual/othervm TranslucentShapedFrameTest
  * @run main/manual/othervm -Dsun.java2d.noddraw=true TranslucentShapedFrameTest
  */
+
 import java.awt.Color;
 import java.awt.Frame;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsDevice.WindowTranslucency;
-import java.awt.GraphicsEnvironment;
 import java.awt.Shape;
 import java.awt.geom.Ellipse2D;
 import java.util.concurrent.CountDownLatch;
+
 import javax.swing.JSlider;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
 
 public class TranslucentShapedFrameTest extends javax.swing.JFrame {
     Frame testFrame;
@@ -145,6 +145,7 @@ public class TranslucentShapedFrameTest extends javax.swing.JFrame {
 
         createDisposeGrp.add(createFrameBtn);
         createFrameBtn.setText("Create Frame");
+        createFrameBtn.setSelected(true);
         createFrameBtn.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 createFrameBtnActionPerformed(evt);
@@ -152,7 +153,7 @@ public class TranslucentShapedFrameTest extends javax.swing.JFrame {
         });
 
         createDisposeGrp.add(disposeFrameBtn);
-        disposeFrameBtn.setSelected(true);
+        disposeFrameBtn.setEnabled(false);
         disposeFrameBtn.setText("Dispose Frame");
         disposeFrameBtn.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -268,6 +269,9 @@ public class TranslucentShapedFrameTest extends javax.swing.JFrame {
             testFrame.dispose();
             testFrame = null;
         }
+        disposeFrameBtn.setEnabled(false);
+        createFrameBtn.setEnabled(true);
+        useSwingCb.setEnabled(true);
     }//GEN-LAST:event_disposeFrameBtnActionPerformed
 
     private void createFrameBtnActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_createFrameBtnActionPerformed
@@ -277,6 +281,9 @@ public class TranslucentShapedFrameTest extends javax.swing.JFrame {
                 useSwingCb.isSelected(), shapedCb.isSelected(),
                 (transl < 100), nonOpaqueChb.isSelected(),
                 (float)transl/100f);
+        createFrameBtn.setEnabled(false);
+        disposeFrameBtn.setEnabled(true);
+        useSwingCb.setEnabled(false);
     }//GEN-LAST:event_createFrameBtnActionPerformed
 
     private void passedBtnActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_passedBtnActionPerformed


### PR DESCRIPTION
This manual test was created during the development phase of jdk7 when it was possible to create translucent/non-opaque decorated frames. That was changed by the https://bugs.openjdk.java.net/browse/JDK-6993784

The test allows creating and changing on the fly: translucent/shaped/transparent frames all such windows should be undecorated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (6/9 running) |    |  ⏳ (9/9 running) |

### Issue
 * [JDK-7110890](https://bugs.openjdk.java.net/browse/JDK-7110890): reg test TranslucentShapedFrameTest fails to create non-opaque frame


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/753/head:pull/753`
`$ git checkout pull/753`
