### PR TITLE
8254974: Fix stutter typo in TypeElement

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
@@ -98,7 +98,7 @@ public interface TypeElement extends Element, Parameterizable, QualifiedNameable
      * originating source of information about the type.  For example,
      * if the information about the type is originating from a source
      * file, the elements will be returned in source code order.
-     * (However, in that case the the ordering of {@linkplain
+     * (However, in that case the ordering of {@linkplain
      * Elements.Origin#MANDATED implicitly declared} elements, such as
      * default constructors, is not specified.)
      *


### PR DESCRIPTION
Fix "the the" stutter typo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254974](https://bugs.openjdk.java.net/browse/JDK-8254974): Fix stutter typo in TypeElement


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/755/head:pull/755`
`$ git checkout pull/755`
