### PR TITLE
8255553: [PPC64] Introduce and use setbc and setnbc P10 instructions

### DIFF
--- a/src/hotspot/cpu/ppc/assembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.hpp
@@ -340,6 +340,9 @@ class Assembler : public AbstractAssembler {
     MCRF_OPCODE   = (19u << OPCODE_SHIFT | 0u << 1),
     SETB_OPCODE   = (31u << OPCODE_SHIFT | 128u << 1),
 
+    SETBC_OPCODE  = (31u << OPCODE_SHIFT | 384u << 1),
+    SETNBC_OPCODE = (31u << OPCODE_SHIFT | 448u << 1),
+
     // condition register logic instructions
     CRAND_OPCODE  = (19u << OPCODE_SHIFT | 257u << 1),
     CRNAND_OPCODE = (19u << OPCODE_SHIFT | 225u << 1),
@@ -1676,6 +1679,12 @@ class Assembler : public AbstractAssembler {
   inline void mtcr( Register s);
   // >= Power9
   inline void setb( Register d, ConditionRegister cra);
+
+  // >= Power10
+  inline void setbc( Register d, int biint);
+  inline void setbc( Register d, ConditionRegister cr, Condition cc);
+  inline void setnbc(Register d, int biint);
+  inline void setnbc(Register d, ConditionRegister cr, Condition cc);
 
   // Special purpose registers
   // Exception Register

--- a/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
@@ -384,12 +384,12 @@ inline void Assembler::setb(Register d, ConditionRegister cra)
 inline void Assembler::setbc(Register d, int biint)
                                                   { emit_int32(SETBC_OPCODE | rt(d) | bi(biint)); }
 inline void Assembler::setbc(Register d, ConditionRegister cr, Condition cc) {
-    setbc(d, bi0(cr, cc));
+  setbc(d, bi0(cr, cc));
 }
 inline void Assembler::setnbc(Register d, int biint)
                                                   { emit_int32(SETNBC_OPCODE | rt(d) | bi(biint)); }
 inline void Assembler::setnbc(Register d, ConditionRegister cr, Condition cc) {
-    setnbc(d, bi0(cr, cc));
+  setnbc(d, bi0(cr, cc));
 }
 
 // Special purpose registers

--- a/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
@@ -381,6 +381,17 @@ inline void Assembler::mtcr( Register s)          { Assembler::mtcrf(0xff, s); }
 inline void Assembler::setb(Register d, ConditionRegister cra)
                                                   { emit_int32(SETB_OPCODE | rt(d) | bfa(cra)); }
 
+inline void Assembler::setbc(Register d, int biint)
+                                                  { emit_int32(SETBC_OPCODE | rt(d) | bi(biint)); }
+inline void Assembler::setbc(Register d, ConditionRegister cr, Condition cc) {
+    setbc(d, bi0(cr, cc));
+}
+inline void Assembler::setnbc(Register d, int biint)
+                                                  { emit_int32(SETNBC_OPCODE | rt(d) | bi(biint)); }
+inline void Assembler::setnbc(Register d, ConditionRegister cr, Condition cc) {
+    setnbc(d, bi0(cr, cc));
+}
+
 // Special purpose registers
 // Exception Register
 inline void Assembler::mtxer(Register s1)         { emit_int32(MTXER_OPCODE | rs(s1)); }

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -1527,7 +1527,6 @@ void LIR_Assembler::comp_op(LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2,
 
 void LIR_Assembler::comp_fl2i(LIR_Code code, LIR_Opr left, LIR_Opr right, LIR_Opr dst, LIR_Op2* op){
   const Register Rdst = dst->as_register();
-  Label done;
   if (code == lir_cmp_fd2i || code == lir_ucmp_fd2i) {
     bool is_unordered_less = (code == lir_ucmp_fd2i);
     if (left->is_single_fpu()) {
@@ -1537,18 +1536,13 @@ void LIR_Assembler::comp_fl2i(LIR_Code code, LIR_Opr left, LIR_Opr right, LIR_Op
     } else {
       ShouldNotReachHere();
     }
-    __ li(Rdst, is_unordered_less ? -1 : 1);
-    __ bso(CCR0, done);
+    __ set_cmpu3(Rdst, is_unordered_less); // is_unordered_less ? -1 : 1
   } else if (code == lir_cmp_l2i) {
     __ cmpd(CCR0, left->as_register_lo(), right->as_register_lo());
+    __ set_cmp3(Rdst);  // set result as follows: <: -1, =: 0, >: 1
   } else {
     ShouldNotReachHere();
   }
-  __ mfcr(R0); // set bit 32..33 as follows: <: 0b10, =: 0b00, >: 0b01
-  __ srwi(Rdst, R0, 30);
-  __ srawi(R0, R0, 31);
-  __ orr(Rdst, R0, Rdst); // set result as follows: <: -1, =: 0, >: 1
-  __ bind(done);
 }
 
 

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -161,7 +161,8 @@ class MacroAssembler: public Assembler {
   //
   // branch, jump
   //
-  // set dst to -1, 0, +1
+  // set dst to -1, 0, +1 as follows: if CCR0bi is "greater than", dst is set to 1,
+  // if CCR0bi is "equal", dst is set to 0, otherwise it's set to -1.
   void inline set_cmp3(Register dst);
   // set dst to (treat_unordered_like_less ? -1 : +1)
   void inline set_cmpu3(Register dst, bool treat_unordered_like_less);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -161,6 +161,10 @@ class MacroAssembler: public Assembler {
   //
   // branch, jump
   //
+  // set dst to -1, 0, +1
+  void inline set_cmp3(Register dst);
+  // set dst to (treat_unordered_like_less ? -1 : +1)
+  void inline set_cmpu3(Register dst, bool treat_unordered_like_less);
 
   inline void pd_patch_instruction(address branch, address target, const char* file, int line);
   NOT_PRODUCT(static void pd_print_patched_instruction(address branch);)

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -11418,90 +11418,20 @@ instruct testL_reg_imm(flagsRegCR0 cr0, iRegLsrc src1, uimmL16 src2, immL_0 zero
   ins_pipe(pipe_class_compare);
 %}
 
-instruct cmovI_conIvalueMinus1_conIvalue1(iRegIdst dst, flagsRegSrc crx) %{
-  // no match-rule, false predicate
-  effect(DEF dst, USE crx);
-  predicate(false);
-
-  ins_variable_size_depending_on_alignment(true);
-
-  format %{ "cmovI   $crx, $dst, -1, 0, +1" %}
-  // Worst case is branch + move + branch + move + stop, no stop without scheduler.
-  size(16);
-  ins_encode %{
-    Label done;
-    // li(Rdst, 0);              // equal -> 0
-    __ beq($crx$$CondRegister, done);
-    __ li($dst$$Register, 1);    // greater -> +1
-    __ bgt($crx$$CondRegister, done);
-    __ li($dst$$Register, -1);   // unordered or less -> -1
-    __ bind(done);
-  %}
-  ins_pipe(pipe_class_compare);
-%}
-
-instruct cmovI_conIvalueMinus1_conIvalue0_conIvalue1_Ex(iRegIdst dst, flagsRegSrc crx) %{
-  // no match-rule, false predicate
-  effect(DEF dst, USE crx);
-  predicate(false);
-
-  format %{ "CmovI    $crx, $dst, -1, 0, +1 \t// postalloc expanded" %}
-  postalloc_expand %{
-    //
-    // replaces
-    //
-    //   region  crx
-    //    \       |
-    //     dst=cmovI_conIvalueMinus1_conIvalue0_conIvalue1
-    //
-    // with
-    //
-    //   region
-    //    \
-    //     dst=loadConI16(0)
-    //      |
-    //      ^  region  crx
-    //      |   \       |
-    //      dst=cmovI_conIvalueMinus1_conIvalue1
-    //
-
-    // Create new nodes.
-    MachNode *m1 = new loadConI16Node();
-    MachNode *m2 = new cmovI_conIvalueMinus1_conIvalue1Node();
-
-    // inputs for new nodes
-    m1->add_req(n_region);
-    m2->add_req(n_region, n_crx);
-    m2->add_prec(m1);
-
-    // operands for new nodes
-    m1->_opnds[0] = op_dst;
-    m1->_opnds[1] = new immI16Oper(0);
-    m2->_opnds[0] = op_dst;
-    m2->_opnds[1] = op_crx;
-
-    // registers for new nodes
-    ra_->set_pair(m1->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this)); // dst
-    ra_->set_pair(m2->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this)); // dst
-
-    // Insert new nodes.
-    nodes->push(m1);
-    nodes->push(m2);
-  %}
-%}
-
-// Manifest a CmpL3 result in an integer register. Very painful.
-// This is the test to avoid.
-// (src1 < src2) ? -1 : ((src1 > src2) ? 1 : 0)
-instruct cmpL3_reg_reg_ExEx(iRegIdst dst, iRegLsrc src1, iRegLsrc src2) %{
+// Manifest a CmpL3 result in an integer register.
+instruct cmpL3_reg_reg(iRegIdst dst, iRegLsrc src1, iRegLsrc src2, flagsRegCR0 cr0) %{
   match(Set dst (CmpL3 src1 src2));
-  ins_cost(DEFAULT_COST*5+BRANCH_COST);
+  effect(KILL cr0);
+  ins_cost(DEFAULT_COST * 5);
+  size(VM_Version::has_brw() ? 16 : 20);
 
-  expand %{
-    flagsReg tmp1;
-    cmpL_reg_reg(tmp1, src1, src2);
-    cmovI_conIvalueMinus1_conIvalue0_conIvalue1_Ex(dst, tmp1);
+  format %{ "cmpL3_reg_reg $dst, $src1, $src2" %}
+
+  ins_encode %{
+    __ cmpd(CCR0, $src1$$Register, $src2$$Register);
+    __ set_cmp3($dst$$Register);
   %}
+  ins_pipe(pipe_class_default);
 %}
 
 // Implicit range checks.
@@ -11824,15 +11754,19 @@ instruct cmpF_reg_reg_Ex(flagsReg crx, regF src1, regF src2) %{
 %}
 
 // Compare float, generate -1,0,1
-instruct cmpF3_reg_reg_ExEx(iRegIdst dst, regF src1, regF src2) %{
+instruct cmpF3_reg_reg(iRegIdst dst, regF src1, regF src2, flagsRegCR0 cr0) %{
   match(Set dst (CmpF3 src1 src2));
-  ins_cost(DEFAULT_COST*5+BRANCH_COST);
+  effect(KILL cr0);
+  ins_cost(DEFAULT_COST * 6);
+  size(VM_Version::has_brw() ? 20 : 24);
 
-  expand %{
-    flagsReg tmp1;
-    cmpFUnordered_reg_reg(tmp1, src1, src2);
-    cmovI_conIvalueMinus1_conIvalue0_conIvalue1_Ex(dst, tmp1);
+  format %{ "cmpF3_reg_reg $dst, $src1, $src2" %}
+
+  ins_encode %{
+    __ fcmpu(CCR0, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ set_cmpu3($dst$$Register, true); // C2 requires unordered to get treated like less
   %}
+  ins_pipe(pipe_class_default);
 %}
 
 instruct cmpDUnordered_reg_reg(flagsReg crx, regD src1, regD src2) %{
@@ -11904,15 +11838,19 @@ instruct cmpD_reg_reg_Ex(flagsReg crx, regD src1, regD src2) %{
 %}
 
 // Compare double, generate -1,0,1
-instruct cmpD3_reg_reg_ExEx(iRegIdst dst, regD src1, regD src2) %{
+instruct cmpD3_reg_reg(iRegIdst dst, regD src1, regD src2, flagsRegCR0 cr0) %{
   match(Set dst (CmpD3 src1 src2));
-  ins_cost(DEFAULT_COST*5+BRANCH_COST);
+  effect(KILL cr0);
+  ins_cost(DEFAULT_COST * 6);
+  size(VM_Version::has_brw() ? 20 : 24);
 
-  expand %{
-    flagsReg tmp1;
-    cmpDUnordered_reg_reg(tmp1, src1, src2);
-    cmovI_conIvalueMinus1_conIvalue0_conIvalue1_Ex(dst, tmp1);
+  format %{ "cmpD3_reg_reg $dst, $src1, $src2" %}
+
+  ins_encode %{
+    __ fcmpu(CCR0, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ set_cmpu3($dst$$Register, true); // C2 requires unordered to get treated like less
   %}
+  ins_pipe(pipe_class_default);
 %}
 
 // Compare char

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -1590,10 +1590,7 @@ void TemplateTable::lcmp() {
   __ pop_l(Rscratch); // first operand, deeper in stack
 
   __ cmpd(CCR0, Rscratch, R17_tos); // compare
-  __ mfcr(R17_tos); // set bit 32..33 as follows: <: 0b10, =: 0b00, >: 0b01
-  __ srwi(Rscratch, R17_tos, 30);
-  __ srawi(R17_tos, R17_tos, 31);
-  __ orr(R17_tos, Rscratch, R17_tos); // set result as follows: <: -1, =: 0, >: 1
+  __ set_cmp3(R17_tos); // set result as follows: <: -1, =: 0, >: 1
 }
 
 // fcmpl/fcmpg and dcmpl/dcmpg bytecodes
@@ -1610,21 +1607,10 @@ void TemplateTable::float_cmp(bool is_float, int unordered_result) {
     __ pop_d(Rfirst);
   }
 
-  Label Lunordered, Ldone;
   __ fcmpu(CCR0, Rfirst, Rsecond); // compare
-  if (unordered_result) {
-    __ bso(CCR0, Lunordered);
-  }
-  __ mfcr(R17_tos); // set bit 32..33 as follows: <: 0b10, =: 0b00, >: 0b01
-  __ srwi(Rscratch, R17_tos, 30);
-  __ srawi(R17_tos, R17_tos, 31);
-  __ orr(R17_tos, Rscratch, R17_tos); // set result as follows: <: -1, =: 0, >: 1
-  if (unordered_result) {
-    __ b(Ldone);
-    __ bind(Lunordered);
-    __ load_const_optimized(R17_tos, unordered_result);
-  }
-  __ bind(Ldone);
+  // if unordered_result is 1, treat unordered_result like 'greater than'
+  assert(unordered_result == 1 || unordered_result == -1, "only supported");
+  __ set_cmpu3(R17_tos, (unordered_result == 1) ? false : true);
 }
 
 // Branch_conditional which takes TemplateTable::Condition.

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -1609,8 +1609,8 @@ void TemplateTable::float_cmp(bool is_float, int unordered_result) {
 
   __ fcmpu(CCR0, Rfirst, Rsecond); // compare
   // if unordered_result is 1, treat unordered_result like 'greater than'
-  assert(unordered_result == 1 || unordered_result == -1, "only supported");
-  __ set_cmpu3(R17_tos, (unordered_result == 1) ? false : true);
+  assert(unordered_result == 1 || unordered_result == -1, "unordered_result can be either 1 or -1");
+  __ set_cmpu3(R17_tos, unordered_result != 1);
 }
 
 // Branch_conditional which takes TemplateTable::Condition.


### PR DESCRIPTION
- setbc RT,BI: sets RT to 1 if CR(BI) is 1, otherwise 0.
- setnbc RT,BI: sets RT to -1 if CR(BI) is 1, otherwise 0.
Ref: PowerISA 3.1, page 129.

These instructions are particularly interesting to improve the following
pattern `(src1<src2)? -1: ((src1>src2)? 1: 0)`, which can be found in
`instruct cmpL3_reg_reg_ExEx()@ppc.ad`, by removing its branches.

Long.toString, that generate such pattern in getChars, has showed a
good performance gain by using these new instructions.

Example:
for (int i = 0; i < 200_000; i++)
  res = Long.toString((long)i);

java -Xcomp -XX:CompileThreshold=1 -XX:-TieredCompilation TestToString

Without setbc (average): 0.1178 seconds
With setbc (average): 0.0396 seconds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (2/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Windows x64 (hs/tier1 gc)](https://github.com/jrziviani/jdk/runs/1409309145)
- [Windows x64 (hs/tier1 serviceability)](https://github.com/jrziviani/jdk/runs/1409309180)
- [macOS x64 (hs/tier1 gc)](https://github.com/jrziviani/jdk/runs/1409183126)

### Issue
 * [JDK-8255553](https://bugs.openjdk.java.net/browse/JDK-8255553): [PPC64] Introduce and use setbc and setnbc P10 instructions


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to 68081ca696de690a341e9db2668526521877f1f5
 * @CoreyAshford (no known github.com user name / role)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/907/head:pull/907`
`$ git checkout pull/907`
