### PR TITLE
8255331: Problemlist java/foreign/TestMismatch.java on 32-bit platforms until JDK-8254162

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -560,6 +560,7 @@ java/beans/XMLEncoder/Test6570354.java 8015593 macosx-all
 # jdk_foreign
 
 java/foreign/TestMismatch.java 8249684 macosx-all
+java/foreign/TestMismatch.java 8255270 generic-i586
 
 ############################################################################
 


### PR DESCRIPTION
I would like to have clean x86_32 test runs until JDK-8254162 arrives.

Testing:
  - [x] Affected test on Linux x86_64 (still passes)
  - [x] Affected test on Linux x86_32 (now ignored)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255331](https://bugs.openjdk.java.net/browse/JDK-8255331): Problemlist java/foreign/TestMismatch.java on 32-bit platforms until JDK-8254162


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/833/head:pull/833`
`$ git checkout pull/833`
