### PR TITLE
8253964: [Graal] UnschedulableGraphTest#test01fails with expected:<4> but was:<3>

### DIFF
--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/UnschedulableGraphTest.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/UnschedulableGraphTest.java
@@ -41,6 +41,7 @@ import org.graalvm.compiler.nodes.calc.NegateNode;
 import org.graalvm.compiler.nodes.cfg.Block;
 import org.graalvm.compiler.nodes.extended.OpaqueNode;
 import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.compiler.phases.OptimisticOptimizations;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -96,6 +97,16 @@ public class UnschedulableGraphTest extends GraalCompilerTest {
     private DebugContext getDebugContext(ResolvedJavaMethod method) {
         OptionValues options = new OptionValues(getInitialOptions(), DumpOnError, false);
         return getDebugContext(options, null, method);
+    }
+
+    @Override
+    protected OptimisticOptimizations getOptimisticOptimizations() {
+        /*
+         * Disable optimistic optimizations to make the test more resilient towards wrong/strange
+         * profiling information and the removal of never executed code as this can cause the
+         * assertions in this test to fail since the control flow graph is in an uncommon shape.
+         */
+        return OptimisticOptimizations.NONE;
     }
 
     @Test


### PR DESCRIPTION
This PR fixes a Graal unit test failure in the presence of -Xcomp. The assertion in the test fails with -Xcomp as RemoveNeverExecutedCode triggers since we dont have proper profiles with Xcomp there.

The fix is already tested and integrated in tip graal https://github.com/oracle/graal/commit/287dbdf63ec3bfcce74e910d66c21dccf8e9cc46 .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253964](https://bugs.openjdk.java.net/browse/JDK-8253964): [Graal] UnschedulableGraphTest#test01fails with expected:<4> but was:<3>


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/756/head:pull/756`
`$ git checkout pull/756`
