### PR TITLE
8255449: Improve the exception message of MethodHandles::permuteArguments

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -4739,23 +4739,24 @@ assert((int)twice.invokeExact(21) == 42);
         if (newType.returnType() != oldType.returnType())
             throw newIllegalArgumentException("return types do not match",
                     oldType, newType);
-        if (reorder.length == oldType.parameterCount()) {
-            int limit = newType.parameterCount();
-            boolean bad = false;
-            for (int j = 0; j < reorder.length; j++) {
-                int i = reorder[j];
-                if (i < 0 || i >= limit) {
-                    bad = true; break;
-                }
-                Class<?> src = newType.parameterType(i);
-                Class<?> dst = oldType.parameterType(j);
-                if (src != dst)
-                    throw newIllegalArgumentException("parameter types do not match after reorder",
-                            oldType, newType);
+        if (reorder.length != oldType.parameterCount())
+            throw newIllegalArgumentException("old type parameter count and reorder array length do not match",
+                    oldType, Arrays.toString(reorder));
+
+        int limit = newType.parameterCount();
+        for (int j = 0; j < reorder.length; j++) {
+            int i = reorder[j];
+            if (i < 0 || i >= limit) {
+                throw newIllegalArgumentException("index is out of bounds for new type",
+                        i, newType);
             }
-            if (!bad)  return true;
+            Class<?> src = newType.parameterType(i);
+            Class<?> dst = oldType.parameterType(j);
+            if (src != dst)
+                throw newIllegalArgumentException("parameter types do not match after reorder",
+                        oldType, newType);
         }
-        throw newIllegalArgumentException("bad reorder array: "+Arrays.toString(reorder));
+        return true;
     }
 
     /**

--- a/test/jdk/java/lang/invoke/MethodHandlesPermuteArgumentsTest.java
+++ b/test/jdk/java/lang/invoke/MethodHandlesPermuteArgumentsTest.java
@@ -44,7 +44,7 @@ import java.util.Arrays;
 
 import static org.junit.Assert.*;
 
-public class MethodHandlesPermuteArgumentsTest extends MethodHandlesTest {
+public class MethodHandlesPermuteArgumentsTest extends test.java.lang.invoke.MethodHandlesTest {
 
     @Test // SLOW
     public void testPermuteArguments() throws Throwable {
@@ -58,6 +58,11 @@ public class MethodHandlesPermuteArgumentsTest extends MethodHandlesTest {
         if (CAN_TEST_LIGHTLY)  return;
         testPermuteArguments(4, Integer.class, 2, String.class, 0);
         testPermuteArguments(6, Integer.class, 0, null, 30);
+
+        testBadReorderArrayLength();
+        testBadReorderIndex();
+        testReturnTypeMismatch();
+        testReorderTypeMismatch();
     }
 
     public void testPermuteArguments(int max, Class<?> type1, int t2c, Class<?> type2, int dilution) throws Throwable {
@@ -190,5 +195,57 @@ public class MethodHandlesPermuteArgumentsTest extends MethodHandlesTest {
             System.out.println("bad args:  "+result);
         }
         assertEquals(expected, result);
+    }
+
+    public void testBadReorderArrayLength() throws Throwable {
+        MethodHandle mh = MethodHandles.empty(MethodType.methodType(void.class, int.class, int.class, String.class));
+        MethodType newType = MethodType.methodType(void.class, int.class, String.class);
+        assertThrows(() -> MethodHandles.permuteArguments(mh, newType, 0, 1),
+                IllegalArgumentException.class, ".*old type parameter count and reorder array length do not match.*");
+    }
+
+    public void testBadReorderIndex() throws Throwable {
+        MethodHandle mh = MethodHandles.empty(MethodType.methodType(void.class, int.class, int.class, String.class));
+        MethodType newType = MethodType.methodType(void.class, int.class, String.class);
+        assertThrows(() -> MethodHandles.permuteArguments(mh, newType, 0, 0, 2),
+                IllegalArgumentException.class, ".*index is out of bounds for new type.*");
+        assertThrows(() -> MethodHandles.permuteArguments(mh, newType, 0, 0, -1),
+                IllegalArgumentException.class, ".*index is out of bounds for new type.*");
+    }
+
+    public void testReturnTypeMismatch() throws Throwable {
+        MethodHandle mh = MethodHandles.empty(MethodType.methodType(void.class, int.class, int.class, String.class));
+        MethodType newType = MethodType.methodType(int.class, int.class, String.class);
+        assertThrows(() -> MethodHandles.permuteArguments(mh, newType, 0, 0, 1),
+                IllegalArgumentException.class, ".*return types do not match.*");
+    }
+
+    public void testReorderTypeMismatch() throws Throwable {
+        MethodHandle mh = MethodHandles.empty(MethodType.methodType(void.class, int.class, int.class, String.class));
+        MethodType newType = MethodType.methodType(void.class, double.class, String.class);
+        assertThrows(() -> MethodHandles.permuteArguments(mh, newType, 0, 0, 1),
+                IllegalArgumentException.class, ".*parameter types do not match after reorder.*");
+    }
+
+    private interface RunnableX {
+        void run() throws Throwable;
+    }
+
+    private static void assertThrows(RunnableX r, Class<?> exceptionClass, String messagePattern) throws Throwable {
+        try {
+            r.run();
+        } catch (Throwable e) {
+            if (exceptionClass.isInstance(e)) {
+                assertMatches(e.getMessage(), messagePattern);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    private static void assertMatches(String str, String pattern) {
+        if (!str.matches(pattern)) {
+            throw new AssertionError("'" + str + "' did not match the pattern '" + pattern + "'.");
+        }
     }
 }

--- a/test/jdk/java/lang/invoke/MethodHandlesPermuteArgumentsTest.java
+++ b/test/jdk/java/lang/invoke/MethodHandlesPermuteArgumentsTest.java
@@ -234,6 +234,7 @@ public class MethodHandlesPermuteArgumentsTest extends test.java.lang.invoke.Met
     private static void assertThrows(RunnableX r, Class<?> exceptionClass, String messagePattern) throws Throwable {
         try {
             r.run();
+            fail("Exception expected");
         } catch (Throwable e) {
             if (exceptionClass.isInstance(e)) {
                 assertMatches(e.getMessage(), messagePattern);


### PR DESCRIPTION
Hi,

Currently, if MethodHandles::permuteArguments is used with a reorder array that is the wrong size, or one of the indexes in it is out of bounds of the new type, we simply get the exception message:

    bad reorder array [...]

I think we can improve the exception message by splitting these two error cases, and saying in the message exactly what went wrong.

permuteArguments is a tricky API, so improving the error message here should help to improve developer productivity.

This PR proposes splits the error message into e.g.:

    old type parameter count and reorder array length do not match: (int,int,String)int, [0, 0]

For an incorrect reorder array length, and:

    index is out of bounds for new type: 2, (int,String)int

For an out of bounds index.

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (1/9 failed) |

**Failed test task**
- [macOS x64 (hs/tier1 gc)](https://github.com/JornVernee/jdk/runs/1321553024)

### Issue
 * [JDK-8255449](https://bugs.openjdk.java.net/browse/JDK-8255449): Improve the exception message of MethodHandles::permuteArguments


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/878/head:pull/878`
`$ git checkout pull/878`
