### PR TITLE
8250669: Running JMH micros is broken after JDK-8248135

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -90,11 +90,10 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
     TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
     SMALL_JAVA := false, \
     CLASSPATH := $(MICROBENCHMARK_CLASSPATH), \
-    DISABLED_WARNINGS := processing rawtypes cast serial preview, \
+    DISABLED_WARNINGS := processing rawtypes cast serial, \
     SRC := $(MICROBENCHMARK_SRC), \
     BIN := $(MICROBENCHMARK_CLASSES), \
     JAVA_FLAGS := --add-modules jdk.unsupported --limit-modules java.management, \
-    JAVAC_FLAGS := --enable-preview, \
 ))
 
 $(BUILD_JDK_MICROBENCHMARK): $(JMH_COMPILE_JARS)

--- a/test/micro/org/openjdk/bench/java/io/RecordDeserialization.java
+++ b/test/micro/org/openjdk/bench/java/io/RecordDeserialization.java
@@ -82,7 +82,7 @@ import java.util.stream.IntStream;
 @Measurement(iterations = 10, time = 1)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)
-@Fork(value = 1, warmups = 0, jvmArgsAppend = "--enable-preview")
+@Fork(value = 1, warmups = 0)
 public class RecordDeserialization {
 
     public record PointR(int x, int y) implements Serializable {}


### PR DESCRIPTION
A microbenchmark with --enable-preview was added in JDK-8248135. This had the unintended side effect that we now had to always run with --enable-preview. 

With records out of preview, I think the best course of action now is to not build the micros with preview enabled, and leave it for a future RFE to figure out how to add proper support for preview features.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ⏳ (3/9 running) | ⏳ (2/9 running) |

### Issue
 * [JDK-8250669](https://bugs.openjdk.java.net/browse/JDK-8250669): Running JMH micros is broken after JDK-8248135


### Reviewers
 * [Eric Caspole](https://openjdk.java.net/census#ecaspole) (@ericcaspole - Committer)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/914/head:pull/914`
`$ git checkout pull/914`
