### PR TITLE
8255394: jdk/test/lib/hexdump/ASN1FormatterTest.java fails with ---illegal-access=deny

### DIFF
--- a/test/lib-test/jdk/test/lib/hexdump/ASN1FormatterTest.java
+++ b/test/lib-test/jdk/test/lib/hexdump/ASN1FormatterTest.java
@@ -39,6 +39,7 @@ import static org.testng.Assert.*;
 /*
  * @test
  * @summary ASN.1 formatting
+ * @modules java.base/sun.security.util:open
  * @library /test/lib
  * @compile ASN1FormatterTest.java
  * @run testng jdk.test.lib.hexdump.ASN1FormatterTest

--- a/test/lib-test/jdk/test/lib/hexdump/ASN1FormatterTest.java
+++ b/test/lib-test/jdk/test/lib/hexdump/ASN1FormatterTest.java
@@ -39,7 +39,7 @@ import static org.testng.Assert.*;
 /*
  * @test
  * @summary ASN.1 formatting
- * @modules java.base/sun.security.util:open
+ * @modules java.base/sun.security.util
  * @library /test/lib
  * @compile ASN1FormatterTest.java
  * @run testng jdk.test.lib.hexdump.ASN1FormatterTest

--- a/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
+++ b/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
@@ -412,7 +412,6 @@ public class ASN1Formatter implements HexPrinter.Formatter {
             // Look up the OID; if the class is not accessible just return the numeric form
             Class<?> cl = Class.forName("sun.security.util.KnownOIDs");
             Method findMatch = cl.getDeclaredMethod("findMatch", String.class);
-            findMatch.setAccessible(true);
             Object oid = findMatch.invoke(null, noid);
             return (oid == null) ? noid : noid + " (" + oid.toString() + ")";
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {


### PR DESCRIPTION
To access the internal security APIs to lookup known OIDs the test needs to open java.base/sun.security.util.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ❌ (1/2 failed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |    | 

**Failed test task**
- [macOS x64 (build release)](https://github.com/RogerRiggs/jdk/runs/1315687419)

### Issue
 * [JDK-8255394](https://bugs.openjdk.java.net/browse/JDK-8255394): jdk/test/lib/hexdump/ASN1FormatterTest.java fails with ---illegal-access=deny


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/881/head:pull/881`
`$ git checkout pull/881`
