### PR TITLE
Allocate uninitialized arrays for faster String operations

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -3572,12 +3572,12 @@ public final class String
             throw new OutOfMemoryError("Required length exceeds implementation limit");
         }
         if (len == 1) {
-            final byte[] single = new byte[count];
+            final byte[] single = StringConcatHelper.newArray(count);
             Arrays.fill(single, value[0]);
             return new String(single, coder);
         }
         final int limit = len * count;
-        final byte[] multiple = new byte[limit];
+        final byte[] multiple = StringConcatHelper.newArray(limit);
         System.arraycopy(value, 0, multiple, 0, len);
         int copied = len;
         for (; copied < limit - copied; copied <<= 1) {

--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -491,7 +491,18 @@ final class StringConcatHelper {
     static byte[] newArray(long indexCoder) {
         byte coder = (byte)(indexCoder >> 32);
         int index = (int)indexCoder;
-        return (byte[]) UNSAFE.allocateUninitializedArray(byte.class, index << coder);
+        int length = index << coder;
+        return newArray(length);
+    }
+
+    /**
+     * Allocates an uninitialized byte array
+     * @param length
+     * @return the newly allocated byte array
+     */
+    @ForceInline
+    static byte[] newArray(int length) {
+        return (byte[]) UNSAFE.allocateUninitializedArray(byte.class, length);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -27,11 +27,9 @@ package java.lang;
 
 import java.util.Arrays;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Spliterator;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import jdk.internal.util.ArraysSupport;
@@ -747,7 +745,7 @@ final class StringLatin1 {
     }
 
     public static byte[] toBytes(int[] val, int off, int len) {
-        byte[] ret = new byte[len];
+        byte[] ret = StringConcatHelper.newArray(len);
         for (int i = 0; i < len; i++) {
             int cp = val[off++];
             if (!canEncode(cp)) {

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -33,8 +33,6 @@ import java.util.function.IntConsumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import jdk.internal.util.ArraysSupport;
-import jdk.internal.vm.annotation.DontInline;
-import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 import static java.lang.String.UTF16;
@@ -642,7 +640,7 @@ final class StringUTF16 {
             }
         }
         if (i < len) {
-            byte[] buf = new byte[value.length];
+            byte[] buf = StringConcatHelper.newArray(value.length);
             for (int j = 0; j < i; j++) {
                 putChar(buf, j, getChar(value, j)); // TBD:arraycopy?
             }

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1397,7 +1397,7 @@ public final class Unsafe {
            throw new IllegalArgumentException("Component type is not primitive");
        }
        if (length < 0) {
-           throw new IllegalArgumentException("Negative length");
+           throw new NegativeArraySizeException("Negative length" + length);
        }
        return allocateUninitializedArray0(componentType, length);
     }


### PR DESCRIPTION
(original discussion starts in https://mail.openjdk.java.net/pipermail/core-libs-dev/2020-September/068535.html)

Hello,

currently `jdk.internal.misc.Unsafe` declares `allocateUninitializedArray(Class type, int length)` returning uninitialized array of given primitive type and length.

Allocation of uninitialized arrays is faster especially for larger ones, so we could use them for cases
when we are sure that created array will be completely overwritten.

I've exposed `jdk.internal.misc.Unsafe.allocateUninitializedArray(Class, int)`
via delegating the method of `sun.misc.Unsafe` to measure creation of `byte[]` with benchmark [1]
and got those results:
```
                    (length)  Mode  Cnt      Score      Error   Units
constructor                0  avgt   50      7.639 ±    0.629   ns/op
constructor               10  avgt   50      9.448 ±    0.725   ns/op
constructor              100  avgt   50     21.158 ±    1.865   ns/op
constructor             1000  avgt   50    146.158 ±    9.836   ns/op
constructor            10000  avgt   50    916.321 ±   50.618   ns/op

unsafe                     0  avgt   50      8.057 ±    0.599   ns/op
unsafe                    10  avgt   50      8.308 ±    0.907   ns/op
unsafe                   100  avgt   50     12.232 ±    1.813   ns/op
unsafe                  1000  avgt   50     37.679 ±    1.382   ns/op
unsafe                 10000  avgt   50     78.896 ±    6.758   ns/op
```
As a result I propose to add the following methods into `StringConcatHelper`:
```java
@ForceInline
static byte[] newArray(int length) {
    return (byte[]) UNSAFE.allocateUninitializedArray(byte.class, length);
}
```
along with existing `StringConcatHelper.newArray(long indexCoder)` and utilize them in String-related operations
instead of conventional array creation with new-keyword.

I've used benchmark [2] to measure impact on affected String-methods and found quite a good improvement:
```
                     (length)            original              patched    Units
newString                   8    13.210 ±   0.024     11.793 ±   0.023    ns/op
newString                  64    49.417 ±   0.127     38.568 ±   0.036    ns/op
newString                 128    81.275 ±   0.124     70.237 ±   1.131    ns/op
newString                1024   643.470 ±   1.325    535.306 ±   7.724    ns/op

repeatOneByteString         8    11.436 ±   0.023     10.369 ±   0.026    ns/op
repeatOneByteString        64    19.585 ±   0.772     14.275 ±   0.128    ns/op
repeatOneByteString       128    30.862 ±   0.344     23.056 ±   0.071    ns/op
repeatOneByteString      1024   107.128 ±   0.172     82.634 ±   0.084    ns/op

repeatOneCharString         8    23.019 ±   0.062     20.967 ±   0.142    ns/op
repeatOneCharString        64    45.237 ±   0.088     37.433 ±   0.194    ns/op
repeatOneCharString       128    59.369 ±   0.164     45.048 ±   0.538    ns/op
repeatOneCharString      1024   231.246 ±   0.741    177.738 ±   1.705    ns/op

replaceUtf                  8    17.633 ±   0.101     15.713 ±   0.136    ns/op
replaceUtf                 64    45.335 ±   0.138     36.147 ±   1.930    ns/op
replaceUtf                128    68.151 ±   0.546     47.853 ±   0.608    ns/op
replaceUtf               1024   468.376 ±  16.366    324.165 ± 3 4.502    ns/op
```
So the question is could we include the changes of attached patch into JDK?

With best regards,
Sergey Tsypanov

1. Benchmark for array-allocation
```java
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(jvmArgsAppend = {"-Xms2g", "-Xmx2g"})
public class ArrayAllocationBenchmark {
  private static Unsafe U;

  static {
    try {
      Field f = Unsafe.class.getDeclaredField("theUnsafe");
      f.setAccessible(true);
      U = (Unsafe) f.get(null);
    } catch (Exception e) {
      new RuntimeException(e);
    }
  }

  @Benchmark
  public byte[] constructor(Data data) {
    return new byte[data.length];
  }

  @Benchmark
  public byte[] unsafe(Data data) {
    return (byte[]) U.allocateUninitializedArray(byte.class, data.length);
  }

  @State(Scope.Thread)
  public static class Data {
    @Param({"0", "10", "100", "1000", "10000"})
    private int length;
  }
}
```
2. Benchmark for String-method measurements
```java
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(jvmArgsAppend = {"-Xms2g", "-Xmx2g"})
public class MiscStringBenchmark {

  @Benchmark
  public String newString(Data data){
    return new String(data.codepoints, 0, data.codepoints.length);
  }

  @Benchmark
  public String repeatOneByteString(Data data) {
    return data.oneByteString.repeat(data.length);
  }

  @Benchmark
  public String repeatOneCharString(Data data) {
    return data.oneUtfCharString.repeat(data.length);
  }

  @Benchmark
  public String replaceUtf(Data data){
    return data.utfStringToReplace.replace('я', 'ю');
  }

  @State(Scope.Thread)
  public static class Data {
    @Param({"8", "64", "128", "1024"})
    private int length;
    private final String oneByteString = "a";
    private final String oneUtfCharString = "ё";

    private String utfStringToReplace;
    private int[] codepoints;

    @Setup
    public void setup() {
      String string = oneByteString.repeat(length);
      String utfString = oneUtfCharString.repeat(length);

      String stringToReplace = string + 'z';
      codepoints = stringToReplace.codePoints().toArray();
      utfStringToReplace = utfString + 'я';
    }
  }
}
```

Also see https://mail.openjdk.java.net/pipermail/hotspot-compiler-dev/2020-September/040148.html and https://bugs.openjdk.java.net/browse/JDK-8253577

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/935/head:pull/935`
`$ git checkout pull/935`
