### PR TITLE
8255031 :  Update java/util/prefs/AddNodeChangeListener.java to report more failure info

### DIFF
--- a/test/jdk/java/util/prefs/AddNodeChangeListener.java
+++ b/test/jdk/java/util/prefs/AddNodeChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
  /* @test
   * @bug  7160252 7197662
+  * @key intermittent
   * @summary Checks if events are delivered to a listener
   *          when a child node is added or removed
   * @run main/othervm -Djava.util.prefs.userRoot=. AddNodeChangeListener
@@ -30,15 +31,15 @@
 
 import java.util.prefs.*;
 
- public class AddNodeChangeListener {
+public class AddNodeChangeListener {
 
-     private static boolean failed = false;
-     private static Preferences userRoot, N2;
-     private static NodeChangeListenerAdd ncla;
+    private static final int SLEEP_ITRS = 10;
+    private static boolean failed = false;
+    private static Preferences userRoot, N2;
+    private static NodeChangeListenerAdd ncla;
 
-     public static void main(String[] args)
-         throws BackingStoreException, InterruptedException
-     {
+    public static void main(String[] args)
+             throws BackingStoreException, InterruptedException {
         userRoot = Preferences.userRoot();
         ncla = new NodeChangeListenerAdd();
         userRoot.addNodeChangeListener(ncla);
@@ -49,28 +50,57 @@ import java.util.prefs.*;
         //Should initate a child removed event
         removeNode();
 
-        if (failed)
+        if (failed) {
             throw new RuntimeException("Failed");
+        }
     }
 
     private static void addNode()
-        throws BackingStoreException, InterruptedException
-    {
+            throws BackingStoreException, InterruptedException {
         N2 = userRoot.node("N2");
         userRoot.flush();
-        Thread.sleep(3000);
-        if (ncla.getAddNumber() != 1)
-            failed = true;
+        int passItr = -1;
+        
+        for (int i = 0; i < SLEEP_ITRS; i++) {
+            Thread.sleep(3000);
+            if (ncla.getAddNumber() == 1) {
+                passItr = i;
+                break;
+            }
+        }
+        checkPassItr(passItr, "addNode()");
     }
 
     private static void removeNode()
-        throws BackingStoreException, InterruptedException
-    {
+            throws BackingStoreException, InterruptedException {
         N2.removeNode();
         userRoot.flush();
-        Thread.sleep(3000);
-        if (ncla.getAddNumber() != 0)
+        int passItr = -1;
+        
+        for (int i = 0; i < SLEEP_ITRS; i++) {
+            Thread.sleep(3000);
+            if (ncla.getAddNumber() == 0) {
+                passItr = i;
+                break;
+            }
+        }
+        checkPassItr(passItr, "removeNode()");
+    }
+
+    /* If the listener wasn't notified on iteration 0, throw a RuntimeException
+     * with some contextual information
+     */
+    private static void checkPassItr(int itr, String methodName) {
+        if (itr == 0) {
+            System.out.println(methodName + " test passed");
+        } else { 
             failed = true;
+            if (itr == -1) {
+                throw new RuntimeException("Failed in " + methodName + " - change listener never notified");            
+            } else {
+                throw new RuntimeException("Failed in " + methodName + " - listener notified on iteration " + itr);
+            }
+        }
     }
 
     private static class NodeChangeListenerAdd implements NodeChangeListener {
@@ -90,4 +120,4 @@ import java.util.prefs.*;
             return totalNode;
         }
     }
- }
+}

--- a/test/jdk/java/util/prefs/AddNodeChangeListener.java
+++ b/test/jdk/java/util/prefs/AddNodeChangeListener.java
@@ -62,7 +62,9 @@ public class AddNodeChangeListener {
         int passItr = -1;
 
         for (int i = 0; i < SLEEP_ITRS; i++) {
+            System.out.print("addNode sleep iteration " + i + "...");
             Thread.sleep(3000);
+            System.out.println("done.");
             if (ncla.getAddNumber() == 1) {
                 passItr = i;
                 break;
@@ -78,7 +80,9 @@ public class AddNodeChangeListener {
         int passItr = -1;
 
         for (int i = 0; i < SLEEP_ITRS; i++) {
+            System.out.print("removeNode sleep iteration " + i + "...");
             Thread.sleep(3000);
+            System.out.println("done.");
             if (ncla.getAddNumber() == 0) {
                 passItr = i;
                 break;

--- a/test/jdk/java/util/prefs/AddNodeChangeListener.java
+++ b/test/jdk/java/util/prefs/AddNodeChangeListener.java
@@ -60,7 +60,7 @@ public class AddNodeChangeListener {
         N2 = userRoot.node("N2");
         userRoot.flush();
         int passItr = -1;
-        
+
         for (int i = 0; i < SLEEP_ITRS; i++) {
             Thread.sleep(3000);
             if (ncla.getAddNumber() == 1) {
@@ -76,7 +76,7 @@ public class AddNodeChangeListener {
         N2.removeNode();
         userRoot.flush();
         int passItr = -1;
-        
+
         for (int i = 0; i < SLEEP_ITRS; i++) {
             Thread.sleep(3000);
             if (ncla.getAddNumber() == 0) {
@@ -93,10 +93,10 @@ public class AddNodeChangeListener {
     private static void checkPassItr(int itr, String methodName) {
         if (itr == 0) {
             System.out.println(methodName + " test passed");
-        } else { 
+        } else {
             failed = true;
             if (itr == -1) {
-                throw new RuntimeException("Failed in " + methodName + " - change listener never notified");            
+                throw new RuntimeException("Failed in " + methodName + " - change listener never notified");
             } else {
                 throw new RuntimeException("Failed in " + methodName + " - listener notified on iteration " + itr);
             }


### PR DESCRIPTION
Hi,

The java/util/prefs/AddNodeChangeListener.java test fails once in a while in the automated test system.  Previous failures were traced to machine configuration errors, but that does not appear to be the case this time.

My efforts to reproduce this failure have been unsuccessful.  The only useful information I've gleaned so far from the test failure logs is that the overall duration for running tier1 is longer than usual when the test failure happens.

I would like to make the following updates to the test, in hopes of learning more if and when this test fails again:

* fail faster, to report if it is addNode() or removeNode() that is failing
* make multiple attempts to sleep+check the NodeChangeListener.  (If the test fails after a single sleep, but passes after waiting longer, maybe we just need to sleep for longer to account for the occasional slower tier1 test run).
* a few indentations fixes

Thanks,
-Brent

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/bchristi-git/jdk/runs/1288855569)

### Issue
 * [JDK-8255031](https://bugs.openjdk.java.net/browse/JDK-8255031): Update java/util/prefs/AddNodeChangeListener.java to report more failure info


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/773/head:pull/773`
`$ git checkout pull/773`
