### PR TITLE
8196089: javax/swing/Action/8133039/bug8133039.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -748,7 +748,6 @@ javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all
 javax/swing/JFileChooser/8041694/bug8041694.java 8196302 windows-all,macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
-javax/swing/Action/8133039/bug8133039.java 8196089 windows-all,macosx-all
 javax/swing/JComboBox/6559152/bug6559152.java 8196090 windows-all,macosx-all
 javax/swing/JComboBox/8032878/bug8032878.java 8196092,8196439 windows-all,macosx-all,linux-all
 javax/swing/JComboBox/8072767/bug8072767.java 8196093 windows-all,macosx-all

--- a/test/jdk/javax/swing/Action/8133039/bug8133039.java
+++ b/test/jdk/javax/swing/Action/8133039/bug8133039.java
@@ -89,7 +89,7 @@ public class bug8133039 {
         SwingUtilities.invokeAndWait(bug8133039::createAndShowGUI);
 
         Robot robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
         robot.waitForIdle();
 
         robot.keyPress(KeyEvent.VK_A);
@@ -130,6 +130,7 @@ public class bug8133039 {
         comboBox.getActionMap().put("showPopup", showPopupAction);
 
         frame.getContentPane().add(comboBox);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 


### PR DESCRIPTION
Please review a test fix for an issue seen to be failing on mach5 systems due to timing issue.
Adjusted the autoDelay time and moved the frame to center of screen.
Mach5 job has been run for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8196089](https://bugs.openjdk.java.net/browse/JDK-8196089): javax/swing/Action/8133039/bug8133039.java fails


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/929/head:pull/929`
`$ git checkout pull/929`
