### PR TITLE
8255340: [s390] build failure after JDK-8255208

### DIFF
--- a/src/hotspot/cpu/s390/vm_version_s390.cpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.cpp
@@ -836,7 +836,7 @@ void VM_Version::determine_features() {
                   code_end-code, cbuf_size, cbuf_size-(code_end-code));
 
     // Use existing decode function. This enables the [MachCode] format which is needed to DecodeErrorFile.
-    Disassembler::decode(&cbuf, code, code_end, tty);
+    Disassembler::decode(code, code_end, tty);
   }
 
   // Prepare for detection code execution and clear work buffer.


### PR DESCRIPTION
vm_version_s390.cpp:839:52: error: no matching function for call to 'Disassembler::decode(CodeBuffer*, u_char*&, u_char*&, outputStream*&)'
This function was removed. I'm using the one without the CodeBuffer* argument (like on PPC64).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (1/1 running) | ⏳ (4/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8255340](https://bugs.openjdk.java.net/browse/JDK-8255340): [s390] build failure after JDK-8255208


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/835/head:pull/835`
`$ git checkout pull/835`
