### PR TITLE
JDK-8244088: [Regression] Switch of Gnome theme ends up in deadlocked UI

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
@@ -708,7 +708,7 @@ static int gtk3_unload()
  */
 static void flush_gtk_event_loop()
 {
-    while((*fp_g_main_context_iteration)(NULL));
+    while((*fp_g_main_context_iteration)(NULL, FALSE));
 }
 
 /*

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
@@ -401,7 +401,7 @@ static void         (*fp_g_object_set)(gpointer object,
                                        const gchar *first_property_name,
                                        ...);
 
-static gboolean (*fp_g_main_context_iteration)(GMainContext *context);
+static gboolean (*fp_g_main_context_iteration)(GMainContext *context, gboolean may_block);
 static gboolean (*fp_g_str_has_prefix)(const gchar *str, const gchar *prefix);
 static gchar** (*fp_g_strsplit)(const gchar *string, const gchar *delimiter,
            gint max_tokens);

--- a/src/java.desktop/unix/native/libawt_xawt/awt/swing_GTKEngine.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/swing_GTKEngine.c
@@ -350,7 +350,7 @@ Java_com_sun_java_swing_plaf_gtk_GTKEngine_nativeFinishPainting(
 JNIEXPORT void JNICALL Java_com_sun_java_swing_plaf_gtk_GTKEngine_native_1switch_1theme(
         JNIEnv *env, jobject this)
 {
-    // Note that gtk->flush_event_loop takes care of locks (7053002)
+    // Note that gtk->flush_event_loop takes care of locks (7053002), gdk_threads_enter/gdk_threads_leave should not be used.
     gtk->flush_event_loop();
 }
 

--- a/src/java.desktop/unix/native/libawt_xawt/awt/swing_GTKEngine.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/swing_GTKEngine.c
@@ -350,10 +350,8 @@ Java_com_sun_java_swing_plaf_gtk_GTKEngine_nativeFinishPainting(
 JNIEXPORT void JNICALL Java_com_sun_java_swing_plaf_gtk_GTKEngine_native_1switch_1theme(
         JNIEnv *env, jobject this)
 {
-    // Note that flush_gtk_event_loop takes care of locks (7053002)
-    gtk->gdk_threads_enter();
+    // Note that gtk->flush_event_loop takes care of locks (7053002)
     gtk->flush_event_loop();
-    gtk->gdk_threads_leave();
 }
 
 /*


### PR DESCRIPTION
Issue

https://bugs.openjdk.java.net/browse/JDK-8244088

Problem

While using GTK3 java implementation,  User sees a deadlock issue in UI while trying to switch themes in gnome-tweak-tool.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244088](https://bugs.openjdk.java.net/browse/JDK-8244088): [Regression] Switch of Gnome theme ends up in deadlocked UI


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/932/head:pull/932`
`$ git checkout pull/932`
