### PR TITLE
8255232: G1: Make G1BiasedMappedArray freeable 

### DIFF
--- a/src/hotspot/share/gc/g1/g1BiasedArray.cpp
+++ b/src/hotspot/share/gc/g1/g1BiasedArray.cpp
@@ -35,15 +35,7 @@ G1BiasedMappedArrayBase::G1BiasedMappedArrayBase() :
   _shift_by(0) { }
 
 G1BiasedMappedArrayBase::~G1BiasedMappedArrayBase() {
-  if (_alloc_base != NULL) {
-    FREE_C_HEAP_ARRAY(u_char, _alloc_base);
-    _alloc_base = NULL;
-    _base = NULL;
-    _length = 0;
-    _biased_base = NULL;
-    _bias = 0;
-    _shift_by = 0;
-  }
+  FreeHeap(_alloc_base);
 }
 
 // Allocate a new array, generic version.

--- a/src/hotspot/share/gc/g1/g1BiasedArray.cpp
+++ b/src/hotspot/share/gc/g1/g1BiasedArray.cpp
@@ -26,11 +26,31 @@
 #include "gc/g1/g1BiasedArray.hpp"
 #include "memory/padded.inline.hpp"
 
+G1BiasedMappedArrayBase::G1BiasedMappedArrayBase() :
+  _alloc_base(NULL),
+  _base(NULL),
+  _length(0),
+  _biased_base(NULL),
+  _bias(0),
+  _shift_by(0) { }
+
+G1BiasedMappedArrayBase::~G1BiasedMappedArrayBase() {
+  if (_alloc_base != NULL) {
+    FREE_C_HEAP_ARRAY(u_char, _alloc_base);
+    _alloc_base = NULL;
+    _base = NULL;
+    _length = 0;
+    _biased_base = NULL;
+    _bias = 0;
+    _shift_by = 0;
+  }
+}
+
 // Allocate a new array, generic version.
 address G1BiasedMappedArrayBase::create_new_base_array(size_t length, size_t elem_size) {
   assert(length > 0, "just checking");
   assert(elem_size > 0, "just checking");
-  return PaddedPrimitiveArray<u_char, mtGC>::create_unfreeable(length * elem_size);
+  return PaddedPrimitiveArray<u_char, mtGC>::create(length * elem_size, &_alloc_base);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/gc/g1/g1BiasedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1BiasedArray.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_G1_G1BIASEDARRAY_HPP
 #define SHARE_GC_G1_G1BIASEDARRAY_HPP
 
+#include "memory/allocation.hpp"
 #include "memory/memRegion.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/powerOfTwo.hpp"
@@ -32,10 +33,14 @@
 // Implements the common base functionality for arrays that contain provisions
 // for accessing its elements using a biased index.
 // The element type is defined by the instantiating the template.
-class G1BiasedMappedArrayBase {
+class G1BiasedMappedArrayBase : public CHeapObj<mtGC> {
   friend class VMStructs;
+
+  void* _alloc_base;      // the address the unpadded array has been allocated to
+
 public:
   typedef size_t idx_t;
+
 protected:
   address _base;          // the real base address
   size_t _length;         // the length of the array
@@ -44,12 +49,10 @@ protected:
   uint _shift_by;         // the amount of bits to shift right when mapping to an index of the array.
 
 protected:
-
-  G1BiasedMappedArrayBase() : _base(NULL), _length(0), _biased_base(NULL),
-    _bias(0), _shift_by(0) { }
+  G1BiasedMappedArrayBase();
 
   // Allocate a new array, generic version.
-  static address create_new_base_array(size_t length, size_t elem_size);
+  address create_new_base_array(size_t length, size_t elem_size);
 
   // Initialize the members of this class. The biased start address of this array
   // is the bias (in elements) multiplied by the element size.
@@ -90,8 +93,10 @@ protected:
   void verify_biased_index_inclusive_end(idx_t biased_index) const PRODUCT_RETURN;
 
 public:
-   // Return the length of the array in elements.
-   size_t length() const { return _length; }
+  virtual ~G1BiasedMappedArrayBase();
+
+  // Return the length of the array in elements.
+  size_t length() const { return _length; }
 };
 
 // Array that provides biased access and mapping from (valid) addresses in the

--- a/src/hotspot/share/memory/padded.hpp
+++ b/src/hotspot/share/memory/padded.hpp
@@ -116,6 +116,7 @@ template <class T, MEMFLAGS flags, size_t alignment = DEFAULT_CACHE_LINE_SIZE>
 class PaddedPrimitiveArray {
  public:
   static T* create_unfreeable(size_t length);
+  static T* create(size_t length, void** alloc_base);
 };
 
 #endif // SHARE_MEMORY_PADDED_HPP

--- a/src/hotspot/share/memory/padded.inline.hpp
+++ b/src/hotspot/share/memory/padded.inline.hpp
@@ -82,11 +82,18 @@ T** Padded2DArray<T, flags, alignment>::create_unfreeable(uint rows, uint column
 
 template <class T, MEMFLAGS flags, size_t alignment>
 T* PaddedPrimitiveArray<T, flags, alignment>::create_unfreeable(size_t length) {
+  void* temp;
+  return create(length, &temp);
+}
+
+template <class T, MEMFLAGS flags, size_t alignment>
+T* PaddedPrimitiveArray<T, flags, alignment>::create(size_t length, void** alloc_base) {
   // Allocate a chunk of memory large enough to allow for some alignment.
   void* chunk = AllocateHeap(length * sizeof(T) + alignment, flags);
 
   memset(chunk, 0, length * sizeof(T) + alignment);
 
+  *alloc_base = chunk;
   return (T*)align_up(chunk, alignment);
 }
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that makes G1BiasedMappedArray freeable?

Previously all G1BiasedMappedArray were created as unfreeable i.e. assigned to static variables. However with JDK-8253600 I need one such biased map for the full collector which is created and deleted during full GC. So the biased array should also be freed as necessary to avoid a memory leak.

The alternative would be to statically allocate that map anyway and provide it to the current G1FullCollector instance, but I do not think the single malloc call is perf sensitive compared to full collector work and there is much point in doing something more complicated at this time. In the future I hope that the young gen collector will also be extracted from G1CollectedHeap with the same need. If/when allocation of these helper data structures becomes a problem I would suggest looking into this again.

One option then could be using some ResoureArea for these things in the future.

For this change there should be no change in behavior at all.

Testing: tier1-5

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255232](https://bugs.openjdk.java.net/browse/JDK-8255232): G1: Make G1BiasedMappedArray freeable


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/808/head:pull/808`
`$ git checkout pull/808`
