### PR TITLE
8254670: SVE test uses linux-specific api

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestSVEWithJNI.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestSVEWithJNI.java
@@ -26,7 +26,7 @@
 /**
  * @test
  *
- * @requires os.arch == "aarch64" & vm.compiler2.enabled
+ * @requires os.arch == "aarch64" & vm.compiler2.enabled & os.family == "linux"
  * @summary Verify VM SVE checking behavior
  * @library /test/lib
  * @run main/othervm/native compiler.c2.aarch64.TestSVEWithJNI

--- a/test/hotspot/jtreg/compiler/c2/aarch64/libTestSVEWithJNI.c
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/libTestSVEWithJNI.c
@@ -23,7 +23,7 @@
 *
 */
 
-#ifdef __aarch64__
+#if defined(__aarch64__) && defined (__linux__)
 
 #include <jni.h>
 #include <pthread.h>


### PR DESCRIPTION
The SVE JNI test uses linux-specific api in native code, which is invalid with Windows/AArch64 and macOS/AArch64 ports in. Fixed by simply reducing the test to Linux only.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/nsjian/jdk/runs/1285188744)

### Issue
 * [JDK-8254670](https://bugs.openjdk.java.net/browse/JDK-8254670): SVE test uses linux-specific api


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)
 * vkempik - Committer ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/778/head:pull/778`
`$ git checkout pull/778`
