### PR TITLE
8255416: Investigate err_msg to detect unnecessary uses	

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -2246,7 +2246,7 @@ char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, i
 
   if (result != NULL) {
     if (replace_existing_mapping_with_file_mapping(result, bytes, file_desc) == NULL) {
-      vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
+      vm_exit_during_initialization("Error in mapping Java heap at the given filesystem directory");
     }
   }
   return result;

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1910,7 +1910,7 @@ char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, i
   char* result = pd_attempt_reserve_memory_at(requested_addr, bytes);
   if (result != NULL) {
     if (replace_existing_mapping_with_file_mapping(result, bytes, file_desc) == NULL) {
-      vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
+      vm_exit_during_initialization("Error in mapping Java heap at the given filesystem directory");
     }
   }
   return result;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4219,7 +4219,7 @@ char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, i
   char* result = pd_attempt_reserve_memory_at(requested_addr, bytes);
   if (result != NULL) {
     if (replace_existing_mapping_with_file_mapping(result, bytes, file_desc) == NULL) {
-      vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
+      vm_exit_during_initialization("Error in mapping Java heap at the given filesystem directory");
     }
   }
   return result;

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -360,7 +360,7 @@ char* os::map_memory_to_file_aligned(size_t size, size_t alignment, int file_des
   char* aligned_base = chop_extra_memory(size, alignment, extra_base, extra_size);
   // After we have an aligned address, we can replace anonymous mapping with file mapping
   if (replace_existing_mapping_with_file_mapping(aligned_base, size, file_desc) == NULL) {
-    vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
+    vm_exit_during_initialization("Error in mapping Java heap at the given filesystem directory");
   }
   MemTracker::record_virtual_memory_commit((address)aligned_base, size, CALLER_PC);
   return aligned_base;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3088,10 +3088,10 @@ char* os::map_memory_to_file(char* base, size_t size, int fd) {
 #endif
   if (fileMapping == NULL) {
     if (GetLastError() == ERROR_DISK_FULL) {
-      vm_exit_during_initialization(err_msg("Could not allocate sufficient disk space for Java heap"));
+      vm_exit_during_initialization("Could not allocate sufficient disk space for Java heap");
     }
     else {
-      vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
+      vm_exit_during_initialization("Error in mapping Java heap at the given filesystem directory");
     }
 
     return NULL;

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -170,7 +170,7 @@ static void define_javabase_module(Handle module_handle, jstring version, jstrin
 
     if (pkg_str == NULL || pkg_str->klass() != SystemDictionary::String_klass()) {
       THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                err_msg("Bad package name"));
+                "Bad package name");
     }
 
     int package_len;
@@ -327,7 +327,7 @@ void Modules::define_module(jobject module, jboolean is_open, jstring version,
     oop pkg_str = packages_h->obj_at(x);
     if (pkg_str == NULL || pkg_str->klass() != SystemDictionary::String_klass()) {
       THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                err_msg("Bad package name"));
+                "Bad package name");
     }
 
     int package_len;

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -160,7 +160,7 @@ void CodeCache::check_heap_sizes(size_t non_nmethod_size, size_t profiled_size, 
   size_t total_size = non_nmethod_size + profiled_size + non_profiled_size;
   // Prepare error message
   const char* error = "Invalid code heap sizes";
-  err_msg message("NonNMethodCodeHeapSize (" SIZE_FORMAT "K) + ProfiledCodeHeapSize (" SIZE_FORMAT "K)"
+  FormatBuffer<> message("NonNMethodCodeHeapSize (" SIZE_FORMAT "K) + ProfiledCodeHeapSize (" SIZE_FORMAT "K)"
                   " + NonProfiledCodeHeapSize (" SIZE_FORMAT "K) = " SIZE_FORMAT "K",
           non_nmethod_size/K, profiled_size/K, non_profiled_size/K, total_size/K);
 

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahMode.hpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahMode.hpp
@@ -32,16 +32,16 @@ class ShenandoahHeuristics;
 #define SHENANDOAH_CHECK_FLAG_SET(name)                                     \
   do {                                                                      \
     if (!(name)) {                                                          \
-      err_msg message("GC mode needs -XX:+" #name " to work correctly");    \
-      vm_exit_during_initialization("Error", message);                      \
+      const char *msg = "GC mode needs -XX:+" #name " to work correctly";   \
+      vm_exit_during_initialization("Error", msg);                          \
     }                                                                       \
   } while (0)
 
 #define SHENANDOAH_CHECK_FLAG_UNSET(name)                                   \
   do {                                                                      \
     if ((name)) {                                                           \
-      err_msg message("GC mode needs -XX:-" #name " to work correctly");    \
-      vm_exit_during_initialization("Error", message);                      \
+      const char* msg = "GC mode needs -XX:-" #name " to work correctly";   \
+      vm_exit_during_initialization("Error", msg);                          \
     }                                                                       \
   } while (0)
 

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahMode.hpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahMode.hpp
@@ -32,16 +32,16 @@ class ShenandoahHeuristics;
 #define SHENANDOAH_CHECK_FLAG_SET(name)                                     \
   do {                                                                      \
     if (!(name)) {                                                          \
-      const char* msg = "GC mode needs -XX:+" #name " to work correctly";   \
-      vm_exit_during_initialization("Error", msg);                          \
+      vm_exit_during_initialization("Error",                                \
+              "GC mode needs -XX:+" #name " to work correctly");            \
     }                                                                       \
   } while (0)
 
 #define SHENANDOAH_CHECK_FLAG_UNSET(name)                                   \
   do {                                                                      \
     if ((name)) {                                                           \
-      const char* msg = "GC mode needs -XX:-" #name " to work correctly";   \
-      vm_exit_during_initialization("Error", msg);                          \
+      vm_exit_during_initialization("Error",                                \
+              "GC mode needs -XX:-" #name " to work correctly");            \
     }                                                                       \
   } while (0)
 

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahMode.hpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahMode.hpp
@@ -32,7 +32,7 @@ class ShenandoahHeuristics;
 #define SHENANDOAH_CHECK_FLAG_SET(name)                                     \
   do {                                                                      \
     if (!(name)) {                                                          \
-      const char *msg = "GC mode needs -XX:+" #name " to work correctly";   \
+      const char* msg = "GC mode needs -XX:+" #name " to work correctly";   \
       vm_exit_during_initialization("Error", msg);                          \
     }                                                                       \
   } while (0)

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -152,7 +152,7 @@ static JavaThread* get_current_thread(bool allow_null=true) {
   JavaThread* thread = get_current_thread();             \
   if (thread == NULL) {                                  \
     env->ThrowNew(JNIJVMCI::InternalError::clazz(),      \
-        err_msg("Cannot call into HotSpot from JVMCI shared library without attaching current thread")); \
+        "Cannot call into HotSpot from JVMCI shared library without attaching current thread"); \
     return;                                              \
   }                                                      \
   JVMCITraceMark jtm("CompilerToVM::" #name);            \
@@ -163,7 +163,7 @@ static JavaThread* get_current_thread(bool allow_null=true) {
   JavaThread* thread = get_current_thread();             \
   if (thread == NULL) {                                  \
     env->ThrowNew(JNIJVMCI::InternalError::clazz(),      \
-        err_msg("Cannot call into HotSpot from JVMCI shared library without attaching current thread")); \
+        "Cannot call into HotSpot from JVMCI shared library without attaching current thread"); \
     return result;                                       \
   }                                                      \
   JVMCITraceMark jtm("CompilerToVM::" #name);            \

--- a/src/hotspot/share/utilities/formatBuffer.hpp
+++ b/src/hotspot/share/utilities/formatBuffer.hpp
@@ -121,7 +121,9 @@ public:
   // Dummy overload preventing misuse of err_msg for a string without format arguments.
   // If compilation fails because of ambiguity between this and real constructor, you
   // could drop err_msg use at all.
-  inline FormatErrBuffer(const char* msg) { ShouldNotReachHere(); }
+  // It is also intentionally not defined to produce a link-time failure, in case of
+  // (not sane) compiler selects this by some way.
+  FormatErrBuffer(const char* msg);
 };
 
 template <size_t bufsz>

--- a/src/hotspot/share/utilities/formatBuffer.hpp
+++ b/src/hotspot/share/utilities/formatBuffer.hpp
@@ -113,7 +113,25 @@ void FormatBuffer<bufsz>::append(const char* format, ...) {
   va_end(argp);
 }
 
-// Used to format messages.
-typedef FormatBuffer<> err_msg;
+template <size_t bufsz = FormatBufferBase::BufferSize>
+class FormatErrBuffer : public FormatBuffer<bufsz> {
+public:
+  inline FormatErrBuffer(const char* format, ...) ATTRIBUTE_PRINTF(2, 3);
+
+  // Dummy overload preventing misuse of err_msg for a string without format arguments.
+  // If compilation fails because of ambiguity between this and real constructor, you
+  // could drop err_msg use at all.
+  inline FormatErrBuffer(const char* msg) { ShouldNotReachHere(); }
+};
+
+template <size_t bufsz>
+FormatErrBuffer<bufsz>::FormatErrBuffer(const char * format, ...) : FormatBuffer<bufsz>() {
+  va_list argp;
+  va_start(argp, format);
+  FormatBuffer<bufsz>::printv(format, argp);
+  va_end(argp);
+}
+
+typedef FormatErrBuffer<> err_msg;
 
 #endif // SHARE_UTILITIES_FORMATBUFFER_HPP

--- a/src/hotspot/share/utilities/formatBuffer.hpp
+++ b/src/hotspot/share/utilities/formatBuffer.hpp
@@ -58,8 +58,8 @@ class FormatBuffer : public FormatBufferBase {
   inline void print(const char* format, ...)  ATTRIBUTE_PRINTF(2, 3);
   inline void printv(const char* format, va_list ap) ATTRIBUTE_PRINTF(2, 0);
 
-  char* buffer() { return _buf; }
-  int size() { return bufsz; }
+  char* buffer() const { return _buf; }
+  int size() const { return bufsz; }
 
  private:
   FormatBuffer(const FormatBuffer &); // prevent copies
@@ -114,9 +114,11 @@ void FormatBuffer<bufsz>::append(const char* format, ...) {
 }
 
 template <size_t bufsz = FormatBufferBase::BufferSize>
-class FormatErrBuffer : public FormatBuffer<bufsz> {
+class FormatErrBuffer : private FormatBuffer<bufsz> {
 public:
   inline FormatErrBuffer(const char* format, ...) ATTRIBUTE_PRINTF(2, 3);
+
+  operator const char *() const { return FormatBuffer<bufsz>::buffer(); }
 
   // Dummy overload preventing misuse of err_msg for a string without format arguments.
   // If compilation fails because of ambiguity between this and real constructor, you

--- a/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp
@@ -177,7 +177,7 @@ void OopStorageParIterPerf::show_task(const Task* task, Tickspan duration, uint 
 
 void OopStorageParIterPerf::run_test(uint nthreads) {
   if (nthreads <= _num_workers) {
-    SCOPED_TRACE(err_msg("Running test with %u threads", nthreads).buffer());
+    SCOPED_TRACE((const char*)err_msg("Running test with %u threads", nthreads));
     Closure closure;
     Task task(&_storage, &closure, nthreads);
     Tickspan t = run_task(&task, nthreads);

--- a/test/hotspot/gtest/utilities/test_align.cpp
+++ b/test/hotspot/gtest/utilities/test_align.cpp
@@ -37,7 +37,7 @@ static constexpr T max_alignment() {
   return max ^ (max >> 1);
 }
 
-#define log(...) SCOPED_TRACE(err_msg(__VA_ARGS__).buffer())
+#define log(...) SCOPED_TRACE((const char*)err_msg(__VA_ARGS__))
 
 struct StaticTestAlignmentsResult {
   uint64_t _value;


### PR DESCRIPTION
Hi,

When a single string without formatting arguments is provided to `err_msg`, it's redundancy, as the same message could be used without any err_msg. This is a follow-up to the discussion https://github.com/openjdk/jdk/pull/812#discussion_r511784050

Please review a change that makes `err_msg` with a single string to fail compilation. 

Detected uses of err_msg with a single string were eliminated as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255416](https://bugs.openjdk.java.net/browse/JDK-8255416): Investigate err_msg to detect unnecessary uses


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/905/head:pull/905`
`$ git checkout pull/905`
