### PR TITLE
8255343: java/util/stream/SpliteratorTest.java fails on 32-bit platforms with "Misaligned access at address: 12"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -852,8 +852,6 @@ com/sun/jdi/InvokeHangTest.java                                 8218463 linux-al
 
 # jdk_util
 
-java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java 8254162 generic-i586
-
 ############################################################################
 
 # jdk_instrument

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -852,7 +852,7 @@ com/sun/jdi/InvokeHangTest.java                                 8218463 linux-al
 
 # jdk_util
 
-java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java 8255343 generic-i586
+java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java 8254162 generic-i586
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -852,6 +852,8 @@ com/sun/jdi/InvokeHangTest.java                                 8218463 linux-al
 
 # jdk_util
 
+java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java 8255343 generic-i586
+
 ############################################################################
 
 # jdk_instrument

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/SegmentTestDataProvider.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/SegmentTestDataProvider.java
@@ -40,12 +40,12 @@ import org.testng.annotations.DataProvider;
 public class SegmentTestDataProvider {
 
     static VarHandle BYTE_HANDLE = MemoryLayouts.JAVA_BYTE.varHandle(byte.class);
-    static VarHandle CHAR_HANDLE = MemoryLayouts.JAVA_CHAR.varHandle(char.class);
-    static VarHandle SHORT_HANDLE = MemoryLayouts.JAVA_SHORT.varHandle(short.class);
-    static VarHandle INT_HANDLE = MemoryLayouts.JAVA_INT.varHandle(int.class);
-    static VarHandle LONG_HANDLE = MemoryLayouts.JAVA_LONG.varHandle(long.class);
-    static VarHandle FLOAT_HANDLE = MemoryLayouts.JAVA_FLOAT.varHandle(float.class);
-    static VarHandle DOUBLE_HANDLE = MemoryLayouts.JAVA_DOUBLE.varHandle(double.class);
+    static VarHandle CHAR_HANDLE = MemoryLayouts.JAVA_CHAR.withBitAlignment(8).varHandle(char.class);
+    static VarHandle SHORT_HANDLE = MemoryLayouts.JAVA_SHORT.withBitAlignment(8).varHandle(short.class);
+    static VarHandle INT_HANDLE = MemoryLayouts.JAVA_INT.withBitAlignment(8).varHandle(int.class);
+    static VarHandle LONG_HANDLE = MemoryLayouts.JAVA_LONG.withBitAlignment(8).varHandle(long.class);
+    static VarHandle FLOAT_HANDLE = MemoryLayouts.JAVA_FLOAT.withBitAlignment(8).varHandle(float.class);
+    static VarHandle DOUBLE_HANDLE = MemoryLayouts.JAVA_DOUBLE.withBitAlignment(8).varHandle(double.class);
 
     static boolean compareSegmentsByte(Collection<MemorySegment> segments1, Collection<MemorySegment> segments2, boolean isOrdered) {
         Function<MemorySegment, Byte> mapper = segment -> (byte)BYTE_HANDLE.get(segment.baseAddress());


### PR DESCRIPTION
It currently fails on x86_32 with `java.lang.IllegalStateException: Misaligned access at address: 12`. I checked that once JDK-8254162 integrates, that issue is gone. Until then, having clean x86_32 testing is beneficial for other work.

Testing:
 - [x] `java/util/stream` tests on Linux x86_64 (still passes)
 - [x] `java/util/stream` tests on Linux x86_32 (start to pass)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255343](https://bugs.openjdk.java.net/browse/JDK-8255343): java/util/stream/SpliteratorTest.java fails on 32-bit platforms with "Misaligned access at address: 12"


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Contributors
 * Maurizio Cimadamore `<mcimadamore@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/836/head:pull/836`
`$ git checkout pull/836`
