### PR TITLE
8255078: sun/net/ftp/imp/FtpClient$MLSxParser uses wrong datetime format

### DIFF
--- a/test/jdk/sun/net/ftp/TestFtpTimeValue.java
+++ b/test/jdk/sun/net/ftp/TestFtpTimeValue.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8255078
+ * @summary verify that datetime in MDTM and MLSD responses are properly parsed
+ * @library /test/lib
+ * @modules java.base/sun.net.ftp
+ * @build jdk.test.lib.Asserts
+ * @run main TestFtpTimeValue
+ */
+
+import jdk.test.lib.Asserts;
+import sun.net.ftp.FtpClient;
+
+import java.io.*;
+import java.net.*;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+
+public class TestFtpTimeValue {
+    private enum TestCase {
+        AmTimeNoMilli(2019, 4, 20, 10, 57, 13, 0),
+        AmTimeWithMilli(2019, 4, 20, 10, 57, 13, 50),
+        PmTimeNoMilli(2019, 4, 20, 22, 57, 13, 0),
+        PmTimeWithMilli(2019, 4, 20, 22, 57, 13, 50),
+        ;
+
+        public final Date expectedCreated;
+        public final Date expectedModified;
+        public final String create;
+        public final String modify;
+
+        TestCase(int year, int month, int day, int hrs, int min, int sec, int milliseconds) {
+            var calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("GMT"));
+            // month is 0-based in Calendar
+            calendar.set(year, month - 1, day, hrs, min, sec);
+            calendar.set(Calendar.MILLISECOND, milliseconds);
+            expectedCreated = calendar.getTime();
+            var s = String.format("%4d%2d%2d%2d%2d%2d", year, month, day, hrs, min, sec);
+            if (milliseconds != 0) {
+                s += "." + String.format("%3d", milliseconds);
+            }
+            create = s;
+
+            calendar.add(GregorianCalendar.SECOND, 1);
+            expectedModified = calendar.getTime();
+            s = String.format("%4d%2d%2d%2d%2d%2d", year, month, day, hrs, min, sec + 1);
+            if (milliseconds != 0) {
+                s += "." + String.format("%3d", milliseconds);
+            }
+            modify = s;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        try (FtpServer server = new FtpServer();
+             FtpClient client = FtpClient.create()) {
+            (new Thread(server)).start();
+            int port = server.getPort();
+            var loopback = InetAddress.getLoopbackAddress();
+            client.connect(new InetSocketAddress(loopback, port));
+            client.enablePassiveMode(true);
+            for (var testCase : TestCase.values()) {
+                Asserts.assertEQ(testCase.expectedModified, client.getLastModified(testCase.name()),
+                        "wrong modified date from MDTM for " + testCase);
+            }
+            for (var it = client.listFiles(null); it.hasNext(); ) {
+                var e = it.next();
+                Asserts.assertEQ(TestCase.valueOf(e.getName()).expectedCreated, e.getCreated(),
+                        "wrong created date from MLSD for " + e);
+                Asserts.assertEQ(TestCase.valueOf(e.getName()).expectedModified, e.getLastModified(),
+                        "wrong modified date from MLSD for " + e);
+            }
+        }
+    }
+
+    private static class FtpServer implements AutoCloseable, Runnable {
+        private final ServerSocket serverSocket;
+        private final ServerSocket pasv;
+
+        FtpServer() throws IOException {
+            var loopback = InetAddress.getLoopbackAddress();
+            serverSocket = new ServerSocket();
+            serverSocket.bind(new InetSocketAddress(loopback, 0));
+            pasv = new ServerSocket();
+            pasv.bind(new InetSocketAddress(loopback, 0));
+        }
+
+        public void handleClient(Socket client) throws IOException {
+            String str;
+
+            client.setSoTimeout(2000);
+            BufferedReader in = new BufferedReader(new InputStreamReader(client.getInputStream()));
+            PrintWriter out = new PrintWriter(client.getOutputStream(), true);
+            out.println("220 FTP serverSocket is ready.");
+            boolean done = false;
+            while (!done) {
+                try {
+                    str = in.readLine();
+                } catch (SocketException e) {
+                    done = true;
+                    continue;
+                }
+                String cmd = str.substring(0, str.indexOf(" ") > 0 ? str.indexOf(" ") : str.length());
+                String args = (cmd.equals(str)) ? "" : str.substring(str.indexOf(" ") + 1);
+                System.err.println("C> " + str);
+                switch (cmd) {
+                    case "QUIT":
+                        out.println("221 Goodbye.");
+                        System.err.println("S> 221");
+                        done = true;
+                        break;
+                    case "MDTM": {
+                        var testCase = TestCase.valueOf(args);
+                        out.println("213 " + testCase.modify);
+                        System.err.println("S> 213");
+                        break;
+                    }
+                    case "MLSD":
+                        try (var socket = pasv.accept();
+                             var dout = new PrintWriter(socket.getOutputStream(), true)) {
+                            out.println("150 MLSD start");
+                            System.err.println("S> 150");
+                            for (var testCase : TestCase.values()) {
+                                dout.printf("modify=%s;create=%s; %s%n",
+                                            testCase.modify, testCase.create, testCase.name());
+                            }
+                        }
+                        out.println("226 MLSD done.");
+                        System.err.println("S> 226");
+                        break;
+                    case "EPSV":
+                        if ("all".equalsIgnoreCase(args)) {
+                            out.println("200 EPSV ALL command successful.");
+                            System.err.println("S> 200");
+                            continue;
+                        }
+                        out.println("229 Entering Extended Passive Mode (|||" + pasv.getLocalPort() + "|)");
+                        System.err.println("S> 229");
+                        break;
+                    default:
+                        System.err.println("S> 500");
+                        out.println("500 unsupported command: " + str);
+                }
+            }
+        }
+
+        public int getPort() {
+            return serverSocket.getLocalPort();
+        }
+
+        public void close() throws IOException {
+            serverSocket.close();
+            pasv.close();
+        }
+
+        @Override
+        public void run() {
+            try (Socket client = serverSocket.accept()) {
+                handleClient(client);
+            } catch (Throwable t) {
+                t.printStackTrace();
+                throw new RuntimeException("Problem in test execution", t);
+            }
+        }
+    }
+}

--- a/test/jdk/sun/net/ftp/TestFtpTimeValue.java
+++ b/test/jdk/sun/net/ftp/TestFtpTimeValue.java
@@ -92,9 +92,9 @@ public class TestFtpTimeValue {
             for (var it = client.listFiles(null); it.hasNext(); ) {
                 var e = it.next();
                 Asserts.assertEQ(TestCase.valueOf(e.getName()).expectedCreated, e.getCreated(),
-                        "wrong created date from MLSD for " + e);
+                        "wrong created date from MLSD for " + e.getName());
                 Asserts.assertEQ(TestCase.valueOf(e.getName()).expectedModified, e.getLastModified(),
-                        "wrong modified date from MLSD for " + e);
+                        "wrong modified date from MLSD for " + e.getName());
             }
         }
     }


### PR DESCRIPTION
Hi all,

could you please review this small patch?

according to [RFC3659](https://tools.ietf.org/html/rfc3659), time values in MLSx response have the following format: 
>    time-val = 14DIGIT [ "." 1*DIGIT ] 
> 
>    The leading, mandatory, fourteen digits are to be interpreted as, in 
>    order from the leftmost, four digits giving the year, with a range of 
>    1000--9999, two digits giving the month of the year, with a range of 
>    01--12, two digits giving the day of the month, with a range of 
>    01--31, two digits giving the hour of the day, with a range of 
>    00--23, two digits giving minutes past the hour, with a range of 
>    00--59, and finally, two digits giving seconds past the minute, with 
>    a range of 00--60 (with 60 being used only at a leap second). Years 
>    in the tenth century, and earlier, cannot be expressed. This is not 
>    considered a serious defect of the protocol. 
> 
>    The optional digits, which are preceded by a period, give decimal 
>    fractions of a second. These may be given to whatever precision is 
>    appropriate to the circumstance, however implementations MUST NOT add 
>    precision to time-vals where that precision does not exist in the 
>    underlying value being transmitted. 
> 
>    Symbolically, a time-val may be viewed as 
> 
>   YYYYMMDDHHMMSS.sss 
> 
>    The "." and subsequent digits ("sss") are optional. However the "." 
>    MUST NOT appear unless at least one following digit also appears. 
> 

`MLSxParser`, however, uses `SimpleDateFormat("yyyyMMddhhmmss")` (which is wrong b/c it uses `hh` instead of `HH` and doesn't account for optional `.sss`) to parse modify/create facts and ignore any parse exceptions.

`FtpClient` actually already has and uses `SimpleDateFormat` w/ right formats in `getLastModified` where it parses MDTM response, the patch refactors the code to reuse the same `SimpleDateFormat` in `MLSxParser`.

testing:
* [x] tier1
* [x] `test/jdk/sun/net` on `{linux,windows,macosx}-x64`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/iignatev/jdk/runs/1299657512)

### Issue
 * [JDK-8255078](https://bugs.openjdk.java.net/browse/JDK-8255078): sun/net/ftp/imp/FtpClient$MLSxParser uses wrong datetime format


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/776/head:pull/776`
`$ git checkout pull/776`
