### PR TITLE
8007632: DES/3DES keys support in PKCS12 keystore

### DIFF
--- a/src/java.base/share/classes/sun/security/util/KnownOIDs.java
+++ b/src/java.base/share/classes/sun/security/util/KnownOIDs.java
@@ -353,8 +353,6 @@ public enum KnownOIDs {
     // OIW secsig 1.3.14.3.*
     OIW_DES_CBC("1.3.14.3.2.7", "DES/CBC", "DES"),
 
-    DESede("1.3.14.3.2.17", "DESede"),
-
     OIW_DSA("1.3.14.3.2.12", "DSA") {
         @Override
         boolean registerNames() { return false; }
@@ -369,6 +367,8 @@ public enum KnownOIDs {
         @Override
         boolean registerNames() { return false; }
     },
+
+    DESede("1.3.14.3.2.17", "DESede"),
 
     SHA_1("1.3.14.3.2.26", "SHA-1", "SHA", "SHA1"),
 

--- a/src/java.base/share/classes/sun/security/util/KnownOIDs.java
+++ b/src/java.base/share/classes/sun/security/util/KnownOIDs.java
@@ -351,8 +351,7 @@ public enum KnownOIDs {
     ECDH("1.3.132.1.12"),
 
     // OIW secsig 1.3.14.3.*
-    OIW_DES_CBC("1.3.14.3.2.7", "DES/CBC"),
-    OIW_DES_ECB("1.3.14.3.2.6", "DES/ECB", "DES"),
+    OIW_DES_CBC("1.3.14.3.2.7", "DES/CBC", "DES"),
 
     DESede("1.3.14.3.2.17", "DESede"),
 

--- a/src/java.base/share/classes/sun/security/util/KnownOIDs.java
+++ b/src/java.base/share/classes/sun/security/util/KnownOIDs.java
@@ -352,6 +352,9 @@ public enum KnownOIDs {
 
     // OIW secsig 1.3.14.3.*
     OIW_DES_CBC("1.3.14.3.2.7", "DES/CBC"),
+    OIW_DES_ECB("1.3.14.3.2.6", "DES/ECB", "DES"),
+
+    DESede("1.3.14.3.2.17", "DESede"),
 
     OIW_DSA("1.3.14.3.2.12", "DSA") {
         @Override

--- a/test/jdk/sun/security/pkcs12/P12SecretKey.java
+++ b/test/jdk/sun/security/pkcs12/P12SecretKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,11 @@
 
 /*
  * @test
- * @bug 8149411
+ * @bug 8149411 8007632
  * @summary Get AES key from keystore (uses SecretKeySpec not SecretKeyFactory)
+ * @run main P12SecretKey pkcs12 AES 128
+ * @run main P12SecretKey pkcs12 DES 56
+ * @run main P12SecretKey pkcs12 DESede 168
  */
 
 import java.io.File;
@@ -43,20 +46,19 @@ public class P12SecretKey {
 
     public static void main(String[] args) throws Exception {
         P12SecretKey testp12 = new P12SecretKey();
-        String keystoreType = "pkcs12";
-        if (args != null && args.length > 0) {
-            keystoreType = args[0];
-        }
-        testp12.run(keystoreType);
+        String keystoreType = args[0];
+        String algName = args[1];
+        int keySize = Integer.parseInt(args[2]);
+        testp12.run(keystoreType, algName, keySize);
     }
 
-    private void run(String keystoreType) throws Exception {
+    private void run(String keystoreType, String algName, int keySize) throws Exception {
         char[] pw = "password".toCharArray();
         KeyStore ks = KeyStore.getInstance(keystoreType);
         ks.load(null, pw);
 
-        KeyGenerator kg = KeyGenerator.getInstance("AES");
-        kg.init(128);
+        KeyGenerator kg = KeyGenerator.getInstance(algName);
+        kg.init(keySize);
         SecretKey key = kg.generateKey();
 
         KeyStore.SecretKeyEntry ske = new KeyStore.SecretKeyEntry(key);


### PR DESCRIPTION
Hi All,

DES and DESede keys are supported by JKS/JCEKS but not supported by PKCS#12 keystores.
This issue prevents the migration of legacy applications to PKCS#12 keystore. For example, an application has some old 3DES keys that are required for certain legacy features. Java PKCS12 keystore does not support DES/3DES keys, thus, application can’t migrate to PKCS#12
This patch adds OIDs for the DES/DESede algorithms. It is the only changes required to support DES/3DES keys in the PKCS#12 keystore.
sun/security/pkcs12/P12SecretKey test is updated to verify new secret keys in the PKCS#12 keystore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (7/9 running) |    |  ⏳ (9/9 running) |

### Issue
 * [JDK-8007632](https://bugs.openjdk.java.net/browse/JDK-8007632): DES/3DES keys support in PKCS12 keystore


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/877/head:pull/877`
`$ git checkout pull/877`
