### PR TITLE
8255466: C2 crashes at ciObject::get_oop() const+0x0

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3046,9 +3046,11 @@ TypeOopPtr::TypeOopPtr(TYPES t, PTR ptr, ciKlass* k, bool xk, ciObject* o, int o
         } else if (klass() == ciEnv::current()->Class_klass() &&
                    _offset >= InstanceMirrorKlass::offset_of_static_fields()) {
           // Static fields
-          assert(o != NULL, "must be constant");
-          ciInstanceKlass* k = o->as_instance()->java_lang_Class_klass()->as_instance_klass();
-          ciField* field = k->get_field_by_offset(_offset, true);
+          ciField* field = NULL;
+          if (const_oop() != NULL) {
+            ciInstanceKlass* k = const_oop()->as_instance()->java_lang_Class_klass()->as_instance_klass();
+            field = k->get_field_by_offset(_offset, true);
+          }
           if (field != NULL) {
             BasicType basic_elem_type = field->layout_type();
             _is_ptr_to_narrowoop = UseCompressedOops && is_reference_type(basic_elem_type);

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -100,7 +100,10 @@ static bool is_vector_shuffle(ciKlass* klass) {
 }
 
 static bool is_klass_initialized(const TypeInstPtr* vec_klass) {
-  assert(vec_klass->const_oop()->as_instance()->java_lang_Class_klass(), "klass instance expected");
+  if (vec_klass->const_oop() == NULL) {
+    return false; // uninitialized or some kind of unsafe access
+  }
+  assert(vec_klass->const_oop()->as_instance()->java_lang_Class_klass() != NULL, "klass instance expected");
   ciInstanceKlass* klass =  vec_klass->const_oop()->as_instance()->java_lang_Class_klass()->as_instance_klass();
   return klass->is_initialized();
 }

--- a/test/hotspot/jtreg/compiler/unsafe/TestUnsafeStaticFieldAccess.java
+++ b/test/hotspot/jtreg/compiler/unsafe/TestUnsafeStaticFieldAccess.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8255466
+ * @summary unsafe access to static field causes crash
+ * @modules java.base/jdk.internal.misc
+ *
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,TestUnsafeStaticFieldAccess::* TestUnsafeStaticFieldAccess
+ *
+ */
+
+import jdk.internal.misc.Unsafe;
+import java.lang.reflect.Field;
+
+public class TestUnsafeStaticFieldAccess {
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    private static final long offset;
+    private static volatile Class<?> clazz;
+
+    private static int field;
+
+    static {
+        long o = 0;
+        for (Field f : TestUnsafeStaticFieldAccess.class.getDeclaredFields()) {
+            if (f.getName().equals("field")) {
+                o = UNSAFE.staticFieldOffset(f);
+                break;
+            }
+        }
+        offset = o;
+        clazz = TestUnsafeStaticFieldAccess.class;
+    }
+
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 12000; i++) {
+            UNSAFE.getInt(clazz, offset);
+        }
+    }
+}


### PR DESCRIPTION
Graal testing hit this issue with product VM. Tom R. suggested that it could be the case of reflective unsafe static field access that would eventually be optimized away because the Class is null:
`if (staticFieldBase != null) {
  return Unsafe.getInt(staticFieldBase, Unsafe.staticFieldOffset(field));
}`

I suggest to replace assert with runtime check. Note, `o` value is assigned to `_const_oop` so semantically new code is the same except additional runtime check.

I also noticed that const_oop is accessed without check for NULL in new Vector API code. I added check there too.

Passed tier1-3 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255466](https://bugs.openjdk.java.net/browse/JDK-8255466): C2 crashes at ciObject::get_oop() const+0x0


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to da8be5298c8d22bf8e1b26f3d943c26091df5f76


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/890/head:pull/890`
`$ git checkout pull/890`
