### PR TITLE
8255005: Fix indentation levels in classFileParser.cpp

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -3902,7 +3902,6 @@ void ClassFileParser::parse_classfile_attributes(const ClassFileStream* const cf
             parsed_record_attribute = true;
             record_attribute_start = cfs->current();
             record_attribute_length = attribute_length;
-            cfs->skip_u1(attribute_length, CHECK);
           } else if (tag == vmSymbols::tag_permitted_subclasses()) {
             if (supports_sealed_types()) {
               if (parsed_permitted_subclasses_attribute) {
@@ -3918,11 +3917,9 @@ void ClassFileParser::parse_classfile_attributes(const ClassFileStream* const cf
               permitted_subclasses_attribute_start = cfs->current();
               permitted_subclasses_attribute_length = attribute_length;
             }
-            cfs->skip_u1(attribute_length, CHECK);
-          } else {
-            // Unknown attribute
-            cfs->skip_u1(attribute_length, CHECK);
           }
+          // Skip attribute_length for any attribute where major_verson >= JAVA_16_VERSION
+          cfs->skip_u1(attribute_length, CHECK);
         } else {
           // Unknown attribute
           cfs->skip_u1(attribute_length, CHECK);

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -3893,9 +3893,17 @@ void ClassFileParser::parse_classfile_attributes(const ClassFileStream* const cf
                          class_info_index, CHECK);
           _nest_host = class_info_index;
 
-        } else if (_major_version >= JAVA_15_VERSION) {
-          // Check for PermittedSubclasses tag
-          if (tag == vmSymbols::tag_permitted_subclasses()) {
+        } else if (_major_version >= JAVA_16_VERSION) {
+          if (tag == vmSymbols::tag_record()) {
+            if (parsed_record_attribute) {
+              classfile_parse_error("Multiple Record attributes in class file %s", THREAD);
+              return;
+            }
+            parsed_record_attribute = true;
+            record_attribute_start = cfs->current();
+            record_attribute_length = attribute_length;
+            cfs->skip_u1(attribute_length, CHECK);
+          } else if (tag == vmSymbols::tag_permitted_subclasses()) {
             if (supports_sealed_types()) {
               if (parsed_permitted_subclasses_attribute) {
                 classfile_parse_error("Multiple PermittedSubclasses attributes in class file %s", CHECK);
@@ -3910,18 +3918,6 @@ void ClassFileParser::parse_classfile_attributes(const ClassFileStream* const cf
               permitted_subclasses_attribute_start = cfs->current();
               permitted_subclasses_attribute_length = attribute_length;
             }
-            cfs->skip_u1(attribute_length, CHECK);
-
-          } else if (_major_version >= JAVA_16_VERSION) {
-            if (tag == vmSymbols::tag_record()) {
-              if (parsed_record_attribute) {
-                classfile_parse_error("Multiple Record attributes in class file %s", THREAD);
-                return;
-              }
-              parsed_record_attribute = true;
-              record_attribute_start = cfs->current();
-              record_attribute_length = attribute_length;
-              }
             cfs->skip_u1(attribute_length, CHECK);
           } else {
             // Unknown attribute


### PR DESCRIPTION
Please review this very small change to fix indentation in classFileParser.cpp and move the check for the PermittedSubclasses attribute inside of the "if (major_version >= 16)" block.

Fix was tested with tiers 1 and 2 on Linux, Mac OSX, and Windows, and tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255005](https://bugs.openjdk.java.net/browse/JDK-8255005): Fix indentation levels in classFileParser.cpp


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/931/head:pull/931`
`$ git checkout pull/931`
