### PR TITLE
8255210: [Vector API] jdk/incubator/vector/Int256VectorTests.java crashes on AVX512 machines

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -4424,9 +4424,9 @@ instruct insert8D(vec dst, vec src, regD val, immI idx, rRegL tmp, legVec vtmp) 
 
 // =======================Int Reduction==========================================
 
-instruct reductionI(rRegI dst, rRegI src1, vec src2, vec vtmp1, vec vtmp2) %{
+instruct reductionI(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec vtmp2) %{
   predicate(vector_element_basic_type(n->in(2)) == T_INT &&
-            vector_length(n->in(2)) < 16); // src2
+            vector_length(n->in(2)) <= 16); // src2
   match(Set dst (AddReductionVI src1 src2));
   match(Set dst (MulReductionVI src1 src2));
   match(Set dst (AndReductionV  src1 src2));
@@ -4441,26 +4441,6 @@ instruct reductionI(rRegI dst, rRegI src1, vec src2, vec vtmp1, vec vtmp2) %{
     int vlen = vector_length(this, $src2);
     __ reduceI(opcode, vlen, $dst$$Register, $src1$$Register, $src2$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
   %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct reduction16I(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec vtmp2) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_INT &&
-            vector_length(n->in(2)) == 16); // src2
-  match(Set dst (AddReductionVI src1 src2));
-  match(Set dst (MulReductionVI src1 src2));
-  match(Set dst (AndReductionV  src1 src2));
-  match(Set dst ( OrReductionV  src1 src2));
-  match(Set dst (XorReductionV  src1 src2));
-  match(Set dst (MinReductionV  src1 src2));
-  match(Set dst (MaxReductionV  src1 src2));
-  effect(TEMP vtmp1, TEMP vtmp2);
-  format %{ "vector_reduction_int $dst,$src1,$src2 ; using $vtmp1, $vtmp2 as TEMP" %}
-  ins_encode %{
-    int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src2);
-    __ reduceI(opcode, vlen, $dst$$Register, $src1$$Register, $src2$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
-%}
   ins_pipe( pipe_slow );
 %}
 


### PR DESCRIPTION
Hi all,

Please review the fix of an AVX512 crash for Vector API.
The reason is that reductionI in x86.ad didn't use legVec for code generation, which is required by Assembler::vphaddd.

Testing:
 - test/jdk/jdk/incubator/vector all passed on both AVX256 and AVX512 machines

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/DamonFool/jdk/runs/1290466971)

### Issue
 * [JDK-8255210](https://bugs.openjdk.java.net/browse/JDK-8255210): [Vector API] jdk/incubator/vector/Int256VectorTests.java crashes on AVX512 machines


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * sviswanathan - Committer ⚠️ Added manually
 * jbhateja - Committer ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/791/head:pull/791`
`$ git checkout pull/791`
