### PR TITLE
8255576: (fs) Files.isHidden() throws ArrayIndexOutOfBoundsException (unix)

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -352,7 +352,14 @@ public abstract class UnixFileSystemProvider
         UnixPath name = file.getFileName();
         if (name == null)
             return false;
-        return (name.asByteArray()[0] == '.');
+
+        byte[] path;
+        if (name.isEmpty()) { // corner case for empty paths
+            path = name.getFileSystem().defaultDirectory();
+        } else {
+            path = name.asByteArray();
+        }
+        return path[0] == '.';
     }
 
     /**

--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -243,7 +243,7 @@ class UnixPath implements Path {
     }
 
     // returns {@code true} if this path is an empty path
-    private boolean isEmpty() {
+    boolean isEmpty() {
         return path.length == 0;
     }
 

--- a/test/jdk/java/nio/file/Files/Misc.java
+++ b/test/jdk/java/nio/file/Files/Misc.java
@@ -87,12 +87,8 @@ public class Misc {
      * Tests isHidden
      */
     static void testIsHidden(Path tmpdir) throws IOException {
-        // an empty path must not throw an AIOOB
-        try {
-            isHidden(Path.of(""));
-        } catch (ArrayIndexOutOfBoundsException exception) {
-            throw new AssertionError("8255576", exception);
-        }
+        // passing an empty path must not throw any runtime exception
+        isHidden(Path.of(""));
 
         assertTrue(!isHidden(tmpdir));
 

--- a/test/jdk/java/nio/file/Files/Misc.java
+++ b/test/jdk/java/nio/file/Files/Misc.java
@@ -88,7 +88,7 @@ public class Misc {
      */
     static void testIsHidden(Path tmpdir) throws IOException {
         // passing an empty path must not throw any runtime exception
-        isHidden(Path.of(""));
+        assertTrue(!isHidden(Path.of("")));
 
         assertTrue(!isHidden(tmpdir));
 

--- a/test/jdk/java/nio/file/Files/Misc.java
+++ b/test/jdk/java/nio/file/Files/Misc.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 6838333 8005566 8032220 8215467
+ * @bug 4313887 6838333 8005566 8032220 8215467 8255576
  * @summary Unit test for miscellenous methods in java.nio.file.Files
  * @library ..
  */
@@ -87,6 +87,13 @@ public class Misc {
      * Tests isHidden
      */
     static void testIsHidden(Path tmpdir) throws IOException {
+        // an empty path must not throw an AIOOB
+        try {
+            isHidden(Path.of(""));
+        } catch (ArrayIndexOutOfBoundsException exception) {
+            throw new AssertionError("8255576", exception);
+        }
+
         assertTrue(!isHidden(tmpdir));
 
         Path file = tmpdir.resolve(".foo");


### PR DESCRIPTION
This PR fixes a corner case of `Files.isHidden(Path)` where the given path is an empty path: `Path.of("")`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255576](https://bugs.openjdk.java.net/browse/JDK-8255576): (fs) Files.isHidden() throws ArrayIndexOutOfBoundsException (unix)


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/952/head:pull/952`
`$ git checkout pull/952`
