### PR TITLE
8255393: sun/security/util/DerValue/Indefinite.java fails with ---illegal-access=deny

### DIFF
--- a/test/jdk/sun/security/util/DerValue/Indefinite.java
+++ b/test/jdk/sun/security/util/DerValue/Indefinite.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6731685 8249783 8255393
+ * @bug 6731685 8249783
  * @summary CertificateFactory.generateCertificates throws IOException on PKCS7 cert chain
  * @modules java.base/sun.security.util:+open
  * @library /test/lib

--- a/test/jdk/sun/security/util/DerValue/Indefinite.java
+++ b/test/jdk/sun/security/util/DerValue/Indefinite.java
@@ -23,9 +23,9 @@
 
 /*
  * @test
- * @bug 6731685 8249783
+ * @bug 6731685 8249783 8255393
  * @summary CertificateFactory.generateCertificates throws IOException on PKCS7 cert chain
- * @modules java.base/sun.security.util
+ * @modules java.base/sun.security.util:+open
  * @library /test/lib
  */
 
@@ -35,7 +35,6 @@ import java.util.Arrays;
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.Utils;
-import jdk.test.lib.hexdump.HexPrinter;
 import sun.security.util.*;
 
 public class Indefinite {


### PR DESCRIPTION
The test calls Field::setAccessible and needs an "open" access to the internal class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255393](https://bugs.openjdk.java.net/browse/JDK-8255393): sun/security/util/DerValue/Indefinite.java fails with ---illegal-access=deny


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to dac4c6549e6da087f403b970f57858c4cdaf4672


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/864/head:pull/864`
`$ git checkout pull/864`
