### PR TITLE
JDK-8255612: Explicitly disable dtrace for Oracle OpenJDK Linux builds

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -406,7 +406,7 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_cpu: "x64",
             dependencies: ["devkit", "gtest", "graphviz", "pandoc", "graalunit_lib"],
             configure_args: concat(common.configure_args_64bit,
-                "--with-zlib=system",
+                "--with-zlib=system", "--disable-dtrace",
                 (isWsl(input) ? [ "--host=x86_64-unknown-linux-gnu",
                     "--build=x86_64-unknown-linux-gnu" ] : [])),
         },


### PR DESCRIPTION
The OpenJDK build on Linux will determine if the JVM feature "dtrace" should be enabled based on the availability of dtrace on the build host. For Oracle produced OpenJDK builds, we implicitly had this disabled because our build environment didn't have it installed. Rather than having to trust the build host to not have dtrace installed, we would like to make this setting explicit. We don't want to change the default behavior of OpenJDK, so we are adding this configure flag to the jib-profiles.js configuration where appropriate, so it only affects Oracle produced builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255612](https://bugs.openjdk.java.net/browse/JDK-8255612): Explicitly disable dtrace for Oracle OpenJDK Linux builds


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/946/head:pull/946`
`$ git checkout pull/946`
