### PR TITLE
8255065: Zero: accessor_entry misses the IRIW case

### DIFF
--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -596,6 +596,9 @@ int ZeroInterpreter::accessor_entry(Method* method, intptr_t UNUSED, TRAPS) {
     break;
   }
   if (entry->is_volatile()) {
+    if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
+      OrderAccess::fence();
+    }
     switch (entry->flag_state()) {
     case ctos:
       SET_LOCALS_INT(object->char_field_acquire(entry->f2_as_index()), 0);


### PR DESCRIPTION
While doing a change in related area, I noticed there is no IRIW handling block in `ZeroInterpreter::accessor_entry` when reading volatile fields. This probably breaks PPC64 Zero.

There is a block in `bytecodeInterpreter.cpp` for [common field access](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp#L1899-L1901):

```
          if (cache->is_volatile()) {
            if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
              OrderAccess::fence();
            }
```

Attention @TheRealMDoerr ;)

Testing:
 - [x] Linux x86_64 zero fastdebug build (includes jmod generation with Zero)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ❌ (5/9 failed) | ❌ (2/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Linux x64 (hs/tier1 runtime)](https://github.com/shipilev/jdk/runs/1282539475)
- [Linux x64 (hs/tier1 serviceability)](https://github.com/shipilev/jdk/runs/1282539492)
- [Linux x64 (jdk/tier1 part 1)](https://github.com/shipilev/jdk/runs/1282539346)
- [Linux x64 (jdk/tier1 part 2)](https://github.com/shipilev/jdk/runs/1282539364)
- [Linux x64 (jdk/tier1 part 3)](https://github.com/shipilev/jdk/runs/1282539389)
- [Windows x64 (hs/tier1 common)](https://github.com/shipilev/jdk/runs/1282680396)
- [Windows x64 (hs/tier1 compiler)](https://github.com/shipilev/jdk/runs/1282680411)
- [macOS x64 (hs/tier1 runtime)](https://github.com/shipilev/jdk/runs/1282538374)

### Issue
 * [JDK-8255065](https://bugs.openjdk.java.net/browse/JDK-8255065): Zero: accessor_entry misses the IRIW case


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/766/head:pull/766`
`$ git checkout pull/766`
