### PR TITLE
8255074: sun.nio.fs.WindowsPath::getPathForWin32Calls synchronizes on String object

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
@@ -206,7 +206,7 @@ class WindowsPath implements Path {
         // directory on removal media devices can change during the lifetime
         // of the VM)
         if (type != WindowsPathType.DRIVE_RELATIVE) {
-            synchronized (path) {
+            synchronized (this) {
                 pathForWin32Calls = new WeakReference<String>(resolved);
             }
         }


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch?

from JBS:
`sun.nio.fs.WindowsPath::getPathForWin32Calls` synchronizes on `path` field, which is a `String` object: 
```
        if (type != WindowsPathType.DRIVE_RELATIVE) { 
            synchronized (path) { 
                pathForWin32Calls = new WeakReference<String>(resolved); 
            } 
        } 
```
this might lead to a deadlock, synchronizing on `this` is appropriate here.

testing:
* [x] tier1
* [x] `test/jdk/java/nio` on windows-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ❌ (2/5 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |  ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build hotspot no-pch)](https://github.com/iignatev/jdk/runs/1283596580)
- [Linux x64 (build hotspot zero)](https://github.com/iignatev/jdk/runs/1283596601)
- [Windows x64 (hs/tier1 compiler)](https://github.com/iignatev/jdk/runs/1283835113)

### Issue
 * [JDK-8255074](https://bugs.openjdk.java.net/browse/JDK-8255074): sun.nio.fs.WindowsPath::getPathForWin32Calls synchronizes on String object 


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/774/head:pull/774`
`$ git checkout pull/774`
