### PR TITLE
8241806: The sun/awt/shell/FileSystemViewMemoryLeak.java is unstable

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -261,7 +261,6 @@ java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all
 java/awt/print/PrinterJob/TestPgfmtSetMPA.java 8198343 generic-all
 sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all
 sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all
-sun/awt/shell/FileSystemViewMemoryLeak.java 8241806 windows-all
 sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java 8022403 generic-all
 sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java 8196102 generic-all
 sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java 8196180 windows-all,macosx-all

--- a/test/jdk/sun/awt/shell/FileSystemViewMemoryLeak.java
+++ b/test/jdk/sun/awt/shell/FileSystemViewMemoryLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,10 +27,12 @@
  * @summary FileSystemView.isDrive(File) memory leak on "C:\" file reference
  * @modules java.desktop/sun.awt.shell
  * @requires (os.family == "windows")
- * @run main/othervm  -Xmx8m FileSystemViewMemoryLeak
+ * @run main/othervm -Xmx8m FileSystemViewMemoryLeak
  */
 import java.io.File;
 import java.text.NumberFormat;
+import java.util.concurrent.TimeUnit;
+
 import javax.swing.filechooser.FileSystemView;
 
 public class FileSystemViewMemoryLeak {
@@ -38,6 +40,9 @@ public class FileSystemViewMemoryLeak {
     public static void main(String[] args) {
         test();
     }
+
+    // Will run the test no more than 90 seconds
+    static long endtime = System.nanoTime() + TimeUnit.SECONDS.toNanos(90);
 
     private static void test() {
 
@@ -52,6 +57,10 @@ public class FileSystemViewMemoryLeak {
         int iMax = 50000;
         long lastPercentFinished = 0L;
         for (int i = 0; i < iMax; i++) {
+            if (isComplete()) {
+                System.out.println("Time is over");
+                return;
+            }
 
             long percentFinished = Math.round(((i * 1000d) / (double) iMax));
 
@@ -76,6 +85,10 @@ public class FileSystemViewMemoryLeak {
             // "isDrive()" seems to be the painful method...
             boolean drive = fileSystemView.isDrive(root);
         }
+    }
+
+    private static boolean isComplete() {
+        return endtime - System.nanoTime() < 0;
     }
 }
 

--- a/test/jdk/sun/awt/shell/FileSystemViewMemoryLeak.java
+++ b/test/jdk/sun/awt/shell/FileSystemViewMemoryLeak.java
@@ -27,7 +27,7 @@
  * @summary FileSystemView.isDrive(File) memory leak on "C:\" file reference
  * @modules java.desktop/sun.awt.shell
  * @requires (os.family == "windows")
- * @run main/othervm -Xmx8m FileSystemViewMemoryLeak
+ * @run main/othervm/timeout=320 -Xmx8m FileSystemViewMemoryLeak
  */
 import java.io.File;
 import java.text.NumberFormat;
@@ -41,8 +41,8 @@ public class FileSystemViewMemoryLeak {
         test();
     }
 
-    // Will run the test no more than 90 seconds
-    static long endtime = System.nanoTime() + TimeUnit.SECONDS.toNanos(90);
+    // Will run the test no more than 300 seconds
+    static long endtime = System.nanoTime() + TimeUnit.SECONDS.toNanos(300);
 
     private static void test() {
 


### PR DESCRIPTION
The test may work up to 15 minutes on some systems.
The solution is to limit the time execution to 90 seconds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8241806](https://bugs.openjdk.java.net/browse/JDK-8241806): The sun/awt/shell/FileSystemViewMemoryLeak.java is unstable


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**) ⚠️ Review applies to 7ad4ed44342c3dad53e61dcb5a42b2ca1061f3c3
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/923/head:pull/923`
`$ git checkout pull/923`
