### PR TITLE
8233560: [TESTBUG] ToolTipManager/Test6256140.java is failing on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -783,7 +783,6 @@ javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-al
 javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JTree/6263446/bug6263446.java 8213125 macosx-all
-javax/swing/ToolTipManager/Test6256140.java 8233560 macosx-all
 javax/swing/text/View/8014863/bug8014863.java 8233561 macosx-all
 javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233562 macosx-all
 javax/swing/text/JTextComponent/6361367/bug6361367.java 8233569 macosx-all

--- a/test/jdk/javax/swing/ToolTipManager/Test6256140.java
+++ b/test/jdk/javax/swing/ToolTipManager/Test6256140.java
@@ -40,49 +40,58 @@ public class Test6256140 {
 
     private final static String initialText = "value";
     private final static JLabel toolTipLabel = new JLabel("tip");
+    private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
 
-        Robot robot = new Robot();
-        robot.setAutoDelay(10);
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    createAndShowGUI();
+                }
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                createAndShowGUI();
+            Point point = ft.getLocationOnScreen();
+            robot.mouseMove(point.x, point.y);
+            robot.waitForIdle();
+            robot.mouseMove(point.x + 3, point.y + 3);
+            robot.waitForIdle();
+
+            robot.keyPress(KeyEvent.VK_A);
+            robot.keyRelease(KeyEvent.VK_A);
+            robot.waitForIdle();
+
+            if (!isTooltipShowning()) {
+                throw new RuntimeException("Tooltip is not shown");
             }
-        });
-        robot.waitForIdle();
 
-        Point point = ft.getLocationOnScreen();
-        robot.mouseMove(point.x, point.y);
-        robot.mouseMove(point.x + 3, point.y + 3);
+            robot.keyPress(KeyEvent.VK_ESCAPE);
+            robot.keyRelease(KeyEvent.VK_ESCAPE);
+            robot.waitForIdle();
 
-        robot.keyPress(KeyEvent.VK_A);
-        robot.keyRelease(KeyEvent.VK_A);
-        robot.waitForIdle();
+            if (isTooltipShowning()) {
+                throw new RuntimeException("Tooltip must be hidden now");
+            }
 
-        if (!isTooltipShowning()) {
-            throw new RuntimeException("Tooltip is not shown");
-        }
+            if (isTextEqual()) {
+                throw new RuntimeException("FormattedTextField must *not* cancel the updated value this time");
+            }
 
-        robot.keyPress(KeyEvent.VK_ESCAPE);
-        robot.keyRelease(KeyEvent.VK_ESCAPE);
-        robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_ESCAPE);
+            robot.keyRelease(KeyEvent.VK_ESCAPE);
+            robot.waitForIdle();
 
-        if (isTooltipShowning()) {
-            throw new RuntimeException("Tooltip must be hidden now");
-        }
-
-        if (isTextEqual()) {
-            throw new RuntimeException("FormattedTextField must *not* cancel the updated value this time");
-        }
-
-        robot.keyPress(KeyEvent.VK_ESCAPE);
-        robot.keyRelease(KeyEvent.VK_ESCAPE);
-        robot.waitForIdle();
-
-        if (!isTextEqual()) {
-            throw new RuntimeException("FormattedTextField must cancel the updated value");
+            if (!isTextEqual()) {
+                throw new RuntimeException("FormattedTextField must cancel the updated value");
+            }
+        } finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
+            }
         }
     }
 
@@ -116,7 +125,7 @@ public class Test6256140 {
         ToolTipManager.sharedInstance().setDismissDelay(Integer.MAX_VALUE);
         ToolTipManager.sharedInstance().setInitialDelay(0);
 
-        final JFrame frame = new JFrame();
+        frame = new JFrame();
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setLayout(new FlowLayout());
 


### PR DESCRIPTION
Please review a test fix for a test issue seen to be failing on mach5 macos systems due to timing issue.
Modified the test to modify setAutoDelay() time, added delay() after frame is made visible, added waitForIdle() and also finally dispose of the frame.
Mach5 job has been run for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8233560](https://bugs.openjdk.java.net/browse/JDK-8233560): [TESTBUG] ToolTipManager/Test6256140.java  is failing on macos


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/901/head:pull/901`
`$ git checkout pull/901`
