### PR TITLE
8255471: ZGC: Rework root iterators and closures

### DIFF
--- a/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
@@ -55,7 +55,7 @@ bool ZBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
 
   // Heal oops and disarm
   ZNMethodOopClosure cl;
-  ZNMethod::nmethod_oops_do(nm, &cl);
+  ZNMethod::nmethod_oops_do_inner(nm, &cl);
   disarm(nm);
 
   return true;

--- a/src/hotspot/share/gc/z/zHeapIterator.cpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.cpp
@@ -23,12 +23,14 @@
 
 #include "precompiled.hpp"
 #include "classfile/classLoaderData.hpp"
+#include "gc/shared/barrierSetNMethod.hpp"
 #include "gc/shared/taskqueue.inline.hpp"
 #include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zGlobals.hpp"
 #include "gc/z/zGranuleMap.inline.hpp"
 #include "gc/z/zHeapIterator.hpp"
 #include "gc/z/zLock.inline.hpp"
+#include "gc/z/zNMethod.hpp"
 #include "gc/z/zOop.inline.hpp"
 #include "memory/iterator.inline.hpp"
 #include "utilities/bitMap.inline.hpp"
@@ -92,8 +94,8 @@ public:
   }
 };
 
-template <bool Concurrent, bool Weak>
-class ZHeapIteratorRootOopClosure : public ZRootsIteratorClosure {
+template <bool Weak>
+class ZHeapIteratorRootOopClosure : public OopClosure {
 private:
   const ZHeapIteratorContext& _context;
 
@@ -102,11 +104,7 @@ private:
       return NativeAccess<AS_NO_KEEPALIVE | ON_PHANTOM_OOP_REF>::oop_load(p);
     }
 
-    if (Concurrent) {
-      return NativeAccess<AS_NO_KEEPALIVE>::oop_load(p);
-    }
-
-    return RawAccess<>::oop_load(p);
+    return NativeAccess<AS_NO_KEEPALIVE>::oop_load(p);
   }
 
 public:
@@ -120,22 +118,6 @@ public:
 
   virtual void do_oop(narrowOop* p) {
     ShouldNotReachHere();
-  }
-
-  virtual void do_thread(Thread* thread) {
-    CodeBlobToOopClosure code_cl(this, false /* fix_oop_relocations */);
-    thread->oops_do(this, &code_cl);
-  }
-
-  virtual ZNMethodEntry nmethod_entry() const {
-    if (ClassUnloading) {
-      // All encountered nmethods should have been "entered" during stack walking
-      return ZNMethodEntry::VerifyDisarmed;
-    } else {
-      // All nmethods are considered roots and will be visited.
-      // Make sure that the unvisited gets fixed and disarmed before proceeding.
-      return ZNMethodEntry::PreBarrier;
-    }
   }
 };
 
@@ -180,7 +162,7 @@ ZHeapIterator::ZHeapIterator(uint nworkers, bool visit_weaks) :
     _bitmaps_lock(),
     _queues(nworkers),
     _array_queues(nworkers),
-    _concurrent_roots(),
+    _concurrent_roots(ClassLoaderData::_claim_other),
     _weak_roots(),
     _concurrent_weak_roots(),
     _terminator(nworkers, &_queues) {
@@ -255,10 +237,59 @@ bool ZHeapIterator::mark_object(oop obj) {
   return bitmap->try_set_bit(index);
 }
 
-template <bool Concurrent, bool Weak, typename RootsIterator>
-void ZHeapIterator::push_roots(const ZHeapIteratorContext& context, RootsIterator& iter) {
-  ZHeapIteratorRootOopClosure<Concurrent, Weak> cl(context);
-  iter.oops_do(&cl);
+typedef ClaimingCLDToOopClosure<ClassLoaderData::_claim_other> ZHeapIteratorCLDCLosure;
+
+class ZHeapIteratorNMethodClosure : public NMethodClosure {
+private:
+  OopClosure* const        _cl;
+  BarrierSetNMethod* const _bs_nm;
+
+public:
+  ZHeapIteratorNMethodClosure(OopClosure* cl) :
+      _cl(cl),
+      _bs_nm(BarrierSet::barrier_set()->barrier_set_nmethod()) {}
+
+  virtual void do_nmethod(nmethod* nm) {
+    assert(!ClassUnloading, "Only used if class unloading is turned off");
+
+    // ClassUnloading is turned off, all nmethods are considered strong,
+    // not only those on the call stacks. The heap iteration might happen
+    // before the concurrent processign of the code cache, make sure that
+    // all nmethods have been processed before visiting the oops.
+    _bs_nm->nmethod_entry_barrier(nm);
+
+    ZNMethod::nmethod_oops_do(nm, _cl);
+  }
+};
+
+typedef ThreadToOopClosure ZHeapIteratorThreadClosure;
+
+void ZHeapIterator::push_strong_roots(const ZHeapIteratorContext& context) {
+  ZHeapIteratorRootOopClosure<false /* Weak */> cl(context);
+  ZHeapIteratorCLDCLosure cld_cl(&cl);
+  ZHeapIteratorNMethodClosure nm_cl(&cl);
+  ZHeapIteratorThreadClosure thread_cl(&cl);
+
+  _concurrent_roots.apply(&cl,
+                          &cld_cl,
+                          &thread_cl,
+                          &nm_cl);
+}
+
+void ZHeapIterator::push_weak_roots(const ZHeapIteratorContext& context) {
+  ZHeapIteratorRootOopClosure<true  /* Weak */> cl(context);
+  _concurrent_weak_roots.apply(&cl);
+
+  AlwaysTrueClosure is_alive;
+  _weak_roots.apply(&is_alive, &cl);
+}
+
+template <bool VisitWeaks>
+void ZHeapIterator::push_roots(const ZHeapIteratorContext& context) {
+  push_strong_roots(context);
+  if (VisitWeaks) {
+    push_weak_roots(context);
+  }
 }
 
 template <bool VisitReferents>
@@ -343,14 +374,9 @@ void ZHeapIterator::drain_and_steal(const ZHeapIteratorContext& context, ObjectC
 }
 
 template <bool VisitWeaks>
-void ZHeapIterator::object_iterate_inner(const ZHeapIteratorContext& context, ObjectClosure* cl) {
-  push_roots<true  /* Concurrent */, false /* Weak */>(context, _concurrent_roots);
-  if (VisitWeaks) {
-    push_roots<false /* Concurrent */, true  /* Weak */>(context, _weak_roots);
-    push_roots<true  /* Concurrent */, true  /* Weak */>(context, _concurrent_weak_roots);
-  }
-
-  drain_and_steal<VisitWeaks>(context, cl);
+void ZHeapIterator::object_iterate_inner(const ZHeapIteratorContext& context, ObjectClosure* object_cl) {
+  push_roots<VisitWeaks>(context);
+  drain_and_steal<VisitWeaks>(context, object_cl);
 }
 
 void ZHeapIterator::object_iterate(ObjectClosure* cl, uint worker_id) {

--- a/src/hotspot/share/gc/z/zHeapIterator.hpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.hpp
@@ -46,23 +46,26 @@ class ZHeapIterator : public ParallelObjectIterator {
   friend class ZHeapIteratorContext;
 
 private:
-  const bool                         _visit_weaks;
-  ZStatTimerDisable                  _timer_disable;
-  ZHeapIteratorBitMaps               _bitmaps;
-  ZLock                              _bitmaps_lock;
-  ZHeapIteratorQueues                _queues;
-  ZHeapIteratorArrayQueues           _array_queues;
-  ZConcurrentRootsIteratorClaimOther _concurrent_roots;
-  ZWeakRootsIterator                 _weak_roots;
-  ZConcurrentWeakRootsIterator       _concurrent_weak_roots;
-  TaskTerminator                     _terminator;
+  const bool                   _visit_weaks;
+  ZStatTimerDisable            _timer_disable;
+  ZHeapIteratorBitMaps         _bitmaps;
+  ZLock                        _bitmaps_lock;
+  ZHeapIteratorQueues          _queues;
+  ZHeapIteratorArrayQueues     _array_queues;
+  ZConcurrentRootsIterator     _concurrent_roots;
+  ZWeakRootsIterator           _weak_roots;
+  ZConcurrentWeakRootsIterator _concurrent_weak_roots;
+  TaskTerminator               _terminator;
 
   ZHeapIteratorBitMap* object_bitmap(oop obj);
 
   bool mark_object(oop obj);
 
-  template <bool Concurrent, bool Weak, typename RootsIterator>
-  void push_roots(const ZHeapIteratorContext& context, RootsIterator& iter);
+  void push_strong_roots(const ZHeapIteratorContext& context);
+  void push_weak_roots(const ZHeapIteratorContext& context);
+
+  template <bool VisitWeaks>
+  void push_roots(const ZHeapIteratorContext& context);
 
   template <bool VisitReferents>
   void follow_object(const ZHeapIteratorContext& context, oop obj);

--- a/src/hotspot/share/gc/z/zNMethod.hpp
+++ b/src/hotspot/share/gc/z/zNMethod.hpp
@@ -27,16 +27,9 @@
 #include "memory/allocation.hpp"
 
 class nmethod;
-class OopClosure;
+class NMethodClosure;
 class ZReentrantLock;
 class ZWorkers;
-
-enum class ZNMethodEntry {
-  PreBarrier,
-  Disarm,
-  VerifyDisarmed,
-  None
-};
 
 class ZNMethod : public AllStatic {
 private:
@@ -56,10 +49,11 @@ public:
   static void disarm(nmethod* nm);
 
   static void nmethod_oops_do(nmethod* nm, OopClosure* cl);
+  static void nmethod_oops_do_inner(nmethod* nm, OopClosure* cl);
 
-  static void oops_do_begin();
-  static void oops_do_end();
-  static void oops_do(OopClosure* cl, ZNMethodEntry entry);
+  static void nmethods_do_begin();
+  static void nmethods_do_end();
+  static void nmethods_do(NMethodClosure* cl);
 
   static ZReentrantLock* lock_for_nmethod(nmethod* nm);
 

--- a/src/hotspot/share/gc/z/zOopClosures.hpp
+++ b/src/hotspot/share/gc/z/zOopClosures.hpp
@@ -53,20 +53,15 @@ public:
   virtual bool do_object_b(oop o);
 };
 
-class ZPhantomKeepAliveOopClosure : public ZRootsIteratorClosure {
+class ZPhantomKeepAliveOopClosure : public OopClosure {
 public:
   virtual void do_oop(oop* p);
   virtual void do_oop(narrowOop* p);
-
-  virtual ZNMethodEntry nmethod_entry() const;
 };
-
-class ZPhantomCleanOopClosure : public ZRootsIteratorClosure {
+class ZPhantomCleanOopClosure : public OopClosure {
 public:
   virtual void do_oop(oop* p);
   virtual void do_oop(narrowOop* p);
-
-  virtual ZNMethodEntry nmethod_entry() const;
 };
 
 #endif // SHARE_GC_Z_ZOOPCLOSURES_HPP

--- a/src/hotspot/share/gc/z/zOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/z/zOopClosures.inline.hpp
@@ -80,11 +80,6 @@ inline void ZPhantomKeepAliveOopClosure::do_oop(oop* p) {
   ZBarrier::keep_alive_barrier_on_phantom_oop_field(p);
 }
 
-inline ZNMethodEntry ZPhantomKeepAliveOopClosure::nmethod_entry() const {
-  ShouldNotReachHere();
-  return ZNMethodEntry::None;
-}
-
 inline void ZPhantomKeepAliveOopClosure::do_oop(narrowOop* p) {
   ShouldNotReachHere();
 }
@@ -107,11 +102,6 @@ inline void ZPhantomCleanOopClosure::do_oop(oop* p) {
 
 inline void ZPhantomCleanOopClosure::do_oop(narrowOop* p) {
   ShouldNotReachHere();
-}
-
-inline ZNMethodEntry ZPhantomCleanOopClosure::nmethod_entry() const {
-  ShouldNotReachHere();
-  return ZNMethodEntry::None;
 }
 
 #endif // SHARE_GC_Z_ZOOPCLOSURES_INLINE_HPP

--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -36,8 +36,10 @@
 #include "gc/z/zThread.inline.hpp"
 #include "gc/z/zWorkers.hpp"
 #include "logging/log.hpp"
+#include "prims/jvmtiTagMap.hpp"
 
 static const ZStatCounter ZCounterRelocationContention("Contention", "Relocation Contention", ZStatUnitOpsPerSecond);
+static const ZStatSubPhase ZSubPhasePauseRootsJVMTITagMap("Pause Roots JVMTITagMap");
 
 ZRelocate::ZRelocate(ZWorkers* workers) :
     _workers(workers) {}
@@ -67,8 +69,10 @@ public:
     assert(ZThread::worker_id() == 0, "No multi-thread support");
 
     // During relocation we need to visit the JVMTI
-    // export weak roots to rehash the JVMTI tag map
-    ZRelocateRoots::oops_do(&_cl);
+    // tag map to rehash the entries with the new oop addresses.
+    ZStatTimer timer(ZSubPhasePauseRootsJVMTITagMap);
+    AlwaysTrueClosure always_alive;
+    JvmtiTagMap::weak_oops_do(&always_alive, &_cl);
   }
 };
 

--- a/src/hotspot/share/gc/z/zRootsIterator.hpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.hpp
@@ -24,45 +24,56 @@
 #ifndef SHARE_GC_Z_ZROOTSITERATOR_HPP
 #define SHARE_GC_Z_ZROOTSITERATOR_HPP
 
-#include "classfile/classLoaderDataGraph.hpp"
 #include "gc/shared/oopStorageSetParState.hpp"
-#include "gc/z/zNMethod.hpp"
-#include "memory/allocation.hpp"
+#include "logging/log.hpp"
 #include "memory/iterator.hpp"
 #include "runtime/threadSMR.hpp"
 
-class ZRootsIteratorClosure;
-
-typedef OopStorageSetStrongParState<true /* concurrent */, false /* is_const */> ZOopStorageSetStrongIterator;
-typedef OopStorageSetWeakParState<true /* concurrent */, false /* is_const */> ZOopStorageSetWeakIterator;
-
-template <typename T, void (T::*F)(ZRootsIteratorClosure*)>
-class ZParallelOopsDo {
+template <typename Iterator>
+class ZParallelApply {
 private:
-  T* const      _iter;
+  Iterator      _iter;
   volatile bool _completed;
 
 public:
-  ZParallelOopsDo(T* iter);
-  void oops_do(ZRootsIteratorClosure* cl);
+  ZParallelApply() :
+      _iter(),
+      _completed(false) {}
+
+  template <typename ClosureType>
+  void apply(ClosureType* cl);
+
+  Iterator& iter() {
+    return _iter;
+  }
 };
 
-template <typename T, void (T::*F)(BoolObjectClosure*, ZRootsIteratorClosure*)>
-class ZSerialWeakOopsDo {
+template <typename Iterator>
+class ZSerialWeakApply {
 private:
-  T* const      _iter;
+  Iterator      _iter;
   volatile bool _claimed;
 
 public:
-  ZSerialWeakOopsDo(T* iter);
-  void weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl);
+  ZSerialWeakApply() :
+      _iter(),
+      _claimed(false) {}
+
+  void apply(BoolObjectClosure* is_alive, OopClosure* cl);
 };
 
-class ZRootsIteratorClosure : public OopClosure {
-public:
-  virtual void do_thread(Thread* thread) {}
+class ZStrongOopStorageSetIterator {
+  OopStorageSetStrongParState<true /* concurrent */, false /* is_const */> _iter;
 
-  virtual ZNMethodEntry nmethod_entry() const = 0;
+public:
+  ZStrongOopStorageSetIterator();
+
+  void apply(OopClosure* cl);
+};
+
+class ZStrongCLDsIterator {
+public:
+  void apply(CLDClosure* cl);
 };
 
 class ZJavaThreadsIterator {
@@ -75,80 +86,66 @@ private:
 public:
   ZJavaThreadsIterator();
 
-  void threads_do(ThreadClosure* cl);
+  void apply(ThreadClosure* cl);
 };
 
-class ZRelocateRoots : public AllStatic {
+class ZNMethodsIterator {
 public:
-  static void oops_do(OopClosure* cl);
+  ZNMethodsIterator();
+  ~ZNMethodsIterator();
+
+  void apply(NMethodClosure* cl);
 };
 
 class ZConcurrentRootsIterator {
 private:
-  ZOopStorageSetStrongIterator _oop_storage_set_iter;
-  ZJavaThreadsIterator         _java_threads_iter;
-  const int                    _cld_claim;
-
-  void do_oop_storage_set(ZRootsIteratorClosure* cl);
-  void do_java_threads(ZRootsIteratorClosure* cl);
-  void do_class_loader_data_graph(ZRootsIteratorClosure* cl);
-  void do_code_cache(ZRootsIteratorClosure* cl);
-
-  ZParallelOopsDo<ZConcurrentRootsIterator, &ZConcurrentRootsIterator::do_oop_storage_set>         _oop_storage_set;
-  ZParallelOopsDo<ZConcurrentRootsIterator, &ZConcurrentRootsIterator::do_class_loader_data_graph> _class_loader_data_graph;
-  ZParallelOopsDo<ZConcurrentRootsIterator, &ZConcurrentRootsIterator::do_java_threads>            _java_threads;
-  ZParallelOopsDo<ZConcurrentRootsIterator, &ZConcurrentRootsIterator::do_code_cache>              _code_cache;
+  ZParallelApply<ZStrongOopStorageSetIterator> _oop_storage_set;
+  ZParallelApply<ZStrongCLDsIterator>          _class_loader_data_graph;
+  ZParallelApply<ZJavaThreadsIterator>         _java_threads;
+  ZParallelApply<ZNMethodsIterator>            _nmethods;
 
 public:
   ZConcurrentRootsIterator(int cld_claim);
-  ~ZConcurrentRootsIterator();
 
-  void oops_do(ZRootsIteratorClosure* cl);
+  void apply(OopClosure* cl,
+             CLDClosure* cld_cl,
+             ThreadClosure* thread_cl,
+             NMethodClosure* nm_cl);
 };
 
-class ZConcurrentRootsIteratorClaimStrong : public ZConcurrentRootsIterator {
+class ZWeakOopStorageSetIterator {
+private:
+  OopStorageSetWeakParState<true /* concurrent */, false /* is_const */> _iter;
+
 public:
-  ZConcurrentRootsIteratorClaimStrong() :
-      ZConcurrentRootsIterator(ClassLoaderData::_claim_strong) {}
+  ZWeakOopStorageSetIterator();
+
+  void apply(OopClosure* cl);
+
+  void report_num_dead();
 };
 
-class ZConcurrentRootsIteratorClaimOther : public ZConcurrentRootsIterator {
+class ZJVMTITagMapIterator {
 public:
-  ZConcurrentRootsIteratorClaimOther() :
-      ZConcurrentRootsIterator(ClassLoaderData::_claim_other) {}
-};
-
-class ZConcurrentRootsIteratorClaimNone : public ZConcurrentRootsIterator {
-public:
-  ZConcurrentRootsIteratorClaimNone() :
-      ZConcurrentRootsIterator(ClassLoaderData::_claim_none) {}
+  void apply(BoolObjectClosure* is_alive, OopClosure* cl);
 };
 
 class ZWeakRootsIterator {
 private:
-  void do_jvmti_weak_export(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl);
-
-  ZSerialWeakOopsDo<ZWeakRootsIterator, &ZWeakRootsIterator::do_jvmti_weak_export> _jvmti_weak_export;
+  ZSerialWeakApply<ZJVMTITagMapIterator> _jvmti_tag_map;
 
 public:
   ZWeakRootsIterator();
 
-  void weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl);
-  void oops_do(ZRootsIteratorClosure* cl);
+  void apply(BoolObjectClosure* is_alive, OopClosure* cl);
 };
 
 class ZConcurrentWeakRootsIterator {
 private:
-  ZOopStorageSetWeakIterator _oop_storage_set_iter;
-
-  void do_oop_storage_set(ZRootsIteratorClosure* cl);
-
-  ZParallelOopsDo<ZConcurrentWeakRootsIterator, &ZConcurrentWeakRootsIterator::do_oop_storage_set> _oop_storage_set;
+  ZParallelApply<ZWeakOopStorageSetIterator> _oop_storage_set;
 
 public:
-  ZConcurrentWeakRootsIterator();
-
-  void oops_do(ZRootsIteratorClosure* cl);
+  void apply(OopClosure* cl);
 
   void report_num_dead();
 };

--- a/src/hotspot/share/gc/z/zUnload.cpp
+++ b/src/hotspot/share/gc/z/zUnload.cpp
@@ -72,7 +72,7 @@ public:
     ZReentrantLock* const lock = ZNMethod::lock_for_nmethod(nm);
     ZLocker<ZReentrantLock> locker(lock);
     ZIsUnloadingOopClosure cl;
-    ZNMethod::nmethod_oops_do(nm, &cl);
+    ZNMethod::nmethod_oops_do_inner(nm, &cl);
     return cl.is_unloading();
   }
 };

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -232,6 +232,12 @@ private:
   BarrierSetNMethod* const _bs_nm;
   const bool               _verify_fixed;
 
+  bool trust_nmethod_state() const {
+    // The root iterator will visit non-processed
+    // nmethods class unloading is turned off.
+    return ClassUnloading || _verify_fixed;
+  }
+
 public:
   ZVerifyNMethodClosure(OopClosure* cl, bool verify_fixed) :
       _cl(cl),
@@ -239,7 +245,7 @@ public:
       _verify_fixed(verify_fixed) {}
 
   virtual void do_nmethod(nmethod* nm) {
-    assert(!_verify_fixed | !_bs_nm->is_armed(nm), "Should not encounter any armed nmethods");
+    assert(!trust_nmethod_state() || !_bs_nm->is_armed(nm), "Should not encounter any armed nmethods");
 
     ZNMethod::nmethod_oops_do(nm, _cl);
   }

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -25,6 +25,7 @@
 #include "classfile/classLoaderData.hpp"
 #include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zHeap.inline.hpp"
+#include "gc/z/zNMethod.hpp"
 #include "gc/z/zOop.hpp"
 #include "gc/z/zPageAllocator.hpp"
 #include "gc/z/zResurrection.hpp"
@@ -66,7 +67,7 @@ static void z_verify_possibly_weak_oop(oop* p) {
   }
 }
 
-class ZVerifyRootClosure : public ZRootsIteratorClosure {
+class ZVerifyRootClosure : public OopClosure {
 private:
   const bool _verify_fixed;
 
@@ -89,15 +90,8 @@ public:
     ShouldNotReachHere();
   }
 
-  virtual void do_thread(Thread* thread);
-
   bool verify_fixed() const {
     return _verify_fixed;
-  }
-
-  virtual ZNMethodEntry nmethod_entry() const {
-    // Verification performs its own verification
-    return ZNMethodEntry::None;
   }
 };
 
@@ -181,18 +175,6 @@ public:
   }
 };
 
-void ZVerifyRootClosure::do_thread(Thread* thread) {
-  thread->oops_do_no_frames(this, NULL);
-
-  JavaThread* const jt = thread->as_Java_thread();
-  if (!jt->has_last_Java_frame()) {
-    return;
-  }
-
-  ZVerifyStack verify_stack(this, jt);
-  verify_stack.verify_frames();
-}
-
 class ZVerifyOopClosure : public ClaimMetadataVisitingOopIterateClosure {
 private:
   const bool _verify_weaks;
@@ -221,35 +203,82 @@ public:
   }
 };
 
-template <typename RootsIterator>
-void ZVerify::roots(bool verify_fixed) {
+typedef ClaimingCLDToOopClosure<ClassLoaderData::_claim_none> ZVerifyCLDClosure;
+
+class ZVerifyThreadClosure : public ThreadClosure {
+private:
+  ZVerifyRootClosure* const _cl;
+
+public:
+  ZVerifyThreadClosure(ZVerifyRootClosure* cl) :
+      _cl(cl) {}
+
+  virtual void do_thread(Thread* thread) {
+    thread->oops_do_no_frames(_cl, NULL);
+
+    JavaThread* const jt = thread->as_Java_thread();
+    if (!jt->has_last_Java_frame()) {
+      return;
+    }
+
+    ZVerifyStack verify_stack(_cl, jt);
+    verify_stack.verify_frames();
+  }
+};
+
+class ZVerifyNMethodClosure : public NMethodClosure {
+private:
+  OopClosure* const        _cl;
+  BarrierSetNMethod* const _bs_nm;
+
+public:
+  ZVerifyNMethodClosure(OopClosure* cl) :
+      _cl(cl),
+      _bs_nm(BarrierSet::barrier_set()->barrier_set_nmethod()) {}
+
+  virtual void do_nmethod(nmethod* nm) {
+    assert(!_bs_nm->is_armed(nm), "Should not encounter any armed nmethods");
+
+    ZNMethod::nmethod_oops_do(nm, _cl);
+  }
+};
+
+void ZVerify::roots_concurrent_strong(bool verify_fixed) {
+  ZVerifyRootClosure cl(verify_fixed);
+  ZVerifyCLDClosure cld_cl(&cl);
+  ZVerifyThreadClosure thread_cl(&cl);
+  ZVerifyNMethodClosure nm_cl(&cl);
+
+  ZConcurrentRootsIterator iter(ClassLoaderData::_claim_none);
+  iter.apply(&cl,
+             &cld_cl,
+             &thread_cl,
+             &nm_cl);
+}
+
+void ZVerify::roots_weak() {
+  AlwaysTrueClosure is_alive;
+  ZVerifyRootClosure cl(true /* verify_fixed */);
+  ZWeakRootsIterator iter;
+  iter.apply(&is_alive, &cl);
+}
+
+void ZVerify::roots_concurrent_weak() {
+  ZVerifyRootClosure cl(true /* verify_fixed */);
+  ZConcurrentWeakRootsIterator iter;
+  iter.apply(&cl);
+}
+
+void ZVerify::roots(bool verify_concurrent_strong, bool verify_weaks) {
   assert(SafepointSynchronize::is_at_safepoint(), "Must be at a safepoint");
   assert(!ZResurrection::is_blocked(), "Invalid phase");
 
   if (ZVerifyRoots) {
-    ZVerifyRootClosure cl(verify_fixed);
-    RootsIterator iter;
-    iter.oops_do(&cl);
-  }
-}
-
-void ZVerify::roots_weak() {
-  roots<ZWeakRootsIterator>(true /* verify_fixed */);
-}
-
-void ZVerify::roots_concurrent_strong(bool verify_fixed) {
-  roots<ZConcurrentRootsIteratorClaimNone>(verify_fixed);
-}
-
-void ZVerify::roots_concurrent_weak() {
-  roots<ZConcurrentWeakRootsIterator>(true /* verify_fixed */);
-}
-
-void ZVerify::roots(bool verify_concurrent_strong, bool verify_weaks) {
-  roots_concurrent_strong(verify_concurrent_strong);
-  if (verify_weaks) {
-    roots_weak();
-    roots_concurrent_weak();
+    roots_concurrent_strong(verify_concurrent_strong);
+    if (verify_weaks) {
+      roots_weak();
+      roots_concurrent_weak();
+    }
   }
 }
 

--- a/src/hotspot/share/gc/z/zVerify.hpp
+++ b/src/hotspot/share/gc/z/zVerify.hpp
@@ -31,10 +31,8 @@ class ZPageAllocator;
 
 class ZVerify : public AllStatic {
 private:
-  template <typename RootsIterator> static void roots(bool verify_fixed);
-
-  static void roots_weak();
   static void roots_concurrent_strong(bool verify_fixed);
+  static void roots_weak();
   static void roots_concurrent_weak();
 
   static void roots(bool verify_concurrent_strong, bool verify_weaks);

--- a/src/hotspot/share/gc/z/zWeakRootsProcessor.cpp
+++ b/src/hotspot/share/gc/z/zWeakRootsProcessor.cpp
@@ -41,13 +41,13 @@ public:
   virtual void work() {
     ZPhantomIsAliveObjectClosure is_alive;
     ZPhantomKeepAliveOopClosure keep_alive;
-    _weak_roots.weak_oops_do(&is_alive, &keep_alive);
+    _weak_roots.apply(&is_alive, &keep_alive);
   }
 };
 
 void ZWeakRootsProcessor::process_weak_roots() {
   ZProcessWeakRootsTask task;
-  _workers->run_parallel(&task);
+  _workers->run_serial(&task);
 }
 
 class ZProcessConcurrentWeakRootsTask : public ZTask {
@@ -65,7 +65,7 @@ public:
 
   virtual void work() {
     ZPhantomCleanOopClosure cl;
-    _concurrent_weak_roots.oops_do(&cl);
+    _concurrent_weak_roots.apply(&cl);
   }
 };
 

--- a/src/hotspot/share/memory/iterator.cpp
+++ b/src/hotspot/share/memory/iterator.cpp
@@ -27,7 +27,6 @@
 #include "code/nmethod.hpp"
 #include "memory/iterator.inline.hpp"
 #include "oops/oop.inline.hpp"
-#include "runtime/thread.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -35,11 +34,6 @@ DoNothingClosure do_nothing_cl;
 
 void CLDToOopClosure::do_cld(ClassLoaderData* cld) {
   cld->oops_do(_oop_closure, _cld_claim);
-}
-
-void ThreadToOopClosure::do_thread(Thread* thread) {
-  CodeBlobToOopClosure code_cl(_cl, false /* fix_oop_relocations */);
-  thread->oops_do(_cl, &code_cl);
 }
 
 void ObjectToOopClosure::do_object(oop obj) {

--- a/src/hotspot/share/memory/iterator.cpp
+++ b/src/hotspot/share/memory/iterator.cpp
@@ -23,9 +23,11 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/classLoaderDataGraph.hpp"
 #include "code/nmethod.hpp"
 #include "memory/iterator.inline.hpp"
 #include "oops/oop.inline.hpp"
+#include "runtime/thread.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -33,6 +35,11 @@ DoNothingClosure do_nothing_cl;
 
 void CLDToOopClosure::do_cld(ClassLoaderData* cld) {
   cld->oops_do(_oop_closure, _cld_claim);
+}
+
+void ThreadToOopClosure::do_thread(Thread* thread) {
+  CodeBlobToOopClosure code_cl(_cl, false /* fix_oop_relocations */);
+  thread->oops_do(_cl, &code_cl);
 }
 
 void ObjectToOopClosure::do_object(oop obj) {

--- a/src/hotspot/share/memory/iterator.hpp
+++ b/src/hotspot/share/memory/iterator.hpp
@@ -171,15 +171,6 @@ class MetadataVisitingOopIterateClosure: public ClaimMetadataVisitingOopIterateC
   MetadataVisitingOopIterateClosure(ReferenceDiscoverer* rd = NULL);
 };
 
-class ThreadToOopClosure : public ThreadClosure {
-private:
-  OopClosure* const _cl;
-
-public:
-  ThreadToOopClosure(OopClosure* cl) : _cl(cl) {}
-  void do_thread(Thread* thread);
-};
-
 // ObjectClosure is used for iterating through an object space
 
 class ObjectClosure : public Closure {

--- a/src/hotspot/share/memory/iterator.hpp
+++ b/src/hotspot/share/memory/iterator.hpp
@@ -143,6 +143,12 @@ class CLDToOopClosure : public CLDClosure {
   void do_cld(ClassLoaderData* cld);
 };
 
+template <int claim>
+class ClaimingCLDToOopClosure : public CLDToOopClosure {
+public:
+  ClaimingCLDToOopClosure(OopClosure* cl) : CLDToOopClosure(cl, claim) {}
+};
+
 class ClaimMetadataVisitingOopIterateClosure : public OopIterateClosure {
  protected:
   const int _claim;
@@ -163,6 +169,15 @@ class ClaimMetadataVisitingOopIterateClosure : public OopIterateClosure {
 class MetadataVisitingOopIterateClosure: public ClaimMetadataVisitingOopIterateClosure {
  public:
   MetadataVisitingOopIterateClosure(ReferenceDiscoverer* rd = NULL);
+};
+
+class ThreadToOopClosure : public ThreadClosure {
+private:
+  OopClosure* const _cl;
+
+public:
+  ThreadToOopClosure(OopClosure* cl) : _cl(cl) {}
+  void do_thread(Thread* thread);
 };
 
 // ObjectClosure is used for iterating through an object space


### PR DESCRIPTION
Today we have the ZRootsIteratorClosure type to cater for the different type of roots and their containers (oop storage, threads, nmethods, runtime oop data structures). This closure is then passed down and applied to the different containers. We split the root sets into different sets: concurrent strong, concurrent weak, and non-concurrent weak. Not all of those sets contain all types of containers. This forces some of the code to implement, or at least consider, parts of the ZRootsIteratorClosure interface that it doesn't care about. It also moves some of the closure logic into shared code, even when it's only used by one of the closures.

I propose that we turn this inside out, and use direct closures that match the visited containers (NMethodClosure for nmethods, et.c.). The intention is to make it a bit easier to see from the call sites what code is run and, hopefully, making localized changes stay more local in the code.

Note: I started this code with a version building upon https://bugs.openjdk.java.net/browse/JDK-8212879, but I don't want to wait for that work to finish before sending this out, so the current patch contains handling of non-conurrent weak roots. As soon as that gets integrated, we can get rid of the ZWeakSerial and the associated non-concurrent weak roots handling.

I've tested this on tier1-7 on linux x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255471](https://bugs.openjdk.java.net/browse/JDK-8255471): ZGC: Rework root iterators and closures


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/928/head:pull/928`
`$ git checkout pull/928`
