### PR TITLE
8255379: ProblemList compiler/loopstripmining/BackedgeNodeWithOutOfLoopControl.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -64,6 +64,8 @@ compiler/rtm/print/TestPrintPreciseRTMLockingStatistics.java 8183263 generic-x64
 
 compiler/c2/Test8004741.java 8235801 generic-all
 
+compiler/loopstripmining/BackedgeNodeWithOutOfLoopControl.java 8255120 generic-all
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
A trivial fix to ProblemList compiler/loopstripmining/BackedgeNodeWithOutOfLoopControl.java
in order to reduce the noise in the JDK16 CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255379](https://bugs.openjdk.java.net/browse/JDK-8255379): ProblemList compiler/loopstripmining/BackedgeNodeWithOutOfLoopControl.java 


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/858/head:pull/858`
`$ git checkout pull/858`
