### PR TITLE
7156347: javax/swing/JList/6462008/bug6462008.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -754,7 +754,6 @@ javax/swing/JComboBox/8072767/bug8072767.java 8196093 windows-all,macosx-all
 javax/swing/JFileChooser/4524490/bug4524490.java 8042380 generic-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8193942 generic-all
-javax/swing/JList/6462008/bug6462008.java 7156347 generic-all
 javax/swing/JPopupMenu/6580930/bug6580930.java 7124313 macosx-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JPopupMenu/6675802/bug6675802.java 8196097 windows-all

--- a/test/jdk/javax/swing/JList/6462008/bug6462008.java
+++ b/test/jdk/javax/swing/JList/6462008/bug6462008.java
@@ -61,6 +61,7 @@ public class bug6462008 {
             });
 
             robot.waitForIdle();
+            robot.delay(1000);
 
             setAnchorLead(-1);
             robot.waitForIdle();
@@ -366,6 +367,7 @@ public class bug6462008 {
         frame.getContentPane().add(panel);
 
         frame.setVisible(true);
+        frame.setLocationRelativeTo(null);
     }
 
     private static void checkSelection(int... sels) throws Exception {


### PR DESCRIPTION
Please review a test fix for an issue seen to be failing in mach5 testing which JList selection was not correct which seems to stem from the fact that the keypress event was initiated before the frame is made visible.
Fix by adding a robot delay after setVisible and also moved the frame to centre of screen to avoid problems with keypress on window at left edge of monitor.
Mach5 job was run for several iteration on all 3 platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/prsadhuk/jdk/runs/1290637594)

### Issue
 * [JDK-7156347](https://bugs.openjdk.java.net/browse/JDK-7156347): javax/swing/JList/6462008/bug6462008.java fails


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/793/head:pull/793`
`$ git checkout pull/793`
