### PR TITLE
8255196: Remove unused G1FullGCCompactionPoint::merge() 

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -136,10 +136,6 @@ void G1FullGCCompactionPoint::add(HeapRegion* hr) {
   _compaction_regions->append(hr);
 }
 
-void G1FullGCCompactionPoint::merge(G1FullGCCompactionPoint* other) {
-   _compaction_regions->appendAll(other->regions());
-}
-
 HeapRegion* G1FullGCCompactionPoint::remove_last() {
   return _compaction_regions->pop();
 }

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
@@ -53,7 +53,6 @@ public:
   void update();
   void forward(oop object, size_t size);
   void add(HeapRegion* hr);
-  void merge(G1FullGCCompactionPoint* other);
 
   HeapRegion* remove_last();
   HeapRegion* current_region();


### PR DESCRIPTION
Hi all,

  please review this trivial(?) removal of an unused method.

Test: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255196](https://bugs.openjdk.java.net/browse/JDK-8255196): Remove unused G1FullGCCompactionPoint::merge()


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/798/head:pull/798`
`$ git checkout pull/798`
