### PR TITLE
8253734: C2: Optimize Move nodes

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1268,29 +1268,21 @@ Node* LoadNode::convert_to_signed_load(PhaseGVN& gvn) {
                         is_unaligned_access(), is_mismatched_access());
 }
 
-bool LoadNode::has_reinterpret_variant() {
+bool LoadNode::has_reinterpret_variant(const Type* rt) {
+  BasicType bt = rt->basic_type();
   switch (Opcode()) {
-    case Op_LoadI: return true;
-    case Op_LoadL: return true;
-    case Op_LoadF: return true;
-    case Op_LoadD: return true;
+    case Op_LoadI: return (bt == T_FLOAT);
+    case Op_LoadL: return (bt == T_DOUBLE);
+    case Op_LoadF: return (bt == T_INT);
+    case Op_LoadD: return (bt == T_LONG);
 
     default: return false;
   }
 }
 
-Node* LoadNode::convert_to_reinterpret_load(PhaseGVN& gvn) {
-  assert(has_reinterpret_variant(), "no reinterpret variant: %s", Name());
-  BasicType bt = T_ILLEGAL;
-  const Type* rt = NULL;
-  switch (Opcode()) {
-    case Op_LoadI: bt = T_FLOAT;  rt = Type::FLOAT;    break;
-    case Op_LoadL: bt = T_DOUBLE; rt = Type::DOUBLE;   break;
-    case Op_LoadF: bt = T_INT;    rt = TypeInt::INT;   break;
-    case Op_LoadD: bt = T_LONG;   rt = TypeLong::LONG; break;
-    default:
-      return NULL;
-  }
+Node* LoadNode::convert_to_reinterpret_load(PhaseGVN& gvn, const Type* rt) {
+  BasicType bt = rt->basic_type();
+  assert(has_reinterpret_variant(rt), "no reinterpret variant: %s %s", Name(), type2name(bt));
   bool is_mismatched = is_mismatched_access();
   const TypeRawPtr* raw_type = gvn.type(in(MemNode::Memory))->isa_rawptr();
   if (raw_type == NULL) {
@@ -1301,28 +1293,21 @@ Node* LoadNode::convert_to_reinterpret_load(PhaseGVN& gvn) {
                         is_unaligned_access(), is_mismatched);
 }
 
-bool StoreNode::has_reinterpret_variant() {
+bool StoreNode::has_reinterpret_variant(const Type* vt) {
+  BasicType bt = vt->basic_type();
   switch (Opcode()) {
-    case Op_StoreI: return true;
-    case Op_StoreL: return true;
-    case Op_StoreF: return true;
-    case Op_StoreD: return true;
+    case Op_StoreI: return (bt == T_FLOAT);
+    case Op_StoreL: return (bt == T_DOUBLE);
+    case Op_StoreF: return (bt == T_INT);
+    case Op_StoreD: return (bt == T_LONG);
 
     default: return false;
   }
 }
 
-Node* StoreNode::convert_to_reinterpret_store(PhaseGVN& gvn, Node* val) {
-  assert(has_reinterpret_variant(), "no reinterpret variant: %s, ", Name());
-  BasicType bt = T_ILLEGAL;
-  switch (Opcode()) {
-    case Op_StoreI: bt = T_FLOAT;  break;
-    case Op_StoreL: bt = T_DOUBLE; break;
-    case Op_StoreF: bt = T_INT;    break;
-    case Op_StoreD: bt = T_LONG;   break;
-    default:
-      return NULL;
-  }
+Node* StoreNode::convert_to_reinterpret_store(PhaseGVN& gvn, Node* val, const Type* vt) {
+  BasicType bt = vt->basic_type();
+  assert(has_reinterpret_variant(vt), "no reinterpret variant: %s %s", Name(), type2name(bt));
   StoreNode* st = StoreNode::make(gvn, in(MemNode::Control), in(MemNode::Memory), in(MemNode::Address), raw_adr_type(), val, bt, _mo);
 
   bool is_mismatched = is_mismatched_access();
@@ -2616,6 +2601,7 @@ Node *StoreNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
   Node* mem     = in(MemNode::Memory);
   Node* address = in(MemNode::Address);
+  Node* value   = in(MemNode::ValueIn);
   // Back-to-back stores to same address?  Fold em up.  Generally
   // unsafe if I have intervening uses...  Also disallowed for StoreCM
   // since they must follow each StoreP operation.  Redundant StoreCMs
@@ -2679,11 +2665,16 @@ Node *StoreNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-  if (in(MemNode::ValueIn)->is_Move() && has_reinterpret_variant()) {
-    if (phase->C->post_loop_opts_phase()) {
-      return convert_to_reinterpret_store(*phase, in(MemNode::ValueIn)->in(1));
-    } else {
-      phase->C->record_for_post_loop_opts_igvn(this);
+  // Fold reinterpret cast into memory operation:
+  //    StoreX mem (MoveY2X v) => StoreY mem v
+  if (value->is_Move()) {
+    const Type* vt = value->in(1)->bottom_type();
+    if (has_reinterpret_variant(vt)) {
+      if (phase->C->post_loop_opts_phase()) {
+        return convert_to_reinterpret_store(*phase, value->in(1), vt);
+      } else {
+        phase->C->record_for_post_loop_opts_igvn(this); // attempt the transformation once loop opts are over
+      }
     }
   }
 

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -282,8 +282,8 @@ public:
   Node* convert_to_unsigned_load(PhaseGVN& gvn);
   Node* convert_to_signed_load(PhaseGVN& gvn);
 
-  bool  has_reinterpret_variant();
-  Node* convert_to_reinterpret_load(PhaseGVN& gvn);
+  bool  has_reinterpret_variant(const Type* rt);
+  Node* convert_to_reinterpret_load(PhaseGVN& gvn, const Type* rt);
 
   void pin() { _control_dependency = Pinned; }
   bool has_unknown_control_dependency() const { return _control_dependency == UnknownControl; }
@@ -637,8 +637,8 @@ public:
   // have all possible loads of the value stored been optimized away?
   bool value_never_loaded(PhaseTransform *phase) const;
 
-  bool  has_reinterpret_variant();
-  Node* convert_to_reinterpret_store(PhaseGVN& gvn, Node* val);
+  bool  has_reinterpret_variant(const Type* vt);
+  Node* convert_to_reinterpret_store(PhaseGVN& gvn, Node* val, const Type* vt);
 
   MemBarNode* trailing_membar() const;
 };

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -282,6 +282,9 @@ public:
   Node* convert_to_unsigned_load(PhaseGVN& gvn);
   Node* convert_to_signed_load(PhaseGVN& gvn);
 
+  bool  has_reinterpret_variant();
+  Node* convert_to_reinterpret_load(PhaseGVN& gvn);
+
   void pin() { _control_dependency = Pinned; }
   bool has_unknown_control_dependency() const { return _control_dependency == UnknownControl; }
 
@@ -633,6 +636,9 @@ public:
 
   // have all possible loads of the value stored been optimized away?
   bool value_never_loaded(PhaseTransform *phase) const;
+
+  bool  has_reinterpret_variant();
+  Node* convert_to_reinterpret_store(PhaseGVN& gvn, Node* val);
 
   MemBarNode* trailing_membar() const;
 };

--- a/src/hotspot/share/opto/movenode.cpp
+++ b/src/hotspot/share/opto/movenode.cpp
@@ -356,12 +356,17 @@ Node *CMoveDNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
 Node* MoveNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   if (can_reshape) {
+    // Fold reinterpret cast into memory operation:
+    //    MoveX2Y (LoadX mem) => LoadY mem
     LoadNode* ld = in(1)->isa_Load();
-    if (ld != NULL && (ld->outcnt() == 1) && ld->has_reinterpret_variant()) {
-      if (phase->C->post_loop_opts_phase()) {
-        return ld->convert_to_reinterpret_load(*phase);
-      } else {
-        phase->C->record_for_post_loop_opts_igvn(this);
+    if (ld != NULL && (ld->outcnt() == 1)) { // replace only
+      const Type* rt = bottom_type();
+      if (ld->has_reinterpret_variant(rt)) {
+        if (phase->C->post_loop_opts_phase()) {
+          return ld->convert_to_reinterpret_load(*phase, rt);
+        } else {
+          phase->C->record_for_post_loop_opts_igvn(this); // attempt the transformation once loop opts are over
+        }
       }
     }
   }
@@ -370,8 +375,9 @@ Node* MoveNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
 Node* MoveNode::Identity(PhaseGVN* phase) {
   if (in(1)->is_Move()) {
+    // Back-to-back moves: MoveX2Y (MoveY2X v) => v
     assert(bottom_type() == in(1)->in(1)->bottom_type(), "sanity");
-    return in(1)->in(1); // back-to-back moves
+    return in(1)->in(1);
   }
   return this;
 }

--- a/src/hotspot/share/opto/movenode.hpp
+++ b/src/hotspot/share/opto/movenode.hpp
@@ -98,41 +98,59 @@ class CMoveNNode : public CMoveNode {
 };
 
 //
-class MoveI2FNode : public Node {
+class MoveNode : public Node {
+  protected:
+  MoveNode(Node* value) : Node(NULL, value) {}
+
   public:
-  MoveI2FNode( Node *value ) : Node(0,value) {}
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
+  virtual Node* Identity(PhaseGVN* phase);
+//  virtual const Type* Value(PhaseGVN* phase) const;
+};
+
+class MoveI2FNode : public MoveNode {
+  public:
+  MoveI2FNode(Node* value) : MoveNode(value) {
+    init_class_id(Class_Move);
+  }
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return Type::FLOAT; }
+  virtual const Type* bottom_type() const { return Type::FLOAT; }
   virtual uint ideal_reg() const { return Op_RegF; }
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);
 };
 
-class MoveL2DNode : public Node {
+class MoveL2DNode : public MoveNode {
   public:
-  MoveL2DNode( Node *value ) : Node(0,value) {}
+  MoveL2DNode(Node* value) : MoveNode(value) {
+    init_class_id(Class_Move);
+  }
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return Type::DOUBLE; }
+  virtual const Type* bottom_type() const { return Type::DOUBLE; }
   virtual uint ideal_reg() const { return Op_RegD; }
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);
 };
 
-class MoveF2INode : public Node {
+class MoveF2INode : public MoveNode {
   public:
-  MoveF2INode( Node *value ) : Node(0,value) {}
+  MoveF2INode(Node* value) : MoveNode(value) {
+    init_class_id(Class_Move);
+  }
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return TypeInt::INT; }
+  virtual const Type* bottom_type() const { return TypeInt::INT; }
   virtual uint ideal_reg() const { return Op_RegI; }
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);
 };
 
-class MoveD2LNode : public Node {
+class MoveD2LNode : public MoveNode {
   public:
-  MoveD2LNode( Node *value ) : Node(0,value) {}
+  MoveD2LNode(Node* value) : MoveNode(value) {
+    init_class_id(Class_Move);
+  }
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return TypeLong::LONG; }
+  virtual const Type* bottom_type() const { return TypeLong::LONG; }
   virtual uint ideal_reg() const { return Op_RegL; }
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);

--- a/src/hotspot/share/opto/movenode.hpp
+++ b/src/hotspot/share/opto/movenode.hpp
@@ -100,19 +100,18 @@ class CMoveNNode : public CMoveNode {
 //
 class MoveNode : public Node {
   protected:
-  MoveNode(Node* value) : Node(NULL, value) {}
+  MoveNode(Node* value) : Node(NULL, value) {
+    init_class_id(Class_Move);
+  }
 
   public:
   virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
   virtual Node* Identity(PhaseGVN* phase);
-//  virtual const Type* Value(PhaseGVN* phase) const;
 };
 
 class MoveI2FNode : public MoveNode {
   public:
-  MoveI2FNode(Node* value) : MoveNode(value) {
-    init_class_id(Class_Move);
-  }
+  MoveI2FNode(Node* value) : MoveNode(value) {}
   virtual int Opcode() const;
   virtual const Type* bottom_type() const { return Type::FLOAT; }
   virtual uint ideal_reg() const { return Op_RegF; }
@@ -122,9 +121,7 @@ class MoveI2FNode : public MoveNode {
 
 class MoveL2DNode : public MoveNode {
   public:
-  MoveL2DNode(Node* value) : MoveNode(value) {
-    init_class_id(Class_Move);
-  }
+  MoveL2DNode(Node* value) : MoveNode(value) {}
   virtual int Opcode() const;
   virtual const Type* bottom_type() const { return Type::DOUBLE; }
   virtual uint ideal_reg() const { return Op_RegD; }
@@ -134,9 +131,7 @@ class MoveL2DNode : public MoveNode {
 
 class MoveF2INode : public MoveNode {
   public:
-  MoveF2INode(Node* value) : MoveNode(value) {
-    init_class_id(Class_Move);
-  }
+  MoveF2INode(Node* value) : MoveNode(value) {}
   virtual int Opcode() const;
   virtual const Type* bottom_type() const { return TypeInt::INT; }
   virtual uint ideal_reg() const { return Op_RegI; }
@@ -146,9 +141,7 @@ class MoveF2INode : public MoveNode {
 
 class MoveD2LNode : public MoveNode {
   public:
-  MoveD2LNode(Node* value) : MoveNode(value) {
-    init_class_id(Class_Move);
-  }
+  MoveD2LNode(Node* value) : MoveNode(value) {}
   virtual int Opcode() const;
   virtual const Type* bottom_type() const { return TypeLong::LONG; }
   virtual uint ideal_reg() const { return Op_RegL; }

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -112,6 +112,7 @@ class MemBarNode;
 class MemBarStoreStoreNode;
 class MemNode;
 class MergeMemNode;
+class MoveNode;
 class MulNode;
 class MultiNode;
 class MultiBranchNode;
@@ -721,10 +722,11 @@ public:
     DEFINE_CLASS_ID(Vector,   Node, 13)
       DEFINE_CLASS_ID(VectorMaskCmp, Vector, 0)
     DEFINE_CLASS_ID(ClearArray, Node, 14)
-    DEFINE_CLASS_ID(Halt, Node, 15)
-    DEFINE_CLASS_ID(Opaque1, Node, 16)
+    DEFINE_CLASS_ID(Halt,     Node, 15)
+    DEFINE_CLASS_ID(Opaque1,  Node, 16)
+    DEFINE_CLASS_ID(Move,     Node, 17)
 
-    _max_classes  = ClassMask_Opaque1
+    _max_classes  = ClassMask_Move
   };
   #undef DEFINE_CLASS_ID
 
@@ -870,6 +872,7 @@ public:
   DEFINE_CLASS_QUERY(MemBar)
   DEFINE_CLASS_QUERY(MemBarStoreStore)
   DEFINE_CLASS_QUERY(MergeMem)
+  DEFINE_CLASS_QUERY(Move)
   DEFINE_CLASS_QUERY(Mul)
   DEFINE_CLASS_QUERY(Multi)
   DEFINE_CLASS_QUERY(MultiBranch)


### PR DESCRIPTION
Introduce the following transformations for Move nodes: 
1. `MoveI2F (MoveF2I x) => x`

1. `MoveI2F (LoadI mem) => LoadF mem` 

1. `StoreI mem (MoveF2I x) => StoreF mem x` 

(The same applies to MoveL2D/MoveD2L.)

№1 eliminates redundant operations and №2/№3 avoid reg-to-reg moves in generated code:
```
0x000000010d09964c:   vmovss 0x20(%rsi),%xmm1
0x000000010d099651:   vmovd  %xmm1,%eax                   ;*invokestatic floatToRawIntBits
```
vs
```
0x0000000110c5a6cc:   mov    0x20(%rsi),%eax              ;*invokestatic floatToRawIntBits
``` 

(№2 and №3 are performed late (after loop opts are over) to avoid high-level optimizations passes to handle newly introduced mismatched accesses.)

Testing: tier1-5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/iwanowww/jdk/runs/1297871189)

### Issue
 * [JDK-8253734](https://bugs.openjdk.java.net/browse/JDK-8253734): C2: Optimize Move nodes


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * @blaquez (no known github.com user name / role)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/826/head:pull/826`
`$ git checkout pull/826`
