### PR TITLE
8255352: Archive important test outputs in submit workflow

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -352,18 +352,20 @@ jobs:
 
       - name: Package test results
         if: always()
+        working-directory: build/run-test-prebuilt/test-results/
         run: >
           zip -r9
-          linux-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
-          build/*/test-results/
+          "$HOME/linux-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip"
+          .
         continue-on-error: true
 
       - name: Package test support
         if: always()
+        working-directory: build/run-test-prebuilt/test-support/
         run: >
           zip -r9
-          linux-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
-          build/*/test-support/
+          "$HOME/linux-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip"
+          .
           -i *.jtr
           -i hs_err*
           -i replay*
@@ -761,18 +763,22 @@ jobs:
 
       - name: Package test results
         if: always()
+        working-directory: build/run-test-prebuilt/test-results/
         run: >
+          $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
           zip -r9
-          windows-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
-          build/*/test-results/
+          "$HOME/windows-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip"
+          .
         continue-on-error: true
 
       - name: Package test support
         if: always()
+        working-directory: build/run-test-prebuilt/test-support/
         run: >
+          $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
           zip -r9
-          windows-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
-          build/*/test-support/
+          "$HOME/windows-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip"
+          .
           -i *.jtr
           -i hs_err*
           -i replay*
@@ -1041,18 +1047,20 @@ jobs:
 
       - name: Package test results
         if: always()
+        working-directory: build/run-test-prebuilt/test-results/
         run: >
           zip -r9
-          macos-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
-          build/*/test-results/
+          "$HOME/macos-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip"
+          .
         continue-on-error: true
 
       - name: Package test support
         if: always()
+        working-directory: build/run-test-prebuilt/test-support/
         run: >
           zip -r9
-          macos-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
-          build/*/test-support/
+          "$HOME/macos-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip"
+          .
           -i *.jtr
           -i hs_err*
           -i replay*

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -350,23 +350,37 @@ jobs:
         if: always()
         run: echo "logsuffix=`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`" >> $GITHUB_ENV
 
+      - name: Package test results
+        if: always()
+        run: >
+          zip -r9
+          linux-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
+          build/*/test-results/
+        continue-on-error: true
+
+      - name: Package test support
+        if: always()
+        run: >
+          zip -r9
+          linux-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
+          build/*/test-support/
+          -i *.jtr
+          -i hs_err*
+          -i replay*
+        continue-on-error: true
+
       - name: Persist test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: linux-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}
-          path: build/*/test-results
+          path: linux-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
 
       - name: Persist test outputs
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: linux-x64${{ matrix.artifact }}_testoutputs_${{ env.logsuffix }}
-          path: |
-            build/*/test-support/**/*.jtr
-            build/*/test-support/**/hs_err*
-            build/*/test-support/**/replay*
+          path: linux-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
         continue-on-error: true
 
   linux_x32_build:
@@ -745,23 +759,37 @@ jobs:
         if: always()
         run: echo ("logsuffix=" + ("${{ matrix.test }}" -replace "/", "_" -replace " ", "_")) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
 
+      - name: Package test results
+        if: always()
+        run: >
+          zip -r9
+          windows-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
+          build/*/test-results/
+        continue-on-error: true
+
+      - name: Package test support
+        if: always()
+        run: >
+          zip -r9
+          windows-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
+          build/*/test-support/
+          -i *.jtr
+          -i hs_err*
+          -i replay*
+        continue-on-error: true
+
       - name: Persist test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: windows-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}
-          path: build/*/test-results
+          path: windows-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
 
       - name: Persist test outputs
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: windows-x64${{ matrix.artifact }}_testoutputs_${{ env.logsuffix }}
-          path: |
-            build/*/test-support/**/*.jtr
-            build/*/test-support/**/hs_err*
-            build/*/test-support/**/replay*
+          path: windows-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
         continue-on-error: true
 
   macos_x64_build:
@@ -1011,23 +1039,37 @@ jobs:
         if: always()
         run: echo "logsuffix=`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`" >> $GITHUB_ENV
 
+      - name: Package test results
+        if: always()
+        run: >
+          zip -r9
+          macos-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
+          build/*/test-results/
+        continue-on-error: true
+
+      - name: Package test support
+        if: always()
+        run: >
+          zip -r9
+          macos-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
+          build/*/test-support/
+          -i *.jtr
+          -i hs_err*
+          -i replay*
+        continue-on-error: true
+
       - name: Persist test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: macos-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}
-          path: build/*/test-results
+          path: macos-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
 
       - name: Persist test outputs
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: macos-x64${{ matrix.artifact }}_testoutputs_${{ env.logsuffix }}
-          path: |
-            build/*/test-support/**/*.jtr
-            build/*/test-support/**/hs_err*
-            build/*/test-support/**/replay*
+          path: macos-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
         continue-on-error: true
 
   artifacts:

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -775,7 +775,7 @@ jobs:
         if: always()
         working-directory: build/run-test-prebuilt/test-support/
         run: >
-          $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
+          $env:Path = "$HOME\cygwin\cygwin64\bin;$env:Path" ;
           zip -r9
           "$HOME/windows-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip"
           .

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -350,12 +350,23 @@ jobs:
         if: always()
         run: echo "logsuffix=`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`" >> $GITHUB_ENV
 
-      - name: Persist test logs
+      - name: Persist test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: linux-x64${{ matrix.artifact }}_testlogs_${{ env.logsuffix }}
+          name: linux-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}
           path: build/*/test-results
+        continue-on-error: true
+
+      - name: Persist test outputs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux-x64${{ matrix.artifact }}_testoutputs_${{ env.logsuffix }}
+          path: |
+            build/*/test-support/**/*.jtr
+            build/*/test-support/**/hs_err*
+            build/*/test-support/**/replay*
         continue-on-error: true
 
   linux_x32_build:
@@ -734,12 +745,23 @@ jobs:
         if: always()
         run: echo ("logsuffix=" + ("${{ matrix.test }}" -replace "/", "_" -replace " ", "_")) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
 
-      - name: Persist test logs
+      - name: Persist test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: windows-x64${{ matrix.artifact }}_testlogs_${{ env.logsuffix }}
+          name: windows-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}
           path: build/*/test-results
+        continue-on-error: true
+
+      - name: Persist test outputs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-x64${{ matrix.artifact }}_testoutputs_${{ env.logsuffix }}
+          path: |
+            build/*/test-support/**/*.jtr
+            build/*/test-support/**/hs_err*
+            build/*/test-support/**/replay*
         continue-on-error: true
 
   macos_x64_build:
@@ -989,12 +1011,23 @@ jobs:
         if: always()
         run: echo "logsuffix=`echo ${{ matrix.test }} | sed -e 's!/!_!'g -e 's! !_!'g`" >> $GITHUB_ENV
 
-      - name: Persist test logs
+      - name: Persist test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: macos-x64${{ matrix.artifact }}_testlogs_${{ env.logsuffix }}
+          name: macos-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}
           path: build/*/test-results
+        continue-on-error: true
+
+      - name: Persist test outputs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: macos-x64${{ matrix.artifact }}_testoutputs_${{ env.logsuffix }}
+          path: |
+            build/*/test-support/**/*.jtr
+            build/*/test-support/**/hs_err*
+            build/*/test-support/**/replay*
         continue-on-error: true
 
   artifacts:

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -375,14 +375,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          path: linux-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
+          path: ~/linux-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
 
       - name: Persist test outputs
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          path: linux-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
+          path: ~/linux-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
         continue-on-error: true
 
   linux_x32_build:
@@ -788,14 +788,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          path: windows-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
+          path: ~/windows-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
 
       - name: Persist test outputs
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          path: windows-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
+          path: ~/windows-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
         continue-on-error: true
 
   macos_x64_build:
@@ -1070,14 +1070,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          path: macos-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
+          path: ~/macos-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
 
       - name: Persist test outputs
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          path: macos-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
+          path: ~/macos-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
         continue-on-error: true
 
   artifacts:

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -765,7 +765,7 @@ jobs:
         if: always()
         working-directory: build/run-test-prebuilt/test-results/
         run: >
-          $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
+          $env:Path = "$HOME\cygwin\cygwin64\bin;$env:Path" ;
           zip -r9
           "$HOME/windows-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip"
           .


### PR DESCRIPTION
Currently, we are only archiving `build/*/test-results`. But hs_errs, replays, and test outputs are actually in `build/*/test-support`! Which means once any test fails, we only have the summary of the run, not the bits that would actually help to diagnose the problem. 

Archiving the entire test-support seems too much, it yields 50K artifacts available as 1 GB zip archive in GH GUI. On top of that `upload-artifact` does the upload per-file, which takes tens of minutes on 50K files (and I suspect many API calls).

But we can pick up important test outputs selectively and then also compress them. See sample artifact here:
 https://github.com/shipilev/jdk/runs/1301540541

It packages the final ZIP like this:

```
$ unzip -t test-results_.zip
 Archive:  test-results_.zip
    testing: artifact/                OK
    testing: artifact/linux-x64-debug_testresults_hs_tier1_common.zip   OK
    testing: artifact/linux-x64-debug_testsupport_hs_tier1_common.zip   OK
    ...
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255352](https://bugs.openjdk.java.net/browse/JDK-8255352): Archive important test outputs in submit workflow


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - Committer) ⚠️ Review applies to 7584cbcd045403f994b5a0b72bda87b524cfa235
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/842/head:pull/842`
`$ git checkout pull/842`
