### PR TITLE
8255070: Shenandoah: Use single thread for concurrent CLD liveness test	

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1941,7 +1941,7 @@ private:
   ShenandoahVMWeakRoots<true /*concurrent*/> _vm_roots;
 
   // Roots related to concurrent class unloading
-  ShenandoahClassLoaderDataRoots<true /* concurrent */, false /* single thread*/>
+  ShenandoahClassLoaderDataRoots<true /* concurrent */, true /* single thread*/>
                                              _cld_roots;
   ShenandoahConcurrentNMethodIterator        _nmethod_itr;
   ShenandoahConcurrentStringDedupRoots       _dedup_roots;

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
@@ -149,6 +149,8 @@ private:
   ShenandoahPhaseTimings::Phase _phase;
 
   static uint worker_count(uint n_workers) {
+    if (SINGLE_THREADED) return 1u;
+
     // Limit concurrency a bit, otherwise it wastes resources when workers are tripping
     // over each other. This also leaves free workers to process other parts of the root
     // set, while admitted workers are busy with doing the CLDG walk.

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
@@ -163,6 +163,10 @@ public:
 
   void always_strong_cld_do(CLDClosure* clds, uint worker_id);
   void cld_do(CLDClosure* clds, uint worker_id);
+
+private:
+  typedef void (*CldDo)(CLDClosure*);
+  void cld_do_impl(CldDo f, CLDClosure* clds, uint worker_id);
 };
 
 class ShenandoahRootProcessor : public StackObj {

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
@@ -35,7 +35,6 @@
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 #include "memory/resourceArea.hpp"
-#include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"
 
 template <bool CONCURRENT>
@@ -85,6 +84,10 @@ ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::ShenandoahClassLoad
   if (CONCURRENT && !SINGLE_THREADED) {
     ClassLoaderDataGraph_lock->lock();
   }
+
+  // Non-concurrent mode only runs at safepoints by VM thread
+  assert(CONCURRENT || SafepointSynchronize::is_at_safepoint(), "Must be at a safepoint");
+  assert(CONCURRENT || Thread::current()->is_VM_thread(), "Can only be done by VM thread");
 }
 
 template <bool CONCURRENT, bool SINGLE_THREADED>
@@ -95,47 +98,29 @@ ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::~ShenandoahClassLoa
 }
 
 template <bool CONCURRENT, bool SINGLE_THREADED>
-void ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::always_strong_cld_do(CLDClosure* clds, uint worker_id) {
-  if (SINGLE_THREADED) {
-    if (CONCURRENT) {
-      if (_semaphore.try_acquire()) {
-        ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CLDGRoots, worker_id);
-        MutexLocker locker(ClassLoaderDataGraph_lock, Mutex::_no_safepoint_check_flag);
-        ClassLoaderDataGraph::always_strong_cld_do(clds);
-        _semaphore.claim_all();
-      }
-    } else {
-      assert(SafepointSynchronize::is_at_safepoint(), "Must be at a safepoint");
-      assert(Thread::current()->is_VM_thread(), "Can only be done by VM thread");
-      ClassLoaderDataGraph::always_strong_cld_do(clds);
+void ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::cld_do_impl(CldDo f, CLDClosure* clds, uint worker_id) {
+  if (CONCURRENT) {
+    if (_semaphore.try_acquire()) {
+      ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CLDGRoots, worker_id);
+      if (SINGLE_THREADED) ClassLoaderDataGraph_lock->lock();
+      f(clds);
+      if (SINGLE_THREADED) ClassLoaderDataGraph_lock->unlock();
+      _semaphore.claim_all();
     }
-  } else if (_semaphore.try_acquire()) {
-    ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CLDGRoots, worker_id);
-    ClassLoaderDataGraph::always_strong_cld_do(clds);
-    _semaphore.claim_all();
+  } else {
+    f(clds);
   }
+}
+
+
+template <bool CONCURRENT, bool SINGLE_THREADED>
+void ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::always_strong_cld_do(CLDClosure* clds, uint worker_id) {
+  cld_do_impl(&ClassLoaderDataGraph::always_strong_cld_do, clds, worker_id);
 }
 
 template <bool CONCURRENT, bool SINGLE_THREADED>
 void ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::cld_do(CLDClosure* clds, uint worker_id) {
-  if (SINGLE_THREADED) {
-    if (CONCURRENT) {
-      if (_semaphore.try_acquire()) {
-        ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CLDGRoots, worker_id);
-        MutexLocker locker(ClassLoaderDataGraph_lock, Mutex::_no_safepoint_check_flag);
-        ClassLoaderDataGraph::cld_do(clds);
-        _semaphore.claim_all();
-      }
-    } else {
-      assert(SafepointSynchronize::is_at_safepoint(), "Must be at a safepoint");
-      assert(Thread::current()->is_VM_thread(), "Can only be done by VM thread");
-      ClassLoaderDataGraph::cld_do(clds);
-    }
-  } else if (_semaphore.try_acquire()) {
-    ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CLDGRoots, worker_id);
-    ClassLoaderDataGraph::cld_do(clds);
-    _semaphore.claim_all();
-  }
+  cld_do_impl(&ClassLoaderDataGraph::cld_do, clds, worker_id);
 }
 
 class ShenandoahParallelOopsDoThreadClosure : public ThreadClosure {

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
@@ -35,6 +35,7 @@
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 #include "memory/resourceArea.hpp"
+#include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"
 
 template <bool CONCURRENT>


### PR DESCRIPTION
Since the concurrent liveness test does not touch any oops, there is no point to use multi-thread for the task, they just duplicate the work.

Also, multi-thread version requires to acquire ClassLoaderGraph_lock early, which is deadlock prone.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255070](https://bugs.openjdk.java.net/browse/JDK-8255070): Shenandoah: Use single thread for concurrent CLD liveness test


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/777/head:pull/777`
`$ git checkout pull/777`
