### PR TITLE
8186085: (opt) add filter(), flatMap(), and map() methods to OptionalDouble/Int/Long

### DIFF
--- a/src/java.base/share/classes/java/util/OptionalDouble.java
+++ b/src/java.base/share/classes/java/util/OptionalDouble.java
@@ -25,7 +25,10 @@
 package java.util;
 
 import java.util.function.DoubleConsumer;
+import java.util.function.DoubleFunction;
+import java.util.function.DoublePredicate;
 import java.util.function.DoubleSupplier;
+import java.util.function.DoubleUnaryOperator;
 import java.util.function.Supplier;
 import java.util.stream.DoubleStream;
 
@@ -181,6 +184,80 @@ public final class OptionalDouble {
             action.accept(value);
         } else {
             emptyAction.run();
+        }
+    }
+
+    /**
+     * If a value is present, and the value matches the given predicate,
+     * returns an {@code OptionalDouble} describing the value, otherwise returns
+     * an empty {@code OptionalDouble}.
+     *
+     * @param predicate the predicate to apply to a value, if present
+     * @return an {@code OptionalDouble} describing the value of this
+     *         {@code OptionalDouble}, if a value is present and the value matches
+     *         the given predicate, otherwise an empty {@code OptionalDouble}
+     * @throws NullPointerException if the predicate is {@code null}
+     * @since 16
+     */
+    public OptionalDouble filter(DoublePredicate predicate) {
+        Objects.requireNonNull(predicate);
+        if (!isPresent()) {
+            return this;
+        } else {
+            return predicate.test(value) ? this : empty();
+        }
+    }
+
+    /**
+     * If a value is present, returns an {@code OptionalDouble} describing (as if
+     * by {@link #of}) the result of applying the given mapping function to
+     * the value, otherwise returns an empty {@code OptionalDouble}.
+     *
+     * @apiNote
+     * This method supports post-processing on {@code OptionalDouble} values,
+     * without the need to explicitly check for a return status.
+     *
+     * @param mapper the mapping function to apply to a value, if present
+     * @return an {@code OptionalDouble} describing the result of applying a
+     *         mapping function to the value of this {@code OptionalDouble},
+     *         if a value is present, otherwise an empty {@code OptionalDouble}
+     * @throws NullPointerException if the mapping function is {@code null}
+     * @since 16
+     */
+    public OptionalDouble map(DoubleUnaryOperator mapper) {
+        Objects.requireNonNull(mapper);
+        if (!isPresent()) {
+            return empty();
+        } else {
+            return OptionalDouble.of(mapper.applyAsDouble(value));
+        }
+    }
+
+    /**
+     * If a value is present, returns the result of applying the given
+     * {@code OptionalDouble}-bearing mapping function to the value, otherwise returns
+     * an empty {@code OptionalDouble}.
+     *
+     * <p>This method is similar to {@link #map(DoubleUnaryOperator)}, but the mapping
+     * function is one whose result is already an {@code OptionalDouble}, and if
+     * invoked, {@code flatMap} does not wrap it within an additional
+     * {@code OptionalDouble}.
+     *
+     * @param mapper the mapping function to apply to a value, if present
+     * @return the result of applying an {@code OptionalDouble}-bearing mapping
+     *         function to the value of this {@code OptionalDouble}, if a value is
+     *         present, otherwise an empty {@code OptionalDouble}
+     * @throws NullPointerException if the mapping function is {@code null} or
+     *         returns a {@code null} result
+     * @since 16
+     */
+    public OptionalDouble flatMap(DoubleFunction<? extends OptionalDouble> mapper) {
+        Objects.requireNonNull(mapper);
+        if (!isPresent()) {
+            return empty();
+        } else {
+            OptionalDouble r = mapper.apply(value);
+            return Objects.requireNonNull(r);
         }
     }
 

--- a/src/java.base/share/classes/java/util/OptionalInt.java
+++ b/src/java.base/share/classes/java/util/OptionalInt.java
@@ -25,7 +25,10 @@
 package java.util;
 
 import java.util.function.IntConsumer;
+import java.util.function.IntFunction;
+import java.util.function.IntPredicate;
 import java.util.function.IntSupplier;
+import java.util.function.IntUnaryOperator;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
@@ -181,6 +184,80 @@ public final class OptionalInt {
             action.accept(value);
         } else {
             emptyAction.run();
+        }
+    }
+
+    /**
+     * If a value is present, and the value matches the given predicate,
+     * returns an {@code OptionalInt} describing the value, otherwise returns
+     * an empty {@code OptionalInt}.
+     *
+     * @param predicate the predicate to apply to a value, if present
+     * @return an {@code OptionalInt} describing the value of this
+     *         {@code OptionalInt}, if a value is present and the value matches
+     *         the given predicate, otherwise an empty {@code OptionalInt}
+     * @throws NullPointerException if the predicate is {@code null}
+     * @since 16
+     */
+    public OptionalInt filter(IntPredicate predicate) {
+        Objects.requireNonNull(predicate);
+        if (!isPresent()) {
+            return this;
+        } else {
+            return predicate.test(value) ? this : empty();
+        }
+    }
+
+    /**
+     * If a value is present, returns an {@code OptionalInt} describing (as if
+     * by {@link #of}) the result of applying the given mapping function to
+     * the value, otherwise returns an empty {@code OptionalInt}.
+     *
+     * @apiNote
+     * This method supports post-processing on {@code OptionalInt} values,
+     * without the need to explicitly check for a return status.
+     *
+     * @param mapper the mapping function to apply to a value, if present
+     * @return an {@code OptionalInt} describing the result of applying a
+     *         mapping function to the value of this {@code OptionalInt},
+     *         if a value is present, otherwise an empty {@code OptionalInt}
+     * @throws NullPointerException if the mapping function is {@code null}
+     * @since 16
+     */
+    public OptionalInt map(IntUnaryOperator mapper) {
+        Objects.requireNonNull(mapper);
+        if (!isPresent()) {
+            return empty();
+        } else {
+            return OptionalInt.of(mapper.applyAsInt(value));
+        }
+    }
+
+    /**
+     * If a value is present, returns the result of applying the given
+     * {@code OptionalInt}-bearing mapping function to the value, otherwise returns
+     * an empty {@code OptionalInt}.
+     *
+     * <p>This method is similar to {@link #map(IntUnaryOperator)}, but the mapping
+     * function is one whose result is already an {@code OptionalInt}, and if
+     * invoked, {@code flatMap} does not wrap it within an additional
+     * {@code OptionalInt}.
+     *
+     * @param mapper the mapping function to apply to a value, if present
+     * @return the result of applying an {@code OptionalInt}-bearing mapping
+     *         function to the value of this {@code OptionalInt}, if a value is
+     *         present, otherwise an empty {@code OptionalInt}
+     * @throws NullPointerException if the mapping function is {@code null} or
+     *         returns a {@code null} result
+     * @since 16
+     */
+    public OptionalInt flatMap(IntFunction<? extends OptionalInt> mapper) {
+        Objects.requireNonNull(mapper);
+        if (!isPresent()) {
+            return empty();
+        } else {
+            OptionalInt r = mapper.apply(value);
+            return Objects.requireNonNull(r);
         }
     }
 

--- a/src/java.base/share/classes/java/util/OptionalLong.java
+++ b/src/java.base/share/classes/java/util/OptionalLong.java
@@ -25,7 +25,10 @@
 package java.util;
 
 import java.util.function.LongConsumer;
+import java.util.function.LongFunction;
+import java.util.function.LongPredicate;
 import java.util.function.LongSupplier;
+import java.util.function.LongUnaryOperator;
 import java.util.function.Supplier;
 import java.util.stream.LongStream;
 
@@ -181,6 +184,80 @@ public final class OptionalLong {
             action.accept(value);
         } else {
             emptyAction.run();
+        }
+    }
+
+    /**
+     * If a value is present, and the value matches the given predicate,
+     * returns an {@code OptionalLong} describing the value, otherwise returns
+     * an empty {@code OptionalLong}.
+     *
+     * @param predicate the predicate to apply to a value, if present
+     * @return an {@code OptionalLong} describing the value of this
+     *         {@code OptionalLong}, if a value is present and the value matches
+     *         the given predicate, otherwise an empty {@code OptionalLong}
+     * @throws NullPointerException if the predicate is {@code null}
+     * @since 16
+     */
+    public OptionalLong filter(LongPredicate predicate) {
+        Objects.requireNonNull(predicate);
+        if (!isPresent()) {
+            return this;
+        } else {
+            return predicate.test(value) ? this : empty();
+        }
+    }
+
+    /**
+     * If a value is present, returns an {@code OptionalLong} describing (as if
+     * by {@link #of}) the result of applying the given mapping function to
+     * the value, otherwise returns an empty {@code OptionalLong}.
+     *
+     * @apiNote
+     * This method supports post-processing on {@code OptionalLong} values,
+     * without the need to explicitly check for a return status.
+     *
+     * @param mapper the mapping function to apply to a value, if present
+     * @return an {@code OptionalLong} describing the result of applying a
+     *         mapping function to the value of this {@code OptionalLong},
+     *         if a value is present, otherwise an empty {@code OptionalLong}
+     * @throws NullPointerException if the mapping function is {@code null}
+     * @since 16
+     */
+    public OptionalLong map(LongUnaryOperator mapper) {
+        Objects.requireNonNull(mapper);
+        if (!isPresent()) {
+            return empty();
+        } else {
+            return OptionalLong.of(mapper.applyAsLong(value));
+        }
+    }
+
+    /**
+     * If a value is present, returns the result of applying the given
+     * {@code OptionalLong}-bearing mapping function to the value, otherwise returns
+     * an empty {@code OptionalLong}.
+     *
+     * <p>This method is similar to {@link #map(LongUnaryOperator)}, but the mapping
+     * function is one whose result is already an {@code OptionalLong}, and if
+     * invoked, {@code flatMap} does not wrap it within an additional
+     * {@code OptionalLong}.
+     *
+     * @param mapper the mapping function to apply to a value, if present
+     * @return the result of applying an {@code OptionalLong}-bearing mapping
+     *         function to the value of this {@code OptionalLong}, if a value is
+     *         present, otherwise an empty {@code OptionalLong}
+     * @throws NullPointerException if the mapping function is {@code null} or
+     *         returns a {@code null} result
+     * @since 16
+     */
+    public OptionalLong flatMap(LongFunction<? extends OptionalLong> mapper) {
+        Objects.requireNonNull(mapper);
+        if (!isPresent()) {
+            return empty();
+        } else {
+            OptionalLong r = mapper.apply(value);
+            return Objects.requireNonNull(r);
         }
     }
 

--- a/test/jdk/java/util/Optional/BasicDouble.java
+++ b/test/jdk/java/util/Optional/BasicDouble.java
@@ -120,6 +120,41 @@ public class BasicDouble {
     }
 
     @Test(groups = "unit")
+    public void testFilterEmpty() {
+        checkEmpty(OptionalDouble.empty().filter(s -> {fail(); return true;}));
+    }
+
+    @Test(groups = "unit")
+    public void testFilterFalse() {
+        checkEmpty(OptionalDouble.of(DOUBLEVAL).filter(Double::isNaN));
+    }
+
+    @Test(groups = "unit")
+    public void testFilterTrue() {
+        checkPresent(OptionalDouble.of(DOUBLEVAL).filter(s -> s != UNEXPECTED), DOUBLEVAL);
+    }
+
+    @Test(groups = "unit")
+    public void testMapEmpty() {
+        checkEmpty(OptionalDouble.empty().map(s -> {fail(); return DOUBLEVAL;}));
+    }
+
+    @Test(groups = "unit")
+    public void testMapPresent() {
+        checkPresent(OptionalDouble.of(DOUBLEVAL).map(s -> Math.E), Math.E);
+    }
+
+    @Test(groups = "unit")
+    public void testFlatMapEmpty() {
+        checkEmpty(OptionalDouble.empty().flatMap(s -> {fail(); return OptionalDouble.of(DOUBLEVAL);}));
+    }
+
+    @Test(groups = "unit")
+    public void testFlatMapPresent() {
+        checkPresent(OptionalDouble.of(DOUBLEVAL).flatMap(s -> OptionalDouble.of(Math.E)), Math.E);
+    }
+
+    @Test(groups = "unit")
     public void testStreamEmpty() {
         assertEquals(OptionalDouble.empty().stream().toArray(), new double[] { });
     }

--- a/test/jdk/java/util/Optional/BasicInt.java
+++ b/test/jdk/java/util/Optional/BasicInt.java
@@ -121,6 +121,41 @@ public class BasicInt {
     }
 
     @Test(groups = "unit")
+    public void testFilterEmpty() {
+        checkEmpty(OptionalInt.empty().filter(s -> {fail(); return true;}));
+    }
+
+    @Test(groups = "unit")
+    public void testFilterFalse() {
+        checkEmpty(OptionalInt.of(INTVAL).filter(s -> s == UNEXPECTED));
+    }
+
+    @Test(groups = "unit")
+    public void testFilterTrue() {
+        checkPresent(OptionalInt.of(INTVAL).filter(s -> s > 0), INTVAL);
+    }
+
+    @Test(groups = "unit")
+    public void testMapEmpty() {
+        checkEmpty(OptionalInt.empty().map(s -> {fail(); return INTVAL;}));
+    }
+
+    @Test(groups = "unit")
+    public void testMapPresent() {
+        checkPresent(OptionalInt.of(INTVAL).map(s -> 0xC0FFEE), 0xC0FFEE);
+    }
+
+    @Test(groups = "unit")
+    public void testFlatMapEmpty() {
+        checkEmpty(OptionalInt.empty().flatMap(s -> {fail(); return OptionalInt.of(INTVAL);}));
+    }
+
+    @Test(groups = "unit")
+    public void testFlatMapPresent() {
+        checkPresent(OptionalInt.of(INTVAL).flatMap(s -> OptionalInt.of(0xC0FFEE)), 0xC0FFEE);
+    }
+
+    @Test(groups = "unit")
     public void testStreamEmpty() {
         assertEquals(OptionalInt.empty().stream().toArray(), new int[] { });
     }

--- a/test/jdk/java/util/Optional/BasicLong.java
+++ b/test/jdk/java/util/Optional/BasicLong.java
@@ -120,6 +120,41 @@ public class BasicLong {
     }
 
     @Test(groups = "unit")
+    public void testFilterEmpty() {
+        checkEmpty(OptionalLong.empty().filter(s -> {fail(); return true;}));
+    }
+
+    @Test(groups = "unit")
+    public void testFilterFalse() {
+        checkEmpty(OptionalLong.of(LONGVAL).filter(s -> s == UNEXPECTED));
+    }
+
+    @Test(groups = "unit")
+    public void testFilterTrue() {
+        checkPresent(OptionalLong.of(LONGVAL).filter(s -> s > 0), LONGVAL);
+    }
+
+    @Test(groups = "unit")
+    public void testMapEmpty() {
+        checkEmpty(OptionalLong.empty().map(s -> {fail(); return LONGVAL;}));
+    }
+
+    @Test(groups = "unit")
+    public void testMapPresent() {
+        checkPresent(OptionalLong.of(LONGVAL).map(s -> 0xC0FFEEL), 0xC0FFEEL);
+    }
+
+    @Test(groups = "unit")
+    public void testFlatMapEmpty() {
+        checkEmpty(OptionalLong.empty().flatMap(s -> {fail(); return OptionalLong.of(LONGVAL);}));
+    }
+
+    @Test(groups = "unit")
+    public void testFlatMapPresent() {
+        checkPresent(OptionalLong.of(LONGVAL).flatMap(s -> OptionalLong.of(0xC0FFEEL)), 0xC0FFEEL);
+    }
+
+    @Test(groups = "unit")
     public void testStreamEmpty() {
         assertEquals(OptionalLong.empty().stream().toArray(), new long[] { });
     }


### PR DESCRIPTION
Hi all,
This PR intends to add filter, map and flatMap methods to the Optional classes for primitives. The rationale is consistency with the Optional class for objects and user convenience.
Thanks.
Regards,
Kartik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8186085](https://bugs.openjdk.java.net/browse/JDK-8186085): (opt) add filter(), flatMap(), and map() methods to OptionalDouble/Int/Long


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/857/head:pull/857`
`$ git checkout pull/857`
