### PR TITLE
8255555: Bad copyright headers in SocketChannelCompare.java SocketChannelConnectionSetup.java UnixSocketChannelReadWrite.java

### DIFF
--- a/test/micro/org/openjdk/bench/java/net/SocketChannelCompare.java
+++ b/test/micro/org/openjdk/bench/java/net/SocketChannelCompare.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/net/SocketChannelConnectionSetup.java
+++ b/test/micro/org/openjdk/bench/java/net/SocketChannelConnectionSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/net/UnixSocketChannelReadWrite.java
+++ b/test/micro/org/openjdk/bench/java/net/UnixSocketChannelReadWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
…nnelConnectionSetup.java UnixSocketChannelReadWrite.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (5/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8255555](https://bugs.openjdk.java.net/browse/JDK-8255555): Bad copyright headers in SocketChannelCompare.java SocketChannelConnectionSetup.java UnixSocketChannelReadWrite.java


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/912/head:pull/912`
`$ git checkout pull/912`
