### PR TITLE
JDK-8255673: Wrong version in docs bundles

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -687,11 +687,12 @@ var getJibProfilesProfiles = function (input, common, data) {
             dependencies: [
                 "boot_jdk", "devkit", "graphviz", "pandoc", buildJdkDep,
             ],
-            configure_args: [
+            configure_args: concat(
                 "--enable-full-docs",
+                versionArgs(input, common),
                 "--with-build-jdk=" + input.get(buildJdkDep, "home_path")
                     + (input.build_os == "macosx" ? "/Contents/Home" : "")
-            ],
+            ),
             default_make_targets: ["all-docs-bundles"],
             artifacts: {
                 doc_api_spec: {


### PR DESCRIPTION
In JDK-8206311, when I introduced a new docs build profile, I forgot to add the version configure arguments to it. This causes the docs bundles for CI/promoted builds to be generated with the default adhoc version information instead of the specific version for that build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255673](https://bugs.openjdk.java.net/browse/JDK-8255673): Wrong version in docs bundles


### Reviewers
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/959/head:pull/959`
`$ git checkout pull/959`
