### PR TITLE
8251994: VM crashed running TestComplexAddrExpr.java test with -XX:UseAVX=X

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -91,6 +91,8 @@ SuperWord::SuperWord(PhaseIdealLoop* phase) :
 #endif
 }
 
+#define VECTOR_LOOP_SIMD 0 // Experimental vectorization which uses data from loop unrolling.
+
 //------------------------------transform_loop---------------------------
 void SuperWord::transform_loop(IdealLoopTree* lpt, bool do_optimization) {
   assert(UseSuperWord, "should be");
@@ -470,6 +472,7 @@ void SuperWord::SLP_extract() {
   CountedLoopNode *cl = lpt()->_head->as_CountedLoop();
   bool post_loop_allowed = (PostLoopMultiversioning && Matcher::has_predicated_vectors() && cl->is_post_loop());
   if (cl->is_main_loop()) {
+#if VECTOR_LOOP_SIMD
     if (_do_vector_loop) {
       if (mark_generations() != -1) {
         hoist_loads_in_graph(); // this only rebuild the graph; all basic structs need rebuild explicitly
@@ -495,6 +498,7 @@ void SuperWord::SLP_extract() {
       }
 #endif
     }
+#endif // VECTOR_LOOP_SIMD
 
     compute_vector_element_type();
 
@@ -508,14 +512,18 @@ void SuperWord::SLP_extract() {
 
     extend_packlist();
 
+#if VECTOR_LOOP_SIMD
     if (_do_vector_loop) {
       if (_packset.length() == 0) {
+#ifndef PRODUCT
         if (TraceSuperWord) {
           tty->print_cr("\nSuperWord::_do_vector_loop DFA could not build packset, now trying to build anyway");
         }
+#endif
         pack_parallel();
       }
     }
+#endif // VECTOR_LOOP_SIMD
 
     combine_packs();
 
@@ -1723,7 +1731,14 @@ void SuperWord::construct_my_pack_map() {
     Node_List* p = _packset.at(i);
     for (uint j = 0; j < p->size(); j++) {
       Node* s = p->at(j);
-      assert(my_pack(s) == NULL, "only in one pack");
+#ifdef ASSERT
+      if (my_pack(s) != NULL) {
+        s->dump(1);
+        tty->print_cr("packs[%d]:", i);
+        print_pack(p);
+        assert(false, "only in one pack");
+      }
+#endif
       set_my_pack(s, p);
     }
   }
@@ -1738,7 +1753,7 @@ void SuperWord::filter_packs() {
     bool impl = implemented(pk);
     if (!impl) {
 #ifndef PRODUCT
-      if (TraceSuperWord && Verbose) {
+      if ((TraceSuperWord && Verbose) || _vector_loop_debug) {
         tty->print_cr("Unimplemented");
         pk->at(0)->dump();
       }
@@ -1762,7 +1777,7 @@ void SuperWord::filter_packs() {
       bool prof = profitable(pk);
       if (!prof) {
 #ifndef PRODUCT
-        if (TraceSuperWord && Verbose) {
+        if ((TraceSuperWord && Verbose) || _vector_loop_debug) {
           tty->print_cr("Unprofitable");
           pk->at(0)->dump();
         }
@@ -3052,12 +3067,14 @@ bool SuperWord::construct_bb() {
 
   int ii_current = -1;
   unsigned int load_idx = (unsigned int)-1;
-  _ii_order.clear();
+  // Build iterations order if needed
+  bool build_ii_order = _ii_order.is_empty();
   // Create real map of block indices for nodes
   for (int j = 0; j < _block.length(); j++) {
     Node* n = _block.at(j);
     set_bb_idx(n, j);
-    if (_do_vector_loop && n->is_Load()) {
+#if VECTOR_LOOP_SIMD
+    if (build_ii_order && n->is_Load()) {
       if (ii_current == -1) {
         ii_current = _clone_map.gen(n->_idx);
         _ii_order.push(ii_current);
@@ -3067,6 +3084,7 @@ bool SuperWord::construct_bb() {
         _ii_order.push(ii_current);
       }
     }
+#endif // VECTOR_LOOP_SIMD
   }//for
 
   // Ensure extra info is allocated.
@@ -4699,6 +4717,15 @@ bool SuperWord::pack_parallel() {
 #endif
 
   _packset.clear();
+
+  if (_ii_order.is_empty()) {
+#ifndef PRODUCT
+    if (_vector_loop_debug) {
+      tty->print_cr("SuperWord::pack_parallel: EMPTY");
+    }
+#endif
+    return false;
+  }
 
   for (int ii = 0; ii < _iteration_first.length(); ii++) {
     Node* nd = _iteration_first.at(ii);

--- a/test/hotspot/jtreg/compiler/vectorization/TestForEachRem.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestForEachRem.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8251994
+ * @summary Test vectorization of Streams$RangeIntSpliterator::forEachRemaining
+ * @requires vm.compiler2.enabled & vm.compMode != "Xint"
+ *
+ * @run main compiler.vectorization.TestForEachRem test1
+ * @run main compiler.vectorization.TestForEachRem test2
+ * @run main compiler.vectorization.TestForEachRem test3
+ * @run main compiler.vectorization.TestForEachRem test4
+ */
+
+package compiler.vectorization;
+
+import java.util.stream.IntStream;
+
+public class TestForEachRem {
+    static final int RANGE = 512;
+    static final int ITER  = 100;
+
+    static void test1(int[] data) {
+       IntStream.range(0, RANGE).parallel().forEach(j -> {
+           data[j] = j + 1;
+       });
+    }
+
+    static void test2(int[] data) {
+       IntStream.range(0, RANGE - 1).forEach(j -> {
+           data[j] = data[j] + data[j + 1];
+       });
+    }
+
+    static void test3(int[] data, int A, int B) {
+       IntStream.range(0, RANGE - 1).forEach(j -> {
+           data[j] = A * data[j] + B * data[j + 1];
+       });
+    }
+
+    static void test4(int[] data) {
+       IntStream.range(0, RANGE - 1).forEach(j -> {
+           data[j + 1] = data[j];
+       });
+    }
+
+    static void verify(String name, int[] data, int[] gold) {
+        for (int i = 0; i < RANGE; i++) {
+            if (data[i] != gold[i]) {
+                throw new RuntimeException(" Invalid " + name + " result: data[" + i + "]: " + data[i] + " != " + gold[i]);
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        int[] data = new int[RANGE];
+        int[] gold = new int[RANGE];
+
+        if (args.length == 0) {
+            throw new RuntimeException(" Missing test name: test1, test2, test3, test4");
+        }
+
+        if (args[0].equals("test1")) {
+            System.out.println(" Run test1 ...");
+            test1(gold);
+            for (int i = 0; i < ITER; i++) {
+                test1(data);
+            }
+            verify("test1", data, gold);
+            System.out.println(" Finished test1.");
+        }
+
+        if (args[0].equals("test2")) {
+            System.out.println(" Run test2 ...");
+            test1(gold);
+            test2(gold);
+            for (int i = 0; i < ITER; i++) {
+                test1(data); // reset
+                test2(data);
+            }
+            verify("test2", data, gold);
+            System.out.println(" Finished test2.");
+        }
+
+        if (args[0].equals("test3")) {
+            System.out.println(" Run test3 ...");
+            test1(gold);
+            test3(gold, 2, 3);
+            for (int i = 0; i < ITER; i++) {
+                test1(data); // reset
+                test3(data, 2, 3);
+            }
+            verify("test3", data, gold);
+            System.out.println(" Finished test3.");
+        }
+
+        if (args[0].equals("test4")) {
+            System.out.println(" Run test4 ...");
+            test1(gold); // reset
+            test4(gold);
+            for (int i = 0; i < ITER; i++) {
+                test1(data); // reset
+                test4(data);
+            }
+            verify("test4", data, gold);
+            System.out.println(" Finished test4.");
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/vectorization/TestOptionVectorize.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestOptionVectorize.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8251994
+ * @summary Test forced vectorization
+ * @requires vm.compiler2.enabled & vm.compMode != "Xint"
+ *
+ * @run main/othervm -XX:CompileCommand=option,*::test,Vectorize compiler.vectorization.TestOptionVectorize
+ */
+
+package compiler.vectorization;
+
+import java.util.stream.IntStream;
+
+public class TestOptionVectorize {
+    static final int RANGE = 512;
+    static final int ITER  = 100;
+
+    static void init(double[] data) {
+       IntStream.range(0, RANGE).parallel().forEach(j -> {
+           data[j] = j + 1;
+       });
+    }
+
+    static void test(double[] data, double A, double B) {
+        for (int i = RANGE - 1; i > 0; i--) {
+            for (int j = 0; j <= i - 1; j++) {
+                data[j] = A * data[j + 1] + B * data[j];
+            }
+        }
+    }
+
+    static void verify(double[] data, double[] gold) {
+        for (int i = 0; i < RANGE; i++) {
+            if (data[i] != gold[i]) {
+                throw new RuntimeException(" Invalid result: data[" + i + "]: " + data[i] + " != " + gold[i]);
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        double[] data = new double[RANGE];
+        double[] gold = new double[RANGE];
+        System.out.println(" Run test ...");
+        init(gold); // reset
+        test(gold, 1.0, 2.0);
+        for (int i = 0; i < ITER; i++) {
+            init(data); // reset
+            test(data, 1.0, 2.0);
+        }
+        verify(data, gold);
+        System.out.println(" Finished test.");
+    }
+}


### PR DESCRIPTION
To improve a chance to vectorize a loop, a special code in superword tries to hoist loads to the beginning of loop by replacing their memory input with corresponding (same memory slice) loop's memory Phi : 
https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/superword.cpp#L474

Originally loads are ordered by corresponding stores on the same memory slice. But when they are hoisted they loose that ordering - nothing enforce the order. 
In TestComplexAddrExpr.test6 case the ordering is preserved (luckily?) after hoisting only when vector size is 32 bytes (avx2) but they become unordered with 16 (avx=0 or avx1) or 64 (avx512) bytes vectors. 

The mystery of why the test did not fail in our teting environment is also solved! We have old Skylake machines (even my local machine) for which AVX is switched to avx2: 
https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/vm_version_x86.cpp#L721

I have simple fix (use original loads ordering indexes) but looking on the code which causing the issue I see that it is bogus/incomplete - it does not help cases listed for JDK-8076284 changes: 

https://mail.openjdk.java.net/pipermail/hotspot-compiler-dev/2015-April/017645.html 

Using unrolling and cloning information to vectorize is interesting idea but as I see it is not complete. Even if pack_parallel() method is able created packs they are currently all removed by filter_packs() method. 
And additionally the above cases from JDK-8076284 are vectorized without hoisting loads and pack_parallel - I verified it.

The code added by  JDK-8076284  is useless now and I am excluding ti. It needs more work to be useful. I reluctant to remove the code because may be in a future we will have time to invest into it.

There were 2 way to exclude it: add new field in superword class:

```
   bool           _do_vector_loop;  // whether to do vectorization/simd style
+  bool           _do_vector_loop_experimental; // experimental optimization
   bool           _do_reserve_copy; // do reserve copy of the graph(loop) before final modification in output
```
or use `#if VECTOR_LOOP_SIMD` as in current changes. I prefer this one to avoid wasting compilation time. I used first one for testing by setting `_do_vector_loop_experimental(UseNewCode)`.

Testing: tier1-7 with avx2 and avx512.
Performance testing - no regrression.
I also compared jtreg tests output with -XX:+TraceNewVectors to verify that number of created vector nodes did not change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ⏳ (1/9 running) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8251994](https://bugs.openjdk.java.net/browse/JDK-8251994): VM crashed running TestComplexAddrExpr.java test with -XX:UseAVX=X


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/859/head:pull/859`
`$ git checkout pull/859`
