### PR TITLE
8255584: `HttpPrincipal::getName` returns incorrect name

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpPrincipal.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpPrincipal.java
@@ -75,7 +75,7 @@ public class HttpPrincipal implements Principal {
      * @return the contents of this principal in the form realm:username
      */
     public String getName() {
-        return String.format("%s:%s", username, realm);
+        return String.format("%s:%s", realm, username);
     }
 
     /**

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpPrincipal.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpPrincipal.java
@@ -75,7 +75,7 @@ public class HttpPrincipal implements Principal {
      * @return the contents of this principal in the form realm:username
      */
     public String getName() {
-        return username;
+        return String.format("%s:%s", username, realm);
     }
 
     /**

--- a/test/jdk/com/sun/net/httpserver/HttpPrincipalTest.java
+++ b/test/jdk/com/sun/net/httpserver/HttpPrincipalTest.java
@@ -41,7 +41,7 @@ public class HttpPrincipalTest {
 
         assertEquals(principal.getUsername(), "test");
         assertEquals(principal.getRealm(), "123");
-        assertEquals(principal.getName(), "test:123");
+        assertEquals(principal.getName(), "123:test");
         assertEquals(principal.toString(), principal.getName());
         assertEquals(("test"+"123").hashCode(), principal.hashCode());
     }

--- a/test/jdk/com/sun/net/httpserver/HttpPrincipalTest.java
+++ b/test/jdk/com/sun/net/httpserver/HttpPrincipalTest.java
@@ -36,9 +36,13 @@ import static org.testng.Assert.assertEquals;
 public class HttpPrincipalTest {
 
     @Test
-    public void TestGetters() {
+    public void testGetters() {
         var principal = new HttpPrincipal("test", "123");
+
         assertEquals(principal.getUsername(), "test");
         assertEquals(principal.getRealm(), "123");
+        assertEquals(principal.getName(), "test:123");
+        assertEquals(principal.toString(), principal.getName());
+        assertEquals(("test"+"123").hashCode(), principal.hashCode());
     }
 }


### PR DESCRIPTION
Hi,

Could someone please review my fix for JDK-8255584: '`HttpPrincipal::getName` returns incorrect name' ?
The specification for `HttpPrincipal::getName` reports that it should return the name of the HttpPrincipal in the format "realm:username". However, it currently returns the username only.

This fix updates the method to return the name in the correct format as specified by the javadoc. 

Kind regards,
Patrick

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255584](https://bugs.openjdk.java.net/browse/JDK-8255584): `HttpPrincipal::getName` returns incorrect name


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/958/head:pull/958`
`$ git checkout pull/958`
