### PR TITLE
JDK-8255268: 32-bit failures in runtime/Metaspace/elastic

### DIFF
--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT1.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT1.java
@@ -87,8 +87,8 @@ public class TestMetaspaceAllocationMT1 {
             long commitLimit = (i == 1) ? 1024 * 256 : 0;
 
             // Note: reserve limit must be a multiple of Metaspace::reserve_alignment_words()
-            //  (512 K)
-            long reserveLimit = (i == 2) ? 1024 * 512 : 0;
+            //  (512K on 64bit, 1M on 32bit)
+            long reserveLimit = (i == 2) ? 1024 * 1024 : 0;
 
             System.out.println("#### Test: ");
             System.out.println("#### testAllocationCeiling: " + testAllocationCeiling);

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java
@@ -87,8 +87,8 @@ public class TestMetaspaceAllocationMT2 {
             long commitLimit = (i == 1) ? 1024 * 256 : 0;
 
             // Note: reserve limit must be a multiple of Metaspace::reserve_alignment_words()
-            //  (512 K)
-            long reserveLimit = (i == 2) ? 1024 * 512 : 0;
+            //  (512K on 64bit, 1M on 32bit)
+            long reserveLimit = (i == 2) ? 1024 * 1024 : 0;
 
             System.out.println("#### Test: ");
             System.out.println("#### testAllocationCeiling: " + testAllocationCeiling);


### PR DESCRIPTION
Hi,

may I please have reviews for this small test fix? This fixes the elastic metaspace tests on 32bit by increasing the alignment size (which is given in number of words) to a value valid for both 64bit and 32bit.

Tested: these tests, on 32bit and 64bit.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/tstuefe/jdk/runs/1295065859)

### Issue
 * [JDK-8255268](https://bugs.openjdk.java.net/browse/JDK-8255268): 32-bit failures in runtime/Metaspace/elastic


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/817/head:pull/817`
`$ git checkout pull/817`
