### PR TITLE
8255349: Vector API issues on Big Endian

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
@@ -500,7 +500,7 @@ abstract class AbstractVector<E> extends Vector<E> {
     final <F>
     AbstractVector<F> defaultReinterpret(AbstractSpecies<F> rsp) {
         int blen = Math.max(this.bitSize(), rsp.vectorBitSize()) / Byte.SIZE;
-        ByteOrder bo = ByteOrder.LITTLE_ENDIAN;
+        ByteOrder bo = ByteOrder.nativeOrder();
         ByteBuffer bb = ByteBuffer.allocate(blen);
         this.intoByteBuffer(bb, 0, bo);
         VectorMask<F> m = rsp.maskAll(true);


### PR DESCRIPTION
Several jdk/incubator/vector tests are failing with stack overflow due to endless recursion on Big Endian platforms. E.g. Int64VectorLoadStoreTests (see bug for stack trace).
Endianess in defaultReinterpret is currently hard coded and not checked.

In addition, VectorReshapeTests.java is failing due to incorrect size conversion for Big Endian in the test code (castByteArrayData).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255349](https://bugs.openjdk.java.net/browse/JDK-8255349): Vector API issues on Big Endian


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/840/head:pull/840`
`$ git checkout pull/840`
