### PR TITLE
8243583: Change 'final' error checks to throw ICCE

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4438,13 +4438,7 @@ void ClassFileParser::check_super_class_access(const InstanceKlass* this_klass, 
     const InstanceKlass* super_ik = InstanceKlass::cast(super);
 
     if (super->is_final()) {
-      ResourceMark rm(THREAD);
-      Exceptions::fthrow(
-        THREAD_AND_LOCATION,
-        vmSymbols::java_lang_VerifyError(),
-        "class %s cannot inherit from final class %s",
-        this_klass->external_name(),
-        super_ik->external_name());
+      classfile_icce_error("class %s cannot inherit from final class %s", super_ik, THREAD);
       return;
     }
 
@@ -4589,15 +4583,12 @@ static void check_final_method_override(const InstanceKlass* this_klass, TRAPS) 
             if (can_access) {
               // this class can access super final method and therefore override
               ResourceMark rm(THREAD);
-              Exceptions::fthrow(THREAD_AND_LOCATION,
-                                 vmSymbols::java_lang_VerifyError(),
-                                 "class %s overrides final method %s.%s%s",
-                                 this_klass->external_name(),
-                                 super_m->method_holder()->external_name(),
-                                 name->as_C_string(),
-                                 signature->as_C_string()
-                                 );
-              return;
+              THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(),
+                        err_msg("class %s overrides final method %s.%s%s",
+                                this_klass->external_name(),
+                                super_m->method_holder()->external_name(),
+                                name->as_C_string(),
+                                signature->as_C_string()));
             }
           }
 

--- a/test/hotspot/jtreg/runtime/verifier/OverriderMsg.java
+++ b/test/hotspot/jtreg/runtime/verifier/OverriderMsg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ public class OverriderMsg {
         ProcessBuilder pb = ProcessTools.createTestJvm("-cp", ".",  "Overrider");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain(
-            "java.lang.VerifyError: class Overrider overrides final method HasFinal.m(Ljava/lang/String;)V");
+            "java.lang.IncompatibleClassChangeError: class Overrider overrides final method HasFinal.m(Ljava/lang/String;)V");
         output.shouldHaveExitValue(1);
     }
 

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/anonloader/func/finalSuperclass/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/anonloader/func/finalSuperclass/TestDescription.java
@@ -30,9 +30,9 @@
  * VM Testbase keywords: [feature_mlvm]
  * VM Testbase readme:
  * DESCRIPTION
- *     Try to load anonymous class derived from java.lang.System. The verification
- *     system (split verifier and system class loader) should reject such attempt and
- *     throw VerifyError.
+ *     Try to load anonymous class derived from java.lang.System. The class file
+ *     loader should reject such attempt and throw IncompatibleClassChangeError
+ *     because java.lang.System is a final class.
  *
  * @library /vmTestbase
  *          /test/lib
@@ -44,6 +44,6 @@
  * @run main/othervm
  *      vm.mlvm.anonloader.share.ReplaceClassParentTest
  *      -newParent java/lang/System
- *      -requireExceptions java.lang.VerifyError
+ *      -requireExceptions java.lang.IncompatibleClassChangeError
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/runtime/defmeth/ObjectMethodOverridesTest.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/runtime/defmeth/ObjectMethodOverridesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ public class ObjectMethodOverridesTest extends DefMethTest {
 
         ConcreteClass C = b.clazz("C").implement(I).build();
 
-        b.test().loadClass(I).throws_(VerifyError.class).done()
+        b.test().loadClass(I).throws_(IncompatibleClassChangeError.class).done()
         .run();
     }
 
@@ -158,7 +158,7 @@ public class ObjectMethodOverridesTest extends DefMethTest {
 
         ConcreteClass C = b.clazz("C").implement(I).build();
 
-        b.test().loadClass(I).throws_(VerifyError.class).done()
+        b.test().loadClass(I).throws_(IncompatibleClassChangeError.class).done()
         .run();
     }
 
@@ -174,7 +174,7 @@ public class ObjectMethodOverridesTest extends DefMethTest {
 
         ConcreteClass C = b.clazz("C").implement(I).build();
 
-        b.test().loadClass(I).throws_(VerifyError.class).done()
+        b.test().loadClass(I).throws_(IncompatibleClassChangeError.class).done()
         .run();
     }
 
@@ -208,7 +208,7 @@ public class ObjectMethodOverridesTest extends DefMethTest {
 
         ConcreteClass C = b.clazz("C").implement(I).build();
 
-        b.test().loadClass(I).throws_(VerifyError.class).done()
+        b.test().loadClass(I).throws_(IncompatibleClassChangeError.class).done()
         .run();
     }
 
@@ -224,7 +224,7 @@ public class ObjectMethodOverridesTest extends DefMethTest {
 
         ConcreteClass C = b.clazz("C").implement(I).build();
 
-        b.test().loadClass(I).throws_(VerifyError.class).done()
+        b.test().loadClass(I).throws_(IncompatibleClassChangeError.class).done()
         .run();
     }
 
@@ -240,7 +240,7 @@ public class ObjectMethodOverridesTest extends DefMethTest {
 
         ConcreteClass C = b.clazz("C").implement(I).build();
 
-        b.test().loadClass(I).throws_(VerifyError.class).done()
+        b.test().loadClass(I).throws_(IncompatibleClassChangeError.class).done()
         .run();
     }
 }


### PR DESCRIPTION
Please review this small change to throw IncompatibleClassChangeError exceptions instead of VerifyError exceptions for attempts to override Final classes and methods, as described in https://bugs.openjdk.java.net/browse/JDK-8243582.

The fix was tested with tiers 1-2 on Linux, Mac OSX, and Windows, tiers 3-5 on Linux x64, and running the JCK lang, vm, and api tests.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8243583](https://bugs.openjdk.java.net/browse/JDK-8243583): Change 'final' error checks to throw ICCE


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/885/head:pull/885`
`$ git checkout pull/885`
