### PR TITLE
8255378: [Vector API] Remove redundant vector length check after JDK-8254814 and JDK-8255210

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -4425,8 +4425,7 @@ instruct insert8D(vec dst, vec src, regD val, immI idx, rRegL tmp, legVec vtmp) 
 // =======================Int Reduction==========================================
 
 instruct reductionI(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec vtmp2) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_INT &&
-            vector_length(n->in(2)) <= 16); // src2
+  predicate(vector_element_basic_type(n->in(2)) == T_INT); // src2
   match(Set dst (AddReductionVI src1 src2));
   match(Set dst (MulReductionVI src1 src2));
   match(Set dst (AndReductionV  src1 src2));
@@ -4621,8 +4620,7 @@ instruct reduction64B(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec v
 // =======================Short Reduction==========================================
 
 instruct reductionS(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec vtmp2) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_SHORT &&
-            vector_length(n->in(2)) <= 32); // src2
+  predicate(vector_element_basic_type(n->in(2)) == T_SHORT); // src2
   match(Set dst (AddReductionVI src1 src2));
   match(Set dst (MulReductionVI src1 src2));
   match(Set dst (AndReductionV  src1 src2));


### PR DESCRIPTION
Hi all,

As @iwanowww pointed out [1] that there are redundant vector length checks for reductionI [2] and reductionS [3].
It would be better to remove them.

Testing:
 - jdk/incubator/vector on both AVX512 and AVX256 machines

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/pull/791#discussion_r510687005
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/x86.ad#L4429
[3] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/x86.ad#L4625

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255378](https://bugs.openjdk.java.net/browse/JDK-8255378): [Vector API] Remove redundant vector length check after JDK-8254814 and JDK-8255210


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/854/head:pull/854`
`$ git checkout pull/854`
