### PR TITLE
8015602: [macosx] Test javax/swing/SpringLayout/4726194/bug4726194.java fails on MacOSX

### DIFF
--- a/test/jdk/javax/swing/SpringLayout/4726194/bug4726194.java
+++ b/test/jdk/javax/swing/SpringLayout/4726194/bug4726194.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,7 @@ public class bug4726194 {
         String[] constraints = horizontal ? hConstraints : vConstraints;
         test(level, constraints, result, Arrays.asList(new Object[level]));
         JTextField tf = new JTextField("");
+        tf.setBorder(BorderFactory.createEmptyBorder());
         tf.setFont(new Font("Dialog", Font.PLAIN, 6));
         System.out.print("\t\t");
         for (int j = 0; j < constraints.length; j++) {

--- a/test/jdk/javax/swing/SpringLayout/4726194/bug4726194.java
+++ b/test/jdk/javax/swing/SpringLayout/4726194/bug4726194.java
@@ -25,13 +25,22 @@
  * @test
  * @bug 4726194 7124209
  * @summary Tests for 4726194
- * @author Phil Milne
  */
-import java.awt.*;
-import java.lang.reflect.InvocationTargetException;
-import java.util.*;
+
+import java.awt.Font;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import javax.swing.*;
+
+import javax.swing.BorderFactory;
+import javax.swing.JTextField;
+import javax.swing.Spring;
+import javax.swing.SpringLayout;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import static javax.swing.UIManager.getInstalledLookAndFeels;
 
 public class bug4726194 {
 
@@ -40,22 +49,29 @@ public class bug4726194 {
     private static int[] FAIL = new int[3];
     private static boolean TEST_DUPLICATES = false;
 
-    public static void main(String[] args) {
-        try {
-            SwingUtilities.invokeAndWait(new Runnable() {
-                @Override
-                public void run() {
-                    int minLevel = 2;
-                    int maxLevel = 2;
-                    for (int i = minLevel; i <= maxLevel; i++) {
-                        test(i, true);
-                        test(i, false);
-                    }
+    public static void main(String[] args) throws Exception {
+        for (final UIManager.LookAndFeelInfo laf : getInstalledLookAndFeels()) {
+            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+            SwingUtilities.invokeAndWait(() -> {
+                int minLevel = 2;
+                int maxLevel = 2;
+                for (int i = minLevel; i <= maxLevel; i++) {
+                    test(i, true);
+                    test(i, false);
                 }
             });
-        } catch (InterruptedException | InvocationTargetException ex) {
-            ex.printStackTrace();
-            throw new RuntimeException("FAILED: SwingUtilities.invokeAndWait method failed!");
+        }
+    }
+
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            System.out.println("LookAndFeel: " + laf.getClassName());
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored){
+            System.out.println("Unsupported LookAndFeel: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException |
+                IllegalAccessException e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
The test fails on macOS when Aqua L&F is enabled:
> Test4 works well for all our LaFs because they set symmetrical insets for the JTextField, when Aqua sets 6 points for top/bottom and 7 for left/right which breaks the testing routine with the hardcoded values. The empty border should be set for the tested JTextField.
https://bugs.openjdk.java.net/browse/JDK-7124209?focusedCommentId=12231936&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-12231936

Mixed story of this bug.

1. Initially it was found by https://bugs.openjdk.java.net/browse/JDK-7124209
   but for some reason the change for that bug missed the actual fix and just moved the test to the open repo.

2. But it did not appear as failed because it was problemlisted by the
    https://bugs.openjdk.java.net/browse/JDK-8198399
3. Recently it was de-problemlisted by the 
   https://bugs.openjdk.java.net/browse/JDK-8254976
4. But the check via mach5 missed this issue, becouse on the headless systems default L&F is Metal not Aqua.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8015602](https://bugs.openjdk.java.net/browse/JDK-8015602): [macosx] Test javax/swing/SpringLayout/4726194/bug4726194.java fails on MacOSX


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/872/head:pull/872`
`$ git checkout pull/872`
