### PR TITLE
8028281: [TEST_BUG] [macosx] javax/swing/JTabbedPane/7024235/Test7024235.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -759,7 +759,6 @@ javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JPopupMenu/6675802/bug6675802.java 8196097 windows-all
 javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all
 javax/swing/JTabbedPane/4624207/bug4624207.java 8064922 macosx-all
-javax/swing/JTabbedPane/7024235/Test7024235.java 8028281 macosx-all
 javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java 8160720 generic-all
 javax/swing/plaf/basic/Test6984643.java 8198340 windows-all
 javax/swing/text/CSSBorder/6796710/bug6796710.java 8196099 windows-all

--- a/test/jdk/javax/swing/JTabbedPane/7024235/Test7024235.java
+++ b/test/jdk/javax/swing/JTabbedPane/7024235/Test7024235.java
@@ -39,7 +39,6 @@ import javax.swing.UIManager.LookAndFeelInfo;
  * @key headful
  * @bug 7024235
  * @summary Tests JFrame.pack() with the JTabbedPane
- * @author Sergey Malenkov
  * @run main Test7024235
  */
 

--- a/test/jdk/javax/swing/JTabbedPane/7024235/Test7024235.java
+++ b/test/jdk/javax/swing/JTabbedPane/7024235/Test7024235.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,16 +22,14 @@
  */
 
 import java.awt.BorderLayout;
-
 import java.awt.Container;
 import java.awt.Rectangle;
-import java.awt.Toolkit;
+import java.awt.Robot;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
-import javax.swing.JTabbedPane;
-
 import javax.swing.JFrame;
+import javax.swing.JTabbedPane;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
@@ -41,8 +39,6 @@ import javax.swing.UIManager.LookAndFeelInfo;
  * @key headful
  * @bug 7024235
  * @summary Tests JFrame.pack() with the JTabbedPane
- * @library /lib/client/
- * @build ExtendedRobot
  * @author Sergey Malenkov
  * @run main Test7024235
  */
@@ -54,12 +50,15 @@ public class Test7024235 implements Runnable {
     public static void main(String[] args) throws Exception {
         Test7024235 test = new Test7024235();
         for (LookAndFeelInfo info : UIManager.getInstalledLookAndFeels()) {
-            UIManager.setLookAndFeel(info.getClassName());
+            String className = info.getClassName();
+            System.out.println("className = " + className);
+            UIManager.setLookAndFeel(className);
 
             test.test();
             try {
-                ExtendedRobot robot = new ExtendedRobot();
-                robot.waitForIdle(1000);
+                Robot robot = new Robot();
+                robot.waitForIdle();
+                robot.delay(1000);
             }catch(Exception ex) {
                 ex.printStackTrace();
                 throw new Error("Unexpected Failure");
@@ -81,6 +80,7 @@ public class Test7024235 implements Runnable {
             JFrame frame = new JFrame();
             frame.add(BorderLayout.WEST, this.pane);
             frame.pack();
+            frame.setLocationRelativeTo(null);
             frame.setVisible(true);
 
             test("first");
@@ -105,6 +105,9 @@ public class Test7024235 implements Runnable {
         this.passed = true;
         for (int index = 0; index < this.pane.getTabCount(); index++) {
             Rectangle bounds = this.pane.getBoundsAt(index);
+            if (bounds == null) {
+                continue;
+            }
             int centerX = bounds.x + bounds.width / 2;
             int centerY = bounds.y + bounds.height / 2;
             int actual = this.pane.indexAtLocation(centerX, centerY);


### PR DESCRIPTION
The test fails because of a missed null check for the next method:
https://docs.oracle.com/en/java/javase/15/docs/api/java.desktop/javax/swing/JTabbedPane.html#getBoundsAt(int)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8028281](https://bugs.openjdk.java.net/browse/JDK-8028281): [TEST_BUG] [macosx] javax/swing/JTabbedPane/7024235/Test7024235.java  fails


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/852/head:pull/852`
`$ git checkout pull/852`
