### PR TITLE
8233556: [TESTBUG] JPopupMenu tests fail on MacOS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -823,10 +823,7 @@ javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java 8233555 macosx-all
 javax/swing/JRadioButton/8075609/bug8075609.java 8233555 macosx-all
 javax/swing/JRadioButton/8033699/bug8033699.java 8233555 macosx-all
-javax/swing/JPopupMenu/6827786/bug6827786.java 8233556 macosx-all
-javax/swing/JPopupMenu/6544309/bug6544309.java 8233556 macosx-all
-javax/swing/JPopupMenu/4634626/bug4634626.java 8233556 macosx-all
-javax/swing/JPopupMenu/4458079/bug4458079.java 8233556 macosx-all
+javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
 javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8233637 macosx-all
 javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
 javax/swing/JMenuItem/4171437/bug4171437.java 8233641 macosx-all

--- a/test/jdk/javax/swing/JPopupMenu/4458079/bug4458079.java
+++ b/test/jdk/javax/swing/JPopupMenu/4458079/bug4458079.java
@@ -44,9 +44,10 @@ public class bug4458079 extends JFrame implements PopupMenuListener {
     static volatile boolean itemASelected = false;
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
-        robot.waitForIdle();
+        robot.setAutoDelay(100);
         // move mouse outside menu to prevent auto selection
         robot.mouseMove(100,100);
+        robot.waitForIdle();
 
         SwingUtilities.invokeAndWait(new Runnable() {
             public void run() {
@@ -54,18 +55,16 @@ public class bug4458079 extends JFrame implements PopupMenuListener {
             }
         });
 
-        robot.setAutoDelay(50);
-
+        robot.waitForIdle();
+        robot.delay(1000);
         Util.hitMnemonics(robot, KeyEvent.VK_M);
 
         robot.waitForIdle();
-        Thread.sleep(1000);
 
         Util.hitKeys(robot, KeyEvent.VK_DOWN);
         Util.hitKeys(robot, KeyEvent.VK_ENTER);
 
         robot.waitForIdle();
-        Thread.sleep(1000);
 
         if (!itemASelected) {
             throw new RuntimeException("Test failed: arrow key traversal in JMenu broken!");

--- a/test/jdk/javax/swing/JPopupMenu/6544309/bug6544309.java
+++ b/test/jdk/javax/swing/JPopupMenu/6544309/bug6544309.java
@@ -22,16 +22,13 @@
  */
 /*
    @test
-  @key headful
+   @key headful
    @bug 6544309
    @summary Checks that 'Select Input Method' popup menu allows to select
             items with keyboard.
-   @author Mikhail Lapshin
-   @library /lib/client
-   @build ExtendedRobot
    @run main bug6544309
 */
-
+import java.awt.Robot;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -44,12 +41,15 @@ import javax.swing.SwingUtilities;
 public class bug6544309 {
     private JDialog dialog;
     private boolean passed;
-    private static ExtendedRobot robot;
+    private static Robot robot;
 
     public static void main(String[] args) throws Exception {
-        robot = new ExtendedRobot();
+        robot = new Robot();
+        robot.setAutoDelay(100);
         // move mouse outside menu to prevent auto selection
         robot.mouseMove(100,100);
+        robot.waitForIdle();
+
         final bug6544309 test = new bug6544309();
         try {
             SwingUtilities.invokeAndWait(new Runnable() {
@@ -57,6 +57,8 @@ public class bug6544309 {
                     test.setupUI();
                 }
             });
+            robot.waitForIdle();
+            robot.delay(1000);
             test.test();
             System.out.println("Test passed");
         } finally {
@@ -95,13 +97,16 @@ public class bug6544309 {
     private void testImpl() throws Exception {
         robot.waitForIdle();
         System.out.println("Pressing DOWN ARROW");
-        robot.type(KeyEvent.VK_DOWN);
+        robot.keyPress(KeyEvent.VK_DOWN);
+        robot.keyRelease(KeyEvent.VK_DOWN);
         robot.waitForIdle();
         System.out.println("Pressing DOWN ARROW");
-        robot.type(KeyEvent.VK_DOWN);
+        robot.keyPress(KeyEvent.VK_DOWN);
+        robot.keyRelease(KeyEvent.VK_DOWN);
         robot.waitForIdle();
         System.out.println("Pressing SPACE");
-        robot.type(KeyEvent.VK_SPACE);
+        robot.keyPress(KeyEvent.VK_SPACE);
+        robot.keyRelease(KeyEvent.VK_SPACE);
     }
 
     private void checkResult() {

--- a/test/jdk/javax/swing/JPopupMenu/6827786/bug6827786.java
+++ b/test/jdk/javax/swing/JPopupMenu/6827786/bug6827786.java
@@ -49,9 +49,10 @@ public class bug6827786 {
     public static void main(String[] args) throws Exception {
         try {
             Robot robot = new Robot();
-            robot.setAutoDelay(50);
+            robot.setAutoDelay(100);
             // move mouse outside menu to prevent auto selection
-           robot.mouseMove(100,100);
+            robot.mouseMove(100,100);
+            robot.waitForIdle();
 
             SwingUtilities.invokeAndWait(new Runnable() {
 
@@ -61,6 +62,7 @@ public class bug6827786 {
             });
 
             robot.waitForIdle();
+            robot.delay(1000);
 
             SwingUtilities.invokeAndWait(new Runnable() {
 


### PR DESCRIPTION
Please review test fix for issue seen to be failing in mach5 testing on macos.
The tests issue are not reproducible locally so it seems to be timing issue on slower mach5 macos systems.
Adjusted the timing issues in these tests by using waitForIdle, delay and also uses Robot instead of ExtendedRobot which allows us to set autoDelay to more consistent 100ms.
Also, corrected the bugid of JPopupMenu/4634626

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8233556](https://bugs.openjdk.java.net/browse/JDK-8233556): [TESTBUG] JPopupMenu tests fail on MacOS


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/882/head:pull/882`
`$ git checkout pull/882`
