### PR TITLE
8255129: [PPC64, s390] Check vector_size_supported and add VectorReinterpret node

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2062,97 +2062,78 @@ static int frame_slots_bias(int reg_enc, PhaseRegAlloc* ra_) {
 }
 
 const bool Matcher::match_rule_supported(int opcode) {
-  if (!has_match_rule(opcode))
-    return false;
-
-  bool ret_value = true;
-  switch (opcode) {
-  case Op_SqrtD:
-    return VM_Version::has_fsqrt();
-  case Op_CountLeadingZerosI:
-  case Op_CountLeadingZerosL:
-    if (!UseCountLeadingZerosInstructionsPPC64)
-      return false;
-    break;
-  case Op_CountTrailingZerosI:
-  case Op_CountTrailingZerosL:
-    if (!UseCountLeadingZerosInstructionsPPC64 &&
-        !UseCountTrailingZerosInstructionsPPC64)
-      return false;
-    break;
-
-  case Op_PopCountI:
-  case Op_PopCountL:
-    return (UsePopCountInstruction && VM_Version::has_popcntw());
-
-  case Op_StrComp:
-    return SpecialStringCompareTo;
-  case Op_StrEquals:
-    return SpecialStringEquals;
-  case Op_StrIndexOf:
-  case Op_StrIndexOfChar:
-    return SpecialStringIndexOf;
-  case Op_AddVB:
-  case Op_AddVS:
-  case Op_AddVI:
-  case Op_AddVF:
-  case Op_AddVD:
-  case Op_SubVB:
-  case Op_SubVS:
-  case Op_SubVI:
-  case Op_SubVF:
-  case Op_SubVD:
-  case Op_MulVS:
-  case Op_MulVF:
-  case Op_MulVD:
-  case Op_DivVF:
-  case Op_DivVD:
-  case Op_AbsVF:
-  case Op_AbsVD:
-  case Op_NegVF:
-  case Op_NegVD:
-  case Op_SqrtVF:
-  case Op_SqrtVD:
-  case Op_AddVL:
-  case Op_SubVL:
-  case Op_MulVI:
-  case Op_RoundDoubleModeV:
-    return SuperwordUseVSX;
-  case Op_PopCountVI:
-    return (SuperwordUseVSX && UsePopCountInstruction);
-  case Op_FmaVF:
-  case Op_FmaVD:
-    return (SuperwordUseVSX && UseFMA);
-  case Op_Digit:
-    return vmIntrinsics::is_intrinsic_available(vmIntrinsics::_isDigit);
-  case Op_LowerCase:
-    return vmIntrinsics::is_intrinsic_available(vmIntrinsics::_isLowerCase);
-  case Op_UpperCase:
-    return vmIntrinsics::is_intrinsic_available(vmIntrinsics::_isUpperCase);
-  case Op_Whitespace:
-    return vmIntrinsics::is_intrinsic_available(vmIntrinsics::_isWhitespace);
-
-  case Op_CacheWB:
-  case Op_CacheWBPreSync:
-  case Op_CacheWBPostSync:
-    if (!VM_Version::supports_data_cache_line_flush()) {
-      ret_value = false;
-    }
-    break;
+  if (!has_match_rule(opcode)) {
+    return false; // no match rule present
   }
 
-  return ret_value;  // Per default match rules are supported.
+  switch (opcode) {
+    case Op_SqrtD:
+      return VM_Version::has_fsqrt();
+    case Op_CountLeadingZerosI:
+    case Op_CountLeadingZerosL:
+      return UseCountLeadingZerosInstructionsPPC64;
+    case Op_CountTrailingZerosI:
+    case Op_CountTrailingZerosL:
+      return (UseCountLeadingZerosInstructionsPPC64 || UseCountTrailingZerosInstructionsPPC64);
+    case Op_PopCountI:
+    case Op_PopCountL:
+      return (UsePopCountInstruction && VM_Version::has_popcntw());
+
+    case Op_AddVB:
+    case Op_AddVS:
+    case Op_AddVI:
+    case Op_AddVF:
+    case Op_AddVD:
+    case Op_SubVB:
+    case Op_SubVS:
+    case Op_SubVI:
+    case Op_SubVF:
+    case Op_SubVD:
+    case Op_MulVS:
+    case Op_MulVF:
+    case Op_MulVD:
+    case Op_DivVF:
+    case Op_DivVD:
+    case Op_AbsVF:
+    case Op_AbsVD:
+    case Op_NegVF:
+    case Op_NegVD:
+    case Op_SqrtVF:
+    case Op_SqrtVD:
+    case Op_AddVL:
+    case Op_SubVL:
+    case Op_MulVI:
+    case Op_RoundDoubleModeV:
+      return SuperwordUseVSX;
+    case Op_PopCountVI:
+      return (SuperwordUseVSX && UsePopCountInstruction);
+    case Op_FmaVF:
+    case Op_FmaVD:
+      return (SuperwordUseVSX && UseFMA);
+
+    case Op_Digit:
+      return vmIntrinsics::is_intrinsic_available(vmIntrinsics::_isDigit);
+    case Op_LowerCase:
+      return vmIntrinsics::is_intrinsic_available(vmIntrinsics::_isLowerCase);
+    case Op_UpperCase:
+      return vmIntrinsics::is_intrinsic_available(vmIntrinsics::_isUpperCase);
+    case Op_Whitespace:
+      return vmIntrinsics::is_intrinsic_available(vmIntrinsics::_isWhitespace);
+
+    case Op_CacheWB:
+    case Op_CacheWBPreSync:
+    case Op_CacheWBPostSync:
+      return VM_Version::supports_data_cache_line_flush();
+  }
+
+  return true; // Per default match rules are supported.
 }
 
 const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType bt) {
-
-  // TODO
-  // identify extra cases that we might want to provide match rules for
-  // e.g. Op_ vector nodes and other intrinsics while guarding with vlen
-  bool ret_value = match_rule_supported(opcode);
-  // Add rules here.
-
-  return ret_value;  // Per default match rules are supported.
+  if (!match_rule_supported(opcode) || !vector_size_supported(bt, vlen)) {
+    return false;
+  }
+  return true; // Per default match rules are supported.
 }
 
 const bool Matcher::has_predicated_vectors(void) {
@@ -6567,6 +6548,23 @@ instruct storeV16(indirect mem, vecX src) %{
     __ stxvd2x($src$$VectorSRegister, $mem$$Register);
   %}
   ins_pipe(pipe_class_default);
+%}
+
+// Reinterpret: only one vector size used: either L or X
+instruct reinterpretL(iRegLdst dst) %{
+  match(Set dst (VectorReinterpret dst));
+  ins_cost(0);
+  format %{ "reinterpret $dst" %}
+  ins_encode( /*empty*/ );
+  ins_pipe(pipe_class_empty);
+%}
+
+instruct reinterpretX(vecX dst) %{
+  match(Set dst (VectorReinterpret dst));
+  ins_cost(0);
+  format %{ "reinterpret $dst" %}
+  ins_encode( /*empty*/ );
+  ins_pipe(pipe_class_empty);
 %}
 
 // Store Compressed Oop

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1511,60 +1511,28 @@ static Register reg_to_register_object(int register_encoding) {
 }
 
 const bool Matcher::match_rule_supported(int opcode) {
-  if (!has_match_rule(opcode)) return false;
+  if (!has_match_rule(opcode)) {
+    return false; // no match rule present
+  }
 
   switch (opcode) {
-    case Op_CountLeadingZerosI:
-    case Op_CountLeadingZerosL:
-    case Op_CountTrailingZerosI:
-    case Op_CountTrailingZerosL:
-      // Implementation requires FLOGR instruction, which is available since z9.
-      return true;
-
     case Op_ReverseBytesI:
     case Op_ReverseBytesL:
       return UseByteReverseInstruction;
-
-    // PopCount supported by H/W from z/Architecture G5 (z196) on.
     case Op_PopCountI:
     case Op_PopCountL:
-      return UsePopCountInstruction && VM_Version::has_PopCount();
-
-    case Op_StrComp:
-      return SpecialStringCompareTo;
-    case Op_StrEquals:
-      return SpecialStringEquals;
-    case Op_StrIndexOf:
-    case Op_StrIndexOfChar:
-      return SpecialStringIndexOf;
-
-    case Op_GetAndAddI:
-    case Op_GetAndAddL:
-      return true;
-      // return VM_Version::has_AtomicMemWithImmALUOps();
-    case Op_GetAndSetI:
-    case Op_GetAndSetL:
-    case Op_GetAndSetP:
-    case Op_GetAndSetN:
-      return true;  // General CAS implementation, always available.
-
-    default:
-      return true;  // Per default match rules are supported.
-                    // BUT: make sure match rule is not disabled by a false predicate!
+      // PopCount supported by H/W from z/Architecture G5 (z196) on.
+      return (UsePopCountInstruction && VM_Version::has_PopCount());
   }
 
-  return true;  // Per default match rules are supported.
-                // BUT: make sure match rule is not disabled by a false predicate!
+  return true; // Per default match rules are supported.
 }
 
 const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType bt) {
-  // TODO
-  // Identify extra cases that we might want to provide match rules for
-  // e.g. Op_ vector nodes and other intrinsics while guarding with vlen.
-  bool ret_value = match_rule_supported(opcode);
-  // Add rules here.
-
-  return ret_value;  // Per default match rules are supported.
+  if (!match_rule_supported(opcode) || !vector_size_supported(bt, vlen)) {
+    return false;
+  }
+  return true; // Per default match rules are supported.
 }
 
 const bool Matcher::has_predicated_vectors(void) {
@@ -10791,7 +10759,7 @@ instruct Repl2F_imm0(iRegL dst, immFp0 src) %{
   ins_pipe(pipe_class_dummy);
 %}
 
-// Store
+// Load/Store vector
 
 // Store Aligned Packed Byte register to memory (8 Bytes).
 instruct storeA8B(memory mem, iRegL src) %{
@@ -10805,8 +10773,6 @@ instruct storeA8B(memory mem, iRegL src) %{
   ins_pipe(pipe_class_dummy);
 %}
 
-// Load
-
 instruct loadV8(iRegL dst, memory mem) %{
   match(Set dst (LoadVector mem));
   predicate(n->as_LoadVector()->memory_size() == 8);
@@ -10815,6 +10781,15 @@ instruct loadV8(iRegL dst, memory mem) %{
   format %{ "LG      $dst,$mem\t # L(packed8B)" %}
   opcode(LG_ZOPC, LG_ZOPC);
   ins_encode(z_form_rt_mem_opt(dst, mem));
+  ins_pipe(pipe_class_dummy);
+%}
+
+// Reinterpret: only one vector size used
+instruct reinterpret(iRegL dst) %{
+  match(Set dst (VectorReinterpret dst));
+  ins_cost(0);
+  format %{ "reinterpret $dst" %}
+  ins_encode( /*empty*/ );
   ins_pipe(pipe_class_dummy);
 %}
 


### PR DESCRIPTION
match_rule_supported_vector on PPC64 and s390 need to check vector_size_supported.
In addition, an implementation for VectorReinterpret is needed. It can get implemented empty when using src = dst register. Note that these 2 platforms support only one vector size at a time, so there's no need for move between different sizes.

I'd like to clean up match_rule_supported, too. Cases for which we return true don't need to get checked explicitely because true is default. And we don't need to check SpecialString... flags because they are handled by "disabled_by_jvm_flags". So they can still get disabled (e.g. by jdk/bin/java -XX:-TieredCompilation -XX:-SpecialStringIndexOf -XX:+PrintCompilation -XX:+PrintInlining TestString|grep StringLatin1::indexOf).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/TheRealMDoerr/jdk/runs/1287299874)

### Issue
 * [JDK-8255129](https://bugs.openjdk.java.net/browse/JDK-8255129): [PPC64, s390] Check vector_size_supported and add VectorReinterpret node


### Reviewers
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/783/head:pull/783`
`$ git checkout pull/783`
