### PR TITLE
JDK-8255262: Remove use of legacy custom @spec tag

### DIFF
--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -342,7 +342,6 @@ public class FileInputStream extends InputStream
      * @throws     IOException  if an I/O error occurs.
      *
      * @revised 1.4
-     * @spec JSR-51
      */
     public void close() throws IOException {
         if (closed) {
@@ -400,7 +399,6 @@ public class FileInputStream extends InputStream
      * @return  the file channel associated with this file input stream
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public FileChannel getChannel() {
         FileChannel fc = this.channel;

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -366,7 +366,6 @@ public class FileOutputStream extends OutputStream
      * @throws     IOException  if an I/O error occurs.
      *
      * @revised 1.4
-     * @spec JSR-51
      */
     public void close() throws IOException {
         if (closed) {
@@ -425,7 +424,6 @@ public class FileOutputStream extends OutputStream
      * @return  the file channel associated with this file output stream
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public FileChannel getChannel() {
         FileChannel fc = this.channel;

--- a/src/java.base/share/classes/java/io/InputStreamReader.java
+++ b/src/java.base/share/classes/java/io/InputStreamReader.java
@@ -103,7 +103,6 @@ public class InputStreamReader extends Reader {
      * @param  cs       A charset
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public InputStreamReader(InputStream in, Charset cs) {
         super(in);
@@ -119,7 +118,6 @@ public class InputStreamReader extends Reader {
      * @param  dec      A charset decoder
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public InputStreamReader(InputStream in, CharsetDecoder dec) {
         super(in);
@@ -146,7 +144,6 @@ public class InputStreamReader extends Reader {
      * @see java.nio.charset.Charset
      *
      * @revised 1.4
-     * @spec JSR-51
      */
     public String getEncoding() {
         return sd.getEncoding();

--- a/src/java.base/share/classes/java/io/OutputStreamWriter.java
+++ b/src/java.base/share/classes/java/io/OutputStreamWriter.java
@@ -120,7 +120,6 @@ public class OutputStreamWriter extends Writer {
      *         A charset
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public OutputStreamWriter(OutputStream out, Charset cs) {
         super(out);
@@ -139,7 +138,6 @@ public class OutputStreamWriter extends Writer {
      *         A charset encoder
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public OutputStreamWriter(OutputStream out, CharsetEncoder enc) {
         super(out);
@@ -166,7 +164,6 @@ public class OutputStreamWriter extends Writer {
      * @see java.nio.charset.Charset
      *
      * @revised 1.4
-     * @spec JSR-51
      */
     public String getEncoding() {
         return se.getEncoding();

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -121,7 +121,6 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * @see        java.lang.SecurityManager#checkRead(java.lang.String)
      * @see        java.lang.SecurityManager#checkWrite(java.lang.String)
      * @revised 1.4
-     * @spec JSR-51
      */
     public RandomAccessFile(String name, String mode)
         throws FileNotFoundException
@@ -208,7 +207,6 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * @see        java.lang.SecurityManager#checkWrite(java.lang.String)
      * @see        java.nio.channels.FileChannel#force(boolean)
      * @revised 1.4
-     * @spec JSR-51
      */
     public RandomAccessFile(File file, String mode)
         throws FileNotFoundException
@@ -293,7 +291,6 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * @return  the file channel associated with this file
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public final FileChannel getChannel() {
         FileChannel fc = this.channel;
@@ -637,7 +634,6 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * @throws     IOException  if an I/O error occurs.
      *
      * @revised 1.4
-     * @spec JSR-51
      */
     public void close() throws IOException {
         if (closed) {

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -1046,7 +1046,6 @@ abstract class AbstractStringBuilder implements Appendable, CharSequence {
      *          if {@code start} or {@code end} are negative,
      *          if {@code end} is greater than {@code length()},
      *          or if {@code start} is greater than {@code end}
-     * @spec JSR-51
      */
     @Override
     public CharSequence subSequence(int start, int end) {

--- a/src/java.base/share/classes/java/lang/CharSequence.java
+++ b/src/java.base/share/classes/java/lang/CharSequence.java
@@ -54,7 +54,6 @@ import java.util.stream.StreamSupport;
  *
  * @author Mike McCloskey
  * @since 1.4
- * @spec JSR-51
  */
 
 public interface CharSequence {

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -520,7 +520,6 @@ public final class Class<T> implements java.io.Serializable,
      * @jls 12.2 Loading of Classes and Interfaces
      * @jls 12.3 Linking of Classes and Interfaces
      * @since 9
-     * @spec JPMS
      */
     @CallerSensitive
     public static Class<?> forName(Module module, String name) {
@@ -918,7 +917,6 @@ public final class Class<T> implements java.io.Serializable,
      * @return the module that this class or interface is a member of
      *
      * @since 9
-     * @spec JPMS
      */
     public Module getModule() {
         return module;
@@ -1034,7 +1032,6 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @return the package of this class.
      * @revised 9
-     * @spec JPMS
      */
     public Package getPackage() {
         if (isPrimitive() || isArray()) {
@@ -1069,7 +1066,6 @@ public final class Class<T> implements java.io.Serializable,
      * @return the fully qualified package name
      *
      * @since 9
-     * @spec JPMS
      * @jls 6.7 Fully Qualified Names
      */
     public String getPackageName() {
@@ -2765,7 +2761,6 @@ public final class Class<T> implements java.io.Serializable,
      * @see Module#getResourceAsStream(String)
      * @since  1.1
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive
     public InputStream getResourceAsStream(String name) {
@@ -2862,7 +2857,6 @@ public final class Class<T> implements java.io.Serializable,
      * @throws NullPointerException If {@code name} is {@code null}
      * @since  1.1
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive
     public URL getResource(String name) {

--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -227,7 +227,6 @@ import sun.security.util.SecurityConstants;
  * @see      #resolveClass(Class)
  * @since 1.0
  * @revised 9
- * @spec JPMS
  */
 public abstract class ClassLoader {
 
@@ -425,7 +424,6 @@ public abstract class ClassLoader {
      *         method doesn't allow creation of a new class loader.
      *
      * @since  9
-     * @spec JPMS
      */
     protected ClassLoader(String name, ClassLoader parent) {
         this(checkCreateClassLoader(name), name, parent);
@@ -488,7 +486,6 @@ public abstract class ClassLoader {
      * this class loader is not named.
      *
      * @since 9
-     * @spec JPMS
      */
     public String getName() {
         return name;
@@ -743,7 +740,6 @@ public abstract class ClassLoader {
      *         if the class could not be found.
      *
      * @since 9
-     * @spec JPMS
      */
     protected Class<?> findClass(String moduleName, String name) {
         if (moduleName == null) {
@@ -869,7 +865,6 @@ public abstract class ClassLoader {
      *
      * @since  1.1
      * @revised 9
-     * @spec JPMS
      */
     protected final Class<?> defineClass(String name, byte[] b, int off, int len)
         throws ClassFormatError
@@ -1005,7 +1000,6 @@ public abstract class ClassLoader {
      *          class loader or its ancestor.
      *
      * @revised 9
-     * @spec JPMS
      */
     protected final Class<?> defineClass(String name, byte[] b, int off, int len,
                                          ProtectionDomain protectionDomain)
@@ -1081,7 +1075,6 @@ public abstract class ClassLoader {
      *
      * @since  1.5
      * @revised 9
-     * @spec JPMS
      */
     protected final Class<?> defineClass(String name, java.nio.ByteBuffer b,
                                          ProtectionDomain protectionDomain)
@@ -1344,7 +1337,6 @@ public abstract class ClassLoader {
      *
      * @see java.lang.module.ModuleReader#find(String)
      * @since 9
-     * @spec JPMS
      */
     protected URL findResource(String moduleName, String name) throws IOException {
         if (moduleName == null) {
@@ -1396,7 +1388,6 @@ public abstract class ClassLoader {
      *
      * @since  1.1
      * @revised 9
-     * @spec JPMS
      */
     public URL getResource(String name) {
         Objects.requireNonNull(name);
@@ -1462,7 +1453,6 @@ public abstract class ClassLoader {
      *
      * @since  1.2
      * @revised 9
-     * @spec JPMS
      */
     public Enumeration<URL> getResources(String name) throws IOException {
         Objects.requireNonNull(name);
@@ -1561,7 +1551,6 @@ public abstract class ClassLoader {
      *
      * @since  1.2
      * @revised 9
-     * @spec JPMS
      */
     protected URL findResource(String name) {
         return null;
@@ -1597,7 +1586,6 @@ public abstract class ClassLoader {
      *
      * @since  1.2
      * @revised 9
-     * @spec JPMS
      */
     protected Enumeration<URL> findResources(String name) throws IOException {
         return Collections.emptyEnumeration();
@@ -1669,7 +1657,6 @@ public abstract class ClassLoader {
      *
      * @since  1.1
      * @revised 9
-     * @spec JPMS
      */
     public static URL getSystemResource(String name) {
         return getSystemClassLoader().getResource(name);
@@ -1706,7 +1693,6 @@ public abstract class ClassLoader {
      *
      * @since  1.2
      * @revised 9
-     * @spec JPMS
      */
     public static Enumeration<URL> getSystemResources(String name)
         throws IOException
@@ -1739,7 +1725,6 @@ public abstract class ClassLoader {
      *
      * @since  1.1
      * @revised 9
-     * @spec JPMS
      */
     public InputStream getResourceAsStream(String name) {
         Objects.requireNonNull(name);
@@ -1773,7 +1758,6 @@ public abstract class ClassLoader {
      *
      * @since  1.1
      * @revised 9
-     * @spec JPMS
      */
     public static InputStream getSystemResourceAsStream(String name) {
         URL url = getSystemResource(name);
@@ -1824,7 +1808,6 @@ public abstract class ClassLoader {
      *
      * @see Module#isNamed()
      * @since 9
-     * @spec JPMS
      */
     public final Module getUnnamedModule() {
         return unnamedModule;
@@ -1848,7 +1831,6 @@ public abstract class ClassLoader {
      *          {@link RuntimePermission}{@code ("getClassLoader")}
      *
      * @since 9
-     * @spec JPMS
      */
     @CallerSensitive
     public static ClassLoader getPlatformClassLoader() {
@@ -1936,7 +1918,6 @@ public abstract class ClassLoader {
      *
      * @revised  1.4
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive
     public static ClassLoader getSystemClassLoader() {
@@ -2202,7 +2183,6 @@ public abstract class ClassLoader {
      *
      * @since  1.2
      * @revised 9
-     * @spec JPMS
      *
      * @jvms 5.3 Creation and Loading
      * @see <a href="{@docRoot}/../specs/jar/jar.html#package-sealing">
@@ -2241,7 +2221,6 @@ public abstract class ClassLoader {
      * @jvms 5.3 Creation and Loading
      *
      * @since  9
-     * @spec JPMS
      */
     public final Package getDefinedPackage(String name) {
         Objects.requireNonNull(name, "name cannot be null");
@@ -2268,7 +2247,6 @@ public abstract class ClassLoader {
      * @jvms 5.3 Creation and Loading
      *
      * @since  9
-     * @spec JPMS
      */
     public final Package[] getDefinedPackages() {
         return packages().toArray(Package[]::new);
@@ -2314,7 +2292,6 @@ public abstract class ClassLoader {
      *
      * @since  1.2
      * @revised 9
-     * @spec JPMS
      */
     @Deprecated(since="9")
     protected Package getPackage(String name) {
@@ -2350,7 +2327,6 @@ public abstract class ClassLoader {
      *
      * @since  1.2
      * @revised 9
-     * @spec JPMS
      */
     protected Package[] getPackages() {
         Stream<Package> pkgs = packages();

--- a/src/java.base/share/classes/java/lang/IllegalCallerException.java
+++ b/src/java.base/share/classes/java/lang/IllegalCallerException.java
@@ -29,7 +29,6 @@ package java.lang;
  * Thrown to indicate that a method has been called by an inappropriate caller.
  *
  * @since 9
- * @spec JPMS
  * @see StackWalker#getCallerClass
  */
 public class IllegalCallerException extends RuntimeException {

--- a/src/java.base/share/classes/java/lang/LayerInstantiationException.java
+++ b/src/java.base/share/classes/java/lang/LayerInstantiationException.java
@@ -30,7 +30,6 @@ package java.lang;
  *
  * @see ModuleLayer
  * @since 9
- * @spec JPMS
  */
 public class LayerInstantiationException extends RuntimeException {
     @java.io.Serial

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -95,7 +95,6 @@ import sun.security.util.SecurityConstants;
  * be thrown. </p>
  *
  * @since 9
- * @spec JPMS
  * @see Class#getModule()
  */
 

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -142,7 +142,6 @@ import sun.security.util.SecurityConstants;
  * }</pre>
  *
  * @since 9
- * @spec JPMS
  * @see Module#getLayer()
  */
 
@@ -193,7 +192,6 @@ public final class ModuleLayer {
      * should never be shared with untrusted code.
      *
      * @since 9
-     * @spec JPMS
      */
     public static final class Controller {
         private final ModuleLayer layer;

--- a/src/java.base/share/classes/java/lang/Package.java
+++ b/src/java.base/share/classes/java/lang/Package.java
@@ -115,7 +115,6 @@ import jdk.internal.reflect.Reflection;
  *
  * @since 1.2
  * @revised 9
- * @spec JPMS
  */
 public class Package extends NamedPackage implements java.lang.reflect.AnnotatedElement {
     /**
@@ -214,7 +213,6 @@ public class Package extends NamedPackage implements java.lang.reflect.Annotated
      * is returned if it is not known.
      *
      * @revised 9
-     * @spec JPMS
      */
     public String getImplementationVendor() {
         return versionInfo.implVendor;
@@ -344,7 +342,6 @@ public class Package extends NamedPackage implements java.lang.reflect.Annotated
      * @see ClassLoader#getDefinedPackage
      *
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive
     @Deprecated(since="9")
@@ -369,7 +366,6 @@ public class Package extends NamedPackage implements java.lang.reflect.Annotated
      * @see ClassLoader#getDefinedPackages
      *
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive
     public static Package[] getPackages() {

--- a/src/java.base/share/classes/java/lang/StackTraceElement.java
+++ b/src/java.base/share/classes/java/lang/StackTraceElement.java
@@ -115,7 +115,6 @@ public final class StackTraceElement implements java.io.Serializable {
      *         {@code methodName} is null
      * @since 1.5
      * @revised 9
-     * @spec JPMS
      */
     public StackTraceElement(String declaringClass, String methodName,
                              String fileName, int lineNumber) {
@@ -152,7 +151,6 @@ public final class StackTraceElement implements java.io.Serializable {
      *         or {@code methodName} is {@code null}
      *
      * @since 9
-     * @spec JPMS
      */
     public StackTraceElement(String classLoaderName,
                              String moduleName, String moduleVersion,
@@ -212,7 +210,6 @@ public final class StackTraceElement implements java.io.Serializable {
      *         point represented by this stack trace element; {@code null}
      *         if the module name is not available.
      * @since 9
-     * @spec JPMS
      * @see Module#getName()
      */
     public String getModuleName() {
@@ -227,7 +224,6 @@ public final class StackTraceElement implements java.io.Serializable {
      *         point represented by this stack trace element; {@code null}
      *         if the module version is not available.
      * @since 9
-     * @spec JPMS
      * @see java.lang.module.ModuleDescriptor.Version
      */
     public String getModuleVersion() {
@@ -243,7 +239,6 @@ public final class StackTraceElement implements java.io.Serializable {
      *         if the class loader is not named.
      *
      * @since 9
-     * @spec JPMS
      * @see java.lang.ClassLoader#getName()
      */
     public String getClassLoaderName() {
@@ -358,7 +353,6 @@ public final class StackTraceElement implements java.io.Serializable {
      * choose to omit some element in the returned string.
      *
      * @revised 9
-     * @spec JPMS
      * @see    Throwable#printStackTrace()
      */
     public String toString() {
@@ -408,7 +402,6 @@ public final class StackTraceElement implements java.io.Serializable {
      *         execution point as this instance.
      *
      * @revised 9
-     * @spec JPMS
      */
     public boolean equals(Object obj) {
         if (obj==this)

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1940,7 +1940,6 @@ public final class String
      *          or if {@code beginIndex} is greater than {@code endIndex}
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public CharSequence subSequence(int beginIndex, int endIndex) {
         return this.substring(beginIndex, endIndex);
@@ -2038,7 +2037,6 @@ public final class String
      * @see java.util.regex.Pattern
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public boolean matches(String regex) {
         return Pattern.matches(regex, this);
@@ -2095,7 +2093,6 @@ public final class String
      * @see java.util.regex.Pattern
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public String replaceFirst(String regex, String replacement) {
         return Pattern.compile(regex).matcher(this).replaceFirst(replacement);
@@ -2140,7 +2137,6 @@ public final class String
      * @see java.util.regex.Pattern
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public String replaceAll(String regex, String replacement) {
         return Pattern.compile(regex).matcher(this).replaceAll(replacement);
@@ -2301,7 +2297,6 @@ public final class String
      * @see java.util.regex.Pattern
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public String[] split(String regex, int limit) {
         /* fastpath if the regex is a
@@ -2399,7 +2394,6 @@ public final class String
      * @see java.util.regex.Pattern
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public String[] split(String regex) {
         return split(regex, 0);

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -981,7 +981,6 @@ public class Thread implements Runnable {
      *          if the current thread cannot modify this thread
      *
      * @revised 6.0, 14
-     * @spec JSR-51
      */
     public void interrupt() {
         if (this != Thread.currentThread()) {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -153,7 +153,6 @@ public class MethodHandles {
      * @return a lookup object which is trusted minimally
      *
      * @revised 9
-     * @spec JPMS
      */
     public static Lookup publicLookup() {
         return Lookup.PUBLIC_LOOKUP;
@@ -217,7 +216,6 @@ public class MethodHandles {
      * @throws SecurityException if denied by the security manager
      * @throws IllegalAccessException if any of the other access checks specified above fails
      * @since 9
-     * @spec JPMS
      * @see Lookup#dropLookupMode
      * @see <a href="MethodHandles.Lookup.html#cross-module-lookup">Cross-module lookups</a>
      */
@@ -1330,7 +1328,6 @@ public class MethodHandles {
          *  previous lookup class} is always {@code null}.
          *
          *  @since 9
-         *  @spec JPMS
          */
         public static final int MODULE = PACKAGE << 1;
 
@@ -1349,7 +1346,6 @@ public class MethodHandles {
          *  previous lookup class} is always {@code null}.
          *
          *  @since 9
-         *  @spec JPMS
          *  @see #publicLookup()
          */
         public static final int UNCONDITIONAL = PACKAGE << 2;
@@ -1438,7 +1434,6 @@ public class MethodHandles {
          *  @see #dropLookupMode
          *
          *  @revised 9
-         *  @spec JPMS
          */
         public int lookupModes() {
             return allowedModes & ALL_MODES;
@@ -1518,7 +1513,6 @@ public class MethodHandles {
          * @throws NullPointerException if the argument is null
          *
          * @revised 9
-         * @spec JPMS
          * @see #accessClass(Class)
          * @see <a href="#cross-module-lookup">Cross-module lookups</a>
          */
@@ -1665,7 +1659,6 @@ public class MethodHandles {
          *                           <a href="MethodHandles.Lookup.html#secmgr">refuses access</a>
          * @throws NullPointerException if {@code bytes} is {@code null}
          * @since 9
-         * @spec JPMS
          * @see Lookup#privateLookupIn
          * @see Lookup#dropLookupMode
          * @see ClassLoader#defineClass(String,byte[],int,int,ProtectionDomain)
@@ -2317,7 +2310,6 @@ public class MethodHandles {
          * @see #in
          *
          * @revised 9
-         * @spec JPMS
          */
         @Override
         public String toString() {

--- a/src/java.base/share/classes/java/lang/module/Configuration.java
+++ b/src/java.base/share/classes/java/lang/module/Configuration.java
@@ -99,7 +99,6 @@ import jdk.internal.vm.annotation.Stable;
  * }</pre>
  *
  * @since 9
- * @spec JPMS
  * @see java.lang.ModuleLayer
  */
 public final class Configuration {

--- a/src/java.base/share/classes/java/lang/module/FindException.java
+++ b/src/java.base/share/classes/java/lang/module/FindException.java
@@ -33,7 +33,6 @@ package java.lang.module;
  * reasons.
  *
  * @since 9
- * @spec JPMS
  */
 
 public class FindException extends RuntimeException {

--- a/src/java.base/share/classes/java/lang/module/InvalidModuleDescriptorException.java
+++ b/src/java.base/share/classes/java/lang/module/InvalidModuleDescriptorException.java
@@ -31,7 +31,6 @@ package java.lang.module;
  *
  * @see ModuleDescriptor#read
  * @since 9
- * @spec JPMS
  */
 public class InvalidModuleDescriptorException extends RuntimeException {
     @java.io.Serial

--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -88,7 +88,6 @@ import jdk.internal.module.ModuleInfo;
  *
  * @see java.lang.Module
  * @since 9
- * @spec JPMS
  */
 
 public class ModuleDescriptor
@@ -100,7 +99,6 @@ public class ModuleDescriptor
      *
      * @see ModuleDescriptor#modifiers()
      * @since 9
-     * @spec JPMS
      */
     public enum Modifier {
         /**
@@ -135,7 +133,6 @@ public class ModuleDescriptor
      *
      * @see ModuleDescriptor#requires()
      * @since 9
-     * @spec JPMS
      */
 
     public final static class Requires
@@ -147,7 +144,6 @@ public class ModuleDescriptor
          *
          * @see Requires#modifiers()
          * @since 9
-         * @spec JPMS
          */
         public enum Modifier {
 
@@ -365,7 +361,6 @@ public class ModuleDescriptor
      *
      * @see ModuleDescriptor#exports()
      * @since 9
-     * @spec JPMS
      */
 
     public final static class Exports
@@ -377,7 +372,6 @@ public class ModuleDescriptor
          *
          * @see Exports#modifiers()
          * @since 9
-         * @spec JPMS
          */
         public enum Modifier {
 
@@ -573,7 +567,6 @@ public class ModuleDescriptor
      *
      * @see ModuleDescriptor#opens()
      * @since 9
-     * @spec JPMS
      */
 
     public final static class Opens
@@ -584,7 +577,6 @@ public class ModuleDescriptor
          *
          * @see Opens#modifiers()
          * @since 9
-         * @spec JPMS
          */
         public enum Modifier {
 
@@ -774,7 +766,6 @@ public class ModuleDescriptor
      *
      * @see ModuleDescriptor#provides()
      * @since 9
-     * @spec JPMS
      */
 
     public final static class Provides
@@ -949,7 +940,6 @@ public class ModuleDescriptor
      *
      * @see ModuleDescriptor#version()
      * @since 9
-     * @spec JPMS
      */
 
     public final static class Version
@@ -1506,7 +1496,6 @@ public class ModuleDescriptor
      * {@link #build build} method.
      *
      * @since 9
-     * @spec JPMS
      */
     public static final class Builder {
         final String name;

--- a/src/java.base/share/classes/java/lang/module/ModuleFinder.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleFinder.java
@@ -80,7 +80,6 @@ import jdk.internal.module.SystemModuleFinders;
  * <p> A {@code ModuleFinder} is not required to be thread safe. </p>
  *
  * @since 9
- * @spec JPMS
  */
 
 public interface ModuleFinder {

--- a/src/java.base/share/classes/java/lang/module/ModuleReader.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleReader.java
@@ -76,7 +76,6 @@ import java.util.stream.Stream;
  *
  * @see ModuleReference
  * @since 9
- * @spec JPMS
  */
 
 public interface ModuleReader extends Closeable {

--- a/src/java.base/share/classes/java/lang/module/ModuleReference.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleReference.java
@@ -44,7 +44,6 @@ import java.util.Optional;
  * @see ModuleFinder
  * @see ModuleReader
  * @since 9
- * @spec JPMS
  */
 
 public abstract class ModuleReference {

--- a/src/java.base/share/classes/java/lang/module/ResolutionException.java
+++ b/src/java.base/share/classes/java/lang/module/ResolutionException.java
@@ -31,7 +31,6 @@ package java.lang.module;
  *
  * @see Configuration
  * @since 9
- * @spec JPMS
  */
 public class ResolutionException extends RuntimeException {
     @java.io.Serial

--- a/src/java.base/share/classes/java/lang/module/ResolvedModule.java
+++ b/src/java.base/share/classes/java/lang/module/ResolvedModule.java
@@ -37,7 +37,6 @@ import java.util.Set;
  * module's content.
  *
  * @since 9
- * @spec JPMS
  * @see Configuration#modules()
  */
 public final class ResolvedModule {

--- a/src/java.base/share/classes/java/lang/module/package-info.java
+++ b/src/java.base/share/classes/java/lang/module/package-info.java
@@ -208,7 +208,6 @@
  * was enumerated by previous (or parent) resolution. </p>
  *
  * @since 9
- * @spec JPMS
  */
 
 package java.lang.module;

--- a/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
@@ -75,7 +75,6 @@ import sun.security.util.SecurityConstants;
  * @jls 6.6 Access Control
  * @since 1.2
  * @revised 9
- * @spec JPMS
  */
 public class AccessibleObject implements AnnotatedElement {
     static {
@@ -120,7 +119,6 @@ public class AccessibleObject implements AnnotatedElement {
      * @see SecurityManager#checkPermission
      * @see ReflectPermission
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive
     public static void setAccessible(AccessibleObject[] array, boolean flag) {
@@ -198,7 +196,6 @@ public class AccessibleObject implements AnnotatedElement {
      * @see #trySetAccessible
      * @see java.lang.invoke.MethodHandles#privateLookupIn
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive   // overrides in Method/Field/Constructor are @CS
     public void setAccessible(boolean flag) {
@@ -258,7 +255,6 @@ public class AccessibleObject implements AnnotatedElement {
      * @throws SecurityException if the request is denied by the security manager
      *
      * @since 9
-     * @spec JPMS
      * @see java.lang.invoke.MethodHandles#privateLookupIn
      */
     @CallerSensitive
@@ -422,7 +418,6 @@ public class AccessibleObject implements AnnotatedElement {
      * it should use {@link #canAccess(Object)}.
      *
      * @revised 9
-     * @spec JPMS
      */
     @Deprecated(since="9")
     public boolean isAccessible() {
@@ -459,7 +454,6 @@ public class AccessibleObject implements AnnotatedElement {
      *         </ul>
      *
      * @since 9
-     * @spec JPMS
      * @jls 6.6 Access Control
      * @see #trySetAccessible
      * @see #setAccessible(boolean)

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -172,7 +172,6 @@ public final class Constructor<T> extends Executable {
      * @throws SecurityException if the request is denied by the security manager
      *         or this is a constructor for {@code java.lang.Class}
      *
-     * @spec JPMS
      */
     @Override
     @CallerSensitive

--- a/src/java.base/share/classes/java/lang/reflect/InaccessibleObjectException.java
+++ b/src/java.base/share/classes/java/lang/reflect/InaccessibleObjectException.java
@@ -30,7 +30,6 @@ package java.lang.reflect;
  *
  * @see AccessibleObject#setAccessible(boolean)
  * @since 9
- * @spec JPMS
  */
 
 public class InaccessibleObjectException extends RuntimeException {

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -280,7 +280,6 @@ import static java.lang.module.ModuleDescriptor.Modifier.SYNTHETIC;
  * @see         InvocationHandler
  * @since       1.3
  * @revised 9
- * @spec JPMS
  */
 public class Proxy implements java.io.Serializable {
     @java.io.Serial
@@ -371,7 +370,6 @@ public class Proxy implements java.io.Serializable {
      *
      * @see <a href="#membership">Package and Module Membership of Proxy Class</a>
      * @revised 9
-     * @spec JPMS
      */
     @Deprecated
     @CallerSensitive
@@ -993,7 +991,6 @@ public class Proxy implements java.io.Serializable {
      *
      * @see <a href="#membership">Package and Module Membership of Proxy Class</a>
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive
     public static Object newProxyInstance(ClassLoader loader,
@@ -1077,7 +1074,6 @@ public class Proxy implements java.io.Serializable {
      * @throws  NullPointerException if {@code cl} is {@code null}
      *
      * @revised 9
-     * @spec JPMS
      */
     public static boolean isProxyClass(Class<?> cl) {
         return Proxy.class.isAssignableFrom(cl) && ProxyBuilder.isProxyClass(cl);

--- a/src/java.base/share/classes/java/lang/reflect/package-info.java
+++ b/src/java.base/share/classes/java/lang/reflect/package-info.java
@@ -45,6 +45,5 @@
  *
  * @since 1.1
  * @revised 9
- * @spec JPMS
  */
 package java.lang.reflect;

--- a/src/java.base/share/classes/java/net/DatagramSocket.java
+++ b/src/java.base/share/classes/java/net/DatagramSocket.java
@@ -526,7 +526,6 @@ public class DatagramSocket implements java.io.Closeable {
      * @see        SecurityManager#checkMulticast(InetAddress)
      * @see        SecurityManager#checkConnect
      * @revised 1.4
-     * @spec JSR-51
      */
     public void send(DatagramPacket p) throws IOException  {
         delegate().send(p);
@@ -563,7 +562,6 @@ public class DatagramSocket implements java.io.Closeable {
      * @see        java.net.DatagramPacket
      * @see        java.net.DatagramSocket
      * @revised 1.4
-     * @spec JSR-51
      */
     public void receive(DatagramPacket p) throws IOException {
         delegate().receive(p);
@@ -886,7 +884,6 @@ public class DatagramSocket implements java.io.Closeable {
      * as well.
      *
      * @revised 1.4
-     * @spec JSR-51
      */
     public void close() {
         delegate().close();
@@ -914,7 +911,6 @@ public class DatagramSocket implements java.io.Closeable {
      *          or {@code null} if this socket was not created for a channel
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public DatagramChannel getChannel() {
         return null;

--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -529,7 +529,6 @@ public class ServerSocket implements java.io.Closeable {
      * @return the new Socket
      * @see SecurityManager#checkAccept
      * @revised 1.4
-     * @spec JSR-51
      */
     public Socket accept() throws IOException {
         if (isClosed())
@@ -573,7 +572,6 @@ public class ServerSocket implements java.io.Closeable {
      *
      * @since   1.1
      * @revised 1.4
-     * @spec JSR-51
      */
     protected final void implAccept(Socket s) throws IOException {
         SocketImpl si = s.impl;
@@ -717,7 +715,6 @@ public class ServerSocket implements java.io.Closeable {
      *
      * @throws     IOException  if an I/O error occurs when closing the socket.
      * @revised 1.4
-     * @spec JSR-51
      */
     public void close() throws IOException {
         synchronized(closeLock) {
@@ -743,7 +740,6 @@ public class ServerSocket implements java.io.Closeable {
      *          for a channel
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public ServerSocketChannel getChannel() {
         return null;

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -591,7 +591,6 @@ public class Socket implements java.io.Closeable {
      * @throws  IllegalArgumentException if endpoint is null or is a
      *          SocketAddress subclass not supported by this socket
      * @since 1.4
-     * @spec JSR-51
      */
     public void connect(SocketAddress endpoint) throws IOException {
         connect(endpoint, 0);
@@ -613,7 +612,6 @@ public class Socket implements java.io.Closeable {
      *          SocketAddress subclass not supported by this socket, or
      *          if {@code timeout} is negative
      * @since 1.4
-     * @spec JSR-51
      */
     public void connect(SocketAddress endpoint, int timeout) throws IOException {
         if (endpoint == null)
@@ -886,7 +884,6 @@ public class Socket implements java.io.Closeable {
      *          for a channel
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public SocketChannel getChannel() {
         return null;
@@ -935,7 +932,6 @@ public class Socket implements java.io.Closeable {
      *             using {@link #shutdownInput()}
      *
      * @revised 1.4
-     * @spec JSR-51
      */
     public InputStream getInputStream() throws IOException {
         if (isClosed())
@@ -1007,7 +1003,6 @@ public class Socket implements java.io.Closeable {
      * @throws     IOException  if an I/O error occurs when creating the
      *               output stream or if the socket is not connected.
      * @revised 1.4
-     * @spec JSR-51
      */
     public OutputStream getOutputStream() throws IOException {
         if (isClosed())
@@ -1581,7 +1576,6 @@ public class Socket implements java.io.Closeable {
      *
      * @throws     IOException  if an I/O error occurs when closing this socket.
      * @revised 1.4
-     * @spec JSR-51
      * @see #isClosed
      */
     public synchronized void close() throws IOException {

--- a/src/java.base/share/classes/java/net/SocketInputStream.java
+++ b/src/java.base/share/classes/java/net/SocketInputStream.java
@@ -70,7 +70,6 @@ class SocketInputStream extends FileInputStream {
      * @return  the file channel associated with this file input stream
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public final FileChannel getChannel() {
         return null;

--- a/src/java.base/share/classes/java/net/SocketOutputStream.java
+++ b/src/java.base/share/classes/java/net/SocketOutputStream.java
@@ -67,7 +67,6 @@ class SocketOutputStream extends FileOutputStream {
      * @return  the file channel associated with this file output stream
      *
      * @since 1.4
-     * @spec JSR-51
      */
     public final FileChannel getChannel() {
         return null;

--- a/src/java.base/share/classes/java/net/URLClassLoader.java
+++ b/src/java.base/share/classes/java/net/URLClassLoader.java
@@ -206,7 +206,6 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
      *         allow creation of a class loader.
      *
      * @since 9
-     * @spec JPMS
      */
     public URLClassLoader(String name,
                           URL[] urls,
@@ -237,7 +236,6 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
      *         creation of a class loader.
      *
      * @since 9
-     * @spec JPMS
      */
     public URLClassLoader(String name, URL[] urls, ClassLoader parent,
                           URLStreamHandlerFactory factory) {
@@ -531,7 +529,6 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
      * @return      the newly defined {@code Package} object
      *
      * @revised 9
-     * @spec JPMS
      */
     protected Package definePackage(String name, Manifest man, URL url) {
         String specTitle = null, specVersion = null, specVendor = null;

--- a/src/java.base/share/classes/java/security/SecureClassLoader.java
+++ b/src/java.base/share/classes/java/security/SecureClassLoader.java
@@ -108,7 +108,6 @@ public class SecureClassLoader extends ClassLoader {
      *         doesn't allow creation of a class loader.
      *
      * @since 9
-     * @spec JPMS
      */
     protected SecureClassLoader(String name, ClassLoader parent) {
         super(name, parent);

--- a/src/java.base/share/classes/java/util/ResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ResourceBundle.java
@@ -372,7 +372,6 @@ import static sun.security.util.SecurityConstants.GET_CLASSLOADER_PERMISSION;
  * @see ResourceBundleProvider
  * @since 1.1
  * @revised 9
- * @spec JPMS
  */
 public abstract class ResourceBundle {
 
@@ -893,7 +892,6 @@ public abstract class ResourceBundle {
      *         if this method is called in a named module
      * @since 1.6
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive
     public static final ResourceBundle getBundle(String baseName,
@@ -953,7 +951,6 @@ public abstract class ResourceBundle {
      *         specified module
      * @return a resource bundle for the given base name and the default locale
      * @since 9
-     * @spec JPMS
      * @see ResourceBundleProvider
      * @see <a href="#default_behavior">Resource Bundle Search and Loading Strategy</a>
      * @see <a href="#resource-bundle-modules">Resource Bundles and Named Modules</a>
@@ -1007,7 +1004,6 @@ public abstract class ResourceBundle {
      *         be found in the specified {@code module}
      * @return a resource bundle for the given base name and locale in the module
      * @since 9
-     * @spec JPMS
      * @see <a href="#default_behavior">Resource Bundle Search and Loading Strategy</a>
      * @see <a href="#resource-bundle-modules">Resource Bundles and Named Modules</a>
      */
@@ -1056,7 +1052,6 @@ public abstract class ResourceBundle {
      *         if this method is called in a named module
      * @since 1.6
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive
     public static final ResourceBundle getBundle(String baseName, Locale targetLocale,
@@ -1270,7 +1265,6 @@ public abstract class ResourceBundle {
      *        if no resource bundle for the specified base name can be found
      * @since 1.2
      * @revised 9
-     * @spec JPMS
      * @see <a href="#resource-bundle-modules">Resource Bundles and Named Modules</a>
      */
     @CallerSensitive
@@ -1496,7 +1490,6 @@ public abstract class ResourceBundle {
      *         if this method is called in a named module
      * @since 1.6
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive
     public static ResourceBundle getBundle(String baseName, Locale targetLocale,
@@ -2234,7 +2227,6 @@ public abstract class ResourceBundle {
      *
      * @since 1.6
      * @revised 9
-     * @spec JPMS
      * @see ResourceBundle.Control#getTimeToLive(String,Locale)
      */
     @CallerSensitive
@@ -2524,7 +2516,6 @@ public abstract class ResourceBundle {
      *
      * @since 1.6
      * @revised 9
-     * @spec JPMS
      * @see java.util.spi.ResourceBundleProvider
      */
     public static class Control {
@@ -3154,7 +3145,6 @@ public abstract class ResourceBundle {
          *        any I/O operations
          * @see java.util.spi.ResourceBundleProvider#getBundle(String, Locale)
          * @revised 9
-         * @spec JPMS
          */
         public ResourceBundle newBundle(String baseName, Locale locale, String format,
                                         ClassLoader loader, boolean reload)

--- a/src/java.base/share/classes/java/util/ServiceLoader.java
+++ b/src/java.base/share/classes/java/util/ServiceLoader.java
@@ -387,7 +387,6 @@ import jdk.internal.reflect.Reflection;
  * @author Mark Reinhold
  * @since 1.6
  * @revised 9
- * @spec JPMS
  */
 
 public final class ServiceLoader<S>
@@ -437,7 +436,6 @@ public final class ServiceLoader<S>
      *
      * @param  <S> The service type
      * @since 9
-     * @spec JPMS
      */
     public static interface Provider<S> extends Supplier<S> {
         /**
@@ -1352,7 +1350,6 @@ public final class ServiceLoader<S>
      *          service
      *
      * @revised 9
-     * @spec JPMS
      */
     public Iterator<S> iterator() {
 
@@ -1442,7 +1439,6 @@ public final class ServiceLoader<S>
      * @return  A stream that lazily loads providers for this loader's service
      *
      * @since 9
-     * @spec JPMS
      */
     public Stream<Provider<S>> stream() {
         // use cached providers as the source when all providers loaded
@@ -1639,7 +1635,6 @@ public final class ServiceLoader<S>
      *         not declare that it uses {@code service}
      *
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive
     public static <S> ServiceLoader<S> load(Class<S> service,
@@ -1685,7 +1680,6 @@ public final class ServiceLoader<S>
      *         not declare that it uses {@code service}
      *
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive
     public static <S> ServiceLoader<S> load(Class<S> service) {
@@ -1721,7 +1715,6 @@ public final class ServiceLoader<S>
      *         not declare that it uses {@code service}
      *
      * @revised 9
-     * @spec JPMS
      */
     @CallerSensitive
     public static <S> ServiceLoader<S> loadInstalled(Class<S> service) {
@@ -1774,7 +1767,6 @@ public final class ServiceLoader<S>
      *         not declare that it uses {@code service}
      *
      * @since 9
-     * @spec JPMS
      */
     @CallerSensitive
     public static <S> ServiceLoader<S> load(ModuleLayer layer, Class<S> service) {
@@ -1803,7 +1795,6 @@ public final class ServiceLoader<S>
      *         specified in the <a href="#errors">Errors</a> section above.
      *
      * @since 9
-     * @spec JPMS
      */
     public Optional<S> findFirst() {
         Iterator<S> iterator = iterator();

--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -109,7 +109,6 @@ import java.util.stream.StreamSupport;
  * @author      Mark Reinhold
  * @author      JSR-51 Expert Group
  * @since       1.4
- * @spec        JSR-51
  */
 
 public final class Matcher implements MatchResult {

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -771,7 +771,6 @@ import jdk.internal.util.ArraysSupport;
  * @author      Mark Reinhold
  * @author      JSR-51 Expert Group
  * @since       1.4
- * @spec        JSR-51
  */
 
 public final class Pattern

--- a/src/java.base/share/classes/java/util/regex/PatternSyntaxException.java
+++ b/src/java.base/share/classes/java/util/regex/PatternSyntaxException.java
@@ -31,7 +31,6 @@ package java.util.regex;
  *
  * @author  unascribed
  * @since 1.4
- * @spec JSR-51
  */
 
 public class PatternSyntaxException

--- a/src/java.base/share/classes/java/util/spi/AbstractResourceBundleProvider.java
+++ b/src/java.base/share/classes/java/util/spi/AbstractResourceBundleProvider.java
@@ -83,7 +83,6 @@ import static sun.security.util.SecurityConstants.GET_CLASSLOADER_PERMISSION;
  * @see <a href="../ResourceBundle.html#resource-bundle-modules">
  *      Resource Bundles and Named Modules</a>
  * @since 9
- * @spec JPMS
  */
 public abstract class AbstractResourceBundleProvider implements ResourceBundleProvider {
     private static final JavaUtilResourceBundleAccess RB_ACCESS =

--- a/src/java.base/share/classes/java/util/spi/ResourceBundleControlProvider.java
+++ b/src/java.base/share/classes/java/util/spi/ResourceBundleControlProvider.java
@@ -45,7 +45,6 @@ import java.util.ResourceBundle;
  * @author Masayoshi Okutsu
  * @since 1.8
  * @revised 9
- * @spec JPMS
  * @see ResourceBundle#getBundle(String, java.util.Locale, ClassLoader, ResourceBundle.Control)
  *      ResourceBundle.getBundle
  * @see java.util.ServiceLoader#load(Class)

--- a/src/java.base/share/classes/java/util/spi/ResourceBundleProvider.java
+++ b/src/java.base/share/classes/java/util/spi/ResourceBundleProvider.java
@@ -141,7 +141,6 @@ import java.util.ResourceBundle;
  *      Resource Bundles and Named Modules</a>
  * @see java.util.ServiceLoader
  * @since 9
- * @spec JPMS
  */
 public interface ResourceBundleProvider {
     /**

--- a/src/java.compiler/share/classes/javax/lang/model/element/Element.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Element.java
@@ -158,7 +158,6 @@ public interface Element extends javax.lang.model.AnnotatedConstruct {
      * @see ModuleElement#getSimpleName
      * @see RecordComponentElement#getSimpleName
      * @revised 9
-     * @spec JPMS
      */
     Name getSimpleName();
 
@@ -200,7 +199,6 @@ public interface Element extends javax.lang.model.AnnotatedConstruct {
      * @return the enclosing element, or {@code null} if there is none
      * @see Elements#getPackageOf
      * @revised 9
-     * @spec JPMS
      */
     Element getEnclosingElement();
 
@@ -237,7 +235,6 @@ public interface Element extends javax.lang.model.AnnotatedConstruct {
      * @jls 8.8.9 Default Constructor
      * @jls 8.9 Enum Types
      * @revised 9
-     * @spec JPMS
      */
     List<? extends Element> getEnclosedElements();
 

--- a/src/java.compiler/share/classes/javax/lang/model/element/ElementKind.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ElementKind.java
@@ -105,7 +105,6 @@ public enum ElementKind {
     /**
      * A module.
      * @since 9
-     * @spec JPMS
      */
      MODULE,
 

--- a/src/java.compiler/share/classes/javax/lang/model/element/ElementVisitor.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ElementVisitor.java
@@ -205,7 +205,6 @@ public interface ElementVisitor<R, P> {
      * @param p  a visitor-specified parameter
      * @return a visitor-specified result
      * @since 9
-     * @spec JPMS
      */
     default R visitModule(ModuleElement e, P p) {
         return visitUnknown(e, p);

--- a/src/java.compiler/share/classes/javax/lang/model/element/ModuleElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ModuleElement.java
@@ -35,7 +35,6 @@ import javax.lang.model.type.TypeMirror;
  * @see javax.lang.model.util.Elements#getModuleOf
  * @since 9
  * @jls 7.7 Module Declarations
- * @spec JPMS
  */
 public interface ModuleElement extends Element, QualifiedNameable {
     /**
@@ -137,7 +136,6 @@ public interface ModuleElement extends Element, QualifiedNameable {
      * future versions of the Java programming language.
      *
      * @since 9
-     * @spec JPMS
      */
     enum DirectiveKind {
         /** A "requires (static|transitive)* module-name" directive. */
@@ -158,7 +156,6 @@ public interface ModuleElement extends Element, QualifiedNameable {
      * module in the Java Platform Module System.
      *
      * @since 9
-     * @spec JPMS
      */
     interface Directive {
         /**
@@ -225,7 +222,6 @@ public interface ModuleElement extends Element, QualifiedNameable {
      *            additional parameter.
      *
      * @since 9
-     * @spec JPMS
      */
     interface DirectiveVisitor<R, P> {
         /**
@@ -311,7 +307,6 @@ public interface ModuleElement extends Element, QualifiedNameable {
     /**
      * A dependency of a module.
      * @since 9
-     * @spec JPMS
      */
     interface RequiresDirective extends Directive {
         /**
@@ -336,7 +331,6 @@ public interface ModuleElement extends Element, QualifiedNameable {
     /**
      * An exported package of a module.
      * @since 9
-     * @spec JPMS
      */
     interface ExportsDirective extends Directive {
 
@@ -358,7 +352,6 @@ public interface ModuleElement extends Element, QualifiedNameable {
     /**
      * An opened package of a module.
      * @since 9
-     * @spec JPMS
      */
     interface OpensDirective extends Directive {
 
@@ -380,7 +373,6 @@ public interface ModuleElement extends Element, QualifiedNameable {
     /**
      * An implementation of a service provided by a module.
      * @since 9
-     * @spec JPMS
      */
     interface ProvidesDirective extends Directive {
         /**
@@ -399,7 +391,6 @@ public interface ModuleElement extends Element, QualifiedNameable {
     /**
      * A reference to a service used by a module.
      * @since 9
-     * @spec JPMS
      */
     interface UsesDirective extends Directive {
         /**

--- a/src/java.compiler/share/classes/javax/lang/model/element/PackageElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/PackageElement.java
@@ -115,7 +115,6 @@ public interface PackageElement extends Element, QualifiedNameable {
      * @return the enclosing module or {@code null} if no such module exists
      *
      * @revised 9
-     * @spec JPMS
      */
     @Override
     Element getEnclosingElement();

--- a/src/java.compiler/share/classes/javax/lang/model/element/UnknownDirectiveException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/UnknownDirectiveException.java
@@ -39,7 +39,6 @@ import javax.lang.model.UnknownEntityException;
  * @author Peter von der Ah&eacute;
  * @see ModuleElement.DirectiveVisitor#visitUnknown
  * @since 9
- * @spec JPMS
  */
 public class UnknownDirectiveException extends UnknownEntityException {
 

--- a/src/java.compiler/share/classes/javax/lang/model/type/TypeKind.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/TypeKind.java
@@ -157,7 +157,6 @@ public enum TypeKind {
      * A pseudo-type corresponding to a module element.
      * @see NoType
      * @since 9
-     * @spec JPMS
      */
     MODULE;
 

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor6.java
@@ -140,7 +140,6 @@ public abstract class AbstractElementVisitor6<R, P> implements ElementVisitor<R,
      * @return   {@inheritDoc}
      *
      * @since 9
-     * @spec JPMS
      */
     @Override
     public R visitModule(ModuleElement e, P p) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor9.java
@@ -48,7 +48,6 @@ import static javax.lang.model.SourceVersion.*;
  * @see AbstractElementVisitor7
  * @see AbstractElementVisitor8
  * @since 9
- * @spec JPMS
  */
 @SupportedSourceVersion(RELEASE_14)
 public abstract class AbstractElementVisitor9<R, P> extends AbstractElementVisitor8<R, P> {

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementFilter.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementFilter.java
@@ -238,7 +238,6 @@ public class ElementFilter {
      * @return a list of modules in {@code elements}
      * @param elements the elements to filter
      * @since 9
-     * @spec JPMS
      */
     public static List<ModuleElement>
             modulesIn(Iterable<? extends Element> elements) {
@@ -250,7 +249,6 @@ public class ElementFilter {
      * @return a set of modules in {@code elements}
      * @param elements the elements to filter
      * @since 9
-     * @spec JPMS
      */
     public static Set<ModuleElement>
             modulesIn(Set<? extends Element> elements) {
@@ -287,7 +285,6 @@ public class ElementFilter {
      * @return a list of {@code exports} directives in {@code directives}
      * @param directives the directives to filter
      * @since 9
-     * @spec JPMS
      */
     public static List<ExportsDirective>
             exportsIn(Iterable<? extends Directive> directives) {
@@ -310,7 +307,6 @@ public class ElementFilter {
      * @return a list of {@code provides} directives in {@code directives}
      * @param directives the directives to filter
      * @since 9
-     * @spec JPMS
      */
     public static List<ProvidesDirective>
             providesIn(Iterable<? extends Directive> directives) {
@@ -322,7 +318,6 @@ public class ElementFilter {
      * @return a list of {@code requires} directives in {@code directives}
      * @param directives the directives to filter
      * @since 9
-     * @spec JPMS
      */
     public static List<RequiresDirective>
             requiresIn(Iterable<? extends Directive> directives) {
@@ -334,7 +329,6 @@ public class ElementFilter {
      * @return a list of {@code uses} directives in {@code directives}
      * @param directives the directives to filter
      * @since 9
-     * @spec JPMS
      */
     public static List<UsesDirective>
             usesIn(Iterable<? extends Directive> directives) {

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor9.java
@@ -60,7 +60,6 @@ import javax.lang.model.SourceVersion;
  * @see ElementKindVisitor7
  * @see ElementKindVisitor8
  * @since 9
- * @spec JPMS
  */
 @SupportedSourceVersion(RELEASE_14)
 public class ElementKindVisitor9<R, P> extends ElementKindVisitor8<R, P> {

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
@@ -74,7 +74,6 @@ import static javax.lang.model.SourceVersion.*;
  * @see ElementScanner8
  * @see ElementScanner14
  * @since 9
- * @spec JPMS
  */
 @SupportedSourceVersion(RELEASE_14)
 public class ElementScanner9<R, P> extends ElementScanner8<R, P> {

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -203,7 +203,6 @@ public interface Elements {
      * @return the named module element, or {@code null} if it cannot be found
      * @see #getAllModuleElements
      * @since 9
-     * @spec JPMS
      */
     default ModuleElement getModuleElement(CharSequence name) {
         return null;
@@ -489,7 +488,6 @@ public interface Elements {
      * @param e the element being examined
      * @return the module of an element
      * @since 9
-     * @spec JPMS
      */
     default ModuleElement getModuleOf(Element e) {
         return null;

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor9.java
@@ -56,7 +56,6 @@ import static javax.lang.model.SourceVersion.*;
  * @see SimpleElementVisitor8
  * @see SimpleElementVisitor14
  * @since 9
- * @spec JPMS
  */
 @SupportedSourceVersion(RELEASE_14)
 public class SimpleElementVisitor9<R, P> extends SimpleElementVisitor8<R, P> {

--- a/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileManager.java
@@ -180,7 +180,6 @@ public class ForwardingJavaFileManager<M extends JavaFileManager> implements Jav
 
     /**
      * @since 9
-     * @spec JPMS
      */
     @Override
     public Location getLocationForModule(Location location, String moduleName) throws IOException {
@@ -189,7 +188,6 @@ public class ForwardingJavaFileManager<M extends JavaFileManager> implements Jav
 
     /**
      * @since 9
-     * @spec JPMS
      */
     @Override
     public Location getLocationForModule(Location location, JavaFileObject fo) throws IOException {
@@ -198,7 +196,6 @@ public class ForwardingJavaFileManager<M extends JavaFileManager> implements Jav
 
     /**
      * @since 9
-     * @spec JPMS
      */
     @Override
     public <S> ServiceLoader<S> getServiceLoader(Location location, Class<S> service) throws  IOException {
@@ -207,7 +204,6 @@ public class ForwardingJavaFileManager<M extends JavaFileManager> implements Jav
 
     /**
      * @since 9
-     * @spec JPMS
      */
     @Override
     public String inferModuleName(Location location) throws IOException {
@@ -216,7 +212,6 @@ public class ForwardingJavaFileManager<M extends JavaFileManager> implements Jav
 
     /**
      * @since 9
-     * @spec JPMS
      */
     @Override
     public Iterable<Set<Location>> listLocationsForModules(Location location) throws IOException {

--- a/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
@@ -165,7 +165,6 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
          *
          * @return true if this location is expected to contain modules
          * @since 9
-         * @spec JPMS
          */
         default boolean isModuleOrientedLocation() {
             return getName().matches("\\bMODULE\\b");
@@ -473,7 +472,6 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
      * @throws IllegalArgumentException if the location is neither an output location nor a
      * module-oriented location
      * @since 9
-     * @spec JPMS
      */ // TODO: describe failure modes
     default Location getLocationForModule(Location location, String moduleName) throws IOException {
         throw new UnsupportedOperationException();
@@ -497,7 +495,6 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
      * @throws IllegalArgumentException if the location is neither an output location nor a
      * module-oriented location
      * @since 9
-     * @spec JPMS
      */
     default Location getLocationForModule(Location location, JavaFileObject fo) throws IOException {
         throw new UnsupportedOperationException();
@@ -521,7 +518,6 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
      * @throws IOException if an I/O error occurred
      * @throws UnsupportedOperationException if this operation if not supported by this file manager
      * @since 9
-     * @spec JPMS
      */ // TODO: describe failure modes
     default <S> ServiceLoader<S> getServiceLoader(Location location, Class<S> service) throws  IOException {
         throw new UnsupportedOperationException();
@@ -540,7 +536,6 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
      * @throws UnsupportedOperationException if this operation if not supported by this file manager
      * @throws IllegalArgumentException if the location is not one known to this file manager
      * @since 9
-     * @spec JPMS
      */ // TODO: describe failure modes
     default String inferModuleName(Location location) throws IOException {
         throw new UnsupportedOperationException();
@@ -560,7 +555,6 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
      * @throws UnsupportedOperationException if this operation if not supported by this file manager
      * @throws IllegalArgumentException if the location is not a module-oriented location
      * @since 9
-     * @spec JPMS
      */ // TODO: describe failure modes
     default Iterable<Set<Location>> listLocationsForModules(Location location) throws IOException {
         throw new UnsupportedOperationException();

--- a/src/java.compiler/share/classes/javax/tools/StandardLocation.java
+++ b/src/java.compiler/share/classes/javax/tools/StandardLocation.java
@@ -64,7 +64,6 @@ public enum StandardLocation implements Location {
 
     /**
      * Location to search for modules containing annotation processors.
-     * @spec JPMS
      * @since 9
      */
     ANNOTATION_PROCESSOR_MODULE_PATH,
@@ -83,35 +82,30 @@ public enum StandardLocation implements Location {
 
     /**
      * Location to search for the source code of modules.
-     * @spec JPMS
      * @since 9
      */
     MODULE_SOURCE_PATH,
 
     /**
      * Location to search for upgradeable system modules.
-     * @spec JPMS
      * @since 9
      */
     UPGRADE_MODULE_PATH,
 
     /**
      * Location to search for system modules.
-     * @spec JPMS
      * @since 9
      */
     SYSTEM_MODULES,
 
     /**
      * Location to search for precompiled user modules.
-     * @spec JPMS
      * @since 9
      */
     MODULE_PATH,
 
     /**
      * Location to search for module patches.
-     * @spec JPMS
      * @since 9
      */
     PATCH_MODULE_PATH;
@@ -129,7 +123,6 @@ public enum StandardLocation implements Location {
      * @return a location
      *
      * @revised 9
-     * @spec JPMS
      */
     public static Location locationFor(final String name) {
         if (locations.isEmpty()) {

--- a/src/java.instrument/share/classes/java/lang/instrument/ClassFileTransformer.java
+++ b/src/java.instrument/share/classes/java/lang/instrument/ClassFileTransformer.java
@@ -192,7 +192,6 @@ public interface ClassFileTransformer {
      *         or {@code null} if no transform is performed
      *
      * @revised 9
-     * @spec JPMS
      */
     default byte[]
     transform(  ClassLoader         loader,
@@ -231,7 +230,6 @@ public interface ClassFileTransformer {
      *         or {@code null} if no transform is performed
      *
      * @since  9
-     * @spec JPMS
      */
     default byte[]
     transform(  Module              module,

--- a/src/java.instrument/share/classes/java/lang/instrument/Instrumentation.java
+++ b/src/java.instrument/share/classes/java/lang/instrument/Instrumentation.java
@@ -729,7 +729,6 @@ public interface Instrumentation {
      *
      * @see #isModifiableModule(Module)
      * @since 9
-     * @spec JPMS
      */
     void redefineModule(Module module,
                         Set<Module> extraReads,
@@ -750,7 +749,6 @@ public interface Instrumentation {
      * @throws NullPointerException if the module is {@code null}
      *
      * @since 9
-     * @spec JPMS
      */
     boolean isModifiableModule(Module module);
 }

--- a/src/java.instrument/share/classes/java/lang/instrument/UnmodifiableModuleException.java
+++ b/src/java.instrument/share/classes/java/lang/instrument/UnmodifiableModuleException.java
@@ -30,7 +30,6 @@ package java.lang.instrument;
  *
  * @see Instrumentation#redefineModule
  * @since 9
- * @spec JPMS
  */
 
 public class UnmodifiableModuleException extends RuntimeException {

--- a/src/java.management/share/classes/java/lang/management/ThreadInfo.java
+++ b/src/java.management/share/classes/java/lang/management/ThreadInfo.java
@@ -888,7 +888,6 @@ public class ThreadInfo {
      *         {@code null} otherwise.
      *
      * @revised 9
-     * @spec JPMS
      */
     public static ThreadInfo from(CompositeData cd) {
         if (cd == null) {


### PR DESCRIPTION
The change is (just) to remove legacy usages of a JDK-private custom tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255262](https://bugs.openjdk.java.net/browse/JDK-8255262): Remove use of legacy custom @spec tag


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Mark Reinhold](https://openjdk.java.net/census#mr) (@mbreinhold - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/814/head:pull/814`
`$ git checkout pull/814`
