### PR TITLE
8196465: javax/swing/JComboBox/8182031/ComboPopupTest.java fails on Linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -767,7 +767,6 @@ javax/swing/text/DefaultCaret/HidingSelection/HidingSelectionTest.java 8194048 w
 javax/swing/text/DefaultCaret/HidingSelection/MultiSelectionTest.java 8213562 linux-all
 javax/swing/text/JTextComponent/5074573/bug5074573.java 8196100 windows-all
 javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
-javax/swing/JComboBox/8182031/ComboPopupTest.java 8196465 linux-all,macosx-all
 javax/swing/JFileChooser/6738668/bug6738668.java 8194946 generic-all
 javax/swing/JFileChooser/8021253/bug8021253.java 8169954 windows-all,linux-all,macosx-all
 javax/swing/JFileChooser/8062561/bug8062561.java 8196466 linux-all,macosx-all

--- a/test/jdk/javax/swing/JComboBox/8182031/ComboPopupTest.java
+++ b/test/jdk/javax/swing/JComboBox/8182031/ComboPopupTest.java
@@ -69,14 +69,15 @@ public class ComboPopupTest {
     public ComboPopupTest() throws Exception {
         try {
             Robot robot = new Robot();
-            robot.setAutoDelay(200);
+            robot.setAutoDelay(100);
             SwingUtilities.invokeAndWait(() -> start());
             blockTillDisplayed(comboBox);
             robot.waitForIdle();
-            robot.mouseMove(p.x + d.width-1, p.y + d.height/2);
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mouseMove(p.x + d.width/2, p.y + d.height/2);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
+            robot.delay(100);
 
             System.out.println("popmenu visible " + comboBox.isPopupVisible());
             if (!comboBox.isPopupVisible()) {


### PR DESCRIPTION
Please review a test fix for an issue seen to be failing in mach5 testing on linux whereby the combo popup is not opening.
The issue is not reproducible locally in ubuntu18.04 but mach5 testing on ubuntu18.04 was able to see the issue. 
Combo popup was opened by clicking at right edge of combo box, which sometimes is not set properly at mach5 system, so mouse click is clicked at wrong location of frame, thereby not opening the combo popup.
 Modified the test to open the combo popup by clicking on middle of combobox which now works for all. Also, made robot autodelay consistent with other test to be 100ms. Also, changed deprecated constant to appropriate constants.
Mach5 job was run for several iteration on all 3 platforms. Link in JBS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/prsadhuk/jdk/runs/1297525580)

### Issue
 * [JDK-8196465](https://bugs.openjdk.java.net/browse/JDK-8196465): javax/swing/JComboBox/8182031/ComboPopupTest.java fails on Linux


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/829/head:pull/829`
`$ git checkout pull/829`
