### PR TITLE
8255562: delete UseRDPCForConstantTableBase

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -360,9 +360,6 @@
           "Limit of ops to make speculative when using CMOVE")              \
           range(0, max_jint)                                                \
                                                                             \
-  product(bool, UseRDPCForConstantTableBase, false,                         \
-          "Use Sparc RDPC instruction for the constant table base.")        \
-                                                                            \
   notproduct(bool, PrintIdealGraph, false,                                  \
           "Print ideal graph to XML file / network interface. "             \
           "By default attempts to connect to the visualizer on a socket.")  \

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -434,7 +434,6 @@ public:
 
   virtual void emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const;
   virtual uint size(PhaseRegAlloc* ra_) const;
-  virtual bool pinned() const { return UseRDPCForConstantTableBase; }
 
   static const RegMask& static_out_RegMask() { return _out_RegMask; }
   virtual const RegMask& out_RegMask() const { return static_out_RegMask(); }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -555,6 +555,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "ForceNUMA",                     JDK_Version::jdk(15), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "InsertMemBarAfterArraycopy",    JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "Debugging",                     JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
+  { "UseRDPCForConstantTableBase",   JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
 
 #ifdef TEST_VERIFY_SPECIAL_JVM_FLAGS
   // These entries will generate build errors.  Their purpose is to test the macros.
@@ -575,9 +576,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "MaxInlineSize",                JDK_Version::undefined(), JDK_Version::jdk(15), JDK_Version::jdk(16) },
   { "FreqInlineSize",               JDK_Version::undefined(), JDK_Version::jdk(15), JDK_Version::jdk(16) },
   { "MaxTrivialSize",               JDK_Version::undefined(), JDK_Version::jdk(15), JDK_Version::jdk(16) },
-#else
-  { "UseRDPCForConstantTableBase",  JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
-#endif /*COMPILER2*/
+#endif
 
   { NULL, JDK_Version(0), JDK_Version(0) }
 };
@@ -991,11 +990,8 @@ static bool append_to_string_flag(JVMFlag* flag, const char* new_value, JVMFlagO
 const char* Arguments::handle_aliases_and_deprecation(const char* arg, bool warn) {
   const char* real_name = real_flag_name(arg);
   JDK_Version since = JDK_Version();
-
   switch (is_deprecated_flag(arg, &since)) {
-    case  0:
-    /*fall through*/
-    case -1: {
+  case -1: {
       // Obsolete or expired, so don't process normally,
       // but allow for an obsolete flag we're still
       // temporarily allowing.
@@ -1006,6 +1002,8 @@ const char* Arguments::handle_aliases_and_deprecation(const char* arg, bool warn
       // as obsoletion must come first.
       return NULL;
     }
+    case 0:
+      return real_name;
     case 1: {
       if (warn) {
         char version[256];

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -575,8 +575,9 @@ static SpecialFlag const special_jvm_flags[] = {
   { "MaxInlineSize",                JDK_Version::undefined(), JDK_Version::jdk(15), JDK_Version::jdk(16) },
   { "FreqInlineSize",               JDK_Version::undefined(), JDK_Version::jdk(15), JDK_Version::jdk(16) },
   { "MaxTrivialSize",               JDK_Version::undefined(), JDK_Version::jdk(15), JDK_Version::jdk(16) },
-  { "UseRDPCForConstantTableBase",  JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(16) },
-#endif
+#else
+  { "UseRDPCForConstantTableBase",  JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
+#endif /*COMPILER2*/
 
   { NULL, JDK_Version(0), JDK_Version(0) }
 };
@@ -990,8 +991,11 @@ static bool append_to_string_flag(JVMFlag* flag, const char* new_value, JVMFlagO
 const char* Arguments::handle_aliases_and_deprecation(const char* arg, bool warn) {
   const char* real_name = real_flag_name(arg);
   JDK_Version since = JDK_Version();
+
   switch (is_deprecated_flag(arg, &since)) {
-  case -1: {
+    case  0:
+    /*fall through*/
+    case -1: {
       // Obsolete or expired, so don't process normally,
       // but allow for an obsolete flag we're still
       // temporarily allowing.
@@ -1002,8 +1006,6 @@ const char* Arguments::handle_aliases_and_deprecation(const char* arg, bool warn
       // as obsoletion must come first.
       return NULL;
     }
-    case 0:
-      return real_name;
     case 1: {
       if (warn) {
         char version[256];

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -575,6 +575,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "MaxInlineSize",                JDK_Version::undefined(), JDK_Version::jdk(15), JDK_Version::jdk(16) },
   { "FreqInlineSize",               JDK_Version::undefined(), JDK_Version::jdk(15), JDK_Version::jdk(16) },
   { "MaxTrivialSize",               JDK_Version::undefined(), JDK_Version::jdk(15), JDK_Version::jdk(16) },
+  { "UseRDPCForConstantTableBase",  JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(16) },
 #endif
 
   { NULL, JDK_Version(0), JDK_Version(0) }


### PR DESCRIPTION
UseRDPCForConstantTableBase was a SPARC-exclusive flag. Sparc has been removed 
from hotspot, so remove this flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255562](https://bugs.openjdk.java.net/browse/JDK-8255562): delete UseRDPCForConstantTableBase


### Reviewers
 * [Volker Simonis](https://openjdk.java.net/census#simonis) (@simonis - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/949/head:pull/949`
`$ git checkout pull/949`
