### PR TITLE
8255401: Shenandoah: Allow oldval and newval registers to overlap in cmpxchg_oop()

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -477,7 +477,8 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
   bool is_narrow = UseCompressedOops;
   Assembler::operand_size size = is_narrow ? Assembler::word : Assembler::xword;
 
-  assert_different_registers(addr, expected, new_val, tmp1, tmp2);
+  assert_different_registers(addr, expected, tmp1, tmp2);
+  assert_different_registers(addr, new_val,  tmp1, tmp2);
 
   Label step4, done;
 

--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -638,7 +638,8 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
                                                 bool exchange, Register tmp1, Register tmp2) {
   assert(ShenandoahCASBarrier, "Should only be used when CAS barrier is enabled");
   assert(oldval == rax, "must be in rax for implicit use in cmpxchg");
-  assert_different_registers(oldval, newval, tmp1, tmp2);
+  assert_different_registers(oldval, tmp1, tmp2);
+  assert_different_registers(newval, tmp1, tmp2);
 
   Label L_success, L_failure;
 


### PR DESCRIPTION
We encountered a failure in testing:

Internal Error (/home/jenkins/workspace/nightly/jdk-jdk/src/hotspot/share/asm/register.hpp:141), pid=15470, tid=15611
assert(a != b && a != c && a != d && b != c && b != d && c != d) failed: registers must be different: a=0x0000000000000000, b=0x0000000000000000, c=0x000000000000000b, d=0x000000000000000a

in:

Stack: [0x00007fb8fa2e3000,0x00007fb8fa3e4000], sp=0x00007fb8fa3deca0, free space=1007k
Native frames: (J=compiled Java code, A=aot compiled Java code, j=interpreted, Vv=VM code, C=native code)
V [libjvm.so+0x156890e] ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler*, RegisterImpl*, Address, RegisterImpl*, RegisterImpl*, bool, RegisterImpl*, RegisterImpl*)+0xde
V [libjvm.so+0x3ec1d1] compareAndSwapN_shenandoahNode::emit(CodeBuffer&, PhaseRegAlloc*) const+0x571 

It seems to appear very rarely.

The failure is that both newval and oldval are the same register (rax). I believe it is ok for the two registers to overlap:
- It is not expected that newval is preserved across the cmpxchg
- The CAS will override newval, but:
  - The first CAS is unaffected by the overlap
  - The retry-loop is only entered when previous-value == old-value, and thus newval will still hold the same value

For aarch64 it matters even less, because newval is never overridden.

Testing: hotspot_gc_shenandoah (x86 & aarch64).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ❌ (1/2 failed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (build debug)](https://github.com/rkennke/jdk/runs/1311209663)

### Issue
 * [JDK-8255401](https://bugs.openjdk.java.net/browse/JDK-8255401): Shenandoah: Allow oldval and newval registers to overlap in cmpxchg_oop()


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/871/head:pull/871`
`$ git checkout pull/871`
