### PR TITLE
8143021: [TEST_BUG] Test javax/swing/JColorChooser/Test6541987.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -741,7 +741,6 @@ javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 802462
 # The next test below is an intermittent failure
 javax/swing/JComboBox/8033069/bug8033069ScrollBar.java 8163367 generic-all
 javax/swing/JColorChooser/Test6827032.java 8197825 windows-all
-javax/swing/JColorChooser/Test6541987.java 8143021 windows-all,linux-all,macosx-all
 javax/swing/JTable/4235420/bug4235420.java     8079127 generic-all
 javax/swing/JSplitPane/4201995/bug4201995.java 8079127 generic-all
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all

--- a/test/jdk/javax/swing/JColorChooser/Test6541987.java
+++ b/test/jdk/javax/swing/JColorChooser/Test6541987.java
@@ -103,5 +103,6 @@ public class Test6541987 implements Runnable {
             throw new Error("unexpected color: " + color);
         }
         frame.setVisible(false);
+        frame.dispose();
     }
 }

--- a/test/jdk/javax/swing/JColorChooser/Test6541987.java
+++ b/test/jdk/javax/swing/JColorChooser/Test6541987.java
@@ -42,24 +42,33 @@ import javax.swing.SwingUtilities;
 
 public class Test6541987 implements Runnable {
     private static Robot robot;
+    private static JFrame frame;
 
-    public static void main(String[] args) throws AWTException {
-        robot = new Robot();
-        // test escape after selection
-        start();
-        click(KeyEvent.VK_ESCAPE);
-        robot.waitForIdle();
-        // test double escape after editing
-        start();
-        click(KeyEvent.VK_1);
-        click(KeyEvent.VK_0);
-        click(KeyEvent.VK_ESCAPE);
-        click(KeyEvent.VK_ESCAPE);
-        robot.waitForIdle();
-        // all windows should be closed
-        for (Window window : Window.getWindows()) {
-            if (window.isVisible()) {
-                throw new Error("found visible window: " + window.getName());
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(100);
+            // test escape after selection
+            start();
+            click(KeyEvent.VK_ESCAPE);
+            robot.waitForIdle();
+            // test double escape after editing
+            start();
+            click(KeyEvent.VK_1);
+            click(KeyEvent.VK_0);
+            click(KeyEvent.VK_ESCAPE);
+            click(KeyEvent.VK_ESCAPE);
+            robot.waitForIdle();
+            robot.delay(500);
+            // all windows should be closed
+            for (Window window : Window.getWindows()) {
+                if (window.isVisible()) {
+                    throw new Error("found visible window: " + window.getName());
+                }
+            }
+	} finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
             }
         }
     }
@@ -85,7 +94,8 @@ public class Test6541987 implements Runnable {
 
     public void run() {
         String title = getClass().getName();
-        JFrame frame = new JFrame(title);
+        frame = new JFrame(title);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
 
         Color color = JColorChooser.showDialog(frame, title, Color.BLACK);
@@ -93,6 +103,5 @@ public class Test6541987 implements Runnable {
             throw new Error("unexpected color: " + color);
         }
         frame.setVisible(false);
-        frame.dispose();
     }
 }

--- a/test/jdk/javax/swing/JColorChooser/Test6541987.java
+++ b/test/jdk/javax/swing/JColorChooser/Test6541987.java
@@ -66,7 +66,7 @@ public class Test6541987 implements Runnable {
                     throw new Error("found visible window: " + window.getName());
                 }
             }
-	} finally {
+        } finally {
             if (frame != null) {
                 SwingUtilities.invokeAndWait(frame::dispose);
             }


### PR DESCRIPTION
`Please review a test fix for an issue seen to be failing on mach5 systems due to timing issue of keyevents.
Modified test to add setAutoDelay and moved the frame to center of screen.
Mach5 job has been run for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (8/8 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8143021](https://bugs.openjdk.java.net/browse/JDK-8143021): [TEST_BUG] Test javax/swing/JColorChooser/Test6541987.java fails


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/936/head:pull/936`
`$ git checkout pull/936`
