### PR TITLE
8255534: Shenandoah: Fix CmpP optimization wrt native-LRB

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -1043,8 +1043,10 @@ void ShenandoahBarrierSetC2::verify_gc_barriers(Compile* compile, CompilePhase p
 #endif
 
 void ShenandoahBarrierSetC2::maybe_step_over_cmpp_inputs(Node*& in1, Node*& in2) const {
+  // If first input is NULL, then skip the LRB barriers (except native) on the second input
   if (in1->bottom_type() == TypePtr::NULL_PTR &&
-      (in2->Opcode() != Op_ShenandoahLoadReferenceBarrier || !((ShenandoahLoadReferenceBarrierNode*)in2)->is_native())) {
+      !((in2->Opcode() == Op_ShenandoahLoadReferenceBarrier) &&
+        ((ShenandoahLoadReferenceBarrierNode*)in2)->is_native())) {
     in2 = step_over_gc_barrier(in2);
   }
 }

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -1042,6 +1042,13 @@ void ShenandoahBarrierSetC2::verify_gc_barriers(Compile* compile, CompilePhase p
 }
 #endif
 
+void ShenandoahBarrierSetC2::maybe_step_over_cmpp_inputs(Node*& in1, Node*& in2) const {
+  if (in1->bottom_type() == TypePtr::NULL_PTR &&
+      (in2->Opcode() != Op_ShenandoahLoadReferenceBarrier || !((ShenandoahLoadReferenceBarrierNode*)in2)->is_native())) {
+    in2 = step_over_gc_barrier(in2);
+  }
+}
+
 Node* ShenandoahBarrierSetC2::ideal_node(PhaseGVN* phase, Node* n, bool can_reshape) const {
   if (is_shenandoah_wb_pre_call(n)) {
     uint cnt = ShenandoahBarrierSetC2::write_ref_field_pre_entry_Type()->domain()->cnt();
@@ -1059,14 +1066,8 @@ Node* ShenandoahBarrierSetC2::ideal_node(PhaseGVN* phase, Node* n, bool can_resh
   if (n->Opcode() == Op_CmpP) {
     Node* in1 = n->in(1);
     Node* in2 = n->in(2);
-    if (in1->bottom_type() == TypePtr::NULL_PTR &&
-        (in1->Opcode() != Op_ShenandoahLoadReferenceBarrier || !((ShenandoahLoadReferenceBarrierNode*)in1)->is_native())) {
-      in2 = step_over_gc_barrier(in2);
-    }
-    if (in2->bottom_type() == TypePtr::NULL_PTR &&
-        (in2->Opcode() != Op_ShenandoahLoadReferenceBarrier || !((ShenandoahLoadReferenceBarrierNode*)in2)->is_native())) {
-      in1 = step_over_gc_barrier(in1);
-    }
+    maybe_step_over_cmpp_inputs(in1, in2);
+    maybe_step_over_cmpp_inputs(in2, in1);
     PhaseIterGVN* igvn = phase->is_IterGVN();
     if (in1 != n->in(1)) {
       if (igvn != NULL) {

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -1043,7 +1043,7 @@ void ShenandoahBarrierSetC2::verify_gc_barriers(Compile* compile, CompilePhase p
 #endif
 
 void ShenandoahBarrierSetC2::maybe_step_over_cmpp_inputs(Node*& in1, Node*& in2) const {
-  // If first input is NULL, then skip the LRB barriers (except native) on the second input
+  // If first input is NULL, then step over the barriers (except LRB native) on the second input
   if (in1->bottom_type() == TypePtr::NULL_PTR &&
       !((in2->Opcode() == Op_ShenandoahLoadReferenceBarrier) &&
         ((ShenandoahLoadReferenceBarrierNode*)in2)->is_native())) {

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.hpp
@@ -81,6 +81,8 @@ private:
 
   static bool clone_needs_barrier(Node* src, PhaseGVN& gvn);
 
+  void maybe_step_over_cmpp_inputs(Node*& in1, Node*& in2) const;
+
 protected:
   virtual Node* load_at_resolved(C2Access& access, const Type* val_type) const;
   virtual Node* store_at_resolved(C2Access& access, C2AccessValue& val) const;

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.hpp
@@ -81,8 +81,6 @@ private:
 
   static bool clone_needs_barrier(Node* src, PhaseGVN& gvn);
 
-  void maybe_step_over_cmpp_inputs(Node*& in1, Node*& in2) const;
-
 protected:
   virtual Node* load_at_resolved(C2Access& access, const Type* val_type) const;
   virtual Node* store_at_resolved(C2Access& access, C2AccessValue& val) const;


### PR DESCRIPTION
JDK-8254314 introduced the following code:

    if (in1->bottom_type() == TypePtr::NULL_PTR &&
        (in1->Opcode() != Op_ShenandoahLoadReferenceBarrier || !((ShenandoahLoadReferenceBarrierNode*)in1)->is_native())) {
      in2 = step_over_gc_barrier(in2);
    }

However, the check for LRB and !native are the wrong way around: they should check if *in2* are not native LRB.

The bug is currently only observed in the conc-weakrefs branch, but may manifest (rarely) in mainline too. 

I am also putting in some refactoring to avoid duped code for good measure.

Testing: hotspot_gc_shenandoah (also in conc-weakrefs-branch where it manifests)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (1/9 running) | ✔️ (9/9 passed) | ⏳ (9/9 running) | ⏳ (1/9 running) |

### Issue
 * [JDK-8255534](https://bugs.openjdk.java.net/browse/JDK-8255534): Shenandoah: Fix CmpP optimization wrt native-LRB


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/902/head:pull/902`
`$ git checkout pull/902`
