### PR TITLE
8255489: Unify the parsing of @lambda-proxy and @lambda-form-invokers tags in a classlist

### DIFF
--- a/src/hotspot/share/classfile/classListParser.cpp
+++ b/src/hotspot/share/classfile/classListParser.cpp
@@ -115,13 +115,6 @@ bool ClassListParser::parse_one_line() {
       _line_len = len;
     }
 
-    // Check if the line is output TRACE_RESOLVE
-    if (strncmp(_line, LambdaFormInvokers::lambda_form_invoker_tag(),
-                strlen(LambdaFormInvokers::lambda_form_invoker_tag())) == 0) {
-      LambdaFormInvokers::append(os::strdup((const char*)_line, mtInternal));
-      continue;
-    }
-
     // valid line
     break;
   }
@@ -133,6 +126,7 @@ bool ClassListParser::parse_one_line() {
   _source = NULL;
   _interfaces_specified = false;
   _indy_items->clear();
+  _lambda_form_line = false;
 
   if (_line[0] == '@') {
     return parse_at_tags();
@@ -213,6 +207,15 @@ bool ClassListParser::parse_at_tags() {
     }
     // set the class name
     _class_name = _indy_items->at(1);
+    return true;
+  } else if (strcmp(_indy_items->at(0), LAMBDA_FORM_TAG) == 0) {
+    for (int i = _line_len; i >= 0; i--) {
+      if (_line[i] == '\0') {
+        _line[i] = ' ';
+      }
+    }
+    LambdaFormInvokers::append(os::strdup((const char*)_line, mtInternal));
+    _lambda_form_line = true;
     return true;
   } else {
     error("Invalid @ tag at the beginning of line \"%s\" line #%d", _line, _line_no);

--- a/src/hotspot/share/classfile/classListParser.cpp
+++ b/src/hotspot/share/classfile/classListParser.cpp
@@ -179,8 +179,8 @@ bool ClassListParser::parse_one_line() {
   return true;
 }
 
-void ClassListParser::split_tokens_by_whitespace() {
-  int start = 0;
+void ClassListParser::split_tokens_by_whitespace(int offset) {
+  int start = offset;
   int end;
   bool done = false;
   while (!done) {
@@ -197,28 +197,40 @@ void ClassListParser::split_tokens_by_whitespace() {
   }
 }
 
+int ClassListParser::split_at_tag_from_line() {
+  _token = _line;
+  char* ptr;
+  if ((ptr = strchr(_line, ' ')) == NULL) {
+    error("Too few items following the @ tag \"%s\" line #%d", _line, _line_no);
+    return 0;
+  }
+  *ptr++ = '\0';
+  while (*ptr == ' ' || *ptr == '\t') ptr++;
+  return (int)(ptr - _line);
+}
+
 bool ClassListParser::parse_at_tags() {
   assert(_line[0] == '@', "must be");
-  split_tokens_by_whitespace();
-  if (strcmp(_indy_items->at(0), LAMBDA_PROXY_TAG) == 0) {
-    if (_indy_items->length() < 3) {
-      error("Line with @ tag has too few items \"%s\" line #%d", _line, _line_no);
+  int offset;
+  if ((offset = split_at_tag_from_line()) == 0) {
+    return false;
+  }
+
+  if (strcmp(_token, LAMBDA_PROXY_TAG) == 0) {
+    split_tokens_by_whitespace(offset);
+    if (_indy_items->length() < 2) {
+      error("Line with @ tag has too few items \"%s\" line #%d", _token, _line_no);
       return false;
     }
     // set the class name
-    _class_name = _indy_items->at(1);
+    _class_name = _indy_items->at(0);
     return true;
-  } else if (strcmp(_indy_items->at(0), LAMBDA_FORM_TAG) == 0) {
-    for (int i = _line_len; i >= 0; i--) {
-      if (_line[i] == '\0') {
-        _line[i] = ' ';
-      }
-    }
-    LambdaFormInvokers::append(os::strdup((const char*)_line, mtInternal));
+  } else if (strcmp(_token, LAMBDA_FORM_TAG) == 0) {
+    LambdaFormInvokers::append(os::strdup((const char*)(_line + offset), mtInternal));
     _lambda_form_line = true;
     return true;
   } else {
-    error("Invalid @ tag at the beginning of line \"%s\" line #%d", _line, _line_no);
+    error("Invalid @ tag at the beginning of line \"%s\" line #%d", _token, _line_no);
     return false;
   }
 }
@@ -435,7 +447,7 @@ bool ClassListParser::is_matching_cp_entry(constantPoolHandle &pool, int cp_inde
   CDSIndyInfo cii;
   populate_cds_indy_info(pool, cp_index, &cii, THREAD);
   GrowableArray<const char*>* items = cii.items();
-  int indy_info_offset = 2;
+  int indy_info_offset = 1;
   if (_indy_items->length() - indy_info_offset != items->length()) {
     return false;
   }

--- a/src/hotspot/share/classfile/classListParser.hpp
+++ b/src/hotspot/share/classfile/classListParser.hpp
@@ -122,7 +122,8 @@ public:
     return _instance;
   }
   bool parse_one_line();
-  void split_tokens_by_whitespace();
+  void split_tokens_by_whitespace(int offset);
+  int split_at_tag_from_line();
   bool parse_at_tags();
   char* _token;
   void error(const char* msg, ...);

--- a/src/hotspot/share/classfile/classListParser.hpp
+++ b/src/hotspot/share/classfile/classListParser.hpp
@@ -30,7 +30,8 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/hashtable.inline.hpp"
 
-#define LAMBDA_PROXY_TAG "@lambda-proxy:"
+#define LAMBDA_PROXY_TAG "@lambda-proxy"
+#define LAMBDA_FORM_TAG  "@lambda-form-invoker"
 
 class ID2KlassTable : public KVHashtable<int, InstanceKlass*, mtInternal> {
 public:
@@ -99,6 +100,7 @@ class ClassListParser : public StackObj {
   GrowableArray<int>* _interfaces;
   bool                _interfaces_specified;
   const char*         _source;
+  bool                _lambda_form_line;
 
   bool parse_int_option(const char* option_name, int* value);
   bool parse_uint_option(const char* option_name, int* value);
@@ -161,6 +163,8 @@ public:
   Klass* load_current_class(TRAPS);
 
   bool is_loading_from_source();
+
+  bool lambda_form_line() { return _lambda_form_line; }
 
   // Look up the super or interface of the current class being loaded
   // (in this->load_current_class()).

--- a/src/hotspot/share/classfile/lambdaFormInvokers.cpp
+++ b/src/hotspot/share/classfile/lambdaFormInvokers.cpp
@@ -23,7 +23,6 @@
  */
 
 #include "precompiled.hpp"
-#include "classfile/classListParser.hpp"
 #include "classfile/classLoadInfo.hpp"
 #include "classfile/classFileStream.hpp"
 #include "classfile/dictionary.hpp"
@@ -67,9 +66,7 @@ void LambdaFormInvokers::regenerate_holder_classes(TRAPS) {
   int len = _lambdaform_lines->length();
   objArrayHandle list_lines = oopFactory::new_objArray_handle(SystemDictionary::String_klass(), len, CHECK);
   for (int i = 0; i < len; i++) {
-    char* record = _lambdaform_lines->at(i);
-    record += strlen(LAMBDA_FORM_TAG) + 1; // skip the @lambda_form_invoker prefix
-    Handle h_line = java_lang_String::create_from_str(record, CHECK);
+    Handle h_line = java_lang_String::create_from_str(_lambdaform_lines->at(i), CHECK);
     list_lines->obj_at_put(i, h_line());
   }
 

--- a/src/hotspot/share/classfile/lambdaFormInvokers.cpp
+++ b/src/hotspot/share/classfile/lambdaFormInvokers.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/classListParser.hpp"
 #include "classfile/classLoadInfo.hpp"
 #include "classfile/classFileStream.hpp"
 #include "classfile/dictionary.hpp"
@@ -67,7 +68,7 @@ void LambdaFormInvokers::regenerate_holder_classes(TRAPS) {
   objArrayHandle list_lines = oopFactory::new_objArray_handle(SystemDictionary::String_klass(), len, CHECK);
   for (int i = 0; i < len; i++) {
     char* record = _lambdaform_lines->at(i);
-    record += strlen(lambda_form_invoker_tag()) + 1; // skip the @lambda_form_invoker prefix
+    record += strlen(LAMBDA_FORM_TAG) + 1; // skip the @lambda_form_invoker prefix
     Handle h_line = java_lang_String::create_from_str(record, CHECK);
     list_lines->obj_at_put(i, h_line());
   }

--- a/src/hotspot/share/classfile/lambdaFormInvokers.hpp
+++ b/src/hotspot/share/classfile/lambdaFormInvokers.hpp
@@ -42,9 +42,5 @@ class LambdaFormInvokers : public AllStatic {
   static GrowableArray<char*>* lambdaform_lines() {
     return _lambdaform_lines;
   }
-
-  static const char* lambda_form_invoker_tag() {
-    return "@lambda-form-invoker";
-  }
 };
 #endif // SHARE_MEMORY_LAMBDAFORMINVOKERS_HPP

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -1096,6 +1096,9 @@ int MetaspaceShared::preload_classes(const char* class_list_path, TRAPS) {
   int class_count = 0;
 
   while (parser.parse_one_line()) {
+    if (parser.lambda_form_line()) {
+      continue;
+    }
     Klass* klass = parser.load_current_class(THREAD);
     if (HAS_PENDING_EXCEPTION) {
       if (klass == NULL &&

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "jvm.h"
 #include "classfile/classFileStream.hpp"
+#include "classfile/classListParser.hpp"
 #include "classfile/classListWriter.hpp"
 #include "classfile/classLoader.hpp"
 #include "classfile/classLoaderData.hpp"
@@ -32,7 +33,6 @@
 #include "classfile/classLoadInfo.hpp"
 #include "classfile/javaAssertions.hpp"
 #include "classfile/javaClasses.inline.hpp"
-#include "classfile/lambdaFormInvokers.hpp"
 #include "classfile/moduleEntry.hpp"
 #include "classfile/modules.hpp"
 #include "classfile/packageEntry.hpp"
@@ -3883,7 +3883,7 @@ JVM_ENTRY(void, JVM_LogLambdaFormInvoker(JNIEnv *env, jstring line))
     Handle h_line (THREAD, JNIHandles::resolve_non_null(line));
     char* c_line = java_lang_String::as_utf8_string(h_line());
     ClassListWriter w;
-    w.stream()->print_cr("%s %s", LambdaFormInvokers::lambda_form_invoker_tag(), c_line);
+    w.stream()->print_cr("%s %s", LAMBDA_FORM_TAG, c_line);
   }
 #endif // INCLUDE_CDS
 JVM_END

--- a/test/hotspot/jtreg/runtime/cds/appcds/BadBSM.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/BadBSM.java
@@ -42,7 +42,7 @@ public class BadBSM {
 
     OutputAnalyzer out = TestCommon.dump(appJar,
         TestCommon.list("WrongBSM",
-                        "@lambda-proxy: WrongBSM 7"));
+                        "@lambda-proxy WrongBSM 7"));
     out.shouldHaveExitValue(0);
     out.shouldContain( "is_supported_invokedynamic check failed for cp_index 7");
   }

--- a/test/hotspot/jtreg/runtime/cds/appcds/DumpClassListWithLF.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/DumpClassListWithLF.java
@@ -105,5 +105,12 @@ public class DumpClassListWithLF extends ClassListFormatBase {
                 "Hello",
                 "@lambda-form-invoker [SPECIES_RESOLVE] java.lang.invoke.BoundMethodHandle$Species_L L"),
                 "Incorrect number of items in the line: 3");
+        // 10. The line with incorrect (less) number of items.
+        dumpShouldFail(
+            "TESTCASE 10: With incorrect @lambda-form-invoker tag",
+            appJar, classlist(
+                "Hello",
+                "@lambda-form-invoker-xxx [LF_RESOLVE] java.lang.invoke.DirectMethodHandle$Holder invokeStatic"),
+                "Invalid @ tag at the beginning of line \"@lambda-form-invoker-xxx\" line #2");
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaProxyClasslist.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaProxyClasslist.java
@@ -73,5 +73,12 @@ public class LambdaProxyClasslist {
         TestCommon.list("LambHello",
                         "@lambda-proxy LambHello run ()Ljava/lang/Runnable; ()V REF_invokeStatic LambHello lambda$doTest$0 ()V ()V "));
     out.shouldHaveExitValue(0);
+
+    // 6. Error on invalid @lambda-proxy tag
+    out = TestCommon.dump(appJar,
+        TestCommon.list("LambHello",
+                        "@lambda-proxy: LambHello run ()Ljava/lang/Runnable; ()V REF_invokeStatic LambHello lambda$doTest$0 ()V ()V"));
+    out.shouldContain("Invalid @ tag at the beginning of line \"@lambda-proxy:\" line #2")
+       .shouldHaveExitValue(1);
   }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaProxyClasslist.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaProxyClasslist.java
@@ -43,35 +43,35 @@ public class LambdaProxyClasslist {
     // 1. No error with a correct @lambda-proxy entry.
     OutputAnalyzer out = TestCommon.dump(appJar,
         TestCommon.list("LambHello",
-                        "@lambda-proxy: LambHello run ()Ljava/lang/Runnable; ()V REF_invokeStatic LambHello lambda$doTest$0 ()V ()V"));
+                        "@lambda-proxy LambHello run ()Ljava/lang/Runnable; ()V REF_invokeStatic LambHello lambda$doTest$0 ()V ()V"));
     out.shouldHaveExitValue(0);
 
     // 2. Error if the @lambda-proxy entry is too short.
     out = TestCommon.dump(appJar,
         TestCommon.list("LambHello",
-                        "@lambda-proxy: LambHello"));
+                        "@lambda-proxy LambHello"));
     out.shouldContain("An error has occurred while processing class list file")
-       .shouldContain("Line with @ tag has too few items \"@lambda-proxy:\" line #2")
+       .shouldContain("Line with @ tag has too few items \"@lambda-proxy\" line #2")
        .shouldContain("class list format error")
        .shouldHaveExitValue(1);
 
     // 3. Warning message if there's an incorrect signature in the @lambda-proxy entry.
     out = TestCommon.dump(appJar,
         TestCommon.list("LambHello",
-                        "@lambda-proxy: LambHello run ()Ljava/lang/Runnable; ()V REF_invokeStatic LambHello lambda$doTest$0 ()V ()Z"));
+                        "@lambda-proxy LambHello run ()Ljava/lang/Runnable; ()V REF_invokeStatic LambHello lambda$doTest$0 ()V ()Z"));
     out.shouldContain("[warning][cds] No invoke dynamic constant pool entry can be found for class LambHello. The classlist is probably out-of-date.")
        .shouldHaveExitValue(0);
 
     // 4. More blank spaces in between items should be fine.
     out = TestCommon.dump(appJar,
         TestCommon.list("LambHello",
-                        "@lambda-proxy:  LambHello run  ()Ljava/lang/Runnable; ()V REF_invokeStatic LambHello lambda$doTest$0 ()V ()V"));
+                        "@lambda-proxy  LambHello run  ()Ljava/lang/Runnable; ()V REF_invokeStatic LambHello lambda$doTest$0 ()V ()V"));
     out.shouldHaveExitValue(0);
 
     // 5. Trailing spaces at the end of the @lambda-proxy line should be fine.
     out = TestCommon.dump(appJar,
         TestCommon.list("LambHello",
-                        "@lambda-proxy: LambHello run ()Ljava/lang/Runnable; ()V REF_invokeStatic LambHello lambda$doTest$0 ()V ()V "));
+                        "@lambda-proxy LambHello run ()Ljava/lang/Runnable; ()V REF_invokeStatic LambHello lambda$doTest$0 ()V ()V "));
     out.shouldHaveExitValue(0);
   }
 }


### PR DESCRIPTION
With this change, the parsing of the `@lambda-proxy` and the `@lambda-form-invokers` tags in a classlist will be performed in the same function - `ClassListParser::parse_at_tags()`.

Also removing the `:` of the `@lambda-proxy:` to be consistent with the `@lambda-form-invokers `tag.

Ran tiers 1 through 4 tests successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255489](https://bugs.openjdk.java.net/browse/JDK-8255489): Unify the parsing of @lambda-proxy and @lambda-form-invokers tags in a classlist


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to a3b75186683badd1fe7a7e26197d9297f16b3356
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/942/head:pull/942`
`$ git checkout pull/942`
