### PR TITLE
7190589:  [macosx] In the test bug4278839 never press ctrl+arrow

### DIFF
--- a/test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java
+++ b/test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,12 +62,6 @@ public class bug4278839 extends JFrame {
             robo.waitForIdle();
 
             area.setCaretPosition(0);
-
-            if ("Aqua".equals(UIManager.getLookAndFeel().getID())) {
-                Util.hitKeys(robo, KeyEvent.VK_HOME);
-            } else {
-                Util.hitKeys(robo, KeyEvent.VK_CONTROL, KeyEvent.VK_HOME);
-            }
             robo.waitForIdle();
 
             passed &= moveCaret(true) == 1;
@@ -152,6 +146,7 @@ public class bug4278839 extends JFrame {
         frame = new JFrame();
         frame.setTitle("Bug# 4278839");
         frame.setSize(200, 200);
+        frame.setLocationRelativeTo(null);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         area = new JTextArea("\naaa bbb\nccc ddd\n");
         frame.getContentPane().add(new JScrollPane(area));


### PR DESCRIPTION
After one of the fixes in the bug4278839.java test, Yuri(@yan-too) suggested that the check for the Aqua L&F should be updated to check the macOS instead. That code was needed to move the cursor to the beginning of the test, but since then another fix was integrated:
https://hg.openjdk.java.net/jdk/jdk/rev/9db62a092725
The "area.setCaretPosition(0);" has the same purpose and the old code became useless and can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-7190589](https://bugs.openjdk.java.net/browse/JDK-7190589): [macosx] In the test bug4278839 never press ctrl+arrow


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/848/head:pull/848`
`$ git checkout pull/848`
