### PR TITLE
8255448: Fastdebug JVM crashes with Vector API when PrintAssembly is turned on

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -489,6 +489,7 @@ void JVMState::format(PhaseRegAlloc *regalloc, const Node *n, outputStream* st) 
         ciField* cifield;
         if (iklass != NULL) {
           st->print(" [");
+          iklass->nof_nonstatic_fields(); // FIXME: iklass->_nonstatic_fields == NULL
           cifield = iklass->nonstatic_field_at(0);
           cifield->print_name_on(st);
           format_helper(regalloc, st, fld_node, ":", 0, &scobjs);

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -489,7 +489,6 @@ void JVMState::format(PhaseRegAlloc *regalloc, const Node *n, outputStream* st) 
         ciField* cifield;
         if (iklass != NULL) {
           st->print(" [");
-          iklass->nof_nonstatic_fields(); // FIXME: iklass->_nonstatic_fields == NULL
           cifield = iklass->nonstatic_field_at(0);
           cifield->print_name_on(st);
           format_helper(regalloc, st, fld_node, ":", 0, &scobjs);

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -242,11 +242,19 @@ void PhaseVector::scalarize_vbox_node(VectorBoxNode* vec_box) {
     SafePointNode* sfpt = safepoints.pop()->as_SafePoint();
 
     uint first_ind = (sfpt->req() - sfpt->jvms()->scloff());
+    ciKlass* cik = vec_box->box_type()->is_oopptr()->klass();
+    assert(cik->is_instance_klass(), "Not supported allocation.");
+    ciInstanceKlass *iklass = NULL;
+    int n_fields = -1;
+    if (cik->is_instance_klass()) {
+        iklass = cik->as_instance_klass();
+        n_fields = iklass->nof_nonstatic_fields();
+    }
     Node* sobj = new SafePointScalarObjectNode(vec_box->box_type(),
 #ifdef ASSERT
                                                NULL,
 #endif // ASSERT
-                                               first_ind, /*n_fields=*/1);
+                                               first_ind, n_fields=1);
     sobj->init_req(0, C->root());
     sfpt->add_req(vec_value);
 

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -241,20 +241,16 @@ void PhaseVector::scalarize_vbox_node(VectorBoxNode* vec_box) {
   while (safepoints.size() > 0) {
     SafePointNode* sfpt = safepoints.pop()->as_SafePoint();
 
+    ciInstanceKlass* iklass = vec_box->box_type()->klass()->as_instance_klass();
+    int n_fields = iklass->nof_nonstatic_fields();
+    assert(n_fields == 1, "sanity");
+
     uint first_ind = (sfpt->req() - sfpt->jvms()->scloff());
-    ciKlass* cik = vec_box->box_type()->is_oopptr()->klass();
-    assert(cik->is_instance_klass(), "Not supported allocation.");
-    ciInstanceKlass *iklass = NULL;
-    int n_fields = -1;
-    if (cik->is_instance_klass()) {
-        iklass = cik->as_instance_klass();
-        n_fields = iklass->nof_nonstatic_fields();
-    }
     Node* sobj = new SafePointScalarObjectNode(vec_box->box_type(),
 #ifdef ASSERT
                                                NULL,
 #endif // ASSERT
-                                               first_ind, n_fields=1);
+                                               first_ind, n_fields);
     sobj->init_req(0, C->root());
     sfpt->add_req(vec_value);
 


### PR DESCRIPTION
8255448: Fastdebug JVM crashes with Vector API when PrintAssembly is turned on

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255448](https://bugs.openjdk.java.net/browse/JDK-8255448): Fastdebug JVM crashes with Vector API when PrintAssembly is turned on


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Contributors
 * Huang Wang `<wanghuang3@huawei.com>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/853/head:pull/853`
`$ git checkout pull/853`
