### PR TITLE
8255374: Add a dropReturn MethodHandle combinator

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -5222,8 +5222,7 @@ assertEquals("xy", h3.invoke("x", "y", 1, "a", "b", "c"));
             return target;
         MethodType newType = oldType.changeReturnType(void.class);
         BoundMethodHandle result = target.rebind();
-        LambdaForm lform = result.form;
-        lform = lform.editor().filterReturnForm(V_TYPE, true);
+        LambdaForm lform = result.editor().filterReturnForm(V_TYPE, true);
         result = result.copyWith(newType, lform);
         return result;
     }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -62,6 +62,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.lang.invoke.LambdaForm.BasicType.V_TYPE;
 import static java.lang.invoke.MethodHandleImpl.Intrinsic;
 import static java.lang.invoke.MethodHandleNatives.Constants.*;
 import static java.lang.invoke.MethodHandleStatics.newIllegalArgumentException;
@@ -5202,6 +5203,29 @@ assertEquals("xy", h3.invoke("x", "y", 1, "a", "b", "c"));
         Objects.requireNonNull(target);
         Objects.requireNonNull(newTypes);
         return dropArgumentsToMatch(target, skip, newTypes, pos, false);
+    }
+
+    /**
+     * Drop the return value of the target handle (if any).
+     * The returned method handle will have a {@code void} return type.
+     *
+     * @param target the method handle to adapt
+     * @return a possibly adapted method handle
+     * @throws NullPointerException if {@code target} is null
+     * @since 16
+     */
+    public static MethodHandle dropReturn(MethodHandle target) {
+        Objects.requireNonNull(target);
+        MethodType oldType = target.type();
+        Class<?> oldReturnType = oldType.returnType();
+        if (oldReturnType == void.class)
+            return target;
+        MethodType newType = oldType.changeReturnType(void.class);
+        BoundMethodHandle result = target.rebind();
+        LambdaForm lform = result.form;
+        lform = lform.editor().filterReturnForm(V_TYPE, true);
+        result = result.copyWith(newType, lform);
+        return result;
     }
 
     /**

--- a/test/jdk/java/lang/invoke/MethodHandles/TestDropReturn.java
+++ b/test/jdk/java/lang/invoke/MethodHandles/TestDropReturn.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8027823
+ * @run testng TestDropReturn
+ */
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+import static java.lang.invoke.MethodType.methodType;
+import static org.testng.Assert.assertEquals;
+
+public class TestDropReturn {
+
+    @Test(dataProvider = "dropReturnCases")
+    public void testDropReturn(Class<?> cls, Object testValue) throws Throwable {
+        MethodHandle mh = MethodHandles.identity(cls);
+        assertEquals(mh.type(), methodType(cls, cls));
+        Object x = mh.invoke(testValue);
+        assertEquals(x, testValue);
+
+        mh = MethodHandles.dropReturn(mh);
+        assertEquals(mh.type(), methodType(void.class, cls));
+        mh.invoke(testValue); // should at least work
+    }
+
+    @DataProvider
+    public static Object[][] dropReturnCases() {
+        return new Object[][]{
+            { boolean.class, true         },
+            { byte.class,    (byte) 10    },
+            { char.class,    'x'          },
+            { short.class,   (short) 10   },
+            { int.class,     10           },
+            { long.class,    10L          },
+            { float.class,   10F          },
+            { double.class,  10D          },
+            { Object.class,  new Object() },
+            { String.class,  "ABCD"       },
+        };
+    }
+}

--- a/test/jdk/java/lang/invoke/MethodHandles/TestDropReturn.java
+++ b/test/jdk/java/lang/invoke/MethodHandles/TestDropReturn.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8027823
+ * @bug 8255398
  * @run testng TestDropReturn
  */
 


### PR DESCRIPTION
Hi,

This patch adds a `dropReturn` combinator to `MethodHandles` that can be used to create a new method handle that drops the return value, from a given method handle. Similar to the following code:

```
MethodHandle target = ...;
Class<?> targetReturnType = target.type().returnType();
if (targetReturnType != void.class)
    target = filterReturnValue(target, empty(methodType(void.class, targetReturnType))); 
// use target
```

But as a short-hand.

Thanks,
Jorn

CSR link: https://bugs.openjdk.java.net/browse/JDK-8255398

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255374](https://bugs.openjdk.java.net/browse/JDK-8255374): Add a dropReturn MethodHandle combinator


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to 22ae65d0e6b96b980a09b5ad4475db4a05077ec0


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/866/head:pull/866`
`$ git checkout pull/866`
