### PR TITLE
8255564: InterpreterMacroAssembler::remove_activation() needs to restore thread right after VM call on x86_32

### DIFF
--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1005,9 +1005,9 @@ void InterpreterMacroAssembler::remove_activation(
   push(state);
   set_last_Java_frame(rthread, noreg, rbp, (address)pc());
   super_call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::at_unwind), rthread);
+  NOT_LP64(get_thread(rthread);) // call_VM clobbered it, restore
   reset_last_Java_frame(rthread, true);
   pop(state);
-  NOT_LP64(get_thread(rthread);) // call_VM clobbered it, restore
   bind(fast_path);
 
   // get the value of _do_not_unlock_if_synchronized into rdx


### PR DESCRIPTION
Currently, it restores thread register a bit too late for reset_last_Java_frame().

It is probably not a problem right now, cause there is no 32-bit GC that supports concurrent stack processing. It crashes Shenandoah GC with concurrent stack processing on x86_32, which I am working on.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255564](https://bugs.openjdk.java.net/browse/JDK-8255564): InterpreterMacroAssembler::remove_activation() needs to restore thread right after VM call on x86_32


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/919/head:pull/919`
`$ git checkout pull/919`
