### PR TITLE
8255338: CodeSections are never frozen

### DIFF
--- a/src/hotspot/share/asm/assembler.cpp
+++ b/src/hotspot/share/asm/assembler.cpp
@@ -199,19 +199,6 @@ void Label::patch_instructions(MacroAssembler* masm) {
       continue;
     }
 
-#ifdef ASSERT
-    // Cross-section branches only work if the
-    // intermediate section boundaries are frozen.
-    if (target_sect != branch_sect) {
-      for (int n = MIN2(target_sect, branch_sect),
-               nlimit = (target_sect + branch_sect) - n;
-           n < nlimit; n++) {
-        CodeSection* cs = cb->code_section(n);
-        assert(cs->is_frozen(), "cross-section branch needs stable offsets");
-      }
-    }
-#endif //ASSERT
-
     // Push the target offset into the branch instruction.
     masm->pd_patch_instruction(branch, target, file, line);
   }

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -176,28 +176,6 @@ void CodeBuffer::initialize_section_size(CodeSection* cs, csize_t size) {
   if (_insts.has_locs())  cs->initialize_locs(1);
 }
 
-void CodeBuffer::freeze_section(CodeSection* cs) {
-  CodeSection* next_cs = (cs == consts())? NULL: code_section(cs->index()+1);
-  csize_t frozen_size = cs->size();
-  if (next_cs != NULL) {
-    frozen_size = next_cs->align_at_start(frozen_size);
-  }
-  address old_limit = cs->limit();
-  address new_limit = cs->start() + frozen_size;
-  relocInfo* old_locs_limit = cs->locs_limit();
-  relocInfo* new_locs_limit = cs->locs_end();
-  // Patch the limits.
-  cs->_limit = new_limit;
-  cs->_locs_limit = new_locs_limit;
-  cs->_frozen = true;
-  if (next_cs != NULL && !next_cs->is_allocated() && !next_cs->is_frozen()) {
-    // Give remaining buffer space to the following section.
-    next_cs->initialize(new_limit, old_limit - new_limit);
-    next_cs->initialize_shared_locs(new_locs_limit,
-                                    old_locs_limit - new_locs_limit);
-  }
-}
-
 void CodeBuffer::set_blob(BufferBlob* blob) {
   _blob = blob;
   if (blob != NULL) {
@@ -506,18 +484,6 @@ void CodeBuffer::compute_final_layout(CodeBuffer* dest) const {
       } else {
         guarantee(padding == 0, "In first iteration no padding should be needed.");
       }
-      #ifdef ASSERT
-      if (prev_cs != NULL && prev_cs->is_frozen() && n < (SECT_LIMIT - 1)) {
-        // Make sure the ends still match up.
-        // This is important because a branch in a frozen section
-        // might target code in a following section, via a Label,
-        // and without a relocation record.  See Label::patch_instructions.
-        address dest_start = buf+buf_offset;
-        csize_t start2start = cs->start() - prev_cs->start();
-        csize_t dest_start2start = dest_start - prev_dest_cs->start();
-        assert(start2start == dest_start2start, "cannot stretch frozen sect");
-      }
-      #endif //ASSERT
       prev_dest_cs = dest_cs;
       prev_cs      = cs;
     }
@@ -896,9 +862,6 @@ void CodeBuffer::expand(CodeSection* which_cs, csize_t amount) {
   // Resizing must be allowed
   {
     if (blob() == NULL)  return;  // caller must check for blob == NULL
-    for (int n = 0; n < (int)SECT_LIMIT; n++) {
-      guarantee(!code_section(n)->is_frozen(), "resizing not allowed when frozen");
-    }
   }
 
   // Figure new capacity for each section.
@@ -1224,9 +1187,8 @@ void CodeBuffer::decode() {
 
 void CodeSection::print(const char* name) {
   csize_t locs_size = locs_end() - locs_start();
-  tty->print_cr(" %7s.code = " PTR_FORMAT " : " PTR_FORMAT " : " PTR_FORMAT " (%d of %d)%s",
-                name, p2i(start()), p2i(end()), p2i(limit()), size(), capacity(),
-                is_frozen()? " [frozen]": "");
+  tty->print_cr(" %7s.code = " PTR_FORMAT " : " PTR_FORMAT " : " PTR_FORMAT " (%d of %d)",
+                name, p2i(start()), p2i(end()), p2i(limit()), size(), capacity());
   tty->print_cr(" %7s.locs = " PTR_FORMAT " : " PTR_FORMAT " : " PTR_FORMAT " (%d of %d) point=%d",
                 name, p2i(locs_start()), p2i(locs_end()), p2i(locs_limit()), locs_size, locs_capacity(), locs_point_off());
   if (PrintRelocations) {

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -92,7 +92,6 @@ class CodeSection {
   relocInfo*  _locs_limit;      // first byte after relocation information buf
   address     _locs_point;      // last relocated position (grows upward)
   bool        _locs_own;        // did I allocate the locs myself?
-  bool        _frozen;          // no more expansion of this section
   bool        _scratch_emit;    // Buffer is used for scratch emit, don't relocate.
   char        _index;           // my section number (SECT_INST, etc.)
   CodeBuffer* _outer;           // enclosing CodeBuffer
@@ -109,7 +108,6 @@ class CodeSection {
     _locs_limit    = NULL;
     _locs_point    = NULL;
     _locs_own      = false;
-    _frozen        = false;
     _scratch_emit  = false;
     debug_only(_index = (char)-1);
     debug_only(_outer = (CodeBuffer*)badAddress);
@@ -161,12 +159,10 @@ class CodeSection {
   address     locs_point() const    { return _locs_point; }
   csize_t     locs_point_off() const{ return (csize_t)(_locs_point - _start); }
   csize_t     locs_capacity() const { return (csize_t)(_locs_limit - _locs_start); }
-  csize_t     locs_remaining()const { return (csize_t)(_locs_limit - _locs_end); }
 
   int         index() const         { return _index; }
   bool        is_allocated() const  { return _start != NULL; }
   bool        is_empty() const      { return _start == _end; }
-  bool        is_frozen() const     { return _frozen; }
   bool        has_locs() const      { return _locs_end != NULL; }
 
   // Mark scratch buffer.
@@ -184,8 +180,6 @@ class CodeSection {
   void    set_end(address pc)       { assert(allocates2(pc), "not in CodeBuffer memory: " INTPTR_FORMAT " <= " INTPTR_FORMAT " <= " INTPTR_FORMAT, p2i(_start), p2i(pc), p2i(_limit)); _end = pc; }
   void    set_mark(address pc)      { assert(contains2(pc), "not in codeBuffer");
                                       _mark = pc; }
-  void    set_mark_off(int offset)  { assert(contains2(offset+_start),"not in codeBuffer");
-                                      _mark = offset + _start; }
   void    set_mark()                { _mark = _end; }
   void    clear_mark()              { _mark = NULL; }
 
@@ -258,10 +252,6 @@ class CodeSection {
   static csize_t end_slop()         { return MAX2((int)sizeof(jdouble), (int)CodeEntryAlignment); }
 
   csize_t align_at_start(csize_t off) const { return (csize_t) align_up(off, alignment()); }
-
-  // Mark a section frozen.  Assign its remaining space to
-  // the following section.  It will never expand after this point.
-  inline void freeze();         //  { _outer->freeze_section(this); }
 
   // Ensure there's enough space left in the current section.
   // Return true if there was an expansion.
@@ -463,8 +453,6 @@ class CodeBuffer: public StackObj {
 
   void initialize_section_size(CodeSection* cs, csize_t size);
 
-  void freeze_section(CodeSection* cs);
-
   // helper for CodeBuffer::expand()
   void take_over_code_from(CodeBuffer* cs);
 
@@ -648,12 +636,6 @@ class CodeBuffer: public StackObj {
       _code_strings.free(); // sets _strings Null as a side-effect.
     }
   }
-
-  // Print the comment associated with offset on stream, if there is one.
-  virtual void print_block_comment(outputStream* stream, address block_begin) {
-    intptr_t offset = (intptr_t)(block_begin - _total_start);  // I assume total_start is not correct for all code sections.
-    _code_strings.print_block_comment(stream, offset);
-  }
 #endif
 
   // Code generation
@@ -678,9 +660,6 @@ class CodeBuffer: public StackObj {
       oop_recorder()->copy_values_to(nm);
     }
   }
-
-  // Transform an address from the code in this code buffer to a specified code buffer
-  address transform_address(const CodeBuffer &cb, address addr) const;
 
   void block_comment(intptr_t offset, const char * comment) PRODUCT_RETURN;
   const char* code_string(const char* str) PRODUCT_RETURN_(return NULL;);
@@ -709,11 +688,6 @@ class CodeBuffer: public StackObj {
 #include CPU_HEADER(codeBuffer)
 
 };
-
-
-inline void CodeSection::freeze() {
-  _outer->freeze_section(this);
-}
 
 inline bool CodeSection::maybe_expand_to_ensure_remaining(csize_t amount) {
   if (remaining() < amount) { _outer->expand(this, amount); return true; }

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -561,10 +561,8 @@ class CodeBuffer: public StackObj {
   address       insts_begin() const      { return _insts.start();      }
   address       insts_end() const        { return _insts.end();        }
   void      set_insts_end(address end)   {        _insts.set_end(end); }
-  address       insts_limit() const      { return _insts.limit();      }
   address       insts_mark() const       { return _insts.mark();       }
   void      set_insts_mark()             {        _insts.set_mark();   }
-  void    clear_insts_mark()             {        _insts.clear_mark(); }
 
   // is there anything in the buffer other than the current section?
   bool    is_pure() const                { return insts_size() == total_content_size(); }


### PR DESCRIPTION
CodeSections are never actually frozen, so code for freezing can be removed along with some assertions and guarantees.

A few other minor cleanups, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255338](https://bugs.openjdk.java.net/browse/JDK-8255338): CodeSections are never frozen


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**) ⚠️ Review applies to 37aca0c21cec03b99ea6810fb43d226f36559c3a
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/834/head:pull/834`
`$ git checkout pull/834`
