### PR TITLE
8255373: Submit workflow artifact name is always "test-results_.zip"

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   prerequisites:
     name: Prerequisites
+    id: prerequisites
     runs-on: "ubuntu-latest"
     outputs:
       should_run: ${{ steps.check_submit.outputs.should_run }}
@@ -1004,6 +1005,7 @@ jobs:
     if: always()
     continue-on-error: true
     needs:
+      - prerequisites
       - linux_x64_test
       - windows_x64_test
       - macos_x64_test

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -39,6 +39,7 @@ jobs:
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Determine unique bundle identifier
+        id: check_bundle_id
         run: echo "::set-output name=bundle_id::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
         if: steps.check_submit.outputs.should_run != 'false'
 

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -14,7 +14,6 @@ on:
 jobs:
   prerequisites:
     name: Prerequisites
-    id: prerequisites
     runs-on: "ubuntu-latest"
     outputs:
       should_run: ${{ steps.check_submit.outputs.should_run }}


### PR DESCRIPTION
The output for the `prerequisites` step is `bundle_id: ${{ steps.check_bundle_id.outputs.bundle_id }}`, but there is no `check_bundle_id` step name to properly reference. Then `artifacts` should actually need `prerequisites` to access `needs.prerequisites.outputs.bundle_id`.

See the final artifact name in the workflow:
  https://github.com/shipilev/jdk/actions/runs/325845086

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255373](https://bugs.openjdk.java.net/browse/JDK-8255373): Submit workflow artifact name is always "test-results_.zip" 


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - Committer)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/849/head:pull/849`
`$ git checkout pull/849`
