### PR TITLE
8253101: Clean up CallStaticJavaNode EA flags

### DIFF
--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -716,8 +716,6 @@ public:
       init_flags(Flag_is_macro);
       C->add_macro_node(this);
     }
-    _is_scalar_replaceable = false;
-    _is_non_escaping = false;
   }
   CallStaticJavaNode(const TypeFunc* tf, address addr, const char* name, int bci,
                      const TypePtr* adr_type)
@@ -725,14 +723,8 @@ public:
     init_class_id(Class_CallStaticJava);
     // This node calls a runtime stub, which often has narrow memory effects.
     _adr_type = adr_type;
-    _is_scalar_replaceable = false;
-    _is_non_escaping = false;
     _name = name;
   }
-
-  // Result of Escape Analysis
-  bool _is_scalar_replaceable;
-  bool _is_non_escaping;
 
   // If this is an uncommon trap, return the request code, else zero.
   int uncommon_trap_request() const;

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -246,9 +246,6 @@ bool ConnectionGraph::compute_escape() {
     if (n->is_Allocate()) {
       n->as_Allocate()->_is_non_escaping = noescape;
     }
-    if (n->is_CallStaticJava()) {
-      n->as_CallStaticJava()->_is_non_escaping = noescape;
-    }
     if (noescape && ptn->scalar_replaceable()) {
       adjust_scalar_replaceable_state(ptn);
       if (ptn->scalar_replaceable()) {
@@ -3068,11 +3065,6 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
           // so it could be eliminated if it has no uses.
           alloc->as_Allocate()->_is_scalar_replaceable = true;
         }
-        if (alloc->is_CallStaticJava()) {
-          // Set the scalar_replaceable flag for boxing method
-          // so it could be eliminated if it has no uses.
-          alloc->as_CallStaticJava()->_is_scalar_replaceable = true;
-        }
         continue;
       }
       if (!n->is_CheckCastPP()) { // not unique CheckCastPP.
@@ -3120,11 +3112,6 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
         // Set the scalar_replaceable flag for allocation
         // so it could be eliminated.
         alloc->as_Allocate()->_is_scalar_replaceable = true;
-      }
-      if (alloc->is_CallStaticJava()) {
-        // Set the scalar_replaceable flag for boxing method
-        // so it could be eliminated.
-        alloc->as_CallStaticJava()->_is_scalar_replaceable = true;
       }
       set_escape_state(ptnode_adr(n->_idx), es); // CheckCastPP escape state
       // in order for an object to be scalar-replaceable, it must be:


### PR DESCRIPTION
Please review this small change to cleanup fields: _is_scalar_replaceable and _is_non_escaping from CallStaticJavaNode as well as code which assigns to those fields.

The change was tested with run-test-tier[1-3] on Linux arm64 and x86-64.

Thanks,
Jason

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253101](https://bugs.openjdk.java.net/browse/JDK-8253101): Clean up CallStaticJavaNode EA flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/889/head:pull/889`
`$ git checkout pull/889`
