### PR TITLE
8255582: Introduce SemaphoreLock and SemaphoreLocker

### DIFF
--- a/src/hotspot/share/runtime/semaphore.hpp
+++ b/src/hotspot/share/runtime/semaphore.hpp
@@ -59,4 +59,35 @@ class Semaphore : public CHeapObj<mtSynchronizer> {
   void wait_with_safepoint_check(JavaThread* thread);
 };
 
+// Small wrapper to provide semaphore version of a lock.
+// Useful for low-level leaf locks.
+class SemaphoreLock : public CHeapObj<mtSynchronizer> {
+  Semaphore _semaphore;
+
+public:
+  SemaphoreLock() : _semaphore(1) {}
+
+  void lock()     { _semaphore.wait(); }
+  void unlock()   { _semaphore.signal(); }
+  bool try_lock() { return _semaphore.trywait(); }
+};
+
+// Convenience RAII class to lock a SemaphoreLock.
+class SemaphoreLocker : public StackObj {
+  SemaphoreLock* const _lock;
+
+public:
+  SemaphoreLocker(SemaphoreLock* lock) : _lock(lock) {
+    if (_lock != NULL) {
+      _lock->lock();
+    }
+  }
+
+  ~SemaphoreLocker() {
+    if (_lock != NULL) {
+      _lock->unlock();
+    }
+  }
+};
+
 #endif // SHARE_RUNTIME_SEMAPHORE_HPP

--- a/test/hotspot/gtest/runtime/test_semaphore.cpp
+++ b/test/hotspot/gtest/runtime/test_semaphore.cpp
@@ -103,3 +103,31 @@ TEST(Semaphore, trywait) {
     }
   }
 }
+
+TEST(SemaphoreLock, lock_unlock) {
+  SemaphoreLock lock;
+  lock.lock();
+  lock.unlock();
+}
+
+TEST(SemaphoreLock, try_lock) {
+  SemaphoreLock lock;
+  lock.lock();
+  ASSERT_EQ(lock.try_lock(), false);
+  lock.unlock();
+
+  ASSERT_EQ(lock.try_lock(), true);
+  lock.unlock();
+}
+
+TEST(SemaphoreLocker, sanity) {
+  SemaphoreLock lock;
+
+  {
+    SemaphoreLocker sl(&lock);
+    ASSERT_EQ(lock.try_lock(), false);
+  }
+
+  ASSERT_EQ(lock.try_lock(), true);
+  lock.unlock();
+}


### PR DESCRIPTION
Semaphores can be used as low-level locks, but the readability of the code using them could be better. I propose that we introduce two new classes:

SemaphoreLock - which provides the operations lock, unlock, try_lock.

SemaphoreLocker - Equivalent to MutexLocker.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255582](https://bugs.openjdk.java.net/browse/JDK-8255582): Introduce SemaphoreLock and SemaphoreLocker


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/927/head:pull/927`
`$ git checkout pull/927`
