### PR TITLE
JDK-8255603: Memory/Performance regression after JDK-8210985

### DIFF
--- a/src/java.base/share/classes/sun/security/util/Cache.java
+++ b/src/java.base/share/classes/sun/security/util/Cache.java
@@ -265,8 +265,7 @@ class MemoryCache<K,V> extends Cache<K,V> {
         else
             this.queue = null;
 
-        int buckets = (int)(maxSize / LOAD_FACTOR) + 1;
-        cacheMap = new LinkedHashMap<>(buckets, LOAD_FACTOR, true);
+        cacheMap = new LinkedHashMap<>(1, LOAD_FACTOR, true);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/util/Cache.java
+++ b/src/java.base/share/classes/sun/security/util/Cache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
It seems that there exists a memory/performance regression that was introduced with JDK-8210985: Update the default SSL session cache size to 20480.

The idea to limit the maixmum SSL session cache size by itself is good. Unfortunately, as per the current implementation of sun.security.util.MemoryCache, it also modifies the initial size of the LinkedHashMap that is backing the cache to initialize with more than the maximum size.

I suggest to restore the original behavior that initializes with an initialCapacity of 1 in most cases. That was true when before JDK-8210985, the property javax.net.ssl.sessionCacheSize was not set at all.
In case it was set, the initial size would have been like now, (javax.net.ssl.sessionCacheSize / 0.75f) + 1, which still seems strange.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (4/4 passed) |

### Issue
 * [JDK-8255603](https://bugs.openjdk.java.net/browse/JDK-8255603): Memory/Performance regression after JDK-8210985


### Reviewers
 * [Volker Simonis](https://openjdk.java.net/census#simonis) (@simonis - **Reviewer**)
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/937/head:pull/937`
`$ git checkout pull/937`
