### PR TITLE
7190978: javax/swing/JComponent/7154030/bug7154030.java fails on mac

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -731,7 +731,6 @@ javax/sound/midi/Sequencer/MetaCallback.java 8178698 linux-all
 javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 8233177 linux-all,windows-all
 
 javax/swing/border/TestTitledBorderLeak.java 8213531 linux-all
-javax/swing/JComponent/7154030/bug7154030.java 7190978 generic-all
 javax/swing/JComponent/6683775/bug6683775.java 8172337 generic-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedTranslucentPerPixelTranslucentGradient.java 8233582 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedPerPixelTranslucentGradient.java 8233582 linux-all

--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -33,6 +33,7 @@ import javax.swing.SwingUtilities;
 import java.awt.AWTException;
 import java.awt.AlphaComposite;
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
@@ -52,13 +53,14 @@ import java.io.File;
  * @library /lib/client/
  * @build Util
  * @build ExtendedRobot
- * @run main/othervm -Dsun.java2d.uiScale=1 bug7154030
+ * @run main bug7154030
  */
 
 public class bug7154030 {
 
     private static JButton button = null;
     private static JFrame frame;
+    private static int locx, locy;
 
     public static void main(String[] args) throws Exception {
         try {
@@ -88,14 +90,17 @@ public class bug7154030 {
 
                     frame.setContentPane(desktop);
                     frame.setSize(300, 300);
-                    frame.setLocation(0, 0);
+                    Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+                    locx = screenSize.width/2;
+                    locy = screenSize.height/2;
+                    frame.setLocation(locx, locy);
                     frame.setVisible(true);
                     frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
                 }
             });
 
             robot.waitForIdle(1000);
-            imageInit = robot.createScreenCapture(new Rectangle(0, 0, 300, 300));
+            imageInit = robot.createScreenCapture(new Rectangle(locx, locy, 300, 300));
 
             SwingUtilities.invokeAndWait(new Runnable() {
 
@@ -106,7 +111,7 @@ public class bug7154030 {
             });
 
             robot.waitForIdle(500);
-            imageShow = robot.createScreenCapture(new Rectangle(0, 0, 300, 300));
+            imageShow = robot.createScreenCapture(new Rectangle(locx, locy, 300, 300));
             if (Util.compareBufferedImages(imageInit, imageShow)) {
                 ImageIO.write(imageInit, "png", new File("imageInit.png"));
                 ImageIO.write(imageShow, "png", new File("imageShow.png"));
@@ -123,7 +128,7 @@ public class bug7154030 {
             });
 
             robot.waitForIdle(500);
-            imageHide = robot.createScreenCapture(new Rectangle(0, 0, 300, 300));
+            imageHide = robot.createScreenCapture(new Rectangle(locx, locy, 300, 300));
 
             if (!Util.compareBufferedImages(imageInit, imageHide)) {
                 ImageIO.write(imageInit, "png", new File("imageInit.png"));
@@ -142,7 +147,7 @@ public class bug7154030 {
             });
 
             robot.waitForIdle(500);
-            imageInit = robot.createScreenCapture(new Rectangle(0, 0, 300, 300));
+            imageInit = robot.createScreenCapture(new Rectangle(locx, locy, 300, 300));
 
             SwingUtilities.invokeAndWait(new Runnable() {
 
@@ -153,7 +158,7 @@ public class bug7154030 {
             });
 
             robot.waitForIdle(500);
-            imageShow = robot.createScreenCapture(new Rectangle(0, 0, 300, 300));
+            imageShow = robot.createScreenCapture(new Rectangle(locx, locy, 300, 300));
 
             SwingUtilities.invokeAndWait(new Runnable() {
 
@@ -170,7 +175,7 @@ public class bug7154030 {
             }
 
             robot.waitForIdle(500);
-            imageHide = robot.createScreenCapture(new Rectangle(0, 0, 300, 300));
+            imageHide = robot.createScreenCapture(new Rectangle(locx, locy, 300, 300));
 
             if (!Util.compareBufferedImages(imageInit, imageHide)) {
                 ImageIO.write(imageInit, "png", new File("imageInit.png"));

--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -39,6 +39,8 @@ import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+import java.io.File;
 
 /*
  * @test
@@ -50,7 +52,7 @@ import java.awt.image.BufferedImage;
  * @library /lib/client/
  * @build Util
  * @build ExtendedRobot
- * @run main bug7154030
+ * @run main/othervm -Dsun.java2d.uiScale=1 bug7154030
  */
 
 public class bug7154030 {
@@ -86,13 +88,13 @@ public class bug7154030 {
 
                     frame.setContentPane(desktop);
                     frame.setSize(300, 300);
-                    frame.setLocation(0, 0);
+                    frame.setLocationRelativeTo(null);
                     frame.setVisible(true);
                     frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
                 }
             });
 
-            robot.waitForIdle(500);
+            robot.waitForIdle(1000);
             imageInit = robot.createScreenCapture(new Rectangle(0, 0, 300, 300));
 
             SwingUtilities.invokeAndWait(new Runnable() {
@@ -106,6 +108,8 @@ public class bug7154030 {
             robot.waitForIdle(500);
             imageShow = robot.createScreenCapture(new Rectangle(0, 0, 300, 300));
             if (Util.compareBufferedImages(imageInit, imageShow)) {
+                ImageIO.write(imageInit, "png", new File("imageInit"));
+                ImageIO.write(imageShow, "png", new File("imageShow"));
                 throw new Exception("Failed to show opaque button");
             }
 
@@ -122,6 +126,8 @@ public class bug7154030 {
             imageHide = robot.createScreenCapture(new Rectangle(0, 0, 300, 300));
 
             if (!Util.compareBufferedImages(imageInit, imageHide)) {
+                ImageIO.write(imageInit, "png", new File("imageInit"));
+                ImageIO.write(imageHide, "png", new File("imageHide"));
                 throw new Exception("Failed to hide opaque button");
             }
 
@@ -158,6 +164,8 @@ public class bug7154030 {
             });
 
             if (Util.compareBufferedImages(imageInit, imageShow)) {
+                ImageIO.write(imageInit, "png", new File("imageInit"));
+                ImageIO.write(imageShow, "png", new File("imageShow"));
                 throw new Exception("Failed to show non-opaque button");
             }
 
@@ -165,6 +173,8 @@ public class bug7154030 {
             imageHide = robot.createScreenCapture(new Rectangle(0, 0, 300, 300));
 
             if (!Util.compareBufferedImages(imageInit, imageHide)) {
+                ImageIO.write(imageInit, "png", new File("imageInit"));
+                ImageIO.write(imageHide, "png", new File("imageHide"));
                 throw new Exception("Failed to hide non-opaque button");
             }
         } finally {

--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -59,7 +59,7 @@ public class bug7154030 {
 
     private static JButton button = null;
     private static JFrame frame;
-    private static int locx, locy;
+    private static int locx, locy, frw, frh;
 
     public static void main(String[] args) throws Exception {
         try {
@@ -100,8 +100,10 @@ public class bug7154030 {
             Rectangle bounds = frame.getBounds();
             locx = bounds.x;
             locy = bounds.y;
+            frw = bounds.width;
+            frh = bounds.height;
 
-            imageInit = robot.createScreenCapture(new Rectangle(locx, locy, 300, 300));
+            imageInit = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
 
             SwingUtilities.invokeAndWait(new Runnable() {
 
@@ -112,7 +114,7 @@ public class bug7154030 {
             });
 
             robot.waitForIdle(500);
-            imageShow = robot.createScreenCapture(new Rectangle(locx, locy, 300, 300));
+            imageShow = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
             if (Util.compareBufferedImages(imageInit, imageShow)) {
                 ImageIO.write(imageInit, "png", new File("imageInit.png"));
                 ImageIO.write(imageShow, "png", new File("imageShow.png"));
@@ -129,7 +131,7 @@ public class bug7154030 {
             });
 
             robot.waitForIdle(500);
-            imageHide = robot.createScreenCapture(new Rectangle(locx, locy, 300, 300));
+            imageHide = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
 
             if (!Util.compareBufferedImages(imageInit, imageHide)) {
                 ImageIO.write(imageInit, "png", new File("imageInit.png"));
@@ -148,7 +150,7 @@ public class bug7154030 {
             });
 
             robot.waitForIdle(500);
-            imageInit = robot.createScreenCapture(new Rectangle(locx, locy, 300, 300));
+            imageInit = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
 
             SwingUtilities.invokeAndWait(new Runnable() {
 
@@ -159,7 +161,7 @@ public class bug7154030 {
             });
 
             robot.waitForIdle(500);
-            imageShow = robot.createScreenCapture(new Rectangle(locx, locy, 300, 300));
+            imageShow = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
 
             SwingUtilities.invokeAndWait(new Runnable() {
 
@@ -176,7 +178,7 @@ public class bug7154030 {
             }
 
             robot.waitForIdle(500);
-            imageHide = robot.createScreenCapture(new Rectangle(locx, locy, 300, 300));
+            imageHide = robot.createScreenCapture(new Rectangle(locx, locy, frw, frh));
 
             if (!Util.compareBufferedImages(imageInit, imageHide)) {
                 ImageIO.write(imageInit, "png", new File("imageInit.png"));

--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -33,7 +33,7 @@ import javax.swing.SwingUtilities;
 import java.awt.AWTException;
 import java.awt.AlphaComposite;
 import java.awt.Color;
-import java.awt.Dimension;
+import java.awt.GraphicsEnvironment;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
@@ -90,9 +90,11 @@ public class bug7154030 {
 
                     frame.setContentPane(desktop);
                     frame.setSize(300, 300);
-                    Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-                    locx = screenSize.width/2;
-                    locy = screenSize.height/2;
+                    Rectangle rect = GraphicsEnvironment.getLocalGraphicsEnvironment().
+                                      getDefaultScreenDevice().getDefaultConfiguration().
+                                      getBounds();
+                    locx = rect.width/2;
+                    locy = rect.height/2;
                     frame.setLocation(locx, locy);
                     frame.setVisible(true);
                     frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);

--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -88,7 +88,7 @@ public class bug7154030 {
 
                     frame.setContentPane(desktop);
                     frame.setSize(300, 300);
-                    frame.setLocationRelativeTo(null);
+                    frame.setLocation(0, 0);
                     frame.setVisible(true);
                     frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
                 }
@@ -108,8 +108,8 @@ public class bug7154030 {
             robot.waitForIdle(500);
             imageShow = robot.createScreenCapture(new Rectangle(0, 0, 300, 300));
             if (Util.compareBufferedImages(imageInit, imageShow)) {
-                ImageIO.write(imageInit, "png", new File("imageInit"));
-                ImageIO.write(imageShow, "png", new File("imageShow"));
+                ImageIO.write(imageInit, "png", new File("imageInit.png"));
+                ImageIO.write(imageShow, "png", new File("imageShow.png"));
                 throw new Exception("Failed to show opaque button");
             }
 
@@ -126,8 +126,8 @@ public class bug7154030 {
             imageHide = robot.createScreenCapture(new Rectangle(0, 0, 300, 300));
 
             if (!Util.compareBufferedImages(imageInit, imageHide)) {
-                ImageIO.write(imageInit, "png", new File("imageInit"));
-                ImageIO.write(imageHide, "png", new File("imageHide"));
+                ImageIO.write(imageInit, "png", new File("imageInit.png"));
+                ImageIO.write(imageHide, "png", new File("imageHide.png"));
                 throw new Exception("Failed to hide opaque button");
             }
 
@@ -164,8 +164,8 @@ public class bug7154030 {
             });
 
             if (Util.compareBufferedImages(imageInit, imageShow)) {
-                ImageIO.write(imageInit, "png", new File("imageInit"));
-                ImageIO.write(imageShow, "png", new File("imageShow"));
+                ImageIO.write(imageInit, "png", new File("imageInit.png"));
+                ImageIO.write(imageShow, "png", new File("imageShow.png"));
                 throw new Exception("Failed to show non-opaque button");
             }
 
@@ -173,8 +173,8 @@ public class bug7154030 {
             imageHide = robot.createScreenCapture(new Rectangle(0, 0, 300, 300));
 
             if (!Util.compareBufferedImages(imageInit, imageHide)) {
-                ImageIO.write(imageInit, "png", new File("imageInit"));
-                ImageIO.write(imageHide, "png", new File("imageHide"));
+                ImageIO.write(imageInit, "png", new File("imageInit.png"));
+                ImageIO.write(imageHide, "png", new File("imageHide.png"));
                 throw new Exception("Failed to hide non-opaque button");
             }
         } finally {

--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -33,7 +33,6 @@ import javax.swing.SwingUtilities;
 import java.awt.AWTException;
 import java.awt.AlphaComposite;
 import java.awt.Color;
-import java.awt.GraphicsEnvironment;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
@@ -90,18 +89,18 @@ public class bug7154030 {
 
                     frame.setContentPane(desktop);
                     frame.setSize(300, 300);
-                    Rectangle rect = GraphicsEnvironment.getLocalGraphicsEnvironment().
-                                      getDefaultScreenDevice().getDefaultConfiguration().
-                                      getBounds();
-                    locx = rect.width/2;
-                    locy = rect.height/2;
-                    frame.setLocation(locx, locy);
+                    frame.setLocationRelativeTo(null);
                     frame.setVisible(true);
                     frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
                 }
             });
 
             robot.waitForIdle(1000);
+
+            Rectangle bounds = frame.getBounds();
+            locx = bounds.x;
+            locy = bounds.y;
+
             imageInit = robot.createScreenCapture(new Rectangle(locx, locy, 300, 300));
 
             SwingUtilities.invokeAndWait(new Runnable() {


### PR DESCRIPTION
Please review a test fix for an issue seen where robot image capture is wrong if screen scale factor is more, which could result in button or frame to move out of captured dimension of 300,300.
Fixed by setting uiScale=1 in the test which can still reproduce JDK-7154030.
Mach5 job has been run for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-7190978](https://bugs.openjdk.java.net/browse/JDK-7190978): javax/swing/JComponent/7154030/bug7154030.java fails on mac


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/955/head:pull/955`
`$ git checkout pull/955`
