### PR TITLE
8167355: [macos 10.12] Timeout in javax/swing/JTextArea/TextViewOOM/TextViewOOM.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -786,7 +786,6 @@ javax/swing/tree/DefaultTreeCellRenderer/7142955/bug7142955.java 8199076 generic
 javax/swing/UIDefaults/6302464/bug6302464.java 8199079 macosx-all
 javax/swing/UIDefaults/8149879/InternalResourceBundle.java 8199054 windows-all
 javax/swing/PopupFactory/8048506/bug8048506.java 8202660 windows-all
-javax/swing/JTextArea/TextViewOOM/TextViewOOM.java 8167355 generic-all
 javax/swing/JPopupMenu/8075063/ContextMenuScrollTest.java 202880 linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all
 javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all


### PR DESCRIPTION
Please review a deproblemlisting of a test timeout issue seen in macos long time back in mach5 nightly testing.
It seems to be another of the samevm issue that was fixed by running client test in othervm mode https://bugs.openjdk.java.net/browse/CODETOOLS-7902131
Testing on recent builds is green. 
Mach5 job has been run for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8167355](https://bugs.openjdk.java.net/browse/JDK-8167355): [macos 10.12] Timeout in javax/swing/JTextArea/TextViewOOM/TextViewOOM.java


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/862/head:pull/862`
`$ git checkout pull/862`
