### PR TITLE
8199060: Test javax/swing/text/html/parser/Parser/6990651/bug6990651.java is unstable

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -780,7 +780,6 @@ javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java 8065099,8208565 mac
 javax/swing/SwingWorker/6432565/bug6432565.java 8199077 generic-all
 javax/swing/SwingWorker/6880336/NestedWorkers.java 8199049 windows-all
 javax/swing/text/DefaultCaret/6938583/bug6938583.java 8199058 generic-all
-javax/swing/text/html/parser/Parser/6990651/bug6990651.java 8199060 generic-all
 javax/swing/text/html/parser/Parser/HtmlCommentTagParseTest/HtmlCommentTagParseTest.java 8199073 generic-all
 javax/swing/text/StyledEditorKit/8016833/bug8016833.java 8199055 generic-all
 javax/swing/text/Utilities/8134721/bug8134721.java 8199062 generic-all


### PR DESCRIPTION
The test previously failed because of an error when jtreg tried to clean the state of the threads in agenvm mode.
Since then the client tests started to use othervm mode and the code in jtreg was updated as well by the
https://bugs.openjdk.java.net/browse/CODETOOLS-7902131

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 runtime)](https://github.com/mrserb/jdk/runs/1304737735)

### Issue
 * [JDK-8199060](https://bugs.openjdk.java.net/browse/JDK-8199060): Test javax/swing/text/html/parser/Parser/6990651/bug6990651.java is unstable


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/856/head:pull/856`
`$ git checkout pull/856`
