### PR TITLE
8233641: [TESTBUG] JMenuItem test bug4171437.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -793,7 +793,6 @@ javax/swing/JRadioButton/8033699/bug8033699.java 8233555 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
 javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8233637 macosx-all
 javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
-javax/swing/JMenuItem/4171437/bug4171437.java 8233641 macosx-all
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all

--- a/test/jdk/javax/swing/JMenuItem/4171437/bug4171437.java
+++ b/test/jdk/javax/swing/JMenuItem/4171437/bug4171437.java
@@ -44,21 +44,21 @@ public class bug4171437 {
 
     public static void main(String[] args) throws Exception {
         try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
             SwingUtilities.invokeAndWait(new Runnable() {
                 public void run() {
                     createAndShowGUI();
                 }
             });
 
-            Robot robot = new Robot();
-            robot.setAutoDelay(50);
             robot.waitForIdle();
+            robot.delay(1000);
 
             Util.hitMnemonics(robot, KeyEvent.VK_F);
             Util.hitKeys(robot, KeyEvent.VK_C);
 
             robot.waitForIdle();
-            Thread.sleep(1000);
 
             if (!closeActivated || customActivated) {
                 throw new RuntimeException("Didn't pass the muster");
@@ -109,6 +109,7 @@ public class bug4171437 {
         frame.setSize(300, 300);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 }


### PR DESCRIPTION
Please review a test fix for a test issue seen to be failing on mach5 macos systems due to timing issue.
Modified the test to modify setAutoDelay() time, added delay() after frame is made visible and moved the frame to centre of screen.
Mach5 job has been run for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8233641](https://bugs.openjdk.java.net/browse/JDK-8233641): [TESTBUG] JMenuItem test bug4171437.java fails on macos


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/922/head:pull/922`
`$ git checkout pull/922`
