### PR TITLE
8254871: Remove unnecessary string copy in NetworkInterface.c

### DIFF
--- a/src/java.base/unix/native/libnet/NetworkInterface.c
+++ b/src/java.base/unix/native/libnet/NetworkInterface.c
@@ -205,7 +205,6 @@ JNIEXPORT jobject JNICALL Java_java_net_NetworkInterface_getByName0
     jboolean isCopy;
     const char* name_utf;
     char *colonP;
-    char searchName[IFNAMESIZE];
     jobject obj = NULL;
 
     if (name != NULL) {
@@ -229,15 +228,11 @@ JNIEXPORT jobject JNICALL Java_java_net_NetworkInterface_getByName0
 
     // search the list of interfaces based on name,
     // if it is virtual sub interface search with parent first.
-    strncpy(searchName, name_utf, IFNAMESIZE);
-    searchName[IFNAMESIZE - 1] = '\0';
-    colonP = strchr(searchName, ':');
-    if (colonP != NULL) {
-        *colonP = '\0';
-    }
+    colonP = strchr(name_utf, ':');
+    size_t limit = colonP != NULL ? (size_t)(colonP - name_utf) : strlen(name_utf);
     curr = ifs;
     while (curr != NULL) {
-        if (strcmp(searchName, curr->name) == 0) {
+        if (strlen(curr->name) == limit && memcmp(name_utf, curr->name, limit) == 0) {
             break;
         }
         curr = curr->next;


### PR DESCRIPTION
A small improvement to avoid extra string copy.

[Tests]
Jtreg hotspot::hotspot_all_no_apps, jdk::jdk_core and langtools::tier1.
No new failure found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254871](https://bugs.openjdk.java.net/browse/JDK-8254871): Remove unnecessary string copy in NetworkInterface.c


### Reviewers
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/821/head:pull/821`
`$ git checkout pull/821`
