### PR TITLE
JDK-8255620: Build race between modulegraphs and exploded-image-optimize targets

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1083,9 +1083,9 @@ ifneq ($(COMPILE_TYPE), cross)
   exploded-image: exploded-image-optimize
 endif
 
-# The runnable-buildjdk target guarantees that the BUILD_JDK is done
+# The runnable-buildjdk target guarantees that the buildjdk is done
 # building and ready to be used. The exact set of dependencies it needs
-# depends on what kind of BUILDJDK is used for the current configuration.
+# depends on what kind of buildjdk is used for the current configuration.
 runnable-buildjdk:
 ifeq ($(CREATE_BUILDJDK), true)
   ifneq ($(CREATING_BUILDJDK), true)

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -338,7 +338,7 @@ $(eval $(call SetupTarget, test-image-demos-jdk, \
 
 $(eval $(call SetupTarget, generate-summary, \
     MAKEFILE := GenerateModuleSummary, \
-    DEPS := jmods buildtools-modules, \
+    DEPS := jmods buildtools-modules runnable-buildjdk, \
 ))
 
 ################################################################################
@@ -468,7 +468,7 @@ $(eval $(call SetupTarget, docs-jdk-api-javadoc, \
 $(eval $(call SetupTarget, docs-jdk-api-modulegraph, \
     MAKEFILE := Docs, \
     TARGET := docs-jdk-api-modulegraph, \
-    DEPS := buildtools-modules, \
+    DEPS := buildtools-modules runnable-buildjdk, \
 ))
 
 $(eval $(call SetupTarget, docs-javase-api-javadoc, \
@@ -479,7 +479,7 @@ $(eval $(call SetupTarget, docs-javase-api-javadoc, \
 $(eval $(call SetupTarget, docs-javase-api-modulegraph, \
     MAKEFILE := Docs, \
     TARGET := docs-javase-api-modulegraph, \
-    DEPS := buildtools-modules, \
+    DEPS := buildtools-modules runnable-buildjdk, \
 ))
 
 $(eval $(call SetupTarget, docs-reference-api-javadoc, \
@@ -490,7 +490,7 @@ $(eval $(call SetupTarget, docs-reference-api-javadoc, \
 $(eval $(call SetupTarget, docs-reference-api-modulegraph, \
     MAKEFILE := Docs, \
     TARGET := docs-reference-api-modulegraph, \
-    DEPS := buildtools-modules, \
+    DEPS := buildtools-modules runnable-buildjdk, \
 ))
 
 # The gensrc steps for jdk.jdi create html spec files.
@@ -1083,6 +1083,18 @@ ifneq ($(COMPILE_TYPE), cross)
   exploded-image: exploded-image-optimize
 endif
 
+# The runnable-buildjdk target guarantees that the BUILD_JDK is done
+# building and ready to be used. The exact set of dependencies it needs
+# depends on what kind of BUILDJDK is used for the current configuration.
+runnable-buildjdk:
+ifeq ($(CREATE_BUILDJDK), true)
+  ifneq ($(CREATING_BUILDJDK), true)
+    runnable-buildjdk: create-buildjdk
+  endif
+else ifeq ($(EXTERNAL_BUILDJDK), false)
+  runnable-buildjdk: exploded-image
+endif
+
 create-buildjdk: create-buildjdk-interim-image
 
 docs-jdk-api: docs-jdk-api-javadoc
@@ -1186,7 +1198,7 @@ all-bundles: product-bundles test-bundles docs-bundles static-libs-bundles
 ALL_TARGETS += buildtools hotspot hotspot-libs hotspot-gensrc gensrc gendata \
     copy java libs static-libs launchers jmods \
     jdk.jdwp.agent-gensrc $(ALL_MODULES) demos \
-    exploded-image-base exploded-image \
+    exploded-image-base exploded-image runnable-buildjdk \
     create-buildjdk docs-jdk-api docs-javase-api docs-reference-api docs-jdk \
     docs-javase docs-reference docs-javadoc mac-bundles product-images legacy-images \
     docs-image docs-javase-image docs-reference-image all-docs-images \


### PR DESCRIPTION
When I reorganized top level docs build targets in JDK-8206311, a race was introduced. The docs-*-modulegraph targets use the BUILD_JDK to run a build tool. For this to work, the BUILD_JDK needs to be ready for usage. In a normal native build, this means that the exploded-image-optimize target needs to be done. This dependency is however missing, so we sometimes get errors like this:

* For target support_docs_JDK_API-gengraphs__gengraphs_JDK_API_exec:
Error occurred during initialization of boot layer
java.lang.module.FindException: Error reading module: /w/jdk/build/jdk/modules/jdk.security.jgss
Caused by: java.lang.module.InvalidModuleDescriptorException: Truncated module-info.class

To fix this, I propose adding a new top level target "runnable-buildjdk". This new target will do different things depending which kind of BUILD_JDK the current configuration is set to use. The default BUILD_JDK is just the exploded image. When cross compiling, we either create a BUILD_JDK explicitly, or we use an externally provided BUILD_JDK. By introducing this virtual target, we don't need to sprinkle these conditionals in quite so many places.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255620](https://bugs.openjdk.java.net/browse/JDK-8255620): Build race between modulegraphs and exploded-image-optimize targets


### Reviewers
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/947/head:pull/947`
`$ git checkout pull/947`
