### PR TITLE
8255615: Zero: demote ZeroStack::abi_stack_available guarantee to assert

### DIFF
--- a/src/hotspot/cpu/zero/stack_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/stack_zero.inline.hpp
@@ -47,7 +47,7 @@ inline void ZeroStack::overflow_check(int required_words, TRAPS) {
 // to use under normal circumstances.  Note that the returned
 // value can be negative.
 inline int ZeroStack::abi_stack_available(Thread *thread) const {
-  guarantee(Thread::current() == thread, "should run in the same thread");
+  assert(Thread::current() == thread, "should run in the same thread");
   int stack_used = thread->stack_base() - (address) &stack_used
     + (StackOverflow::stack_guard_zone_size() + StackOverflow::stack_shadow_zone_size());
   int stack_free = thread->stack_size() - stack_used;


### PR DESCRIPTION
It is currently `guarantee`, which slows down release bits unnecessarily. The affected method is private, and so what that `assert` really does is checks that no internal Zero code calls it with a wrong `thread` -- something that should be caught by `fastdebug` builds.

```
inline int ZeroStack::abi_stack_available(Thread *thread) const {
  guarantee(Thread::current() == thread, "should run in the same thread");
```

On my TR 3970X, changing that `guarantee` to `assert` improves:
 - Zero x86_64 release "make images" times from ~9.5 minutes to ~7.5 minutes
 - Zero x86_64 release "make bootcycle-images" times from ~49 minutes to ~44 minutes

Attention @jerboaa and @gnu-andrew, who have to suffer through the Zero build times occasionally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (8/8 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255615](https://bugs.openjdk.java.net/browse/JDK-8255615): Zero: demote ZeroStack::abi_stack_available guarantee to assert


### Reviewers
 * @AlphaHot (no known github.com user name / role)
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/943/head:pull/943`
`$ git checkout pull/943`
