### PR TITLE
8255494: PKCS7 should use digest algorithm to verify the signature

### DIFF
--- a/src/java.base/share/classes/sun/security/util/SignatureUtil.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureUtil.java
@@ -283,6 +283,32 @@ public class SignatureUtil {
     }
 
     /**
+     * Extracts the key algorithm name from a signature
+     * algorithm name in either the "DIGESTwithENCRYPTION" or the
+     * "DIGESTwithENCRYPTIONandWHATEVER" format.
+     *
+     * @return the key algorithm name, or null if the input
+     *      is not in either of the formats.
+     */
+    public static String extractKeyAlgFromDwithE(String signatureAlgorithm) {
+        signatureAlgorithm = signatureAlgorithm.toUpperCase(Locale.ENGLISH);
+        int with = signatureAlgorithm.indexOf("WITH");
+        String keyAlgorithm = null;
+        if (with > 0) {
+            int and = signatureAlgorithm.indexOf("AND", with + 4);
+            if (and > 0) {
+                keyAlgorithm = signatureAlgorithm.substring(with + 4, and);
+            } else {
+                keyAlgorithm = signatureAlgorithm.substring(with + 4);
+            }
+            if (keyAlgorithm.equalsIgnoreCase("ECDSA")) {
+                keyAlgorithm = "EC";
+            }
+        }
+        return keyAlgorithm;
+    }
+
+    /**
      * Returns default AlgorithmParameterSpec for a key used in a signature.
      * This is only useful for RSASSA-PSS now, which is the only algorithm
      * that must be initialized with a AlgorithmParameterSpec now.

--- a/test/jdk/sun/security/pkcs/pkcs7/TwoHash.java
+++ b/test/jdk/sun/security/pkcs/pkcs7/TwoHash.java
@@ -60,15 +60,18 @@ public class TwoHash {
             throw new RuntimeException("Should be verified");
         }
 
-        // Modify the SHA256withECDSA signature algorithm to
-        // SHA384withECDSA. This does not matter because HASH here
-        // is not used at all.
+        // Modify the SHA256withECDSA signature algorithm (OID encoded as
+        // "06 08 2A 86 48 CE 3D 04 03 02") to SHA384withECDSA (OID encoded as
+        // "06 08 2A 86 48 CE 3D 04 03 03"). ISO_8859_1 charset is chosen
+        // because it's a strictly one byte per char encoding.
         String s = new String(signature, StandardCharsets.ISO_8859_1);
-        String s1 = s.replace("\u002A\u0086\u0048\u00CE\u003D\u0004\u0003\u0002",
-                "\u002A\u0086\u0048\u00CE\u003D\u0004\u0003\u0003");
+        String s1 = s.replace(
+                "\u0006\u0008\u002A\u0086\u0048\u00CE\u003D\u0004\u0003\u0002",
+                "\u0006\u0008\u002A\u0086\u0048\u00CE\u003D\u0004\u0003\u0003");
         byte[] modified = s1.getBytes(StandardCharsets.ISO_8859_1);
 
-        // The modified signature should still verify.
+        // The modified signature should still verify because the HASH
+        // part of signature algorithm is ignored.
         if (new PKCS7(modified).verify(content) == null) {
             throw new RuntimeException("Should be verified");
         }

--- a/test/jdk/sun/security/pkcs/pkcs7/TwoHash.java
+++ b/test/jdk/sun/security/pkcs/pkcs7/TwoHash.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8255494
+ * @summary Make sure the signature algorithm to verify a PKCS7 block is
+ *      DIGwithENC instead of HASHwithENC.
+ * @modules java.base/sun.security.pkcs
+ *          java.base/sun.security.tools.keytool
+ *          java.base/sun.security.x509
+ */
+
+import sun.security.pkcs.PKCS7;
+import sun.security.tools.keytool.CertAndKeyGen;
+import sun.security.x509.X500Name;
+
+import java.nio.charset.StandardCharsets;
+import java.security.cert.X509Certificate;
+
+public class TwoHash {
+    public static void main(String[] args) throws Exception {
+
+        byte[] content = "Hello You fool I love you".getBytes();
+
+        CertAndKeyGen cak = new CertAndKeyGen("EC", "SHA512withECDSA");
+        cak.generate("secp256r1");
+        byte[] signature = PKCS7.generateNewSignedData(
+                "SHA256withECDSA",
+                null,
+                cak.getPrivateKey(),
+                new X509Certificate[] {cak.getSelfCertificate(new X500Name("CN=Me"), 1000)},
+                content,
+                false,
+                true, // direct sign, so that RFC 6211 check is not possible
+                null);
+
+        // The original signature should verify.
+        if (new PKCS7(signature).verify(content) == null) {
+            throw new RuntimeException("Should be verified");
+        }
+
+        // Modify the SHA256withECDSA signature algorithm to
+        // SHA384withECDSA. This does not matter because HASH here
+        // is not used at all.
+        String s = new String(signature, StandardCharsets.ISO_8859_1);
+        String s1 = s.replace("\u002A\u0086\u0048\u00CE\u003D\u0004\u0003\u0002",
+                "\u002A\u0086\u0048\u00CE\u003D\u0004\u0003\u0003");
+        byte[] modified = s1.getBytes(StandardCharsets.ISO_8859_1);
+
+        // The modified signature should still verify.
+        if (new PKCS7(modified).verify(content) == null) {
+            throw new RuntimeException("Should be verified");
+        }
+    }
+}


### PR DESCRIPTION
This is a regression made by [JDK-8242068](https://bugs.openjdk.java.net/browse/JDK-8242068). When the digest algorithm is not the same as the hash part of the signature algorithm, we used to combine the digest algorithm with the key part of the signature algorithm into a new signature algorithm and use it when generating a signature. The previous code change uses the signature algorithm in the SignerInfo directly. This bugfix will revert to the old behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255494](https://bugs.openjdk.java.net/browse/JDK-8255494): PKCS7 should use digest algorithm to verify the signature


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/916/head:pull/916`
`$ git checkout pull/916`
