### PR TITLE
8255299: Drop explicit zeroing at instantiation of Atomic* objects

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -87,7 +87,7 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
     // Used to ensure that each spun class name is unique
-    private static final AtomicInteger counter = new AtomicInteger(0);
+    private static final AtomicInteger counter = new AtomicInteger();
 
     // For dumping generated classes to disk, for debugging purposes
     private static final ProxyClassesDumper dumper;

--- a/src/java.base/share/classes/java/util/Timer.java
+++ b/src/java.base/share/classes/java/util/Timer.java
@@ -120,7 +120,7 @@ public class Timer {
     /**
      * This ID is used to generate thread names.
      */
-    private static final AtomicInteger nextSerialNumber = new AtomicInteger(0);
+    private static final AtomicInteger nextSerialNumber = new AtomicInteger();
     private static int serialNumber() {
         return nextSerialNumber.getAndIncrement();
     }

--- a/src/java.base/share/classes/java/util/stream/AbstractShortCircuitTask.java
+++ b/src/java.base/share/classes/java/util/stream/AbstractShortCircuitTask.java
@@ -68,7 +68,7 @@ abstract class AbstractShortCircuitTask<P_IN, P_OUT, R,
     protected AbstractShortCircuitTask(PipelineHelper<P_OUT> helper,
                                        Spliterator<P_IN> spliterator) {
         super(helper, spliterator);
-        sharedResult = new AtomicReference<>(null);
+        sharedResult = new AtomicReference<>();
     }
 
     /**

--- a/src/java.base/share/classes/sun/net/ResourceManager.java
+++ b/src/java.base/share/classes/sun/net/ResourceManager.java
@@ -62,7 +62,7 @@ public class ResourceManager {
             }
         } catch (NumberFormatException e) {}
         maxSockets = defmax;
-        numSockets = new AtomicInteger(0);
+        numSockets = new AtomicInteger();
     }
 
     public static void beforeUdpCreate() throws SocketException {

--- a/src/java.desktop/share/classes/java/awt/EventQueue.java
+++ b/src/java.desktop/share/classes/java/awt/EventQueue.java
@@ -95,7 +95,7 @@ import jdk.internal.access.JavaSecurityAccess;
  * @since       1.1
  */
 public class EventQueue {
-    private static final AtomicInteger threadInitNumber = new AtomicInteger(0);
+    private static final AtomicInteger threadInitNumber = new AtomicInteger();
 
     private static final int LOW_PRIORITY = 0;
     private static final int NORM_PRIORITY = 1;

--- a/src/java.desktop/share/classes/javax/swing/TimerQueue.java
+++ b/src/java.desktop/share/classes/javax/swing/TimerQueue.java
@@ -248,7 +248,7 @@ class TimerQueue implements Runnable
          * Sequence number to break scheduling ties, and in turn to
          * guarantee FIFO order among tied entries.
          */
-        private static final AtomicLong sequencer = new AtomicLong(0);
+        private static final AtomicLong sequencer = new AtomicLong();
 
         /** Sequence number to break ties FIFO */
         private final long sequenceNumber;

--- a/src/java.desktop/share/classes/sun/awt/AppContext.java
+++ b/src/java.desktop/share/classes/sun/awt/AppContext.java
@@ -208,7 +208,7 @@ public final class AppContext {
      * number is 1.  If so, it returns the sole AppContext without
      * checking Thread.currentThread().
      */
-    private static final AtomicInteger numAppContexts = new AtomicInteger(0);
+    private static final AtomicInteger numAppContexts = new AtomicInteger();
 
 
     /*

--- a/src/java.logging/share/classes/java/util/logging/LogRecord.java
+++ b/src/java.logging/share/classes/java/util/logging/LogRecord.java
@@ -72,7 +72,7 @@ import static jdk.internal.logger.SurrogateLogger.isFilteredFrame;
 
 public class LogRecord implements java.io.Serializable {
     private static final AtomicLong globalSequenceNumber
-        = new AtomicLong(0);
+        = new AtomicLong();
 
     /**
      * Logging message level

--- a/src/java.net.http/share/classes/jdk/internal/net/http/WindowUpdateSender.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/WindowUpdateSender.java
@@ -39,7 +39,7 @@ abstract class WindowUpdateSender {
 
     final int limit;
     final Http2Connection connection;
-    final AtomicInteger received = new AtomicInteger(0);
+    final AtomicInteger received = new AtomicInteger();
 
     WindowUpdateSender(Http2Connection connection) {
         this(connection, connection.clientSettings.getParameter(SettingsFrame.INITIAL_WINDOW_SIZE));

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
@@ -375,7 +375,7 @@ public class SSLFlowDelegate {
             scheduler.stop();
         }
 
-        AtomicInteger count = new AtomicInteger(0);
+        AtomicInteger count = new AtomicInteger();
 
         // minimum number of bytes required to call unwrap.
         // Usually this is 0, unless there was a buffer underflow.

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SubscriberWrapper.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SubscriberWrapper.java
@@ -74,7 +74,7 @@ public abstract class SubscriberWrapper
     private final CompletableFuture<Void> cf;
     private final SequentialScheduler pushScheduler;
     private final AtomicReference<Throwable> errorRef = new AtomicReference<>();
-    final AtomicLong upstreamWindow = new AtomicLong(0);
+    final AtomicLong upstreamWindow = new AtomicLong();
 
     /**
      * Wraps the given downstream subscriber. For each call to {@link

--- a/src/java.rmi/share/classes/java/rmi/server/ObjID.java
+++ b/src/java.rmi/share/classes/java/rmi/server/ObjID.java
@@ -84,7 +84,7 @@ public final class ObjID implements Serializable {
     /** indicate compatibility with JDK 1.1.x version of class */
     private static final long serialVersionUID = -6386392263968365220L;
 
-    private static final AtomicLong nextObjNum = new AtomicLong(0);
+    private static final AtomicLong nextObjNum = new AtomicLong();
     private static final UID mySpace = new UID();
     private static final SecureRandom secureRandom = new SecureRandom();
 

--- a/src/java.rmi/share/classes/sun/rmi/runtime/RuntimeUtil.java
+++ b/src/java.rmi/share/classes/sun/rmi/runtime/RuntimeUtil.java
@@ -30,7 +30,6 @@ import java.security.Permission;
 import java.security.PrivilegedAction;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
@@ -70,7 +69,7 @@ public final class RuntimeUtil {
         scheduler = new ScheduledThreadPoolExecutor(
             schedulerThreads,
             new ThreadFactory() {
-                private final AtomicInteger count = new AtomicInteger(0);
+                private final AtomicInteger count = new AtomicInteger();
                 public Thread newThread(Runnable runnable) {
                     try {
                         return AccessController.doPrivileged(

--- a/src/java.rmi/share/classes/sun/rmi/server/UnicastServerRef.java
+++ b/src/java.rmi/share/classes/sun/rmi/server/UnicastServerRef.java
@@ -128,8 +128,6 @@ public class UnicastServerRef extends UnicastRef
     private static final Map<Class<?>,?> withoutSkeletons =
         Collections.synchronizedMap(new WeakHashMap<Class<?>,Void>());
 
-    private final AtomicInteger methodCallIDCount = new AtomicInteger(0);
-
     /**
      * Create a new (empty) Unicast server remote reference.
      * The filter is null to defer to the  default ObjectInputStream filter, if any.

--- a/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPTransport.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPTransport.java
@@ -115,7 +115,7 @@ public class TCPTransport extends Transport {
             });
 
     /** total connections handled */
-    private static final AtomicInteger connectionCount = new AtomicInteger(0);
+    private static final AtomicInteger connectionCount = new AtomicInteger();
 
     /** client host for the current thread's connection */
     private static final ThreadLocal<ConnectionHandler>

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
@@ -48,7 +48,7 @@ import jdk.jfr.internal.SecuritySupport;
  * an event stream.
  */
 abstract class AbstractEventStream implements EventStream {
-    private final static AtomicLong counter = new AtomicLong(0);
+    private final static AtomicLong counter = new AtomicLong();
 
     private final Object terminated = new Object();
     private final Runnable flushOperation = () -> dispatcher().runFlushActions();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/ThrowableTracer.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/ThrowableTracer.java
@@ -32,7 +32,7 @@ import jdk.jfr.internal.handlers.EventHandler;
 
 public final class ThrowableTracer {
 
-    private static final AtomicLong numThrowables = new AtomicLong(0);
+    private static final AtomicLong numThrowables = new AtomicLong();
 
     public static void traceError(Error e, String message) {
         if (e instanceof OutOfMemoryError) {


### PR DESCRIPTION
As discussed in https://github.com/openjdk/jdk/pull/510 there is never a reason to explicitly instantiate any instance of `Atomic*` class with its default value, i.e. `new AtomicInteger(0)` could be replaced with `new AtomicInteger()` which is faster:
```java
@State(Scope.Thread)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@BenchmarkMode(value = Mode.AverageTime)
public class AtomicBenchmark {
  @Benchmark
  public Object defaultValue() {
    return new AtomicInteger();
  }
  @Benchmark
  public Object explicitValue() {
    return new AtomicInteger(0);
  }
}
```
THis benchmark demonstrates that `explicitValue()` is much slower:
```
Benchmark                      Mode  Cnt   Score   Error  Units
AtomicBenchmark.defaultValue   avgt   30   4.778 ± 0.403  ns/op
AtomicBenchmark.explicitValue  avgt   30  11.846 ± 0.273  ns/op
```
So meanwhile https://bugs.openjdk.java.net/browse/JDK-8145948 is still in progress we could trivially replace explicit zeroing with default constructors gaining some performance benefit with no risk.

I've tested the changes locally, both tier1 and tier 2 are ok. 

Could one create an issue for tracking this?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255299](https://bugs.openjdk.java.net/browse/JDK-8255299): Drop explicit zeroing at instantiation of Atomic* objects


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to c1fb362f6d2f4c099c05ef606daf881ebde475de
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to c1fb362f6d2f4c099c05ef606daf881ebde475de
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to c1fb362f6d2f4c099c05ef606daf881ebde475de


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/818/head:pull/818`
`$ git checkout pull/818`
