### PR TITLE
JDK-8254189: Improve comments for StackOverFlow and fix in_xxx() functions

### DIFF
--- a/src/hotspot/share/runtime/stackOverflow.cpp
+++ b/src/hotspot/share/runtime/stackOverflow.cpp
@@ -39,6 +39,11 @@ void StackOverflow::initialize_stack_zone_sizes() {
   // Stack zone sizes must be page aligned.
   size_t page_size = os::vm_page_size();
 
+  // Note: Zone sizes are given via Stack(Red|Yellow|Reserved|Shadow)Pages
+  //  parameters; these names are misleading since they actually contain
+  //  zone size in units-of-4K-size, regardless the actual platform page size,
+  //  which may be larger (e.g. ppc64 has 64K pages).
+
   // We need to adapt the configured number of stack protection pages given
   // in 4K pages to the actual os page size. We must do this before setting
   // up minimal stack sizes etc. in os::init_2().
@@ -64,6 +69,7 @@ void StackOverflow::initialize_stack_zone_sizes() {
   // several times, though.)
   assert(_stack_shadow_zone_size == 0, "This should be called only once.");
   _stack_shadow_zone_size = align_up(StackShadowPages * alignment, page_size);
+
 }
 
 bool StackOverflow::stack_guards_enabled() const {

--- a/src/hotspot/share/runtime/stackOverflow.cpp
+++ b/src/hotspot/share/runtime/stackOverflow.cpp
@@ -69,7 +69,6 @@ void StackOverflow::initialize_stack_zone_sizes() {
   // several times, though.)
   assert(_stack_shadow_zone_size == 0, "This should be called only once.");
   _stack_shadow_zone_size = align_up(StackShadowPages * alignment, page_size);
-
 }
 
 bool StackOverflow::stack_guards_enabled() const {

--- a/src/hotspot/share/runtime/stackOverflow.cpp
+++ b/src/hotspot/share/runtime/stackOverflow.cpp
@@ -39,11 +39,6 @@ void StackOverflow::initialize_stack_zone_sizes() {
   // Stack zone sizes must be page aligned.
   size_t page_size = os::vm_page_size();
 
-  // Note: Zone sizes are given via Stack(Red|Yellow|Reserved|Shadow)Pages
-  //  parameters; these names are misleading since they actually contain
-  //  zone size in units-of-4K-size, regardless the actual platform page size,
-  //  which may be larger (e.g. ppc64 has 64K pages).
-
   // We need to adapt the configured number of stack protection pages given
   // in 4K pages to the actual os page size. We must do this before setting
   // up minimal stack sizes etc. in os::init_2().

--- a/src/hotspot/share/runtime/stackOverflow.hpp
+++ b/src/hotspot/share/runtime/stackOverflow.hpp
@@ -137,12 +137,15 @@ class StackOverflow {
     return _stack_red_zone_size;
   }
 
+  // Returns base of red zone (one-beyond the highest red zone address, so
+  //  itself outside red zone and the highest address of the yellow zone).
   address stack_red_zone_base() const {
     return (address)(stack_end() + stack_red_zone_size());
   }
 
+  // Returns true if address points into the red zone.
   bool in_stack_red_zone(address a) const {
-    return a <= stack_red_zone_base() && a >= stack_end();
+    return a < stack_red_zone_base() && a >= stack_end();
   }
 
   static size_t stack_yellow_zone_size() {
@@ -155,20 +158,25 @@ class StackOverflow {
     return _stack_reserved_zone_size;
   }
 
+  // Returns base of the reserved zone (one-beyond the highest reserved zone address).
   address stack_reserved_zone_base() const {
     return (address)(stack_end() +
                      (stack_red_zone_size() + stack_yellow_zone_size() + stack_reserved_zone_size()));
   }
+
+  // Returns true if address points into the reserved zone.
   bool in_stack_reserved_zone(address a) const {
-    return (a <= stack_reserved_zone_base()) &&
+    return (a < stack_reserved_zone_base()) &&
            (a >= (address)((intptr_t)stack_reserved_zone_base() - stack_reserved_zone_size()));
   }
 
   static size_t stack_yellow_reserved_zone_size() {
     return _stack_yellow_zone_size + _stack_reserved_zone_size;
   }
+
+  // Returns true if a points into either yellow or reserved zone.
   bool in_stack_yellow_reserved_zone(address a) const {
-    return (a <= stack_reserved_zone_base()) && (a >= stack_red_zone_base());
+    return (a < stack_reserved_zone_base()) && (a >= stack_red_zone_base());
   }
 
   // Size of red + yellow + reserved zones.

--- a/test/hotspot/gtest/runtime/test_stackoverflow.cpp
+++ b/test/hotspot/gtest/runtime/test_stackoverflow.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "runtime/os.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/stackOverflow.hpp"
+#include "utilities/align.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
+#include "unittest.hpp"
+
+
+TEST_VM(StackOverflow, basics) {
+  StackOverflow so;
+
+  // Make up a stack range. No need to allocate anything. Size has to be large enough
+  //  to fit sum of all zones into them.
+  address base = (address) 0x40000000;
+  const size_t size = os::vm_page_size() * 100;
+  address end = base - size;
+  so.initialize(base, end);
+
+  // Walking down the "stack" check for consistency of the three "in_stack_xxx" functions
+  enum { normal_stack, reserved_or_yellow_zone, red_zone } where = normal_stack;
+  for (address p = base - 1; p >= end; p -= os::vm_page_size()) {
+    // tty->print_cr(PTR_FORMAT " %d %d %d", p2i(p),
+    //     (int)so.in_stack_reserved_zone(p),
+    //     (int)so.in_stack_yellow_reserved_zone(p),
+    //     (int)so.in_stack_red_zone(p));
+    switch (where) {
+    case normal_stack:
+      ASSERT_FALSE(so.in_stack_red_zone(p));
+      if (so.in_stack_yellow_reserved_zone(p)) {
+        if (StackReservedPages > 0) {
+          ASSERT_TRUE(so.in_stack_reserved_zone(p));
+        } else {
+          ASSERT_FALSE(so.in_stack_reserved_zone(p));
+        }
+        where = reserved_or_yellow_zone;
+      } else {
+        ASSERT_FALSE(so.in_stack_reserved_zone((p)));
+      }
+      break;
+    case reserved_or_yellow_zone:
+      if (so.in_stack_red_zone(p)) {
+        ASSERT_FALSE(so.in_stack_yellow_reserved_zone(p));
+        where = red_zone;
+      } else {
+        ASSERT_TRUE(so.in_stack_yellow_reserved_zone(p));
+      }
+      break;
+    case red_zone:
+      ASSERT_TRUE(so.in_stack_red_zone(p));
+      ASSERT_FALSE(so.in_stack_yellow_reserved_zone(p));
+      ASSERT_FALSE(so.in_stack_reserved_zone((p)));
+      break;
+    }
+  }
+  ASSERT_EQ(where, red_zone);
+
+  // Check bases.
+  ASSERT_FALSE(so.in_stack_red_zone(so.stack_red_zone_base()));
+  ASSERT_TRUE(so.in_stack_red_zone(so.stack_red_zone_base() - 1));
+  ASSERT_FALSE(so.in_stack_reserved_zone(so.stack_reserved_zone_base()));
+  if (so.stack_reserved_zone_size() > 0) {
+    ASSERT_TRUE(so.in_stack_reserved_zone(so.stack_reserved_zone_base() - 1));
+  }
+}

--- a/test/hotspot/gtest/runtime/test_stackoverflow.cpp
+++ b/test/hotspot/gtest/runtime/test_stackoverflow.cpp
@@ -83,6 +83,7 @@ TEST_VM(StackOverflow, basics) {
   // Check bases.
   ASSERT_FALSE(so.in_stack_red_zone(so.stack_red_zone_base()));
   ASSERT_TRUE(so.in_stack_red_zone(so.stack_red_zone_base() - 1));
+  ASSERT_TRUE(so.in_stack_yellow_reserved_zone(so.stack_red_zone_base()));
   ASSERT_FALSE(so.in_stack_reserved_zone(so.stack_reserved_zone_base()));
   if (so.stack_reserved_zone_size() > 0) {
     ASSERT_TRUE(so.in_stack_reserved_zone(so.stack_reserved_zone_base() - 1));


### PR DESCRIPTION
Hi,

may I please have reviews for this small cleanup / fix?

While reviewing JDK-8253717 it was found that comments would help with understanding the StackOverFlow class. Especially the fact that the various _base_ are actually pointing outside their respective zone, since the stack grows downward and a zone (and the stack itself) range is [end, base). If you don't look at this code daily it can be surprising.

This also fixes some small off-by-one errors in various "in_stack_xxx_zone()" methods which test whether a given address is inside a zone and gave wrong results for address=base since base points outside its zone. This had the effect that an address could be in multiple zones.

Finally it adds a small gtest which tests the StackOverFlow methods.

/issue: JDK-8254189

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/tstuefe/jdk/runs/1322483258)

### Issue
 * [JDK-8254189](https://bugs.openjdk.java.net/browse/JDK-8254189): Improve comments for StackOverFlow and fix in_xxx() functions


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Gerard Ziemski](https://openjdk.java.net/census#gziemski) (@gerard-ziemski - Committer) ⚠️ Review applies to cc54ef8d732d86236a483738f082a89836ebe92a


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/795/head:pull/795`
`$ git checkout pull/795`
