### PR TITLE
8255124: KeepAliveStreamCleaner may crash with java.lang.IllegalMonitorStateException: current thread is not owner

### DIFF
--- a/src/java.base/share/classes/sun/net/www/http/KeepAliveStreamCleaner.java
+++ b/src/java.base/share/classes/sun/net/www/http/KeepAliveStreamCleaner.java
@@ -30,6 +30,7 @@ import java.util.LinkedList;
 import sun.net.NetProperties;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -115,7 +116,7 @@ class KeepAliveStreamCleaner
                     long before = System.currentTimeMillis();
                     long timeout = TIMEOUT;
                     while ((kace = poll()) == null) {
-                        waiter.wait(timeout);
+                        waiter.await(timeout, TimeUnit.MILLISECONDS);
 
                         long after = System.currentTimeMillis();
                         long elapsed = after - before;

--- a/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 5045306 6356004 6993490
+ * @bug 5045306 6356004 6993490 8255124
  * @modules java.base/sun.net.www
  *          java.management
  * @library ../../httptest/

--- a/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
@@ -35,6 +35,8 @@
 import java.net.*;
 import java.io.*;
 import java.lang.management.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /* Part 1:
  * The http client makes a connection to a URL whos content contains a lot of
@@ -69,6 +71,10 @@ public class B5045306
     }
 
     public static void clientHttpCalls() {
+        List<Throwable> uncaught = new ArrayList<>();
+        Thread.setDefaultUncaughtExceptionHandler((t, ex) -> {
+            uncaught.add(ex);
+        });
         try {
             System.out.println("http server listen on: " + server.getLocalPort());
             String hostAddr =  InetAddress.getLocalHost().getHostAddress();
@@ -132,6 +138,9 @@ public class B5045306
             e.printStackTrace();
         } finally {
             server.terminate();
+        }
+        if (!uncaught.isEmpty()) {
+            throw new AssertionError("Unhandled exception:", uncaught.get(0));
         }
     }
 }

--- a/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
@@ -140,7 +140,7 @@ public class B5045306
             server.terminate();
         }
         if (!uncaught.isEmpty()) {
-            throw new AssertionError("Unhandled exception:", uncaught.get(0));
+            throw new RuntimeException("Unhandled exception:", uncaught.get(0));
         }
     }
 }


### PR DESCRIPTION
…orStateException: current thread is not owner

The KeepAliveStreamCleaner is calling Condition.wait (i.e. the Object.wait variant), should presumably be calling Condition.await. (NetBeans is producing warnings on the line as well.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/lahodaj/jdk/runs/1288317729)

### Issue
 * [JDK-8255124](https://bugs.openjdk.java.net/browse/JDK-8255124): KeepAliveStreamCleaner may crash with java.lang.IllegalMonitorStateException: current thread is not owner


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/782/head:pull/782`
`$ git checkout pull/782`
