### PR TITLE
8253920: Share method trampolines in CDS dynamic archive

### DIFF
--- a/src/hotspot/share/memory/archiveBuilder.cpp
+++ b/src/hotspot/share/memory/archiveBuilder.cpp
@@ -38,12 +38,34 @@
 #include "oops/instanceKlass.hpp"
 #include "oops/objArrayKlass.hpp"
 #include "oops/oopHandle.inline.hpp"
+#include "runtime/sharedRuntime.hpp"
 #include "utilities/align.hpp"
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/hashtable.inline.hpp"
 
 ArchiveBuilder* ArchiveBuilder::_singleton = NULL;
 intx ArchiveBuilder::_buffer_to_target_delta = 0;
+
+class AdapterHandlerEntry;
+
+class MethodTrampolineInfo {
+  address _c2i_entry_trampoline;
+  AdapterHandlerEntry** _adapter_trampoline;
+public:
+  address c2i_entry_trampoline() { return _c2i_entry_trampoline; }
+  AdapterHandlerEntry** adapter_trampoline() { return _adapter_trampoline; }
+  void set_c2i_entry_trampoline(address addr) { _c2i_entry_trampoline = addr; }
+  void set_adapter_trampoline(AdapterHandlerEntry** entry) { _adapter_trampoline = entry; }
+};
+
+class AdapterToTrampoline : public ResourceHashtable<
+  AdapterHandlerEntry*, MethodTrampolineInfo,
+  primitive_hash<AdapterHandlerEntry*>,
+  primitive_equals<AdapterHandlerEntry*>,
+  941, // prime number
+  ResourceObj::C_HEAP> {};
+
+static AdapterToTrampoline* _adapter_to_trampoline = NULL;
 
 ArchiveBuilder::OtherROAllocMark::~OtherROAllocMark() {
   char* newtop = ArchiveBuilder::singleton()->_ro_region->top();
@@ -259,6 +281,8 @@ void ArchiveBuilder::gather_klasses_and_symbols() {
     // DynamicArchiveBuilder::sort_methods()).
     sort_symbols_and_fix_hash();
     sort_klasses();
+    allocate_method_trampoline_info();
+    allocate_method_trampolines();
   }
 }
 
@@ -797,4 +821,91 @@ void ArchiveBuilder::print_stats(int ro_all, int rw_all, int mc_all) {
 void ArchiveBuilder::clean_up_src_obj_table() {
   SrcObjTableCleaner cleaner;
   _src_obj_table.iterate(&cleaner);
+}
+
+void ArchiveBuilder::allocate_method_trampolines_for(InstanceKlass* ik) {
+  if (ik->methods() != NULL) {
+    for (int j = 0; j < ik->methods()->length(); j++) {
+      // Walk the methods in a deterministic order so that the trampolines are
+      // created in a deterministic order.
+      Method* m = ik->methods()->at(j);
+      AdapterHandlerEntry* ent = m->adapter(); // different methods can share the same AdapterHandlerEntry
+      MethodTrampolineInfo* info = _adapter_to_trampoline->get(ent);
+      if (info->c2i_entry_trampoline() == NULL) {
+        info->set_c2i_entry_trampoline(
+          (address)MetaspaceShared::misc_code_space_alloc(SharedRuntime::trampoline_size()));
+        info->set_adapter_trampoline(
+          (AdapterHandlerEntry**)MetaspaceShared::misc_code_space_alloc(sizeof(AdapterHandlerEntry*)));
+      }
+    }
+  }
+}
+
+void ArchiveBuilder::allocate_method_trampolines() {
+  for (int i = 0; i < _klasses->length(); i++) {
+    Klass* k = _klasses->at(i);
+    if (k->is_instance_klass()) {
+      InstanceKlass* ik = InstanceKlass::cast(k);
+      allocate_method_trampolines_for(ik);
+    }
+  }
+}
+
+// Allocate MethodTrampolineInfo for all Methods that will be archived. Also
+// return the total number of bytes needed by the method trampolines in the MC
+// region.
+size_t ArchiveBuilder::allocate_method_trampoline_info() {
+  size_t total = 0;
+  size_t each_method_bytes =
+    align_up(SharedRuntime::trampoline_size(), BytesPerWord) +
+    align_up(sizeof(AdapterHandlerEntry*), BytesPerWord);
+
+  if (_adapter_to_trampoline == NULL) {
+    _adapter_to_trampoline = new (ResourceObj::C_HEAP, mtClass)AdapterToTrampoline();
+  }
+  int count = 0;
+  for (int i = 0; i < _klasses->length(); i++) {
+    Klass* k = _klasses->at(i);
+    if (k->is_instance_klass()) {
+      InstanceKlass* ik = InstanceKlass::cast(k);
+      if (ik->methods() != NULL) {
+        for (int j = 0; j < ik->methods()->length(); j++) {
+          Method* m = ik->methods()->at(j);
+          AdapterHandlerEntry* ent = m->adapter(); // different methods can share the same AdapterHandlerEntry
+          bool is_created = false;
+          MethodTrampolineInfo* info = _adapter_to_trampoline->put_if_absent(ent, &is_created);
+          if (is_created) {
+            count++;
+          }
+        }
+      }
+    }
+  }
+  if (count == 0) {
+    // We have nothing to archive, but let's avoid having an empty region.
+    total = SharedRuntime::trampoline_size();
+  } else {
+    total = count * each_method_bytes;
+  }
+  return align_up(total, SharedSpaceObjectAlignment);
+}
+
+void ArchiveBuilder::update_method_trampolines() {
+  for (int i = 0; i < klasses()->length(); i++) {
+    Klass* k = klasses()->at(i);
+    if (!k->is_instance_klass()) {
+      continue;
+    }
+    InstanceKlass* ik = InstanceKlass::cast(k);
+    Array<Method*>* methods = ik->methods();
+    for (int j = 0; j < methods->length(); j++) {
+      Method* m = methods->at(j);
+      AdapterHandlerEntry* ent = m->adapter();
+      MethodTrampolineInfo* info = _adapter_to_trampoline->get(ent);
+      // m is the "copy" of the original Method, but its adapter() field is still valid because
+      // we haven't called make_klasses_shareable() yet.
+      m->set_from_compiled_entry(to_target(info->c2i_entry_trampoline()));
+      m->set_adapter_trampoline(to_target(info->adapter_trampoline()));
+    }
+  }
 }

--- a/src/hotspot/share/memory/archiveBuilder.cpp
+++ b/src/hotspot/share/memory/archiveBuilder.cpp
@@ -893,19 +893,18 @@ size_t ArchiveBuilder::allocate_method_trampoline_info() {
 void ArchiveBuilder::update_method_trampolines() {
   for (int i = 0; i < klasses()->length(); i++) {
     Klass* k = klasses()->at(i);
-    if (!k->is_instance_klass()) {
-      continue;
-    }
-    InstanceKlass* ik = InstanceKlass::cast(k);
-    Array<Method*>* methods = ik->methods();
-    for (int j = 0; j < methods->length(); j++) {
-      Method* m = methods->at(j);
-      AdapterHandlerEntry* ent = m->adapter();
-      MethodTrampolineInfo* info = _adapter_to_trampoline->get(ent);
-      // m is the "copy" of the original Method, but its adapter() field is still valid because
-      // we haven't called make_klasses_shareable() yet.
-      m->set_from_compiled_entry(to_target(info->c2i_entry_trampoline()));
-      m->set_adapter_trampoline(to_target(info->adapter_trampoline()));
+    if (k->is_instance_klass()) {
+      InstanceKlass* ik = InstanceKlass::cast(k);
+      Array<Method*>* methods = ik->methods();
+      for (int j = 0; j < methods->length(); j++) {
+        Method* m = methods->at(j);
+        AdapterHandlerEntry* ent = m->adapter();
+        MethodTrampolineInfo* info = _adapter_to_trampoline->get(ent);
+        // m is the "copy" of the original Method, but its adapter() field is still valid because
+        // we haven't called make_klasses_shareable() yet.
+        m->set_from_compiled_entry(to_target(info->c2i_entry_trampoline()));
+        m->set_adapter_trampoline(to_target(info->adapter_trampoline()));
+      }
     }
   }
 }

--- a/src/hotspot/share/memory/archiveBuilder.cpp
+++ b/src/hotspot/share/memory/archiveBuilder.cpp
@@ -902,8 +902,8 @@ void ArchiveBuilder::update_method_trampolines() {
         MethodTrampolineInfo* info = _adapter_to_trampoline->get(ent);
         // m is the "copy" of the original Method, but its adapter() field is still valid because
         // we haven't called make_klasses_shareable() yet.
-        m->set_from_compiled_entry(to_target(info->c2i_entry_trampoline()));
-        m->set_adapter_trampoline(to_target(info->adapter_trampoline()));
+        m->set_from_compiled_entry(info->c2i_entry_trampoline());
+        m->set_adapter_trampoline(info->adapter_trampoline());
       }
     }
   }

--- a/src/hotspot/share/memory/archiveBuilder.hpp
+++ b/src/hotspot/share/memory/archiveBuilder.hpp
@@ -279,6 +279,13 @@ public:
 
   void print_stats(int ro_all, int rw_all, int mc_all);
   static intx _buffer_to_target_delta;
+
+  // Method trampolines related functions
+  void allocate_method_trampolines();
+  void allocate_method_trampolines_for(InstanceKlass* ik);
+  size_t allocate_method_trampoline_info();
+  void update_method_trampolines();
+
 };
 
 #endif // SHARE_MEMORY_ARCHIVEBUILDER_HPP

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -770,6 +770,9 @@ void VM_PopulateDumpSharedSpace::doit() {
 
   builder.relocate_well_known_klasses();
 
+  log_info(cds)("Update method trampolines");
+  builder.update_method_trampolines();
+
   log_info(cds)("Make classes shareable");
   builder.make_klasses_shareable();
 

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1108,10 +1108,8 @@ void Method::unlink_method() {
   _from_interpreted_entry = _i2i_entry;
 
   assert(_from_compiled_entry != NULL, "sanity");
-  if (DumpSharedSpaces) {
-    assert(*((int*)_from_compiled_entry) == 0,
-           "must be NULL during dump time, to be initialized at run time");
-  }
+  assert(*((int*)_from_compiled_entry) == 0,
+         "must be NULL during dump time, to be initialized at run time");
 
   if (is_native()) {
     *native_function_addr() = NULL;

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1107,14 +1107,8 @@ void Method::unlink_method() {
   _i2i_entry = Interpreter::entry_for_cds_method(methodHandle(Thread::current(), this));
   _from_interpreted_entry = _i2i_entry;
 
-  if (DynamicDumpSharedSpaces) {
-    assert(_from_compiled_entry != NULL, "sanity");
-  } else {
-    // TODO: Simplify the adapter trampoline allocation for static archiving.
-    //       Remove the use of CDSAdapterHandlerEntry.
-    CDSAdapterHandlerEntry* cds_adapter = (CDSAdapterHandlerEntry*)adapter();
-    constMethod()->set_adapter_trampoline(cds_adapter->get_adapter_trampoline());
-    _from_compiled_entry = cds_adapter->get_c2i_entry_trampoline();
+  assert(_from_compiled_entry != NULL, "sanity");
+  if (DumpSharedSpaces) {
     assert(*((int*)_from_compiled_entry) == 0,
            "must be NULL during dump time, to be initialized at run time");
   }

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2454,15 +2454,12 @@ class AdapterHandlerTable : public BasicHashtable<mtCode> {
 
  public:
   AdapterHandlerTable()
-    : BasicHashtable<mtCode>(293, (DumpSharedSpaces ? sizeof(CDSAdapterHandlerEntry) : sizeof(AdapterHandlerEntry))) { }
+    : BasicHashtable<mtCode>(293, (sizeof(AdapterHandlerEntry))) { }
 
   // Create a new entry suitable for insertion in the table
   AdapterHandlerEntry* new_entry(AdapterFingerPrint* fingerprint, address i2c_entry, address c2i_entry, address c2i_unverified_entry, address c2i_no_clinit_check_entry) {
     AdapterHandlerEntry* entry = (AdapterHandlerEntry*)BasicHashtable<mtCode>::new_entry(fingerprint->compute_hash());
     entry->init(fingerprint, i2c_entry, c2i_entry, c2i_unverified_entry, c2i_no_clinit_check_entry);
-    if (DumpSharedSpaces) {
-      ((CDSAdapterHandlerEntry*)entry)->init();
-    }
     return entry;
   }
 
@@ -3129,17 +3126,6 @@ void AdapterHandlerEntry::print_adapter_on(outputStream* st) const {
   }
   st->cr();
 }
-
-#if INCLUDE_CDS
-
-void CDSAdapterHandlerEntry::init() {
-  assert(DumpSharedSpaces, "used during dump time only");
-  _c2i_entry_trampoline = (address)MetaspaceShared::misc_code_space_alloc(SharedRuntime::trampoline_size());
-  _adapter_trampoline = (AdapterHandlerEntry**)MetaspaceShared::misc_code_space_alloc(sizeof(AdapterHandlerEntry*));
-};
-
-#endif // INCLUDE_CDS
-
 
 #ifndef PRODUCT
 

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -679,20 +679,6 @@ class AdapterHandlerEntry : public BasicHashtableEntry<mtCode> {
   void print_adapter_on(outputStream* st) const;
 };
 
-// This class is used only with DumpSharedSpaces==true. It holds extra information
-// that's used only during CDS dump time.
-// For details, see comments around Method::link_method()
-class CDSAdapterHandlerEntry: public AdapterHandlerEntry {
-  address               _c2i_entry_trampoline;   // allocated from shared spaces "MC" region
-  AdapterHandlerEntry** _adapter_trampoline;     // allocated from shared spaces "MD" region
-
-public:
-  address get_c2i_entry_trampoline()             const { return _c2i_entry_trampoline; }
-  AdapterHandlerEntry** get_adapter_trampoline() const { return _adapter_trampoline; }
-  void init() NOT_CDS_RETURN;
-};
-
-
 class AdapterHandlerLibrary: public AllStatic {
  private:
   static BufferBlob* _buffer; // the temporary code buffer in CodeCache


### PR DESCRIPTION
This patch is to allow sharing of the same method trampoline for archived Methods with the same AdapterHandleEntry when using CDS dynamic archive. 

Running javac on HelloWorld with CDS dynamic archive, the number of calls to SharedRuntime::generate_trampoline() is reduced to 406 times vs 12601 times without the patch.

In terms of saving on instructions and time (on linux-x64):
instr delta =     -2807662    -0.1369%
time  delta =       -6.860 ms -1.8798%

It passed tiers 1,2,3,4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253920](https://bugs.openjdk.java.net/browse/JDK-8253920): Share method trampolines in CDS dynamic archive


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to af513fb1da0af69af798c5f795eec08635b96995
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**) ⚠️ Review applies to af513fb1da0af69af798c5f795eec08635b96995
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/868/head:pull/868`
`$ git checkout pull/868`
