### PR TITLE
8017179: [macosx] list1 and list2 vistble item isn't desired

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/LWListPeer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/LWListPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,29 @@
 
 package sun.lwawt;
 
-import javax.swing.*;
-import javax.swing.event.*;
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Insets;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.SystemColor;
+import java.awt.event.ActionEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
 import java.awt.peer.ListPeer;
 import java.util.Arrays;
+
+import javax.swing.DefaultListModel;
+import javax.swing.JList;
+import javax.swing.JScrollBar;
+import javax.swing.JScrollPane;
+import javax.swing.JViewport;
+import javax.swing.ListCellRenderer;
+import javax.swing.ListSelectionModel;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
 
 /**
  * Lightweight implementation of {@link ListPeer}. Delegates most of the work to
@@ -65,6 +82,7 @@ final class LWListPeer extends LWComponentPeer<List, LWListPeer.ScrollableJList>
     void initializeImpl() {
         super.initializeImpl();
         setMultipleMode(getTarget().isMultipleMode());
+        makeVisible(getTarget().getVisibleIndex());
         final int[] selectedIndices = getTarget().getSelectedIndexes();
         synchronized (getDelegateLock()) {
             getDelegate().setSkipStateChangedEvent(true);


### PR DESCRIPTION
Some manual test fails when the java.awt.List component is configured by the List#makeVisible() before the "peer" initialization.
The root cause is trivial if the peer exists already then the Component call the proper method, but if the peer does not exists then it should read all properties from the Component during initialization, and initialization of "visibleIndex" was missed when LWListPeer was implemented.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/mrserb/jdk/runs/1279901025)

### Issue
 * [JDK-8017179](https://bugs.openjdk.java.net/browse/JDK-8017179): [macosx] list1 and list2 vistble item isn't desired


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/757/head:pull/757`
`$ git checkout pull/757`
