### PR TITLE
JDK-8255450: runtime/ThreadCountLimit.java causes high system load

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -307,6 +307,7 @@ tier1_runtime = \
  -runtime/cds/CdsSameObjectAlignment.java \
  -runtime/cds/SharedBaseAddress.java \
  -runtime/Thread/CancellableThreadTest.java \
+ -runtime/Thread/ThreadCountLimit.java \
  -runtime/Thread/TestThreadDumpMonitorContention.java \
  -runtime/Unsafe/RangeCheck.java \
   sanity/ \

--- a/test/hotspot/jtreg/runtime/Thread/ThreadCountLimit.java
+++ b/test/hotspot/jtreg/runtime/Thread/ThreadCountLimit.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @summary Stress test that reaches the process limit for thread count, or time limit.
+ * @key stress
  * @run main ThreadCountLimit
  */
 


### PR DESCRIPTION
Hi,

this is rather trivial:

runtime/ThreadCountLimit.java, introduced with JDK-8222671, caused problems on our test machines (JDK-8222671 is private and cannot be accessed from outside Oracle, so all I know comes from its review thread [1]).

The test creates massive amount of threads in order to hit some OS limit which would manifest as an OOM. This affects unrelated processes, unless the test is executed in a jail or with specific limits set.

This test probably should be executed with a specific limit, but for now lets mark it as @stress and remove it from tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ⏳ (1/9 running) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255450](https://bugs.openjdk.java.net/browse/JDK-8255450): runtime/ThreadCountLimit.java causes high system load


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/876/head:pull/876`
`$ git checkout pull/876`
