### PR TITLE
8255233: InterpreterRuntime::at_unwind should be a JRT_LEAF

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -551,7 +551,9 @@ void InterpreterMacroAssembler::remove_activation(
   br(Assembler::AL, fast_path);
   bind(slow_path);
   push(state);
-  call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::at_unwind));
+  set_last_Java_frame(esp, rfp, pc(), rscratch1);
+  super_call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::at_unwind), rthread);
+  reset_last_Java_frame(true);
   pop(state);
   bind(fast_path);
 

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -551,7 +551,7 @@ void InterpreterMacroAssembler::remove_activation(
   br(Assembler::AL, fast_path);
   bind(slow_path);
   push(state);
-  set_last_Java_frame(esp, rfp, pc(), rscratch1);
+  set_last_Java_frame(esp, rfp, (address)pc(), rscratch1);
   super_call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::at_unwind), rthread);
   reset_last_Java_frame(true);
   pop(state);

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -999,7 +999,9 @@ void InterpreterMacroAssembler::remove_activation(
   jmp(fast_path);
   bind(slow_path);
   push(state);
-  call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::at_unwind));
+  set_last_Java_frame(noreg, rbp, pc());
+  super_call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::at_unwind), rthread);
+  reset_last_Java_frame(rthread, true);
   pop(state);
   NOT_LP64(get_thread(rthread);) // call_VM clobbered it, restore
   bind(fast_path);

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -999,7 +999,7 @@ void InterpreterMacroAssembler::remove_activation(
   jmp(fast_path);
   bind(slow_path);
   push(state);
-  set_last_Java_frame(noreg, rbp, pc());
+  set_last_Java_frame(noreg, rbp, (address)pc());
   super_call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::at_unwind), rthread);
   reset_last_Java_frame(rthread, true);
   pop(state);

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -999,7 +999,7 @@ void InterpreterMacroAssembler::remove_activation(
   jmp(fast_path);
   bind(slow_path);
   push(state);
-  set_last_Java_frame(noreg, rbp, (address)pc());
+  set_last_Java_frame(rthread, noreg, rbp, (address)pc());
   super_call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::at_unwind), rthread);
   reset_last_Java_frame(rthread, true);
   pop(state);

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1173,9 +1173,6 @@ JRT_ENTRY(void, InterpreterRuntime::at_safepoint(JavaThread* thread))
 JRT_END
 
 JRT_LEAF(void, InterpreterRuntime::at_unwind(JavaThread* thread))
-  // JRT_END does an implicit safepoint check, hence we are guaranteed to block
-  // if this is called during a safepoint
-
   // This function is called by the interpreter when the return poll found a reason
   // to call the VM. The reason could be that we are returning into a not yet safe
   // to access frame. We handle that below.

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1172,7 +1172,7 @@ JRT_ENTRY(void, InterpreterRuntime::at_safepoint(JavaThread* thread))
   }
 JRT_END
 
-JRT_ENTRY(void, InterpreterRuntime::at_unwind(JavaThread* thread))
+JRT_LEAF(void, InterpreterRuntime::at_unwind(JavaThread* thread))
   // JRT_END does an implicit safepoint check, hence we are guaranteed to block
   // if this is called during a safepoint
 


### PR DESCRIPTION
InterpreterRuntime::at_unwind is called at the very beginning of remove_activation(), to notify concurrent stack processing that a frame is about to be unwound. It is currently a JRT_ENTRY, because it needs a last_Java_frame to see what frame is about to get unwound.

However, there are special return paths used by JVMTI pop frame, that checks if the caller frame is deoptimized, then calls a special path that removes the top activation, assuming that does not enter the deopt handler. The new JRT_ENTRY makes that reasoning invalid.

Therefore, we need this to be a JRT_LEAF, that sets a last Java frame, to make everyone happy. This patch performs that change.

I have run tier 1-5 testing, and manually tested:

while true; do make test JTREG="RETAIN=all" TEST=open/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceEarlyReturn/ForceEarlyReturn002 TEST_OPTS_JAVA_OPTIONS="-XX:+UseZGC -Xmx2g -XX:ZCollectionInterval=0.0001 -XX:ZFragmentationLimit=0.01 -XX:+VerifyOops -XX:+ZVerifyViews" ; done

Before the fix it crashes ~1/15 runs with a bad oop. After the fix, it doesn't crash. I have run it more times than my tmux buffer fits (for a day), and it does not fail any more with this fix.

Unfortunately, my testing on AArch64 has been stalled for a day, so I have sent out this PR without the testing of those bits being finished. I won't push until I get the results back, of course. But I am expecting that to be fine, as there is nothing special going on there and it compiles. Will post a comment when the complete results have arrived.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/fisk/jdk/runs/1320167975)

### Issue
 * [JDK-8255233](https://bugs.openjdk.java.net/browse/JDK-8255233): InterpreterRuntime::at_unwind should be a JRT_LEAF


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to cc3929d194ab5b1727910699812de9350c2bac4d
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/828/head:pull/828`
`$ git checkout pull/828`
