### PR TITLE
8060202: [macosx] Test closed/java/awt/Choice/GetSizeTest/GetSizeTest fails only in MacOSX(10.10)

### DIFF
--- a/test/jdk/java/awt/Choice/GetSizeTest/GetSizeTest.java
+++ b/test/jdk/java/awt/Choice/GetSizeTest/GetSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,14 @@
   run main GetSizeTest.html
 */
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.Choice;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 
 public class GetSizeTest {
 
@@ -40,16 +46,15 @@ public class GetSizeTest {
                          "what choices do I have?",
                          "Will I pick the same thing in the future?",
                 };
-    static boolean passed = false;
-    static Robot robot = null;
+    static volatile boolean passed = false;
 
-    public static void main(String args[])
-    {
+    public static void main(String args[]) throws Exception {
+        Frame f = null;
         try {
-            robot = new Robot();
-            robot.setAutoDelay(50);
+            Robot robot = new Robot();
+            robot.setAutoDelay(150);
 
-            Frame f = new Frame("choice test");
+            f = new Frame("choice test");
 
             Panel p = new Panel();
             p.setLayout(null);
@@ -70,14 +75,7 @@ public class GetSizeTest {
             f.add(p);
 
             f.setSize(300, 300);
-
-            f.addWindowListener(new WindowAdapter() {
-                public void windowClosing(WindowEvent we) {
-                    System.err.println("Test passed");
-                    passed = true;
-                }
-            });
-
+            f.setLocationRelativeTo(null);
             f.setVisible(true);
 
             c.setSize(200, 200);
@@ -88,14 +86,13 @@ public class GetSizeTest {
             Point pt = c.getLocationOnScreen();
             robot.mouseMove(pt.x + c.getWidth() - 10, pt.y + c.getHeight() / 2);
             robot.waitForIdle();
-            robot.mousePress(InputEvent.BUTTON2_MASK);
-            robot.mouseRelease(InputEvent.BUTTON2_MASK);
+            robot.mousePress(InputEvent.BUTTON2_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON2_DOWN_MASK);
             robot.waitForIdle();
-        } catch (Throwable e) {
-            if (robot == null){
-                throw new RuntimeException( "Test failed.Unable to initialize Robot "+e);
+        } finally {
+            if (f != null) {
+                f.dispose();
             }
-            throw new RuntimeException( "Test failed due to thrown exception "+e);
         }
         if (!passed) {
             throw new RuntimeException( "Timeout. Choice component size is not actual size." );


### PR DESCRIPTION
This test is rarely failed(once per a few months), it even was not added to the problem list. And most probably it is caused by some system setup issues.

So I just apply some common cleanups:
 - A little bigger delays
 - The frame to the center of the screen
 - The frame is disposed at the end of the test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/mrserb/jdk/runs/1296323443)

### Issue
 * ⚠️ Failed to retrieve information on issue `8060202`.


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/822/head:pull/822`
`$ git checkout pull/822`
