### PR TITLE
8254877: GCLogPrecious::_lock rank constrains what locks you are allowed to have when crashing

### DIFF
--- a/src/hotspot/share/gc/shared/gcLogPrecious.hpp
+++ b/src/hotspot/share/gc/shared/gcLogPrecious.hpp
@@ -29,6 +29,7 @@
 #include "memory/allocation.hpp"
 #include "utilities/debug.hpp"
 
+class GCLogPreciousLine;
 class Mutex;
 class stringStream;
 
@@ -54,11 +55,14 @@ class stringStream;
 class GCLogPrecious : public AllStatic {
 private:
   // Saved precious lines
-  static stringStream* _lines;
+  static GCLogPreciousLine* volatile _head;
+  static GCLogPreciousLine* _tail;
   // Temporary line buffer
   static stringStream* _temp;
   // Protects the buffers
   static Mutex* _lock;
+
+  static void append_line(const char* const line);
 
   static void vwrite_inner(LogTargetHandle log,
                            const char* format,


### PR DESCRIPTION
Today, when you crash, the GCLogPrecious::_lock is taken. This effectively limits you to only get clean crash reports if you crash or assert without holding a lock of rank tty or lower. It is arguably difficult to know what locks you are going to have when crashing. Therefore, I don't think the precious GC log should constrain possible crashing contexts in that fashion.

This patch inserts the precious GC lines into a linked list instead, that can be traversed concurrently, without holding any locks. This allows you to crash in contexts where "low" ranked locks are held.

I have manually verified that the hs_err precious GC log looks identical before and after my change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ⏳ (1/2 running) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ⏳ (3/9 running) |    | 

### Issue
 * [JDK-8254877](https://bugs.openjdk.java.net/browse/JDK-8254877): GCLogPrecious::_lock rank constrains what locks you are allowed to have when crashing


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/900/head:pull/900`
`$ git checkout pull/900`
