### PR TITLE
8255554: Bad copyright header in AbstractFileSystemProvider.java

### DIFF
--- a/src/java.base/share/classes/sun/nio/fs/AbstractFileSystemProvider.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Could I get the following trivial change reviewed please?
A source file is missing a comma in the Copyright header

Thanks
Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (2/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8255554](https://bugs.openjdk.java.net/browse/JDK-8255554): Bad copyright header in AbstractFileSystemProvider.java


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/909/head:pull/909`
`$ git checkout pull/909`
