### PR TITLE
8254854: [cgroups v1] Metric limits not properly detected on some join controller combinations

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
@@ -158,41 +158,37 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
      * setSubSystemPath based on the contents of /proc/self/cgroup
      */
     private static void setSubSystemControllerPath(CgroupV1Subsystem subsystem, String[] entry) {
-        String controllerName;
-        String base;
-        CgroupV1SubsystemController controller = null;
-        CgroupV1SubsystemController controller2 = null;
+        String controllerName = entry[1];
+        String base = entry[2];
 
-        controllerName = entry[1];
-        base = entry[2];
         if (controllerName != null && base != null) {
-            switch (controllerName) {
-                case "memory":
-                    controller = subsystem.memoryController();
-                    break;
-                case "cpuset":
-                    controller = subsystem.cpuSetController();
-                    break;
-                case "cpu,cpuacct":
-                case "cpuacct,cpu":
-                    controller = subsystem.cpuController();
-                    controller2 = subsystem.cpuAcctController();
-                    break;
-                case "cpuacct":
-                    controller = subsystem.cpuAcctController();
-                    break;
-                case "cpu":
-                    controller = subsystem.cpuController();
-                    break;
-                case "blkio":
-                    controller = subsystem.blkIOController();
-                    break;
-                // Ignore subsystems that we don't support
-                default:
-                    break;
+            for (String cName: controllerName.split(",")) {
+                switch (cName) {
+                    case "memory":
+                        setPath(subsystem, subsystem.memoryController(), base);
+                        break;
+                    case "cpuset":
+                        setPath(subsystem, subsystem.cpuSetController(), base);
+                        break;
+                    case "cpu":
+                        setPath(subsystem, subsystem.cpuController(), base);
+                        break;
+                    case "cpuacct":
+                        setPath(subsystem, subsystem.cpuAcctController(), base);
+                        break;
+                    case "blkio":
+                        setPath(subsystem, subsystem.blkIOController(), base);
+                        break;
+                    // Ignore subsystems that we don't support
+                    default:
+                        break;
+                }
             }
         }
 
+    }
+
+    private static void setPath(CgroupV1Subsystem subsystem, CgroupV1SubsystemController controller, String base) {
         if (controller != null) {
             controller.setPath(base);
             if (controller instanceof CgroupV1MemorySubSystemController) {
@@ -203,9 +199,6 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
                 memorySubSystem.setSwapEnabled(isSwapEnabled);
             }
             subsystem.setActiveSubSystems();
-        }
-        if (controller2 != null) {
-            controller2.setPath(base);
         }
     }
 


### PR DESCRIPTION
Originally only join controllers of form `cpu,cpuacct` would have been recognized.
However, this fails if more controllers are joined at a certain path.

The proposed fix is to be sure to split join controllers on `,` and set the path
accordingly. Otherwise, the Metrics system might be initialized due to some
non-join controllers, yet the limits for join controllers wouldn't be detected. A
test for this can be added once [JDK-8254001](https://bugs.openjdk.java.net/browse/JDK-8254001) has been implemented.

Testing:

- [x] jdk/submit
- [x] container tests on Linux cgroups v1 system.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/jerboaa/jdk/runs/1288736501)

### Issue
 * [JDK-8254854](https://bugs.openjdk.java.net/browse/JDK-8254854): [cgroups v1] Metric limits not properly detected on some join controller combinations


### Reviewers
 * [Bob Vandette](https://openjdk.java.net/census#bobv) (@bobvandette - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/809/head:pull/809`
`$ git checkout pull/809`
