### PR TITLE
8255526: Enable jcheck whitespace checking of build system files

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -15,6 +15,7 @@ domain=openjdk.org
 
 [checks "whitespace"]
 files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java|.*\.cc|.*\.hh|.*\.m|.*\.mm|.*\.gmk|.*\.m4|.*\.ac|Makefile
+ignore-tabs=.*\.gmk|Makefile
 
 [checks "merge"]
 message=Merge

--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -14,7 +14,7 @@ version=0
 domain=openjdk.org
 
 [checks "whitespace"]
-files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java|.*\.cc|.*\.hh|.*\.m|.*\.mm
+files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java|.*\.cc|.*\.hh|.*\.m|.*\.mm|.*\.gmk|.*\.m4|.*\.ac|Makefile
 
 [checks "merge"]
 message=Merge

--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -159,7 +159,7 @@ AC_DEFUN_ONCE([JVM_FEATURES_PARSE_OPTIONS],
   # Likewise, check for deprecated arguments.
   m4_foreach(FEATURE, m4_split(jvm_features_deprecated), [
     AC_ARG_ENABLE(jvm-feature-FEATURE, AS_HELP_STRING(
-        [--enable-jvm-feature-FEATURE], 
+        [--enable-jvm-feature-FEATURE],
         [Deprecated. Option is kept for backwards compatibility and is ignored]))
 
     m4_define(FEATURE_SHELL, [enable_jvm_feature_]m4_translit(FEATURE, -, _))

--- a/make/modules/java.base/gendata/GendataCryptoPolicy.gmk
+++ b/make/modules/java.base/gendata/GendataCryptoPolicy.gmk
@@ -27,7 +27,7 @@
 # In pre-JDK9 releases, Oracle JDK has had a separately downloadable set
 # of policy files which has been a nightmare for deployment.
 #
-# We now create 2 complete initial sets of policy files and package into 
+# We now create 2 complete initial sets of policy files and package into
 # 2 different directories.  The crypto.policy Security property will select
 # the active policy.
 #


### PR DESCRIPTION
With the new Skara tooling, we can finally enable whitespace testing for build system files (makefiles and autoconf files).

/cc build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255526](https://bugs.openjdk.java.net/browse/JDK-8255526): Enable jcheck whitespace checking of build system files


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 236d8360391e1c93af33f20b012b414bab3b02bc


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/898/head:pull/898`
`$ git checkout pull/898`
