### PR TITLE
8255131: G1CollectedHeap::is_in() returns wrong result 

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -60,7 +60,7 @@ void G1BlockOffsetTable::check_index(size_t index, const char* msg) const {
   assert((index) < (_reserved.word_size() >> BOTConstants::LogN_words),
          "%s - index: " SIZE_FORMAT ", _vs.committed_size: " SIZE_FORMAT,
          msg, (index), (_reserved.word_size() >> BOTConstants::LogN_words));
-  assert(G1CollectedHeap::heap()->is_in_exact(address_for_index_raw(index)),
+  assert(G1CollectedHeap::heap()->is_in(address_for_index_raw(index)),
          "Index " SIZE_FORMAT " corresponding to " PTR_FORMAT
          " (%u) is not in committed area.",
          (index),

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2260,12 +2260,7 @@ bool G1CollectedHeap::try_collect(GCCause::Cause cause) {
 }
 
 bool G1CollectedHeap::is_in(const void* p) const {
-  if (is_in_reserved(p) &&
-    _hrm->is_available(addr_to_region((HeapWord*)p))) {
-    return true;
-  } else {
-    return false;
-  }
+  return is_in_reserved(p) && _hrm->is_available(addr_to_region((HeapWord*)p));
 }
 
 // Iteration functions.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2260,28 +2260,13 @@ bool G1CollectedHeap::try_collect(GCCause::Cause cause) {
 }
 
 bool G1CollectedHeap::is_in(const void* p) const {
-  if (_hrm->reserved().contains(p)) {
-    // Given that we know that p is in the reserved space,
-    // heap_region_containing() should successfully
-    // return the containing region.
-    HeapRegion* hr = heap_region_containing(p);
-    return hr->is_in(p);
-  } else {
-    return false;
-  }
-}
-
-#ifdef ASSERT
-bool G1CollectedHeap::is_in_exact(const void* p) const {
-  bool contains = reserved().contains(p);
-  bool available = _hrm->is_available(addr_to_region((HeapWord*)p));
-  if (contains && available) {
+  if (is_in_reserved(p) &&
+    _hrm->is_available(addr_to_region((HeapWord*)p))) {
     return true;
   } else {
     return false;
   }
 }
-#endif
 
 // Iteration functions.
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1136,11 +1136,6 @@ public:
   void decrement_summary_bytes(size_t bytes);
 
   virtual bool is_in(const void* p) const;
-#ifdef ASSERT
-  // Returns whether p is in one of the available areas of the heap. Slow but
-  // extensive version.
-  bool is_in_exact(const void* p) const;
-#endif
 
   // Return "TRUE" iff the given object address is within the collection
   // set. Assumes that the reference points into the heap.

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkBitMap.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkBitMap.cpp
@@ -51,7 +51,7 @@ void G1CMBitMap::clear_region(HeapRegion* region) {
 
 #ifdef ASSERT
 void G1CMBitMap::check_mark(HeapWord* addr) {
-  assert(G1CollectedHeap::heap()->is_in_exact(addr),
+  assert(G1CollectedHeap::heap()->is_in(addr),
          "Trying to access bitmap " PTR_FORMAT " for address " PTR_FORMAT " not in the heap.",
          p2i(this), p2i(addr));
 }

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1304,7 +1304,7 @@ void G1RemSet::cleanup_after_scan_heap_roots() {
 inline void check_card_ptr(CardTable::CardValue* card_ptr, G1CardTable* ct) {
 #ifdef ASSERT
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
-  assert(g1h->is_in_exact(ct->addr_for(card_ptr)),
+  assert(g1h->is_in(ct->addr_for(card_ptr)),
          "Card at " PTR_FORMAT " index " SIZE_FORMAT " representing heap at " PTR_FORMAT " (%u) must be in committed heap",
          p2i(card_ptr),
          ct->index_for(ct->addr_for(card_ptr)),


### PR DESCRIPTION
Hi all,

  please review this change to exchange the broken G1CollectedHeap::is_in() by G1CollectedHeap::is_in_exact() that has the same performance profile and correct.

G1CollectedHeap::is_in() returns true for any region ever committed (and crashes for not yet committed regions), while is_in_exact() (almost) did the right thing. Almost because HeapRegionManager::is_available() would assert if the given pointer is outside the heap and it's not guarded by is_in_reserved.

Test: tier1

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255131](https://bugs.openjdk.java.net/browse/JDK-8255131): G1CollectedHeap::is_in() returns wrong result


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 0fa2e85c3095c0cf9110d00f1c86cb8168503cb5
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/799/head:pull/799`
`$ git checkout pull/799`
