### PR TITLE
8196099: javax/swing/text/CSSBorder/6796710/bug6796710.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -762,7 +762,6 @@ javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all
 javax/swing/JTabbedPane/4624207/bug4624207.java 8064922 macosx-all
 javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java 8160720 generic-all
 javax/swing/plaf/basic/Test6984643.java 8198340 windows-all
-javax/swing/text/CSSBorder/6796710/bug6796710.java 8196099 windows-all
 javax/swing/text/DefaultCaret/HidingSelection/HidingSelectionTest.java 8194048 windows-all
 javax/swing/text/DefaultCaret/HidingSelection/MultiSelectionTest.java 8213562 linux-all
 javax/swing/text/JTextComponent/5074573/bug5074573.java 8196100 windows-all

--- a/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
+++ b/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
@@ -127,8 +127,8 @@ public class bug6796710 {
 
         BufferedImage pnBottomImage = getPnBottomImage();
         if (!Util.compareBufferedImages(bufferedImage, pnBottomImage)) {
-            ImageIO.write(bufferedImage, "png", new File("bufferedImage"));
-            ImageIO.write(pnBottomImage, "png", new File("pnBottomImage"));
+            ImageIO.write(bufferedImage, "png", new File("bufferedImage.png"));
+            ImageIO.write(pnBottomImage, "png", new File("pnBottomImage.png"));
             throw new RuntimeException("The test failed");
         }
 

--- a/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
+++ b/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,12 +28,24 @@
  * @summary Html content in JEditorPane is overlapping on swing components while resizing the application.
  * @library ../../../regtesthelpers
  * @build Util
-   @run main bug6796710
+ * @run main/othervm -Dsun.java2d.uiScale=1 bug6796710
+ * @run main/othervm -Dsun.java2d.uiScale=2 bug6796710
  */
 
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Rectangle;
+import java.awt.Robot;
 import java.awt.image.BufferedImage;
-import javax.swing.*;
+import java.io.File;
+
+import javax.imageio.ImageIO;
+import javax.swing.JButton;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
 
 public class bug6796710 {
     // The page is inlined because we want to be sure that the JEditorPane filled synchronously
@@ -89,6 +101,7 @@ public class bug6796710 {
 
                 frame.setContentPane(pnContent);
                 frame.setSize(400, 600);
+                frame.setLocationRelativeTo(null);
                 frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
                 frame.setVisible(true);
             }
@@ -113,7 +126,10 @@ public class bug6796710 {
         // On Linux platforms realSync doesn't guaranties setSize completion
         Thread.sleep(1000);
 
-        if (!Util.compareBufferedImages(bufferedImage, getPnBottomImage())) {
+        BufferedImage pnBottomImage = getPnBottomImage();
+        if (!Util.compareBufferedImages(bufferedImage, pnBottomImage)) {
+            ImageIO.write(bufferedImage, "png", new File("bufferedImage"));
+            ImageIO.write(pnBottomImage, "png", new File("pnBottomImage"));
             throw new RuntimeException("The test failed");
         }
 

--- a/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
+++ b/test/jdk/javax/swing/text/CSSBorder/6796710/bug6796710.java
@@ -29,7 +29,6 @@
  * @library ../../../regtesthelpers
  * @build Util
  * @run main/othervm -Dsun.java2d.uiScale=1 bug6796710
- * @run main/othervm -Dsun.java2d.uiScale=2 bug6796710
  */
 
 import java.awt.BorderLayout;


### PR DESCRIPTION
This test could fail on windows for two reasons:
 - The window does not fit the small screen, and the robot captures the image outside the screen. Especially if the screen is small but some scale (like 150%) is set.
 - The test paints and captures the button in the frame, then resize the frame and again paint and captures the button. The problem occurs if the fractional scale is used(like 125%), in that case, the button could be shifted by one pixel due to rounding depending on what position it was started to be drawn.

The solution is to always use the same uiscale=1, an updated test still can reproduce the JDK-6796710

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8196099](https://bugs.openjdk.java.net/browse/JDK-8196099): javax/swing/text/CSSBorder/6796710/bug6796710.java fails


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/950/head:pull/950`
`$ git checkout pull/950`
