### PR TITLE
8255533: Incorrect javadoc in DateTimeFormatterBuilder.appendPattern() for 'uu'/'yy'

### DIFF
--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -1556,11 +1556,11 @@ public final class DateTimeFormatterBuilder {
      *    GGGGG   5      appendText(ChronoField.ERA, TextStyle.NARROW)
      *
      *    u       1      appendValue(ChronoField.YEAR, 1, 19, SignStyle.NORMAL)
-     *    uu      2      appendValueReduced(ChronoField.YEAR, 2, 2000)
+     *    uu      2      appendValueReduced(ChronoField.YEAR, 2, 2, 2000)
      *    uuu     3      appendValue(ChronoField.YEAR, 3, 19, SignStyle.NORMAL)
      *    u..u    4..n   appendValue(ChronoField.YEAR, n, 19, SignStyle.EXCEEDS_PAD)
      *    y       1      appendValue(ChronoField.YEAR_OF_ERA, 1, 19, SignStyle.NORMAL)
-     *    yy      2      appendValueReduced(ChronoField.YEAR_OF_ERA, 2, 2000)
+     *    yy      2      appendValueReduced(ChronoField.YEAR_OF_ERA, 2, 2, 2000)
      *    yyy     3      appendValue(ChronoField.YEAR_OF_ERA, 3, 19, SignStyle.NORMAL)
      *    y..y    4..n   appendValue(ChronoField.YEAR_OF_ERA, n, 19, SignStyle.EXCEEDS_PAD)
      *    Y       1      append special localized WeekFields element for numeric week-based-year


### PR DESCRIPTION
Hi,

Please review this simple doc fix in DateTimeFormatterBuilder.appendPattern(). It is missing the value for `maxWidth` argument.

Naoto

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ⏳ (1/9 running) | ⏳ (1/9 running) |

### Issue
 * [JDK-8255533](https://bugs.openjdk.java.net/browse/JDK-8255533): Incorrect javadoc in DateTimeFormatterBuilder.appendPattern() for 'uu'/'yy'


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/908/head:pull/908`
`$ git checkout pull/908`
