### PR TITLE
8255595: delay_to_keep_mmu passes wrong arguments to Monitor wait

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -108,7 +108,7 @@ void G1ConcurrentMarkThread::delay_to_keep_mmu(bool remark) {
       jlong sleep_time_ms = ceil(sleep_time_sec * MILLIUNITS);
       if (sleep_time_ms <= 0) {
         break;                  // Passed end time.
-      } else if (ml.wait(sleep_time_ms, Monitor::_no_safepoint_check_flag)) {
+      } else if (ml.wait(sleep_time_ms)) {
         break;                  // Timeout => reached end time.
       }
       // Other (possibly spurious) wakeup.  Retry with updated sleep time.


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8255595](https://bugs.openjdk.java.net/browse/JDK-8255595): delay_to_keep_mmu passes wrong arguments to Monitor wait


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/933/head:pull/933`
`$ git checkout pull/933`
