### PR TITLE
8255245: C1: Fix output of -XX:+PrintCFGToFile to open it with visualizer

### DIFF
--- a/src/hotspot/share/c1/c1_CFGPrinter.cpp
+++ b/src/hotspot/share/c1/c1_CFGPrinter.cpp
@@ -325,7 +325,7 @@ void CFGPrinterOutput::print_intervals(IntervalList* intervals, const char* name
 
   for (int i = 0; i < intervals->length(); i++) {
     if (intervals->at(i) != NULL) {
-      intervals->at(i)->print_on(output());
+      intervals->at(i)->print_on(output(), true);
     }
   }
 

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -4604,10 +4604,6 @@ bool Interval::intersects_any_children_of(Interval* interval) const {
 
 
 #ifndef PRODUCT
-void Interval::print_on(outputStream* out) const {
-  print_on(out, false);
-}
-
 void Interval::print_on(outputStream* out, bool is_cfg_printer) const {
   const char* SpillState2Name[] = { "no definition", "no spill store", "one spill store", "store at definition", "start in memory", "no optimization" };
   const char* UseKind2Name[] = { "N", "L", "S", "M" };

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -3212,6 +3212,12 @@ void LinearScan::print_reg_num(outputStream* out, int reg_num) {
     return;
   }
 
+  LIR_Opr opr = get_operand(reg_num);
+  assert(opr->is_valid(), "unknown register");
+  opr->print(out);
+}
+
+LIR_Opr LinearScan::get_operand(int reg_num) {
   LIR_Opr opr = LIR_OprFact::illegal();
 
 #ifdef X86
@@ -3231,9 +3237,9 @@ void LinearScan::print_reg_num(outputStream* out, int reg_num) {
     opr = LIR_OprFact::single_xmm(reg_num - pd_first_xmm_reg);
 #endif
   } else {
-    assert(false, "unknown register");
+    // reg_num == -1 or a virtual register, return the illegal operand
   }
-  opr->print(out);
+  return opr;
 }
 
 Interval* LinearScan::find_interval_at(int reg_num) const {
@@ -4599,6 +4605,10 @@ bool Interval::intersects_any_children_of(Interval* interval) const {
 
 #ifndef PRODUCT
 void Interval::print_on(outputStream* out) const {
+  print_on(out, false);
+}
+
+void Interval::print_on(outputStream* out, bool is_cfg_printer) const {
   const char* SpillState2Name[] = { "no definition", "no spill store", "one spill store", "store at definition", "start in memory", "no optimization" };
   const char* UseKind2Name[] = { "N", "L", "S", "M" };
 
@@ -4608,18 +4618,29 @@ void Interval::print_on(outputStream* out) const {
   } else {
     type_name = type2name(type());
   }
-
   out->print("%d %s ", reg_num(), type_name);
-  if (reg_num() < LIR_OprDesc::vreg_base) {
-    LinearScan::print_reg_num(out, assigned_reg());
-  } else if (assigned_reg() != -1 && (LinearScan::num_physical_regs(type()) == 1 || assigned_regHi() != -1)) {
-    LinearScan::calc_operand_for_interval(this)->print(out);
-  } else {
-    // Virtual register that has no assigned register yet.
-    out->print("[ANY]");
-  }
 
-  out->print(" %d %d ", split_parent()->reg_num(), (register_hint(false) != NULL ? register_hint(false)->reg_num() : -1));
+  if (is_cfg_printer) {
+    // Special version for compatibility with C1 Visualizer.
+    LIR_Opr opr = LinearScan::get_operand(reg_num());
+    if (opr->is_valid()) {
+      out->print("\"");
+      opr->print(out);
+      out->print("\" ");
+    }
+  } else {
+    // Improved output for normal debugging.
+    if (reg_num() < LIR_OprDesc::vreg_base) {
+      LinearScan::print_reg_num(out, assigned_reg());
+    } else if (assigned_reg() != -1 && (LinearScan::num_physical_regs(type()) == 1 || assigned_regHi() != -1)) {
+      LinearScan::calc_operand_for_interval(this)->print(out);
+    } else {
+      // Virtual register that has no assigned register yet.
+      out->print("[ANY]");
+    }
+    out->print(" ");
+  }
+  out->print("%d %d ", split_parent()->reg_num(), (register_hint(false) != NULL ? register_hint(false)->reg_num() : -1));
 
   // print ranges
   Range* cur = _first;

--- a/src/hotspot/share/c1/c1_LinearScan.hpp
+++ b/src/hotspot/share/c1/c1_LinearScan.hpp
@@ -369,6 +369,7 @@ class LinearScan : public CompilationResourceObj {
   void        print_lir(int level, const char* label, bool hir_valid = true);
   static void print_reg_num(int reg_num) { print_reg_num(tty, reg_num); }
   static void print_reg_num(outputStream* out, int reg_num);
+  static LIR_Opr get_operand(int reg_num);
 #endif
 
 #ifdef ASSERT
@@ -634,6 +635,8 @@ class Interval : public CompilationResourceObj {
 #ifndef PRODUCT
   void print() const { print_on(tty); }
   void print_on(outputStream* out) const;
+  // Special version for compatibility with C1 Visualizer.
+  void print_on(outputStream* out, bool is_cfg_printer) const;
 
   // Used for debugging
   void print_parent() const;

--- a/src/hotspot/share/c1/c1_LinearScan.hpp
+++ b/src/hotspot/share/c1/c1_LinearScan.hpp
@@ -634,7 +634,9 @@ class Interval : public CompilationResourceObj {
   // printing
 #ifndef PRODUCT
   void print() const { print_on(tty); }
-  void print_on(outputStream* out) const;
+  void print_on(outputStream* out) const {
+    print_on(out, false);
+  }
   // Special version for compatibility with C1 Visualizer.
   void print_on(outputStream* out, bool is_cfg_printer) const;
 


### PR DESCRIPTION
[JDK-8251093](https://bugs.openjdk.java.net/browse/JDK-8251093) introduced some improved logging for intervals. When specifying `-XX:+PrintCFGToFile` to dump the graph to a file to later open it with the C1 visualizer, it also uses the improved interval printing. However, this output can no longer be read by the C1 Visualizer. As the C1 Visualizer is not part of the JDK, we should include the old format again for the output produced by `-XX:+PrintCFGToFile` to be compatible with the visualizer again. The console output can still use the improved logging of JDK-8251093.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/chhagedorn/jdk/runs/1309097477)

### Issue
 * [JDK-8255245](https://bugs.openjdk.java.net/browse/JDK-8255245): C1: Fix output of -XX:+PrintCFGToFile to open it with visualizer


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 695be54615731801cad296a06b66a431c594c656
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - no project role)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/837/head:pull/837`
`$ git checkout pull/837`
