### PR TITLE
8255527: Shenandoah: Let ShenadoahGCStateResetter disable barriers

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -41,18 +41,17 @@
 #include "utilities/debug.hpp"
 
 ShenandoahGCStateResetter::ShenandoahGCStateResetter() :
-  _gc_state(ShenandoahHeap::heap()->gc_state()),
+  _heap(ShenandoahHeap::heap()),
+  _gc_state(_heap->gc_state()),
   _concurrent_weak_root_in_progress(ShenandoahHeap::heap()->is_concurrent_weak_root_in_progress()) {
-  ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  heap->_gc_state.clear();
-  heap->set_concurrent_weak_root_in_progress(false);
+  _heap->_gc_state.clear();
+  _heap->set_concurrent_weak_root_in_progress(false);
 }
 
 ShenandoahGCStateResetter::~ShenandoahGCStateResetter() {
-  ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  heap->_gc_state.set(_gc_state);
-  assert(heap->gc_state() == _gc_state, "Should be restored");
-  heap->set_concurrent_weak_root_in_progress(_concurrent_weak_root_in_progress);
+  _heap->_gc_state.set(_gc_state);
+  assert(_heap->gc_state() == _gc_state, "Should be restored");
+  _heap->set_concurrent_weak_root_in_progress(_concurrent_weak_root_in_progress);
 }
 
 // Check for overflow of number of root types.

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -43,6 +43,9 @@
 ShenandoahGCStateResetter::ShenandoahGCStateResetter() :
   _gc_state(ShenandoahHeap::heap()->gc_state()),
   _concurrent_weak_root_in_progress(ShenandoahHeap::heap()->is_concurrent_weak_root_in_progress()) {
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  heap->_gc_state.clear();
+  heap->set_concurrent_weak_root_in_progress(false);
 }
 
 ShenandoahGCStateResetter::~ShenandoahGCStateResetter() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -43,7 +43,7 @@
 ShenandoahGCStateResetter::ShenandoahGCStateResetter() :
   _gc_state(ShenandoahHeap::heap()->gc_state()),
   _concurrent_weak_root_in_progress(ShenandoahHeap::heap()->is_concurrent_weak_root_in_progress()) {
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  ShenandoahHeap* const heap = ShenandoahHeap::heap();
   heap->_gc_state.clear();
   heap->set_concurrent_weak_root_in_progress(false);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
@@ -30,6 +30,7 @@
 
 class ShenandoahGCStateResetter : public StackObj {
 private:
+  ShenandoahHeap* const _heap;
   const char _gc_state;
   const bool _concurrent_weak_root_in_progress;
 


### PR DESCRIPTION
JDK-8255036 introduced a regression: the new ShenandoahGCStateResetter does not actually disable barriers: it only records old state (without changing it) and then restores that state (i.e a no-op). 

Testing: hotspot_gc_shenandoah (also on conc-weakref branch, where the bug did manifest)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255527](https://bugs.openjdk.java.net/browse/JDK-8255527): Shenandoah: Let ShenadoahGCStateResetter disable barriers


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**) ⚠️ Review applies to e51fb4300439eb1c73730f36ec1ef2f8f73cb621


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/899/head:pull/899`
`$ git checkout pull/899`
