### PR TITLE
8255405: sun/net/ftp/imp/FtpClient uses SimpleDateFormat in not thread-safe manner

### DIFF
--- a/src/java.base/share/classes/sun/net/ftp/impl/FtpClient.java
+++ b/src/java.base/share/classes/sun/net/ftp/impl/FtpClient.java
@@ -1774,7 +1774,7 @@ public class FtpClient extends sun.net.ftp.FtpClient {
         return null;
     }
 
-    private static Date parseRfc3659TimeValue(String s) {
+    private static synchronized Date parseRfc3659TimeValue(String s) {
         Date d = null;
         for (SimpleDateFormat dateFormat : dateFormats) {
             try {

--- a/src/java.base/share/classes/sun/net/ftp/impl/FtpClient.java
+++ b/src/java.base/share/classes/sun/net/ftp/impl/FtpClient.java
@@ -29,8 +29,8 @@ import java.io.*;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.DateFormat;
-import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -1740,7 +1740,8 @@ public class FtpClient extends sun.net.ftp.FtpClient {
         return -1;
     }
 
-    private static final DateTimeFormatter RFC3659_DATETIME_FORMAT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss[.SSS]");
+    private static final DateTimeFormatter RFC3659_DATETIME_FORMAT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss[.SSS]")
+                                                                                      .withZone(ZoneOffset.UTC);
 
     /**
      * Issues the MDTM [path] command to the server to get the modification
@@ -1766,8 +1767,8 @@ public class FtpClient extends sun.net.ftp.FtpClient {
     private static Date parseRfc3659TimeValue(String s) {
         Date result = null;
         try {
-            var d = LocalDateTime.parse(s, RFC3659_DATETIME_FORMAT);
-            result = Date.from(d.atZone(ZoneOffset.systemDefault()).toInstant());
+            var d = ZonedDateTime.parse(s, RFC3659_DATETIME_FORMAT);
+            result = Date.from(d.toInstant());
         } catch (DateTimeParseException ex) {
         }
         return result;

--- a/src/java.base/share/classes/sun/net/ftp/impl/FtpClient.java
+++ b/src/java.base/share/classes/sun/net/ftp/impl/FtpClient.java
@@ -1757,8 +1757,8 @@ public class FtpClient extends sun.net.ftp.FtpClient {
     public Date getLastModified(String path) throws sun.net.ftp.FtpProtocolException, IOException {
         issueCommandCheck("MDTM " + path);
         if (lastReplyCode == FtpReplyCode.FILE_STATUS) {
-            String s = getResponseString().substring(4);
-            return parseRfc3659TimeValue(s);
+            String s = getResponseString();
+            return parseRfc3659TimeValue(s.substring(4, s.length() - 1));
         }
         return null;
     }

--- a/test/jdk/sun/net/ftp/TestFtpTimeValue.java
+++ b/test/jdk/sun/net/ftp/TestFtpTimeValue.java
@@ -61,17 +61,17 @@ public class TestFtpTimeValue {
             calendar.set(year, month - 1, day, hrs, min, sec);
             calendar.set(Calendar.MILLISECOND, milliseconds);
             expectedCreated = calendar.getTime();
-            var s = String.format("%4d%2d%2d%2d%2d%2d", year, month, day, hrs, min, sec);
+            var s = String.format("%4d%02d%02d%02d%02d%02d", year, month, day, hrs, min, sec);
             if (milliseconds != 0) {
-                s += "." + String.format("%3d", milliseconds);
+                s += "." + String.format("%03d", milliseconds);
             }
             create = s;
 
             calendar.add(GregorianCalendar.SECOND, 1);
             expectedModified = calendar.getTime();
-            s = String.format("%4d%2d%2d%2d%2d%2d", year, month, day, hrs, min, sec + 1);
+            s = String.format("%4d%02d%02d%02d%02d%02d", year, month, day, hrs, min, sec + 1);
             if (milliseconds != 0) {
-                s += "." + String.format("%3d", milliseconds);
+                s += "." + String.format("%03d", milliseconds);
             }
             modify = s;
         }

--- a/test/jdk/sun/net/ftp/TestFtpTimeValue.java
+++ b/test/jdk/sun/net/ftp/TestFtpTimeValue.java
@@ -28,7 +28,8 @@
  * @library /test/lib
  * @modules java.base/sun.net.ftp
  * @build jdk.test.lib.Asserts
- * @run main TestFtpTimeValue
+ * @run main/othervm -Duser.timezone=UTC TestFtpTimeValue
+ * @run main/othervm -Duser.timezone=America/Los_Angeles TestFtpTimeValue
  */
 
 import jdk.test.lib.Asserts;
@@ -78,6 +79,7 @@ public class TestFtpTimeValue {
     }
 
     public static void main(String[] args) throws Exception {
+        System.out.println("user.timezone: " + System.getProperty("user.timezone"));
         try (FtpServer server = new FtpServer();
              FtpClient client = FtpClient.create()) {
             (new Thread(server)).start();


### PR DESCRIPTION
Hi all,

could you please review this small and trivial fix?

`sun/net/ftp/imp/FtpClient::dateFormats` is an array of `SimpleDateFormat` which are shared among all instances of `FtpClient`. the fact that `SimpleDateFormat` isn't thread-safe renders`FtpClient` to be non-thread-safe as well. the patch makes the only usage of `dateFormats` array, `parseRfc3659TimeValue` method, `synchronized`.

the problem was reported in #776

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255405](https://bugs.openjdk.java.net/browse/JDK-8255405): sun/net/ftp/imp/FtpClient uses SimpleDateFormat in not thread-safe manner


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Rahul Yadav](https://openjdk.java.net/census#ryadav) (@rhyadav - Committer)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/867/head:pull/867`
`$ git checkout pull/867`
