### PR TITLE
8255047: Add HotSpot UseDebuggerErgo flags

### DIFF
--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -79,7 +79,7 @@
           "be dumped into the corefile.")                               \
                                                                         \
   product(bool, UseCpuAllocPath, false, DIAGNOSTIC,                     \
-             "Use CPU_ALLOC code path in os::active_processor_count ")
+          "Use CPU_ALLOC code path in os::active_processor_count ")
 
 // end of RUNTIME_OS_FLAGS
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4762,7 +4762,16 @@ int os::active_processor_count() {
 
 uint os::processor_id() {
   const int id = Linux::sched_getcpu();
-  assert(id >= 0 && id < _processor_count, "Invalid processor id");
+
+  #ifndef PRODUCT
+  if (LimitedCPUsDebugging && id >= _processor_count) {
+    // Some debuggers limit the processor count without limiting
+    // the returned processor ids. Fake the processor id.
+    return 0;
+  }
+#endif
+
+  assert(id >= 0 && id < _processor_count, "Invalid processor id [%d]", id);
   return (uint)id;
 }
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3217,7 +3217,17 @@ void os::Linux::rebuild_cpu_to_node_map() {
         if (cpu_map[j] != 0) {
           for (size_t k = 0; k < BitsPerCLong; k++) {
             if (cpu_map[j] & (1UL << k)) {
-              cpu_to_node()->at_put(j * BitsPerCLong + k, closest_node);
+              int cpu_index = j * BitsPerCLong + k;
+
+#ifndef PRODUCT
+              if (UseDebuggerErgo1 && cpu_index >= (int)cpu_num) {
+                // Some debuggers limit the processor count without
+                // intercepting the NUMA APIs. Just fake the values.
+                cpu_index = 0;
+              }
+#endif
+
+              cpu_to_node()->at_put(cpu_index, closest_node);
             }
           }
         }
@@ -4763,8 +4773,8 @@ int os::active_processor_count() {
 uint os::processor_id() {
   const int id = Linux::sched_getcpu();
 
-  #ifndef PRODUCT
-  if (LimitedCPUsDebugging && id >= _processor_count) {
+#ifndef PRODUCT
+  if (UseDebuggerErgo1 && id >= _processor_count) {
     // Some debuggers limit the processor count without limiting
     // the returned processor ids. Fake the processor id.
     return 0;

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4099,6 +4099,17 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
   return JNI_OK;
 }
 
+static void override_for_debugger() {
+  // Debugging with limited number of CPUs
+  if (LimitedCPUsDebugging) {
+    FLAG_SET_ERGO_IF_DEFAULT(UseNUMA, false);
+    FLAG_SET_ERGO_IF_DEFAULT(ConcGCThreads, 1);
+    FLAG_SET_ERGO_IF_DEFAULT(ParallelGCThreads, 1);
+    FLAG_SET_ERGO_IF_DEFAULT(CICompilerCount, 2);
+  }
+}
+
+
 jint Arguments::apply_ergo() {
   // Set flags based on ergonomics.
   jint result = set_ergonomics_flags();
@@ -4106,6 +4117,8 @@ jint Arguments::apply_ergo() {
 
   // Set heap size based on available physical memory
   set_heap_size();
+
+  override_for_debugger();
 
   GCConfig::arguments()->initialize();
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3900,6 +3900,22 @@ bool Arguments::handle_deprecated_print_gc_flags() {
   return true;
 }
 
+static void apply_debugger_ergo() {
+  if (UseDebuggerErgo) {
+    // Turn on sub-flags
+    FLAG_SET_ERGO_IF_DEFAULT(UseDebuggerErgo1, true);
+    FLAG_SET_ERGO_IF_DEFAULT(UseDebuggerErgo2, true);
+  }
+
+  if (UseDebuggerErgo2) {
+    // Debugging with limited number of CPUs
+    FLAG_SET_ERGO_IF_DEFAULT(UseNUMA, false);
+    FLAG_SET_ERGO_IF_DEFAULT(ConcGCThreads, 1);
+    FLAG_SET_ERGO_IF_DEFAULT(ParallelGCThreads, 1);
+    FLAG_SET_ERGO_IF_DEFAULT(CICompilerCount, 2);
+  }
+}
+
 // Parse entry point called from JNI_CreateJavaVM
 
 jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
@@ -4096,19 +4112,10 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
   }
 #endif
 
+  apply_debugger_ergo();
+
   return JNI_OK;
 }
-
-static void override_for_debugger() {
-  // Debugging with limited number of CPUs
-  if (LimitedCPUsDebugging) {
-    FLAG_SET_ERGO_IF_DEFAULT(UseNUMA, false);
-    FLAG_SET_ERGO_IF_DEFAULT(ConcGCThreads, 1);
-    FLAG_SET_ERGO_IF_DEFAULT(ParallelGCThreads, 1);
-    FLAG_SET_ERGO_IF_DEFAULT(CICompilerCount, 2);
-  }
-}
-
 
 jint Arguments::apply_ergo() {
   // Set flags based on ergonomics.
@@ -4117,8 +4124,6 @@ jint Arguments::apply_ergo() {
 
   // Set heap size based on available physical memory
   set_heap_size();
-
-  override_for_debugger();
 
   GCConfig::arguments()->initialize();
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -231,9 +231,6 @@ const intx ObjectAlignmentInBytes = 8;
           "Maximum number of pages to include in the page scan procedure")  \
           range(0, max_uintx)                                               \
                                                                             \
-  notproduct(bool, LimitedCPUsDebugging, false    ,                         \
-          "For debugging with limited CPUs")                                \
-                                                                            \
   product(bool, UseAES, false,                                              \
           "Control whether AES instructions are used when available")       \
                                                                             \
@@ -2185,6 +2182,17 @@ const intx ObjectAlignmentInBytes = 8;
                                                                             \
   product(bool, UseNewCode3, false, DIAGNOSTIC,                             \
           "Testing Only: Use the new version while testing")                \
+                                                                            \
+  notproduct(bool, UseDebuggerErgo, false,                                  \
+          "Debugging Only: Adjust the VM to be more debugger-friendly. "    \
+          "Turns on the other UseDebuggerErgo* flags")                      \
+                                                                            \
+  notproduct(bool, UseDebuggerErgo1, false,                                 \
+          "Debugging Only: Enable workarounds for debugger induced "        \
+          "os::processor_id() >= os::processor_count() problems")           \
+                                                                            \
+  notproduct(bool, UseDebuggerErgo2, false,                                 \
+          "Debugging Only: Limit the number of spawned JVM threads")        \
                                                                             \
   /* flags for performance data collection */                               \
                                                                             \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -231,6 +231,9 @@ const intx ObjectAlignmentInBytes = 8;
           "Maximum number of pages to include in the page scan procedure")  \
           range(0, max_uintx)                                               \
                                                                             \
+  notproduct(bool, LimitedCPUsDebugging, false    ,                         \
+          "For debugging with limited CPUs")                                \
+                                                                            \
   product(bool, UseAES, false,                                              \
           "Control whether AES instructions are used when available")       \
                                                                             \


### PR DESCRIPTION
Some debuggers don't work well with many threads, and/or incompletely restricts the number of used CPUs to one.

This flag is intended as a catch-all for HotSpot developers (not available in product builds) to allow us to more easily use those debuggers.

Currently, the proposal is to let the flag fix a few things:
1) Turn down the number of JVM threads
2) Turn off NUMA
3) Force processor_id() to return 0 instead of values above processor_count()

(1) is purely ergonomics: gdb, rr, valgrind is faster and seems to work much better with fewer threads. The values would still be overridable by devs.

(2) and (3) deals with the fact that some debuggers change the reported processor count, but don't change the processor ids returned by sched_getcpu. This causes problems for ZGC and NUMA, that both assumes that they can rely on os::processor_id() < os::processor_count().

The current proposed flag name is -XX:+LimitedCPUsDebugging. I'm not entirely happy with that name, but I been able to find a better name.

An alternative to having one flag, is to split this into two flags, and maybe that would solve the naming problem. However, the usability aspects will be worse.

If we can't find a suitable name, I rather introduce a flag called:
-XX:DebuggerWorkarounds or -XX:DebuggerWorkaround1 

Any suggestions / opinions? I really do want to at least fix the (2, 3) problem, because I keep having to add this to every single branch I'm working on.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/stefank/jdk/runs/1286739854)

### Issue
 * [JDK-8255047](https://bugs.openjdk.java.net/browse/JDK-8255047): Add HotSpot UseDebuggerErgo flags


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/763/head:pull/763`
`$ git checkout pull/763`
