### PR TITLE
8254790: SIGSEGV in string_indexof_char and stringL_indexof_char intrinsics

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -2717,7 +2717,7 @@ void C2_MacroAssembler::string_indexof_char(Register str1, Register cnt1, Regist
     pmovmskb(tmp, vec3);
   }
   bsfl(ch, tmp);
-  addl(result, ch);
+  addptr(result, ch);
 
   bind(FOUND_SEQ_CHAR);
   subptr(result, str1);
@@ -2811,7 +2811,7 @@ void C2_MacroAssembler::stringL_indexof_char(Register str1, Register cnt1, Regis
     pmovmskb(tmp, vec3);
   }
   bsfl(ch, tmp);
-  addl(result, ch);
+  addptr(result, ch);
 
   bind(FOUND_SEQ_CHAR);
   subptr(result, str1);

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -495,7 +495,7 @@ bool C2Compiler::is_intrinsic_supported(const methodHandle& method, bool is_virt
   case vmIntrinsics::_indexOfIU:
   case vmIntrinsics::_indexOfIUL:
   case vmIntrinsics::_indexOfU_char:
-  // case vmIntrinsics::_indexOfL_char: // Disable it until found issues are fixed
+  case vmIntrinsics::_indexOfL_char:
   case vmIntrinsics::_toBytesStringU:
   case vmIntrinsics::_getCharsStringU:
   case vmIntrinsics::_getCharStringU:


### PR DESCRIPTION
The problem was due to 32 bit arithmetic instruction used for 64-bit address in 
string_indexof_char and stringL_indexof_char: "addl(result, ch)".

This patch replaces the addl instruction with addptr and also enables the stringL_indexof_char intrinsic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ❌ (3/5 failed) | ❌ (2/2 failed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |  ❌ (5/9 failed) |

**Failed test tasks**
- [Linux x64 (build debug)](https://github.com/sviswa7/jdk/runs/1283183253)
- [Linux x64 (build hotspot no-pch)](https://github.com/sviswa7/jdk/runs/1283183282)
- [Linux x64 (build release)](https://github.com/sviswa7/jdk/runs/1283183236)
- [Windows x64 (build debug)](https://github.com/sviswa7/jdk/runs/1283183495)
- [Windows x64 (build release)](https://github.com/sviswa7/jdk/runs/1283183479)
- [macOS x64 (hs/tier1 compiler)](https://github.com/sviswa7/jdk/runs/1283324553)
- [macOS x64 (hs/tier1 gc)](https://github.com/sviswa7/jdk/runs/1283324573)
- [macOS x64 (hs/tier1 runtime)](https://github.com/sviswa7/jdk/runs/1283324589)
- [macOS x64 (hs/tier1 serviceability)](https://github.com/sviswa7/jdk/runs/1283324616)
- [macOS x64 (jdk/tier1 part 2)](https://github.com/sviswa7/jdk/runs/1283324485)

### Issue
 * [JDK-8254790](https://bugs.openjdk.java.net/browse/JDK-8254790): SIGSEGV in string_indexof_char and stringL_indexof_char intrinsics


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/772/head:pull/772`
`$ git checkout pull/772`
