### PR TITLE
8255041: Zero: remove old JSR 292 support leftovers

### DIFF
--- a/src/hotspot/cpu/zero/bytecodeInterpreter_zero.hpp
+++ b/src/hotspot/cpu/zero/bytecodeInterpreter_zero.hpp
@@ -153,22 +153,4 @@
 #define SET_LOCALS_LONG_FROM_ADDR(addr, offset) (((VMJavaVal64*)&locals[-((offset)+1)])->l = \
                                                 ((VMJavaVal64*)(addr))->l)
 
-// VMSlots implementation
-
-#define VMSLOTS_SLOT(offset)    ((intptr_t*)&vmslots[(offset)])
-#define VMSLOTS_ADDR(offset)    ((address)vmslots[(offset)])
-#define VMSLOTS_INT(offset)     (*((jint*)&vmslots[(offset)]))
-#define VMSLOTS_FLOAT(offset)   (*((jfloat*)&vmslots[(offset)]))
-#define VMSLOTS_OBJECT(offset)  ((oop)vmslots[(offset)])
-#define VMSLOTS_DOUBLE(offset)  (((VMJavaVal64*)&vmslots[(offset) - 1])->d)
-#define VMSLOTS_LONG(offset)    (((VMJavaVal64*)&vmslots[(offset) - 1])->l)
-
-#define SET_VMSLOTS_SLOT(value, offset)   (*(intptr_t*)&vmslots[(offset)] = *(intptr_t *)(value))
-#define SET_VMSLOTS_ADDR(value, offset)   (*((address *)&vmslots[(offset)]) = (value))
-#define SET_VMSLOTS_INT(value, offset)    (*((jint *)&vmslots[(offset)]) = (value))
-#define SET_VMSLOTS_FLOAT(value, offset)  (*((jfloat *)&vmslots[(offset)]) = (value))
-#define SET_VMSLOTS_OBJECT(value, offset) (*((oop *)&vmslots[(offset)]) = (value))
-#define SET_VMSLOTS_DOUBLE(value, offset) (((VMJavaVal64*)&vmslots[(offset) - 1])->d = (value))
-#define SET_VMSLOTS_LONG(value, offset)   (((VMJavaVal64*)&vmslots[(offset) - 1])->l = (value))
-
 #endif // CPU_ZERO_BYTECODEINTERPRETER_ZERO_HPP

--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -694,56 +694,6 @@ int ZeroInterpreter::empty_entry(Method* method, intptr_t UNUSED, TRAPS) {
   return 0;
 }
 
-// The new slots will be inserted before slot insert_before.
-// Slots < insert_before will have the same slot number after the insert.
-// Slots >= insert_before will become old_slot + num_slots.
-void ZeroInterpreter::insert_vmslots(int insert_before, int num_slots, TRAPS) {
-  JavaThread *thread = THREAD->as_Java_thread();
-  ZeroStack *stack = thread->zero_stack();
-
-  // Allocate the space
-  stack->overflow_check(num_slots, CHECK);
-  stack->alloc(num_slots * wordSize);
-  intptr_t *vmslots = stack->sp();
-
-  // Shuffle everything up
-  for (int i = 0; i < insert_before; i++)
-    SET_VMSLOTS_SLOT(VMSLOTS_SLOT(i + num_slots), i);
-}
-
-void ZeroInterpreter::remove_vmslots(int first_slot, int num_slots, TRAPS) {
-  JavaThread *thread = THREAD->as_Java_thread();
-  ZeroStack *stack = thread->zero_stack();
-  intptr_t *vmslots = stack->sp();
-
-  // Move everything down
-  for (int i = first_slot - 1; i >= 0; i--)
-    SET_VMSLOTS_SLOT(VMSLOTS_SLOT(i), i + num_slots);
-
-  // Deallocate the space
-  stack->set_sp(stack->sp() + num_slots);
-}
-
-BasicType ZeroInterpreter::result_type_of_handle(oop method_handle) {
-  oop method_type = java_lang_invoke_MethodHandle::type(method_handle);
-  oop return_type = java_lang_invoke_MethodType::rtype(method_type);
-  return java_lang_Class::as_BasicType(return_type, (Klass* *) NULL);
-}
-
-intptr_t* ZeroInterpreter::calculate_unwind_sp(ZeroStack* stack,
-                                              oop method_handle) {
-  oop method_type = java_lang_invoke_MethodHandle::type(method_handle);
-  int argument_slots = java_lang_invoke_MethodType::ptype_slot_count(method_type);
-
-  return stack->sp() + argument_slots;
-}
-
-JRT_ENTRY(void, ZeroInterpreter::throw_exception(JavaThread* thread,
-                                                Symbol*     name,
-                                                char*       message))
-  THROW_MSG(name, message);
-JRT_END
-
 InterpreterFrame *InterpreterFrame::build(Method* const method, TRAPS) {
   JavaThread *thread = THREAD->as_Java_thread();
   ZeroStack *stack = thread->zero_stack();

--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.hpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.hpp
@@ -41,12 +41,4 @@
   // Main loop of normal_entry
   static void main_loop(int recurse, TRAPS);
 
- private:
-  // Helpers for method_handle_entry
-  static void insert_vmslots(int insert_before, int num_slots, TRAPS);
-  static void remove_vmslots(int first_slot, int num_slots, TRAPS);
-  static BasicType result_type_of_handle(oop method_handle);
-  static intptr_t* calculate_unwind_sp(ZeroStack* stack, oop method_handle);
-  static void throw_exception(JavaThread* thread, Symbol* name,char *msg=NULL);
-
 #endif // CPU_ZERO_CPPINTERPRETER_ZERO_HPP


### PR DESCRIPTION
JDK-8000780 removed `ZeroInterpreter::method_handle_entry`, but left its helpers around. These have no uses, and can be eliminated. Attention @rkennke, who did the JDK-8000780 a while ago.

Testing:
 - [x] Linux x86_64 fastdebug zero images
 - [x] Linux x86_64 release zero bootcycle-images

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/shipilev/jdk/runs/1279972723)

### Issue
 * [JDK-8255041](https://bugs.openjdk.java.net/browse/JDK-8255041): Zero: remove old JSR 292 support leftovers


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/758/head:pull/758`
`$ git checkout pull/758`
