### PR TITLE
8255225: compiler/aot tests fail on Windows with NPE during artifact resolution

### DIFF
--- a/test/lib/jdk/test/lib/artifacts/ArtifactResolverException.java
+++ b/test/lib/jdk/test/lib/artifacts/ArtifactResolverException.java
@@ -14,14 +14,22 @@ public class ArtifactResolverException extends Exception {
     }
 
     public String toString() {
-        return super.toString() + ": " + getRootCause().toString();
+        Throwable root = getRootCause();
+        if (root != null) {
+            return super.toString() + ": " + root.toString();
+        } else {
+            return super.toString();
+        }
     }
 
     public Throwable getRootCause() {
-        Throwable rootCause = getCause();
-        while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
-            rootCause = rootCause.getCause();
+        Throwable root = getCause();
+        if (root == null) {
+            return null;
         }
-        return rootCause;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        return root;
     }
 }


### PR DESCRIPTION
Bisection shows it started to happen after [JDK-8253660](https://bugs.openjdk.java.net/browse/JDK-8253660). I believe `toString()` there is not very resilient in the face of `null` causes.

Example output:
```
$ make run-test TEST=compiler/aot

STDERR:
java.lang.NullPointerException: Cannot invoke "java.lang.Throwable.getCause()" because "<local1>" is null
at jdk.test.lib.artifacts.ArtifactResolverException.getRootCause(ArtifactResolverException.java:22)
at jdk.test.lib.artifacts.ArtifactResolverException.toString(ArtifactResolverException.java:17)
...
at compiler.aot.AotCompiler.resolveLinker(AotCompiler.java:270)
at compiler.aot.AotCompiler.launchCompiler(AotCompiler.java:112)
at compiler.aot.AotCompiler.main(AotCompiler.java:78)
...
```

...and since it is a part of this block:

```
        } catch (ArtifactResolverException e) {
            System.err.println("artifact resolution error: " + e); // <--- calling to broken toString() here
            e.printStackTrace(System.err);
            // let jaotc try to find linker
            return null;
        }
```

...we never actually get to `// let jaotc try to find linker` part, and that is why I suspect it causes Windows x86_64 tier1/compiler failures in GitHub workflows. See below, `Windows tier1/compiler` tests are now passing. (There are some infra failures in other places on Windows, though).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (jdk/tier1 part 1)](https://github.com/shipilev/jdk/runs/1291818319)

### Issue
 * [JDK-8255225](https://bugs.openjdk.java.net/browse/JDK-8255225): compiler/aot tests fail on Windows with NPE during artifact resolution


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/800/head:pull/800`
`$ git checkout pull/800`
