### PR TITLE
8255595: delay_to_keep_mmu passes wrong arguments to Monitor wait

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -108,7 +108,7 @@ void G1ConcurrentMarkThread::delay_to_keep_mmu(bool remark) {
       jlong sleep_time_ms = ceil(sleep_time_sec * MILLIUNITS);
       if (sleep_time_ms <= 0) {
         break;                  // Passed end time.
-      } else if (ml.wait(sleep_time_ms, Monitor::_no_safepoint_check_flag)) {
+      } else if (ml.wait(sleep_time_ms)) {
         break;                  // Timeout => reached end time.
       }
       // Other (possibly spurious) wakeup.  Retry with updated sleep time.


### PR DESCRIPTION
Please review this trivial fix of the second argument in a call to MonitorLocker::wait.  Because the locker is constructed as no-safepoint-checking, the improper second argument is ignored rather than possibly going into an unexpected state.

/summary Remove improper wait argument.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255595](https://bugs.openjdk.java.net/browse/JDK-8255595): delay_to_keep_mmu passes wrong arguments to Monitor wait


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to b42f992c1ea2b455c73b4c049c1b20a1c5454db9
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to b42f992c1ea2b455c73b4c049c1b20a1c5454db9
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author) ⚠️ Review applies to b42f992c1ea2b455c73b4c049c1b20a1c5454db9


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/934/head:pull/934`
`$ git checkout pull/934`
