### PR TITLE
8233570: [TESTBUG] HTMLEditorKit test bug5043626.java is failing on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -787,7 +787,6 @@ javax/swing/ToolTipManager/Test6256140.java 8233560 macosx-all
 javax/swing/text/View/8014863/bug8014863.java 8233561 macosx-all
 javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233562 macosx-all
 javax/swing/text/JTextComponent/6361367/bug6361367.java 8233569 macosx-all
-javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java 233570 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java 8233555 macosx-all
 javax/swing/JRadioButton/8075609/bug8075609.java 8233555 macosx-all

--- a/test/jdk/javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java
+++ b/test/jdk/javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java
@@ -43,7 +43,7 @@ public class bug5043626 {
     private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
-	try {
+        try {
             robot = new Robot();
             robot.setAutoDelay(100);
 
@@ -64,7 +64,7 @@ public class bug5043626 {
             robot.waitForIdle();
 
             String test = getText();
- 
+
             if (!"1test".equals(test)) {
                 throw new RuntimeException("Begin line action set cursor inside <head> tag");
             }
@@ -77,15 +77,15 @@ public class bug5043626 {
             robot.waitForIdle();
 
             test = getText();
- 
+
             if (!"21test".equals(test)) {
                 throw new RuntimeException("Begin action set cursor inside <head> tag");
             }
-	} finally {
+        } finally {
             if (frame != null) {
                 SwingUtilities.invokeAndWait(frame::dispose);
-	    }
-	}
+            }
+        }
     }
 
     private static String getText() throws Exception {

--- a/test/jdk/javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java
+++ b/test/jdk/javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java
@@ -26,9 +26,6 @@
  * @key headful
  * @bug 5043626
  * @summary  Tests pressing Home or Ctrl+Home set cursor to invisible element <head>
- * @author Alexander Potochkin
- * @library ../../../../regtesthelpers
- * @build Util
  * @run main bug5043626
  */
 
@@ -43,39 +40,52 @@ public class bug5043626 {
 
     private static Document doc;
     private static Robot robot;
+    private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
-        robot = new Robot();
+	try {
+            robot = new Robot();
+            robot.setAutoDelay(100);
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                createAndShowGUI();
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    createAndShowGUI();
+                }
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            robot.keyPress(KeyEvent.VK_HOME);
+            robot.keyRelease(KeyEvent.VK_HOME);
+            robot.keyPress(KeyEvent.VK_1);
+            robot.keyRelease(KeyEvent.VK_1);
+
+            robot.waitForIdle();
+
+            String test = getText();
+ 
+            if (!"1test".equals(test)) {
+                throw new RuntimeException("Begin line action set cursor inside <head> tag");
             }
-        });
 
-        robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_HOME);
+            robot.keyRelease(KeyEvent.VK_HOME);
+            robot.keyPress(KeyEvent.VK_2);
+            robot.keyRelease(KeyEvent.VK_2);
 
-        Util.hitKeys(robot, KeyEvent.VK_HOME);
-        Util.hitKeys(robot, KeyEvent.VK_1);
+            robot.waitForIdle();
 
-        robot.waitForIdle();
-
-        String test = getText();
-
-        if (!"1test".equals(test)) {
-            throw new RuntimeException("Begin line action set cursor inside <head> tag");
-        }
-
-        Util.hitKeys(robot, KeyEvent.VK_HOME);
-        Util.hitKeys(robot, KeyEvent.VK_2);
-
-        robot.waitForIdle();
-
-        test = getText();
-
-        if (!"21test".equals(test)) {
-            throw new RuntimeException("Begin action set cursor inside <head> tag");
-        }
+            test = getText();
+ 
+            if (!"21test".equals(test)) {
+                throw new RuntimeException("Begin action set cursor inside <head> tag");
+            }
+	} finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
+	    }
+	}
     }
 
     private static String getText() throws Exception {
@@ -95,7 +105,7 @@ public class bug5043626 {
     }
 
     private static void createAndShowGUI() {
-        JFrame frame = new JFrame();
+        frame = new JFrame();
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
         JEditorPane editorPane = new JEditorPane();
@@ -104,6 +114,7 @@ public class bug5043626 {
         editorPane.setEditable(true);
         frame.add(editorPane);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
         doc = editorPane.getDocument();
         editorPane.setCaretPosition(doc.getLength());


### PR DESCRIPTION
Please review a test fix for an issue seen to be failing on mach5 systems due to timing issue, which is not reproducible locally.
Modified the test to use setAutoDelay(), delay() after frame is made visible and also moved the frame to centre of screen. Removed the dependancy of Util class and also finally dispose of the frame.
Mach5 job has been run for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8233570](https://bugs.openjdk.java.net/browse/JDK-8233570): [TESTBUG] HTMLEditorKit test bug5043626.java is failing on macos


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/896/head:pull/896`
`$ git checkout pull/896`
