### PR TITLE
8199074: Test javax/swing/DataTransfer/8059739/bug8059739.java is unstable

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -777,7 +777,6 @@ javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/JFileChooser/6868611/bug6868611.java 7059834 windows-all
 javax/swing/SwingWorker/6493680/bug6493680.java 8198410 windows-all
 javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java 8065099,8208565 macosx-all,linux-all
-javax/swing/DataTransfer/8059739/bug8059739.java 8199074 generic-all
 javax/swing/SwingWorker/6432565/bug6432565.java 8199077 generic-all
 javax/swing/SwingWorker/6880336/NestedWorkers.java 8199049 windows-all
 javax/swing/text/DefaultCaret/6938583/bug6938583.java 8199058 generic-all


### PR DESCRIPTION
Please review deproblemlisting of another test which was failing in mach5 testing. Seems like it was failing due to samevmrunnable problem which was fixed by running client test in othervm mode.
Mach5 job has been runn for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ❌ (1/2 failed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) |    | 

**Failed test tasks**
- [Windows x64 (hs/tier1 compiler)](https://github.com/prsadhuk/jdk/runs/1301847240)
- [macOS x64 (build debug)](https://github.com/prsadhuk/jdk/runs/1301730424)

### Issue
 * [JDK-8199074](https://bugs.openjdk.java.net/browse/JDK-8199074): Test javax/swing/DataTransfer/8059739/bug8059739.java is unstable


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/850/head:pull/850`
`$ git checkout pull/850`
