### PR TITLE
8255068: [JVMCI] errors during compiler creation can be hidden

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -46,6 +46,7 @@ import java.util.ServiceLoader;
 import java.util.function.Predicate;
 
 import jdk.vm.ci.code.Architecture;
+import jdk.vm.ci.code.CompilationRequest;
 import jdk.vm.ci.code.CompilationRequestResult;
 import jdk.vm.ci.code.CompiledCode;
 import jdk.vm.ci.code.InstalledCode;
@@ -698,6 +699,19 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
         return null;
     }
 
+    static class ErrorCreatingCompiler implements JVMCICompiler {
+        private final RuntimeException t;
+
+        ErrorCreatingCompiler(RuntimeException t) {
+            this.t = t;
+        }
+
+        @Override
+        public CompilationRequestResult compileMethod(CompilationRequest request) {
+            throw t;
+        }
+    }
+
     @Override
     public JVMCICompiler getCompiler() {
         if (compiler == null) {
@@ -705,10 +719,18 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
                 if (compiler == null) {
                     assert !creatingCompiler : "recursive compiler creation";
                     creatingCompiler = true;
-                    compiler = compilerFactory.createCompiler(this);
-                    creatingCompiler = false;
+                    try {
+                        compiler = compilerFactory.createCompiler(this);
+                    } catch (RuntimeException t) {
+                        compiler = new ErrorCreatingCompiler(t);
+                    } finally {
+                        creatingCompiler = false;
+                    }
                 }
             }
+        }
+        if (compiler instanceof ErrorCreatingCompiler) {
+            throw ((ErrorCreatingCompiler) compiler).t;
         }
         return compiler;
     }


### PR DESCRIPTION
This improves the handling of errors during compiler creation.  @dougxc @vnkozlov

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255068](https://bugs.openjdk.java.net/browse/JDK-8255068): [JVMCI] errors during compiler creation can be hidden


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to a5a6278e99f3a923c1a98deb63dac5cc67172a7c


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/768/head:pull/768`
`$ git checkout pull/768`
