### PR TITLE
8255043: Incorrectly styled copyright text

### DIFF
--- a/src/java.sql/share/classes/javax/sql/package-info.java
+++ b/src/java.sql/share/classes/javax/sql/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/src/test/jdk/test/Test.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/src/test/jdk/test/Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/java/awt/JAWT/MyCanvas.java
+++ b/test/jdk/java/awt/JAWT/MyCanvas.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/java/awt/font/TextLayout/TestLayoutVsICU.java
+++ b/test/jdk/java/awt/font/TextLayout/TestLayoutVsICU.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * Copyright (C) 2013-2014 IBM Corporation and Others. All Rights Reserved.
  */
 

--- a/test/jdk/java/awt/image/multiresolution/MultiResolutionIcon/IconTest.java
+++ b/test/jdk/java/awt/image/multiresolution/MultiResolutionIcon/IconTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/java/beans/Beans/Test4067824.java
+++ b/test/jdk/java/beans/Beans/Test4067824.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 1997, 2007, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/java/beans/Introspector/6380849/TestBeanInfo.java
+++ b/test/jdk/java/beans/Introspector/6380849/TestBeanInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010, 2012, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/java/beans/PropertyEditor/6380849/TestPropertyEditor.java
+++ b/test/jdk/java/beans/PropertyEditor/6380849/TestPropertyEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/java/beans/XMLEncoder/6380849/TestPersistenceDelegate.java
+++ b/test/jdk/java/beans/XMLEncoder/6380849/TestPersistenceDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/javax/imageio/plugins/external_plugin_tests/src/simp/SIMPImageReader.java
+++ b/test/jdk/javax/imageio/plugins/external_plugin_tests/src/simp/SIMPImageReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/javax/imageio/plugins/external_plugin_tests/src/simp/SIMPImageReaderSpi.java
+++ b/test/jdk/javax/imageio/plugins/external_plugin_tests/src/simp/SIMPImageReaderSpi.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/javax/imageio/plugins/external_plugin_tests/src/simp/SIMPMetadata.java
+++ b/test/jdk/javax/imageio/plugins/external_plugin_tests/src/simp/SIMPMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/javax/imageio/plugins/external_plugin_tests/src/simp/SIMPMetadataFormat.java
+++ b/test/jdk/javax/imageio/plugins/external_plugin_tests/src/simp/SIMPMetadataFormat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/javax/imageio/plugins/external_plugin_tests/src/simp/module-info.java
+++ b/test/jdk/javax/imageio/plugins/external_plugin_tests/src/simp/module-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/javax/imageio/plugins/external_plugin_tests/src/simptest/TestSIMPPlugin.java
+++ b/test/jdk/javax/imageio/plugins/external_plugin_tests/src/simptest/TestSIMPPlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/javax/script/JDK_8196959/BadFactoryTest.java
+++ b/test/jdk/javax/script/JDK_8196959/BadFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/jlink/JLinkNegativeTest.java
+++ b/test/jdk/tools/jlink/JLinkNegativeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/jlink/basic/AllModulePath.java
+++ b/test/jdk/tools/jlink/basic/AllModulePath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/jlink/basic/BasicTest.java
+++ b/test/jdk/tools/jlink/basic/BasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/jlink/basic/src/m1/p/ListModules.java
+++ b/test/jdk/tools/jlink/basic/src/m1/p/ListModules.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/jlink/basic/src/test/jdk/test/Adder.java
+++ b/test/jdk/tools/jlink/basic/src/test/jdk/test/Adder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/jlink/basic/src/test/jdk/test/Test.java
+++ b/test/jdk/tools/jlink/basic/src/test/jdk/test/Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/jlink/plugins/ExcludeJmodSectionPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/ExcludeJmodSectionPluginTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/jlink/plugins/LegalFilePluginTest.java
+++ b/test/jdk/tools/jlink/plugins/LegalFilePluginTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/jmod/JmodNegativeTest.java
+++ b/test/jdk/tools/jmod/JmodNegativeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/jmod/JmodTest.java
+++ b/test/jdk/tools/jmod/JmodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/jmod/hashes/HashesTest.java
+++ b/test/jdk/tools/jmod/hashes/HashesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/addexports/manifest/Test1.java
+++ b/test/jdk/tools/launcher/modules/addexports/manifest/Test1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/addexports/manifest/Test2.java
+++ b/test/jdk/tools/launcher/modules/addexports/manifest/Test2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/addexports/src/m1/jdk/test1/Main.java
+++ b/test/jdk/tools/launcher/modules/addexports/src/m1/jdk/test1/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/addexports/src/m2/jdk/test2/Main.java
+++ b/test/jdk/tools/launcher/modules/addexports/src/m2/jdk/test2/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/addexports/src/m3/jdk/test3/Main.java
+++ b/test/jdk/tools/launcher/modules/addexports/src/m3/jdk/test3/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/addmods/src/logger/module-info.java
+++ b/test/jdk/tools/launcher/modules/addmods/src/logger/module-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/addmods/src/test/module-info.java
+++ b/test/jdk/tools/launcher/modules/addmods/src/test/module-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/classpath/src/m/jdk/test/Main.java
+++ b/test/jdk/tools/launcher/modules/classpath/src/m/jdk/test/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/patch/basic/src/test/jdk/test/Main.java
+++ b/test/jdk/tools/launcher/modules/patch/basic/src/test/jdk/test/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/patch/basic/src/test/module-info.java
+++ b/test/jdk/tools/launcher/modules/patch/basic/src/test/module-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/patch/basic/src2/java.base/java/lang2/Object.java
+++ b/test/jdk/tools/launcher/modules/patch/basic/src2/java.base/java/lang2/Object.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/patch/basic/src2/jdk.compiler/com/sun/tools/javac2/Main.java
+++ b/test/jdk/tools/launcher/modules/patch/basic/src2/jdk.compiler/com/sun/tools/javac2/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/patch/basic/src2/jdk.naming.dns/com/sun/jndi/dns2/Zone.java
+++ b/test/jdk/tools/launcher/modules/patch/basic/src2/jdk.naming.dns/com/sun/jndi/dns2/Zone.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/patch/systemmodules/PatchSystemModules.java
+++ b/test/jdk/tools/launcher/modules/patch/systemmodules/PatchSystemModules.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/patch/systemmodules/src/m1/module-info.java
+++ b/test/jdk/tools/launcher/modules/patch/systemmodules/src/m1/module-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/patch/systemmodules/src/m1/p1/Main.java
+++ b/test/jdk/tools/launcher/modules/patch/systemmodules/src/m1/p1/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/patch/systemmodules/src/m2/module-info.java
+++ b/test/jdk/tools/launcher/modules/patch/systemmodules/src/m2/module-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/patch/systemmodules/src/m2/p2/Lib.java
+++ b/test/jdk/tools/launcher/modules/patch/systemmodules/src/m2/p2/Lib.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/patch/systemmodules/src1/m1/module-info.java
+++ b/test/jdk/tools/launcher/modules/patch/systemmodules/src1/m1/module-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/patch/systemmodules/src1/m1/p1/Main.java
+++ b/test/jdk/tools/launcher/modules/patch/systemmodules/src1/m1/p1/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/tools/launcher/modules/patch/systemmodules/src1/m2/p2/Lib.java
+++ b/test/jdk/tools/launcher/modules/patch/systemmodules/src1/m2/p2/Lib.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
In some files, the copyright text is styled as a JavaDoc comment.
Most of the affected files are tests, only one product file is affected:
src/java.sql/share/classes/javax/sql/package-info.java

The chenge is trivial:
```
 - /**
 + /*
    * Copyright (c) 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/mrserb/jdk/runs/1280057355)

### Issue
 * [JDK-8255043](https://bugs.openjdk.java.net/browse/JDK-8255043): Incorrectly styled copyright text


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Committer)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/759/head:pull/759`
`$ git checkout pull/759`
