### PR TITLE
8255389: ConcurrentHashTable::NoOp omits return in non-void return method

### DIFF
--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -191,14 +191,10 @@ class ConcurrentHashTable : public CHeapObj<F> {
     Bucket* get_bucket(size_t idx) { return &_buckets[idx]; }
   };
 
-  // Used as default functor when no functor supplied for some methods.
-  // Note it only accepts the VALUE, and does not define methods with
-  // non-void VALUE returns. Doing so would require defining the neutral
-  // value for VALUE.
-  struct NoOp {
+  // For ignoring the supplied value.
+  struct IgnoreValue {
     void operator()(VALUE*) {}
-    void operator()(bool, VALUE*) {}
-  } noOp;
+  };
 
   // For materializing a supplied value.
   class LazyValueRetrieve {
@@ -431,7 +427,8 @@ class ConcurrentHashTable : public CHeapObj<F> {
   // Same without DELETE_FUNC.
   template <typename LOOKUP_FUNC>
   bool remove(Thread* thread, LOOKUP_FUNC& lookup_f) {
-    return internal_remove(thread, lookup_f, noOp);
+    IgnoreValue ignore_del_f;
+    return internal_remove(thread, lookup_f, ignore_del_f);
   }
 
   // Visit all items with SCAN_FUNC if no concurrent resize. Takes the resize

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -191,11 +191,6 @@ class ConcurrentHashTable : public CHeapObj<F> {
     Bucket* get_bucket(size_t idx) { return &_buckets[idx]; }
   };
 
-  // For ignoring the supplied value.
-  struct IgnoreValue {
-    void operator()(VALUE*) {}
-  };
-
   // For materializing a supplied value.
   class LazyValueRetrieve {
    private:
@@ -427,7 +422,9 @@ class ConcurrentHashTable : public CHeapObj<F> {
   // Same without DELETE_FUNC.
   template <typename LOOKUP_FUNC>
   bool remove(Thread* thread, LOOKUP_FUNC& lookup_f) {
-    IgnoreValue ignore_del_f;
+    struct {
+      void operator()(VALUE*) {}
+    } ignore_del_f;
     return internal_remove(thread, lookup_f, ignore_del_f);
   }
 

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -192,9 +192,11 @@ class ConcurrentHashTable : public CHeapObj<F> {
   };
 
   // Used as default functor when no functor supplied for some methods.
+  // Note it only accepts the VALUE, and does not define methods with
+  // non-void VALUE returns. Doing so would require defining the neutral
+  // value for VALUE.
   struct NoOp {
     void operator()(VALUE*) {}
-    const VALUE& operator()() {}
     void operator()(bool, VALUE*) {}
   } noOp;
 


### PR DESCRIPTION
Static analysis complains there is a non-void return method without a return statement:

```
  struct NoOp {
    void operator()(VALUE*) {}
    const VALUE& operator()() {} // <--- here
    void operator()(bool, VALUE*) {}
  } noOp;
```

AFAICS, this is UB, and we have seen cases like these break compilers in other places. Not in this case, though, because `noOp` is only used as the default functor in `remove`, which does not use this getter-like definition. Still, it would be good to remove that risky definition, so that it is not used accidentally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255389](https://bugs.openjdk.java.net/browse/JDK-8255389): ConcurrentHashTable::NoOp omits return in non-void return method


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 1154fea654870bf027a1766551c34d16c2ef6006
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to e1c6727d63eb782e1a3339b30a001d2db8766b22


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/863/head:pull/863`
`$ git checkout pull/863`
