### PR TITLE
8171998: javax/swing/JMenu/4692443/bug4692443.java fails on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -805,7 +805,6 @@ javax/swing/JPopupMenu/4458079/bug4458079.java 8233556 macosx-all
 javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8233637 macosx-all
 javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
 javax/swing/JMenuItem/4171437/bug4171437.java 8233641 macosx-all
-javax/swing/JMenu/4692443/bug4692443.java 8171998 macosx-all
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all

--- a/test/jdk/javax/swing/JMenu/4692443/bug4692443.java
+++ b/test/jdk/javax/swing/JMenu/4692443/bug4692443.java
@@ -50,6 +50,7 @@ public class bug4692443 {
             pass = new PassedListener();
             passed = false;
             Robot robo = new Robot();
+            robo.setAutoDelay(100);
 
             SwingUtilities.invokeAndWait(new Runnable() {
                 public void run() {
@@ -58,9 +59,9 @@ public class bug4692443 {
             });
 
             robo.waitForIdle();
+            robo.delay(1000);
 
             int altKey = java.awt.event.KeyEvent.VK_ALT;
-            robo.setAutoDelay(100);
             Util.hitMnemonics(robo, KeyEvent.VK_F); // Enter File menu
             robo.keyPress(KeyEvent.VK_S);  // Enter submenu
             robo.keyRelease(KeyEvent.VK_S);
@@ -78,6 +79,7 @@ public class bug4692443 {
              if (mainFrame != null) SwingUtilities.invokeAndWait(() -> mainFrame.dispose());
         }
     }
+
 
     private static void createAndShowGUI() {
         mainFrame = new JFrame("Bug 4692443");
@@ -109,7 +111,7 @@ public class bug4692443 {
         mainFrame.setJMenuBar(mbar);
 
         mainFrame.setSize(200, 200);
-        mainFrame.setLocation(200, 200);
+        mainFrame.setLocationRelativeTo(null);
         mainFrame.setVisible(true);
         mainFrame.toFront();
     }


### PR DESCRIPTION
Please review a test fix for an issue seen to be failing in mach5 testing. Although initially the failure was reported on windows, it is problemlisted only for mac.
It seems to be a timing issue resulting in failure in mach5 macos systems so added a delay after the frame setVisible is called. Also, moved the frame to centre of screen to be consistent with other tests.
Mach5 job has been run for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8171998](https://bugs.openjdk.java.net/browse/JDK-8171998): javax/swing/JMenu/4692443/bug4692443.java fails on Windows


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/873/head:pull/873`
`$ git checkout pull/873`
