### PR TITLE
8251925: C2: RenaissanceStressTest fails with assert(!had_error): bad dominance

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3986,7 +3986,9 @@ bool SWPointer::offset_plus_k(Node* n, bool negate) {
       return true;
     }
   }
+
   if (!is_main_loop_member(n)) {
+    // 'n' is loop invariant. Skip range check dependent CastII nodes before checking if 'n' is dominating the pre loop.
     if (opc == Op_ConvI2L) {
       n = n->in(1);
       if (n->Opcode() == Op_CastII &&
@@ -3995,13 +3997,14 @@ bool SWPointer::offset_plus_k(Node* n, bool negate) {
         assert(!is_main_loop_member(n), "sanity");
         n = n->in(1);
       }
-    }
 
-    if (invariant(n)) {
-      _negate_invar = negate;
-      _invar = n;
-      NOT_PRODUCT(_tracer.offset_plus_k_10(n, _invar, _negate_invar, _offset);)
-      return true;
+      // Check if 'n' can really be used as invariant (not in main loop and dominating the pre loop).
+      if (invariant(n)) {
+        _negate_invar = negate;
+        _invar = n;
+        NOT_PRODUCT(_tracer.offset_plus_k_10(n, _invar, _negate_invar, _offset);)
+        return true;
+      }
     }
     return false;
   }

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -70,7 +70,6 @@ SuperWord::SuperWord(PhaseIdealLoop* phase) :
   _stk(arena(), 8, 0, NULL),              // scratch stack of nodes
   _lpt(NULL),                             // loop tree node
   _lp(NULL),                              // CountedLoopNode
-  _pre_loop_head(NULL),                   // Pre loop CountedLoopNode
   _pre_loop_end(NULL),                    // Pre loop CountedLoopEndNode
   _bb(NULL),                              // basic block
   _iv(NULL),                              // induction var
@@ -166,7 +165,6 @@ void SuperWord::transform_loop(IdealLoopTree* lpt, bool do_optimization) {
       return;
     }
     set_pre_loop_end(pre_end);
-    set_pre_loop_head(pre_end->loopnode());
   }
 
   init(); // initialize data structures
@@ -3446,7 +3444,7 @@ void SuperWord::align_initial_loop_index(MemNode* align_to_ref) {
   Node* lim0 = pre_opaq->in(1);
 
   // Where we put new limit calculations
-  Node* pre_ctrl = pre_end->loopnode()->in(LoopNode::EntryControl);
+  Node* pre_ctrl = pre_loop_head()->in(LoopNode::EntryControl);
 
   // Ensure the original loop limit is available from the
   // pre-loop Opaque1 node.

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -311,7 +311,6 @@ class SuperWord : public ResourceObj {
  private:
   IdealLoopTree* _lpt;             // Current loop tree node
   CountedLoopNode* _lp;            // Current CountedLoopNode
-  CountedLoopNode* _pre_loop_head; // Current CountedLoopNode of pre loop
   CountedLoopEndNode* _pre_loop_end; // Current CountedLoopEndNode of pre loop
   Node*          _bb;              // Current basic block
   PhiNode*       _iv;              // Induction var
@@ -341,13 +340,9 @@ class SuperWord : public ResourceObj {
   }
   int iv_stride() const            { return lp()->stride_con(); }
 
-  void set_pre_loop_head(CountedLoopNode* pre_loop_head) {
-    assert(pre_loop_head != NULL, "must be valid");
-    _pre_loop_head = pre_loop_head;
-  }
   CountedLoopNode* pre_loop_head() const {
-    assert(_pre_loop_head != NULL, "should be set when fetched");
-    return _pre_loop_head;
+    assert(_pre_loop_end != NULL && _pre_loop_end->loopnode() != NULL, "should find head from pre loop end");
+    return _pre_loop_end->loopnode();
   }
   void set_pre_loop_end(CountedLoopEndNode* pre_loop_end) {
     assert(pre_loop_end, "must be valid");


### PR DESCRIPTION
The dominance failures start to occur after the fix for [JDK-8249749](https://bugs.openjdk.java.net/browse/JDK-8249749) which enabled the method `SWPointer::scaled_iv_plus_offset` to call itself recursively and walk the graph to match more instead of stopping immediately (no recursion):
https://github.com/openjdk/jdk/commit/092389e3c91822b1e3f56f203cb7b90e84673f8e#diff-8f29dd005a0f949d108687dabb7379c73dfd85cd782da453509dc9b6cb8c9f81L3789-R3812

We check in `SWPointer::offset_plus_k` if a node is invariant and if so then we choose it as invariant. However, we now have cases in the Renaissance benchmarks where we select an invariant that is pinned to a `CastIINode` between the main and pre loop. An example is shown in the attached image. 5913 SubI is found as an invariant with the improved recursive search enabled by JDK-8249749. The control of 5913 SubI (with `get_ctrl`) is 5298 CastII. The problem is now that we use the invariant 5913 SubI in the pre loop limit check of  5281 CountedLoopEnd (done in `SuperWord::align_initial_loop_index`) because we assume that since the invariant is not part of the main loop, it can float into the pre loop. But this is prevented by 5298 CastII. This results in the dominance assertion failure when checking if the earliest control of 5270 Bool in the pre loop (5297 IfTrue because of 5913 SubI that is used by 5270 Bool) dominates the LCA of 5270 Bool (the pre loop header node).

My suggestion is to improve the invariant check in `SWPointer::offset_plus_k` to also check if the found invariant is not dominated by the pre loop end node. Repeated testing of the RenaissanceStressTest has not resulted in any dominance failures anymore.
![dominance_failure](https://user-images.githubusercontent.com/17833009/97696669-3752d200-1aa6-11eb-9a42-2e36550e2b8b.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8251925](https://bugs.openjdk.java.net/browse/JDK-8251925): C2: RenaissanceStressTest fails with assert(!had_error): bad dominance


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/954/head:pull/954`
`$ git checkout pull/954`
