### PR TITLE
8238263: Create at-requires mechanism for containers

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -75,7 +75,8 @@ requires.properties= \
     vm.compiler2.enabled \
     vm.musl \
     docker.support \
-    test.vm.gc.nvdimm
+    test.vm.gc.nvdimm \
+    jdk.containerized
 
 # Minimum jtreg version
 requiredVersion=5.1 b1

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -58,7 +58,8 @@ requires.properties= \
     vm.hasJFR \
     vm.jvmci \
     docker.support \
-    release.implementor
+    release.implementor \
+    jdk.containerized
 
 # Minimum jtreg version
 requiredVersion=5.1 b1

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -118,6 +118,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.musl", this::isMusl);
         map.put("release.implementor", this::implementor);
         map.put("test.vm.gc.nvdimm", this::isNvdimmTestEnabled);
+        map.put("jdk.containerized", this::jdkContainerized);
         vmGC(map); // vm.gc.X = true/false
         vmOptFinalFlags(map);
 
@@ -542,6 +543,11 @@ public class VMProps implements Callable<Map<String, String>> {
 
     private String isNvdimmTestEnabled() {
         String isEnabled = System.getenv("TEST_VM_GC_NVDIMM");
+        return "" + "true".equalsIgnoreCase(isEnabled);
+    }
+
+    private String jdkContainerized() {
+        String isEnabled = System.getenv("TEST_JDK_CONTAINERIZED");
         return "" + "true".equalsIgnoreCase(isEnabled);
     }
 


### PR DESCRIPTION
Please review this change to add an @requires mechanism called "jdk.containerized" to help mark tests that are incompatible with containers.  Users would add "@requires jdk.containerized != true" to the incompatible tests and then use "make test ... OPTIONS=-Djdk.containerized=true" or "bash jib.sh mach5 -- remote-build-and-test ... --test-make-args JTREG=OPTIONS=-Djdk.containerized=true" to exclude those tests when testing with containers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8238263](https://bugs.openjdk.java.net/browse/JDK-8238263): Create at-requires mechanism for containers


### Reviewers
 * [Bob Vandette](https://openjdk.java.net/census#bobv) (@bobvandette - **Reviewer**)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/844/head:pull/844`
`$ git checkout pull/844`
