### PR TITLE
8255457: Shenandoah: cleanup ShenandoahMarkTask

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.inline.hpp
@@ -133,7 +133,7 @@ inline void ShenandoahConcurrentMark::do_chunked_array_start(ShenandoahObjToScan
       assert(pushed, "overflow queue should always succeed pushing");
     }
 
-    // Split out tasks, as suggested in ObjArrayChunkedTask docs. Record the last
+    // Split out tasks, as suggested in ShenandoahMarkTask docs. Record the last
     // successful right boundary to figure out the irregular tail.
     while ((1 << pow) > (int)ObjArrayMarkingStride &&
            (chunk*2 < ShenandoahMarkTask::chunk_size())) {
@@ -166,7 +166,7 @@ inline void ShenandoahConcurrentMark::do_chunked_array(ShenandoahObjToScanQueue*
 
   assert (ObjArrayMarkingStride > 0, "sanity");
 
-  // Split out tasks, as suggested in ObjArrayChunkedTask docs. Avoid pushing tasks that
+  // Split out tasks, as suggested in ShenandoahMarkTask docs. Avoid pushing tasks that
   // are known to start beyond the array.
   while ((1 << pow) > (int)ObjArrayMarkingStride && (chunk*2 < ShenandoahMarkTask::chunk_size())) {
     pow--;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -184,14 +184,14 @@ jint ShenandoahHeap::initialize() {
   assert((((size_t) base()) & ShenandoahHeapRegion::region_size_bytes_mask()) == 0,
          "Misaligned heap: " PTR_FORMAT, p2i(base()));
 
-#if SHENANDOAH_OPTIMIZED_OBJTASK
-  // The optimized ObjArrayChunkedTask takes some bits away from the full object bits.
+#if SHENANDOAH_OPTIMIZED_MARKTASK
+  // The optimized ShenandoahMarkTask takes some bits away from the full object bits.
   // Fail if we ever attempt to address more than we can.
-  if ((uintptr_t)heap_rs.end() >= ObjArrayChunkedTask::max_addressable()) {
+  if ((uintptr_t)heap_rs.end() >= ShenandoahMarkTask::max_addressable()) {
     FormatBuffer<512> buf("Shenandoah reserved [" PTR_FORMAT ", " PTR_FORMAT") for the heap, \n"
                           "but max object address is " PTR_FORMAT ". Try to reduce heap size, or try other \n"
                           "VM options that allocate heap at lower addresses (HeapBaseMinAddress, AllocateHeapAt, etc).",
-                p2i(heap_rs.base()), p2i(heap_rs.end()), ObjArrayChunkedTask::max_addressable());
+                p2i(heap_rs.base()), p2i(heap_rs.end()), ShenandoahMarkTask::max_addressable());
     vm_exit_during_initialization("Fatal Error", buf);
   }
 #endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
@@ -60,7 +60,7 @@ private:
   E _elem;
 };
 
-// ObjArrayChunkedTask
+// ShenandoahMarkTask
 //
 // Encodes both regular oops, and the array oops plus chunking data for parallel array processing.
 // The design goal is to make the regular oop ops very fast, because that would be the prevailing
@@ -123,15 +123,17 @@ private:
 #endif
 
 #ifdef _LP64
-#define SHENANDOAH_OPTIMIZED_OBJTASK 1
+#define SHENANDOAH_OPTIMIZED_MARKTASK 1
 #else
-#define SHENANDOAH_OPTIMIZED_OBJTASK 0
+#define SHENANDOAH_OPTIMIZED_MARKTASK 0
 #endif
 
-#if SHENANDOAH_OPTIMIZED_OBJTASK
-class ObjArrayChunkedTask
+#if SHENANDOAH_OPTIMIZED_MARKTASK
+class ShenandoahMarkTask
 {
-public:
+private:
+  uintptr_t _obj;
+
   enum {
     chunk_bits   = 10,
     pow_bits     = 5,
@@ -143,22 +145,10 @@ public:
     chunk_shift  = pow_shift + pow_bits
   };
 
-public:
-  ObjArrayChunkedTask(oop o = NULL) {
-    assert(decode_oop(encode_oop(o)) ==  o, "oop can be encoded: " PTR_FORMAT, p2i(o));
-    _obj = encode_oop(o);
-  }
-  ObjArrayChunkedTask(oop o, int chunk, int pow) {
-    assert(decode_oop(encode_oop(o)) == o, "oop can be encoded: " PTR_FORMAT, p2i(o));
-    assert(decode_chunk(encode_chunk(chunk)) == chunk, "chunk can be encoded: %d", chunk);
-    assert(decode_pow(encode_pow(pow)) == pow, "pow can be encoded: %d", pow);
-    _obj = encode_oop(o) | encode_chunk(chunk) | encode_pow(pow);
-  }
-
-  // Trivially copyable.
+  static const uintptr_t oop_decode_mask = right_n_bits(oop_bits) - 3;
 
   inline oop decode_oop(uintptr_t val) const {
-    return (oop) reinterpret_cast<void*>((val >> oop_shift) & right_n_bits(oop_bits));
+    return (oop) reinterpret_cast<void*>((val >> oop_shift) & oop_decode_mask);
   }
 
   inline int decode_chunk(uintptr_t val) const {
@@ -169,8 +159,12 @@ public:
     return (int) ((val >> pow_shift) & right_n_bits(pow_bits));
   }
 
+  inline bool decode_not_chunked(uintptr_t val) const {
+    return (val & ~right_n_bits(oop_bits + pow_bits)) == 0;
+  }
+
   inline uintptr_t encode_oop(oop obj) const {
-    return ((uintptr_t)(void*) obj) << oop_shift;
+    return ((uintptr_t) (void *) obj) << oop_shift;
   }
 
   inline uintptr_t encode_chunk(int chunk) const {
@@ -181,12 +175,42 @@ public:
     return ((uintptr_t) pow) << pow_shift;
   }
 
-  inline oop obj()   const { return decode_oop(_obj);   }
-  inline int chunk() const { return decode_chunk(_obj); }
-  inline int pow()   const { return decode_pow(_obj);   }
-  inline bool is_not_chunked() const { return (_obj & ~right_n_bits(oop_bits + pow_bits)) == 0; }
+public:
+  ShenandoahMarkTask(oop o = NULL) {
+    uintptr_t enc = encode_oop(o);
+    assert(decode_oop(enc) == o,
+           "oop encoding should work: " PTR_FORMAT, p2i(o));
+    assert(decode_not_chunked(enc),
+           "task should not be chunked");
+    _obj = enc;
+  }
 
-  DEBUG_ONLY(bool is_valid() const); // Tasks to be pushed/popped must be valid.
+  ShenandoahMarkTask(oop o, int chunk, int pow) {
+    uintptr_t enc_oop = encode_oop(o);
+    uintptr_t enc_chunk = encode_chunk(chunk);
+    uintptr_t enc_pow = encode_pow(pow);
+    uintptr_t enc = enc_oop | enc_chunk | enc_pow;
+    assert(decode_oop(enc) == o,
+           "oop encoding should work: " PTR_FORMAT, p2i(o));
+    assert(decode_chunk(enc) == chunk,
+           "chunk encoding should work: %d", chunk);
+    assert(decode_pow(enc) == pow,
+           "pow encoding should work: %d", pow);
+    assert(!decode_not_chunked(enc),
+           "task should be chunked");
+    _obj = enc;
+  }
+
+  // Trivially copyable.
+
+public:
+  inline oop  obj()            const { return decode_oop(_obj);   }
+  inline int  chunk()          const { return decode_chunk(_obj); }
+  inline int  pow()            const { return decode_pow(_obj);   }
+
+  inline bool is_not_chunked() const { return decode_not_chunked(_obj); }
+
+  DEBUG_ONLY(bool is_valid() const;) // Tasks to be pushed/popped must be valid.
 
   static uintptr_t max_addressable() {
     return nth_bit(oop_bits);
@@ -195,35 +219,35 @@ public:
   static int chunk_size() {
     return nth_bit(chunk_bits);
   }
-
-private:
-  uintptr_t _obj;
 };
 #else
-class ObjArrayChunkedTask
+class ShenandoahMarkTask
 {
-public:
+private:
   enum {
     chunk_bits  = 10,
     pow_bits    = 5,
   };
+
+  oop _obj;
+  int _chunk;
+  int _pow;
+
 public:
-  ObjArrayChunkedTask(oop o = NULL, int chunk = 0, int pow = 0): _obj(o) {
+  ShenandoahMarkTask(oop o = NULL, int chunk = 0, int pow = 0):
+    _obj(o), _chunk(chunk), _pow(pow) {
     assert(0 <= chunk && chunk < nth_bit(chunk_bits), "chunk is sane: %d", chunk);
     assert(0 <= pow && pow < nth_bit(pow_bits), "pow is sane: %d", pow);
-    _chunk = chunk;
-    _pow = pow;
   }
 
   // Trivially copyable.
 
-  inline oop obj()   const { return _obj; }
-  inline int chunk() const { return _chunk; }
-  inline int pow()  const { return _pow; }
-
+  inline oop obj()             const { return _obj; }
+  inline int chunk()           const { return _chunk; }
+  inline int pow()             const { return _pow; }
   inline bool is_not_chunked() const { return _chunk == 0; }
 
-  DEBUG_ONLY(bool is_valid() const); // Tasks to be pushed/popped must be valid.
+  DEBUG_ONLY(bool is_valid() const;) // Tasks to be pushed/popped must be valid.
 
   static size_t max_addressable() {
     return sizeof(oop);
@@ -232,19 +256,13 @@ public:
   static int chunk_size() {
     return nth_bit(chunk_bits);
   }
-
-private:
-  oop _obj;
-  int _chunk;
-  int _pow;
 };
-#endif // SHENANDOAH_OPTIMIZED_OBJTASK
+#endif // SHENANDOAH_OPTIMIZED_MARKTASK
 
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
-typedef ObjArrayChunkedTask ShenandoahMarkTask;
 typedef BufferedOverflowTaskQueue<ShenandoahMarkTask, mtGC> ShenandoahBufferedOverflowTaskQueue;
 typedef Padded<ShenandoahBufferedOverflowTaskQueue> ShenandoahObjToScanQueue;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
@@ -164,7 +164,7 @@ private:
   }
 
   inline uintptr_t encode_oop(oop obj) const {
-    return ((uintptr_t) (void *) obj) << oop_shift;
+    return ((uintptr_t)(void*) obj) << oop_shift;
   }
 
   inline uintptr_t encode_chunk(int chunk) const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
@@ -157,6 +157,7 @@ private:
   }
 
   inline bool decode_not_chunked(uintptr_t val) const {
+    // No need to shift for a comparison to zero
     return (val & chunk_pow_extract_mask) == 0;
   }
 
@@ -184,10 +185,8 @@ private:
 public:
   ShenandoahMarkTask(oop o = NULL) {
     uintptr_t enc = encode_oop(o);
-    assert(decode_oop(enc) == o,
-           "oop encoding should work: " PTR_FORMAT, p2i(o));
-    assert(decode_not_chunked(enc),
-           "task should not be chunked");
+    assert(decode_oop(enc) == o,    "oop encoding should work: " PTR_FORMAT, p2i(o));
+    assert(decode_not_chunked(enc), "task should not be chunked");
     _obj = enc;
   }
 
@@ -196,14 +195,10 @@ public:
     uintptr_t enc_chunk = encode_chunk(chunk);
     uintptr_t enc_pow = encode_pow(pow);
     uintptr_t enc = enc_oop | enc_chunk | enc_pow;
-    assert(decode_oop(enc) == o,
-           "oop encoding should work: " PTR_FORMAT, p2i(o));
-    assert(decode_chunk(enc) == chunk,
-           "chunk encoding should work: %d", chunk);
-    assert(decode_pow(enc) == pow,
-           "pow encoding should work: %d", pow);
-    assert(!decode_not_chunked(enc),
-           "task should be chunked");
+    assert(decode_oop(enc) == o,       "oop encoding should work: " PTR_FORMAT, p2i(o));
+    assert(decode_chunk(enc) == chunk, "chunk encoding should work: %d", chunk);
+    assert(decode_pow(enc) == pow,     "pow encoding should work: %d", pow);
+    assert(!decode_not_chunked(enc),   "task should be chunked");
     _obj = enc;
   }
 


### PR DESCRIPTION
The code in ObjArrayChunkedTask is rough around the edges, and can be cleaned up. It would be further extended in JDK-8254315, so it makes sense to make the change before the bulk of JDK-8254315 arrives.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x86 (hs/tier1 gc)](https://github.com/shipilev/jdk/runs/1316878597)

### Issue
 * [JDK-8255457](https://bugs.openjdk.java.net/browse/JDK-8255457): Shenandoah: cleanup ShenandoahMarkTask


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/883/head:pull/883`
`$ git checkout pull/883`
