### PR TITLE
8199062: Test javax/swing/text/Utilities/8134721/bug8134721.java is unstable

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -783,7 +783,6 @@ javax/swing/text/DefaultCaret/6938583/bug6938583.java 8199058 generic-all
 javax/swing/text/html/parser/Parser/6990651/bug6990651.java 8199060 generic-all
 javax/swing/text/html/parser/Parser/HtmlCommentTagParseTest/HtmlCommentTagParseTest.java 8199073 generic-all
 javax/swing/text/StyledEditorKit/8016833/bug8016833.java 8199055 generic-all
-javax/swing/text/Utilities/8134721/bug8134721.java 8199062 generic-all
 javax/swing/tree/DefaultTreeCellRenderer/7142955/bug7142955.java 8199076 generic-all
 javax/swing/UIDefaults/6302464/bug6302464.java 8199079 macosx-all
 javax/swing/UIDefaults/8149879/InternalResourceBundle.java 8199054 windows-all


### PR DESCRIPTION
Please review deproblemlisting of another test which was failing in mach5 testing. Seems like it was failing due to samevmrunnable problem which was fixed by running client test in othervm mode.
Mach5 job has been runn for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8199062](https://bugs.openjdk.java.net/browse/JDK-8199062): Test javax/swing/text/Utilities/8134721/bug8134721.java is unstable


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/855/head:pull/855`
`$ git checkout pull/855`
