### PR TITLE
8255038: Adjust adapter_code_size to account for -Xlog:methodhandles in debug builds

### DIFF
--- a/src/hotspot/cpu/x86/methodHandles_x86.hpp
+++ b/src/hotspot/cpu/x86/methodHandles_x86.hpp
@@ -27,7 +27,7 @@
 
 // Adapters
 enum /* platform_dependent_constants */ {
-  adapter_code_size = 3000 DEBUG_ONLY(+ 3000)
+  adapter_code_size = 3000 DEBUG_ONLY(+ 6000)
 };
 
 // Additional helper methods for MethodHandles code generation:


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8254955 trimmed the space allocated for MethodHandleAdapterBlob, but my analysis failed to account for added trace code information being generated when running with -Xlog:methodhandles (on top of the extra tracing/debugging when running with -XX:+VerifyMethodHandles et.c.). This caused a failure in tier3 Windows ZGC tests.

Adjusting the debug size up a notch ensures we stay within bounds.

Testing: tier3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/cl4es/jdk/runs/1280464771)

### Issue
 * [JDK-8255038](https://bugs.openjdk.java.net/browse/JDK-8255038): Adjust adapter_code_size to account for -Xlog:methodhandles in debug builds


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/761/head:pull/761`
`$ git checkout pull/761`
