### PR TITLE
8255330: gtest/MetaspaceGtests.java fail on 32-bit platforms

### DIFF
--- a/test/hotspot/jtreg/gtest/MetaspaceGtests.java
+++ b/test/hotspot/jtreg/gtest/MetaspaceGtests.java
@@ -87,6 +87,7 @@
 
 /* @test id=balanced-no-ccs
  * @summary Run metaspace-related gtests with compressed class pointers off
+ * @requires vm.bits == 64
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml


### PR DESCRIPTION
Seems fairly trivial: `UseCompressedKlassPointers` is only available on 64-bit platforms.

Attention @tstuefe ;)

Testing:
 - [x] Affected test on Linux x86_64
 - [x] Affected test on Linux x86_32

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255330](https://bugs.openjdk.java.net/browse/JDK-8255330): gtest/MetaspaceGtests.java fail on 32-bit platforms


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/831/head:pull/831`
`$ git checkout pull/831`
