### PR TITLE
8255242: Bidi.requiresBidi has misleading exception message

### DIFF
--- a/src/java.base/share/classes/jdk/internal/icu/text/BidiBase.java
+++ b/src/java.base/share/classes/jdk/internal/icu/text/BidiBase.java
@@ -4541,7 +4541,8 @@ public class BidiBase {
 
         if (0 > start || start > limit || limit > text.length) {
             throw new IllegalArgumentException("Value start " + start +
-                      " is out of range 0 to " + limit);
+                      " is out of range 0 to " + limit + ", or limit " + limit +
+                      " is beyond the text length " + text.length);
         }
 
         for (int i = start; i < limit; ++i) {

--- a/test/jdk/java/text/Bidi/BidiConformance.java
+++ b/test/jdk/java/text/Bidi/BidiConformance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6850113 8032446
+ * @bug 6850113 8032446 8255242
  * @summary confirm the behavior of new Bidi implementation. (Backward compatibility)
  * @modules java.desktop
  */
@@ -1397,6 +1397,12 @@ public class BidiConformance {
                 " when limit is textLength+1(too large).");
         }
         catch (IllegalArgumentException e) {
+            if (!e.getMessage().equals(
+                    "Value start 0 is out of range 0 to " + (textLength + 1) +
+                    ", or limit " + (textLength + 1) + " is beyond the text length " + textLength)) {
+                errorHandling("requiresBidi() should throw an IAE" +
+                        " mentioning limit is beyond the text length. Message: " + e.getMessage());
+            }
         }
         catch (ArrayIndexOutOfBoundsException e) {
             errorHandling("requiresBidi() should not throw an AIOoBE " +


### PR DESCRIPTION
Hi,

Please review this small exception message fix.

Naoto

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 compiler)](https://github.com/naotoj/jdk/runs/1298156532)

### Issue
 * [JDK-8255242](https://bugs.openjdk.java.net/browse/JDK-8255242): Bidi.requiresBidi has misleading exception message


### Reviewers
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/841/head:pull/841`
`$ git checkout pull/841`
