### PR TITLE
8233637: [TESTBUG] Swing ActionListenerCalledTwiceTest.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -791,7 +791,6 @@ javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java 8233555 maco
 javax/swing/JRadioButton/8075609/bug8075609.java 8233555 macosx-all
 javax/swing/JRadioButton/8033699/bug8033699.java 8233555 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
-javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8233637 macosx-all
 javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
 javax/swing/JMenuItem/4171437/bug4171437.java 8233641 macosx-all
 

--- a/test/jdk/javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java
+++ b/test/jdk/javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java
@@ -63,13 +63,15 @@ public class ActionListenerCalledTwiceTest {
         }
 
         try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
 
             System.setProperty("apple.laf.useScreenMenuBar", "true");
             SwingUtilities.invokeAndWait(
                     ActionListenerCalledTwiceTest::createAndShowGUI);
 
-            Robot robot = new Robot();
-            robot.setAutoDelay(100);
+            robot.waitForIdle();
+            robot.delay(1000);
 
             testForTwice(robot, "");
 
@@ -99,6 +101,7 @@ public class ActionListenerCalledTwiceTest {
         frame.setJMenuBar(bar);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 


### PR DESCRIPTION
Please review a test fix for a test issue seen to be failing on mach5 macos systems due to timing issue.
Modified the test to added delay() after frame is made visible and moved the frame to centre of screen to be consistent with other tests.
Mach5 job has been run for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8233637](https://bugs.openjdk.java.net/browse/JDK-8233637): [TESTBUG] Swing ActionListenerCalledTwiceTest.java fails on macos


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/926/head:pull/926`
`$ git checkout pull/926`
