### PR TITLE
8255206: [macos] LicenseTest fails on macOS 11

### DIFF
--- a/src/jdk.incubator.jpackage/macosx/classes/jdk/incubator/jpackage/internal/MacDmgBundler.java
+++ b/src/jdk.incubator.jpackage/macosx/classes/jdk/incubator/jpackage/internal/MacDmgBundler.java
@@ -473,15 +473,6 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
 
         //add license if needed
         if (Files.exists(getConfig_LicenseFile(params))) {
-            //hdiutil unflatten your_image_file.dmg
-            pb = new ProcessBuilder(
-                    hdiutil,
-                    "unflatten",
-                    finalDMG.toAbsolutePath().toString()
-            );
-            IOUtils.exec(pb);
-
-            //add license
             pb = new ProcessBuilder(
                     hdiutil,
                     "udifrez",
@@ -490,15 +481,6 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
                     getConfig_LicenseFile(params).toAbsolutePath().toString()
             );
             IOUtils.exec(pb);
-
-            //hdiutil flatten your_image_file.dmg
-            pb = new ProcessBuilder(
-                    hdiutil,
-                    "flatten",
-                    finalDMG.toAbsolutePath().toString()
-            );
-            IOUtils.exec(pb);
-
         }
 
         //Delete the temporary image


### PR DESCRIPTION
I did not reproduce issue with license is not shown as per SQE report. It work as expected. However, jpackage fails due to unflatten/flatten being removed from hdiutil on macOS 11. I am not sure why it was needed, probably some legacy code. Without unflatten/flatten everything works as expected on macOS 11 and 10.5.7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255206](https://bugs.openjdk.java.net/browse/JDK-8255206): [macos] LicenseTest fails on macOS 11


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/847/head:pull/847`
`$ git checkout pull/847`
