### PR TITLE
8196087: java/awt/image/DrawImage/IncorrectUnmanagedImageRotatedClip.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -254,7 +254,6 @@ java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java 8056077 generic-all
 java/awt/image/DrawImage/IncorrectClipXorModeSW2Surface.java 8196025 windows-all
 java/awt/image/DrawImage/IncorrectClipXorModeSurface2Surface.java 8196025 windows-all
 java/awt/image/DrawImage/IncorrectSourceOffset.java 8196086 windows-all
-java/awt/image/DrawImage/IncorrectUnmanagedImageRotatedClip.java 8196087 windows-all
 java/awt/image/MultiResolutionImage/MultiResolutionDrawImageWithTransformTest.java 8198390 generic-all
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8169187 macosx-all,windows-all
 java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all

--- a/test/jdk/java/awt/image/DrawImage/IncorrectUnmanagedImageRotatedClip.java
+++ b/test/jdk/java/awt/image/DrawImage/IncorrectUnmanagedImageRotatedClip.java
@@ -48,7 +48,9 @@ import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
  * @bug 8059942
  * @summary Tests rotated clip when unmanaged image is drawn to VI.
  *          Results of the blit to compatibleImage are used for comparison.
- * @author Sergey Bylokhov
+ * @run main/othervm -Dsun.java2d.uiScale=1 IncorrectUnmanagedImageRotatedClip
+ * @run main/othervm -Dsun.java2d.uiScale=2 IncorrectUnmanagedImageRotatedClip
+ * @run main/othervm -Dsun.java2d.uiScale=3 IncorrectUnmanagedImageRotatedClip
  */
 public final class IncorrectUnmanagedImageRotatedClip {
 


### PR DESCRIPTION
The test draws some specific pattern to the VolatileImage and to the BufferedImage, and then compare pixels.

The test uses the getSnapshot() method to get the pixels from VolatileImage, and this method produces some interpolation "artifacts" if the fractional scale is used in the system(like 125%).

The solution is to use some predefined scale factors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8196087](https://bugs.openjdk.java.net/browse/JDK-8196087): java/awt/image/DrawImage/IncorrectUnmanagedImageRotatedClip.java fails


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/921/head:pull/921`
`$ git checkout pull/921`
