### PR TITLE
JDK-8255544: Create a checked cast

### DIFF
--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -770,7 +770,8 @@ int CodeHeap::segmap_hops(size_t beg, size_t end) {
   if (beg < end) {
     // setup _segmap pointers for faster indexing
     address p = (address)_segmap.low() + beg;
-    int hops_expected = (int)(((end-beg-1)+(free_sentinel-2))/(free_sentinel-1));
+    int hops_expected
+      = checked_cast<int>(((end-beg-1)+(free_sentinel-2))/(free_sentinel-1));
     int nhops = 0;
     size_t ix = end-beg-1;
     while (p[ix] > 0) {

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -446,6 +446,21 @@ inline size_t pointer_delta(const MetaWord* left, const MetaWord* right) {
 #define CAST_TO_FN_PTR(func_type, value) (reinterpret_cast<func_type>(value))
 #define CAST_FROM_FN_PTR(new_type, func_ptr) ((new_type)((address_word)(func_ptr)))
 
+// In many places we've added C-style casts to silence compiler
+// warnings, for example when truncating a size_t to an int when we
+// know the size_t is a small struct. Such casts are risky because
+// they effectively disable useful compiler warnings. We can make our
+// lives safer with this function, which ensures that any cast is
+// reversible without loss of information. It doesn't check
+// everything: it isn't intended to make sure that pointer types are
+// compatible, for example.
+template <typename T2, typename T1>
+T2 checked_cast(T1 thing) {
+  T2 result = static_cast<T2>(thing);
+  assert(static_cast<T1>(result) == thing, "must be");
+  return result;
+}
+
 // Need the correct linkage to call qsort without warnings
 extern "C" {
   typedef int (*_sort_Fn)(const void *, const void *);


### PR DESCRIPTION
In many places we've added C-style casts to silence compiler warnings, for example when truncating a size_t to an int when we know the size_t is a small struct. Such casts are inherently risky, because they effectively disable useful compiler warnings. We should add a form of cast that checks at runtime that a truncation does not overflow.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255544](https://bugs.openjdk.java.net/browse/JDK-8255544): Create a checked cast


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/904/head:pull/904`
`$ git checkout pull/904`
