### PR TITLE
8255368: Math.exp() gives wrong result for large values on x86 32-bit platforms

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86_exp.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_exp.cpp
@@ -493,7 +493,7 @@ void MacroAssembler::fast_exp(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   subl(rsp, 120);
   movl(Address(rsp, 64), tmp);
   lea(tmp, ExternalAddress(static_const_table));
-  movdqu(xmm0, Address(rsp, 128));
+  movsd(xmm0, Address(rsp, 128));
   unpcklpd(xmm0, xmm0);
   movdqu(xmm1, Address(tmp, 64));          // 0x652b82feUL, 0x40571547UL, 0x652b82feUL, 0x40571547UL
   movdqu(xmm6, Address(tmp, 48));          // 0x00000000UL, 0x43380000UL, 0x00000000UL, 0x43380000UL
@@ -585,18 +585,18 @@ void MacroAssembler::fast_exp(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   pextrw(ecx, xmm0, 3);
   andl(ecx, 32752);
   cmpl(ecx, 32752);
-  jcc(Assembler::greaterEqual, L_2TAG_PACKET_3_0_2);
+  jcc(Assembler::aboveEqual, L_2TAG_PACKET_3_0_2);
   cmpl(ecx, 0);
   jcc(Assembler::equal, L_2TAG_PACKET_4_0_2);
   jmp(L_2TAG_PACKET_2_0_2);
   cmpl(ecx, INT_MIN);
-  jcc(Assembler::less, L_2TAG_PACKET_3_0_2);
+  jcc(Assembler::below, L_2TAG_PACKET_3_0_2);
   cmpl(ecx, -1064950997);
-  jcc(Assembler::less, L_2TAG_PACKET_2_0_2);
-  jcc(Assembler::greater, L_2TAG_PACKET_4_0_2);
+  jcc(Assembler::below, L_2TAG_PACKET_2_0_2);
+  jcc(Assembler::above, L_2TAG_PACKET_4_0_2);
   movl(edx, Address(rsp, 128));
   cmpl(edx, -17155601);
-  jcc(Assembler::less, L_2TAG_PACKET_2_0_2);
+  jcc(Assembler::below, L_2TAG_PACKET_2_0_2);
   jmp(L_2TAG_PACKET_4_0_2);
 
   bind(L_2TAG_PACKET_3_0_2);
@@ -614,10 +614,10 @@ void MacroAssembler::fast_exp(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
 
   bind(L_2TAG_PACKET_7_0_2);
   cmpl(eax, 2146435072);
-  jcc(Assembler::greaterEqual, L_2TAG_PACKET_8_0_2);
+  jcc(Assembler::aboveEqual, L_2TAG_PACKET_8_0_2);
   movl(eax, Address(rsp, 132));
   cmpl(eax, INT_MIN);
-  jcc(Assembler::greaterEqual, L_2TAG_PACKET_9_0_2);
+  jcc(Assembler::aboveEqual, L_2TAG_PACKET_9_0_2);
   movsd(xmm0, Address(tmp, 1208));         // 0xffffffffUL, 0x7fefffffUL
   mulsd(xmm0, xmm0);
   movl(edx, 14);

--- a/test/jdk/java/lang/Math/ExpCornerCaseTests.java
+++ b/test/jdk/java/lang/Math/ExpCornerCaseTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011,2020 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8255368
+ * @summary Tests corner cases of Math.exp
+ */
+
+public class ExpCornerCaseTests {
+    private ExpCornerCaseTests(){}
+
+    public static void main(String... args) {
+        int failures = 0;
+
+        failures += testExpCornerCases();
+
+        if (failures > 0) {
+            System.err.printf("Testing exp corner cases incurred %d failures.%n", failures);
+            throw new RuntimeException();
+        }
+    }
+
+    private static int testExpCornerCases() {
+        int failures = 0;
+        double [][] testCases = {
+           {+0x4.0p8,                  Double.POSITIVE_INFINITY},
+           {+0x2.71p12,                Double.POSITIVE_INFINITY},
+         };
+
+        for (double[] testCase : testCases) {
+            failures += testExp(testCase[0], testCase[1]);
+        }
+
+        return failures;
+    }
+
+    private static int testExp(double input, double expected) {
+        int failures = 0;
+        failures += Tests.test("StrictMath.exp", input, StrictMath.exp(input), expected);
+        failures += Tests.test("Math.exp", input, Math.exp(input), expected);
+        return failures;
+    }
+}

--- a/test/jdk/java/lang/Math/ExpCornerCaseTests.java
+++ b/test/jdk/java/lang/Math/ExpCornerCaseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011,2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011,2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Math.exp(10000) produces 0 instead of positive infinity on x86 32-bit platform. The reason was for some jmp instructions, it used jge instead of jae. Also changed movdqu to movsd as it was supposed to load a 64-bit number

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255368](https://bugs.openjdk.java.net/browse/JDK-8255368): Math.exp() gives wrong result for large values on x86 32-bit platforms


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to b23c8cba070572ddd8ed4802bd7a9112f42e5a76
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/894/head:pull/894`
`$ git checkout pull/894`
