### PR TITLE
8255301: Common and strengthen the code in ciMemberName and ciMethodHandle

### DIFF
--- a/src/hotspot/share/ci/ciMemberName.cpp
+++ b/src/hotspot/share/ci/ciMemberName.cpp
@@ -39,11 +39,6 @@ ciMethod* ciMemberName::get_vmtarget() const {
 
 ciMethod* ciMemberName::get_vmtarget_method(oop mname) {
   ASSERT_IN_VM;
-  Metadata* vmtarget = java_lang_invoke_MemberName::vmtarget(mname);
-  if (vmtarget->is_method()) {
-    return CURRENT_ENV->get_method((Method*) vmtarget);
-  } else {
-    fatal("vmtarget should be a method");
-    return NULL; // silence compiler warnings
-  }
+  Method* vmtarget = java_lang_invoke_MemberName::vmtarget(mname);
+  return CURRENT_ENV->get_method(vmtarget);
 }

--- a/src/hotspot/share/ci/ciMemberName.cpp
+++ b/src/hotspot/share/ci/ciMemberName.cpp
@@ -34,10 +34,10 @@
 // Return: MN.vmtarget
 ciMethod* ciMemberName::get_vmtarget() const {
   VM_ENTRY_MARK;
-  return get_vmtarget_no_entry(get_oop());
+  return get_vmtarget_method(get_oop());
 }
 
-ciMethod* ciMemberName::get_vmtarget_no_entry(oop mname) {
+ciMethod* ciMemberName::get_vmtarget_method(oop mname) {
   ASSERT_IN_VM;
   Metadata* vmtarget = java_lang_invoke_MemberName::vmtarget(mname);
   if (vmtarget->is_method()) {

--- a/src/hotspot/share/ci/ciMemberName.cpp
+++ b/src/hotspot/share/ci/ciMemberName.cpp
@@ -34,11 +34,16 @@
 // Return: MN.vmtarget
 ciMethod* ciMemberName::get_vmtarget() const {
   VM_ENTRY_MARK;
-  // FIXME: Share code with ciMethodHandle::get_vmtarget
-  Metadata* vmtarget = java_lang_invoke_MemberName::vmtarget(get_oop());
-  if (vmtarget->is_method())
+  return get_vmtarget_no_entry(get_oop());
+}
+
+ciMethod* ciMemberName::get_vmtarget_no_entry(oop mname) {
+  ASSERT_IN_VM;
+  Metadata* vmtarget = java_lang_invoke_MemberName::vmtarget(mname);
+  if (vmtarget->is_method()) {
     return CURRENT_ENV->get_method((Method*) vmtarget);
-  // FIXME: What if the vmtarget is a Klass?
-  assert(false, "");
-  return NULL;
+  } else {
+    fatal("vmtarget should be a method");
+    return NULL; // silence compiler warnings
+  }
 }

--- a/src/hotspot/share/ci/ciMemberName.cpp
+++ b/src/hotspot/share/ci/ciMemberName.cpp
@@ -34,6 +34,6 @@
 // Return: MN.vmtarget
 ciMethod* ciMemberName::get_vmtarget() const {
   VM_ENTRY_MARK;
-  Method *vmtarget = java_lang_invoke_MemberName::vmtarget(get_oop());
+  Method* vmtarget = java_lang_invoke_MemberName::vmtarget(get_oop());
   return CURRENT_ENV->get_method(vmtarget);
 }

--- a/src/hotspot/share/ci/ciMemberName.cpp
+++ b/src/hotspot/share/ci/ciMemberName.cpp
@@ -34,11 +34,6 @@
 // Return: MN.vmtarget
 ciMethod* ciMemberName::get_vmtarget() const {
   VM_ENTRY_MARK;
-  return get_vmtarget_method(get_oop());
-}
-
-ciMethod* ciMemberName::get_vmtarget_method(oop mname) {
-  ASSERT_IN_VM;
-  Method* vmtarget = java_lang_invoke_MemberName::vmtarget(mname);
+  Method *vmtarget = java_lang_invoke_MemberName::vmtarget(get_oop());
   return CURRENT_ENV->get_method(vmtarget);
 }

--- a/src/hotspot/share/ci/ciMemberName.hpp
+++ b/src/hotspot/share/ci/ciMemberName.hpp
@@ -39,7 +39,8 @@ public:
   bool is_member_name() const { return true; }
 
   ciMethod* get_vmtarget() const;
-  static ciMethod* get_vmtarget_no_entry(oop mname);
+
+  static ciMethod* get_vmtarget_method(oop mname);
 };
 
 #endif // SHARE_CI_CIMEMBERNAME_HPP

--- a/src/hotspot/share/ci/ciMemberName.hpp
+++ b/src/hotspot/share/ci/ciMemberName.hpp
@@ -39,6 +39,7 @@ public:
   bool is_member_name() const { return true; }
 
   ciMethod* get_vmtarget() const;
+  static ciMethod* get_vmtarget_no_entry(oop mname);
 };
 
 #endif // SHARE_CI_CIMEMBERNAME_HPP

--- a/src/hotspot/share/ci/ciMemberName.hpp
+++ b/src/hotspot/share/ci/ciMemberName.hpp
@@ -39,7 +39,6 @@ public:
   bool is_member_name() const { return true; }
 
   ciMethod* get_vmtarget() const;
-
 };
 
 #endif // SHARE_CI_CIMEMBERNAME_HPP

--- a/src/hotspot/share/ci/ciMemberName.hpp
+++ b/src/hotspot/share/ci/ciMemberName.hpp
@@ -40,7 +40,6 @@ public:
 
   ciMethod* get_vmtarget() const;
 
-  static ciMethod* get_vmtarget_method(oop mname);
 };
 
 #endif // SHARE_CI_CIMEMBERNAME_HPP

--- a/src/hotspot/share/ci/ciMethodHandle.cpp
+++ b/src/hotspot/share/ci/ciMethodHandle.cpp
@@ -37,5 +37,5 @@ ciMethod* ciMethodHandle::get_vmtarget() const {
   VM_ENTRY_MARK;
   oop form_oop     = java_lang_invoke_MethodHandle::form(get_oop());
   oop vmentry_oop  = java_lang_invoke_LambdaForm::vmentry(form_oop);
-  return ciMemberName::get_vmtarget_no_entry(vmentry_oop);
+  return ciMemberName::get_vmtarget_method(vmentry_oop);
 }

--- a/src/hotspot/share/ci/ciMethodHandle.cpp
+++ b/src/hotspot/share/ci/ciMethodHandle.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "ci/ciClassList.hpp"
+#include "ci/ciMemberName.hpp"
 #include "ci/ciMethodHandle.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "classfile/javaClasses.hpp"
@@ -36,11 +37,5 @@ ciMethod* ciMethodHandle::get_vmtarget() const {
   VM_ENTRY_MARK;
   oop form_oop     = java_lang_invoke_MethodHandle::form(get_oop());
   oop vmentry_oop  = java_lang_invoke_LambdaForm::vmentry(form_oop);
-  // FIXME: Share code with ciMemberName::get_vmtarget
-  Metadata* vmtarget = java_lang_invoke_MemberName::vmtarget(vmentry_oop);
-  if (vmtarget->is_method())
-    return CURRENT_ENV->get_method((Method*) vmtarget);
-  // FIXME: What if the vmtarget is a Klass?
-  assert(false, "");
-  return NULL;
+  return ciMemberName::get_vmtarget_no_entry(vmentry_oop);
 }

--- a/src/hotspot/share/ci/ciMethodHandle.cpp
+++ b/src/hotspot/share/ci/ciMethodHandle.cpp
@@ -24,7 +24,6 @@
 
 #include "precompiled.hpp"
 #include "ci/ciClassList.hpp"
-#include "ci/ciMemberName.hpp"
 #include "ci/ciMethodHandle.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "classfile/javaClasses.hpp"
@@ -37,5 +36,6 @@ ciMethod* ciMethodHandle::get_vmtarget() const {
   VM_ENTRY_MARK;
   oop form_oop     = java_lang_invoke_MethodHandle::form(get_oop());
   oop vmentry_oop  = java_lang_invoke_LambdaForm::vmentry(form_oop);
-  return ciMemberName::get_vmtarget_method(vmentry_oop);
+  Method* vmtarget = java_lang_invoke_MemberName::vmtarget(vmentry_oop);
+  return CURRENT_ENV->get_method(vmtarget);
 }


### PR DESCRIPTION
There is a TODO item in their `get_vm_target`-s. We can clean those up. It looks to me the caller code does not handle `NULL` result well, which means we better `fatal` ourselves before exposing `NULL` to callers and `SEGV`-ing there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255301](https://bugs.openjdk.java.net/browse/JDK-8255301): Common and strengthen the code in ciMemberName and ciMethodHandle


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to ec242d2203cec41941e7017be16180e472d998a2
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/825/head:pull/825`
`$ git checkout pull/825`
