### PR TITLE
4619330: All built-in java.awt.color.ColorSpace fields should be specified as such

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
@@ -244,25 +244,25 @@ public abstract class ColorSpace implements Serializable {
 
 
     /**
-     * The sRGB color space defined at
+     * The built-in sRGB color space defined at
      * <a href="http://www.w3.org/pub/WWW/Graphics/Color/sRGB.html">
      * http://www.w3.org/pub/WWW/Graphics/Color/sRGB.html</a>.
      */
     @Native public static final int CS_sRGB = 1000;
 
     /**
-     * A built-in linear RGB color space. This space is based on the same RGB
+     * The built-in linear RGB color space. This space is based on the same RGB
      * primaries as {@code CS_sRGB}, but has a linear tone reproduction curve.
      */
     @Native public static final int CS_LINEAR_RGB = 1004;
 
     /**
-     * The CIEXYZ conversion color space defined above.
+     * The built-in CIEXYZ conversion color space defined above.
      */
     @Native public static final int CS_CIEXYZ = 1001;
 
     /**
-     * The Photo YCC conversion color space.
+     * The built-in Photo YCC conversion color space.
      */
     @Native public static final int CS_PYCC = 1002;
 


### PR DESCRIPTION
The wording for ColorSpace.CS_XXX is unified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 serviceability)](https://github.com/mrserb/jdk/runs/1317930111)

### Issue
 * [JDK-4619330](https://bugs.openjdk.java.net/browse/JDK-4619330): All built-in java.awt.color.ColorSpace fields should be specified as such


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/887/head:pull/887`
`$ git checkout pull/887`
