### PR TITLE
8255616: Disable AOT and Graal in Oracle OpenJDK

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -251,6 +251,8 @@ var getJibProfilesCommon = function (input, data) {
         configure_args: concat("--enable-jtreg-failure-handler",
             "--with-exclude-translations=de,es,fr,it,ko,pt_BR,sv,ca,tr,cs,sk,ja_JP_A,ja_JP_HA,ja_JP_HI,ja_JP_I,zh_TW,zh_HK",
             "--disable-manpages",
+            "--disable-jvm-feature-aot",
+            "--disable-jvm-feature-graal",
             "--disable-jvm-feature-shenandoahgc",
             versionArgs(input, common))
     };
@@ -404,7 +406,7 @@ var getJibProfilesProfiles = function (input, common, data) {
         "linux-x64": {
             target_os: "linux",
             target_cpu: "x64",
-            dependencies: ["devkit", "gtest", "graphviz", "pandoc", "graalunit_lib"],
+            dependencies: ["devkit", "gtest", "graphviz", "pandoc"],
             configure_args: concat(common.configure_args_64bit,
                 "--with-zlib=system",
                 (isWsl(input) ? [ "--host=x86_64-unknown-linux-gnu",
@@ -423,7 +425,7 @@ var getJibProfilesProfiles = function (input, common, data) {
         "macosx-x64": {
             target_os: "macosx",
             target_cpu: "x64",
-            dependencies: ["devkit", "gtest", "pandoc", "graalunit_lib"],
+            dependencies: ["devkit", "gtest", "pandoc"],
             configure_args: concat(common.configure_args_64bit, "--with-zlib=system",
                 "--with-macosx-version-max=10.9.0",
                 // Use system SetFile instead of the one in the devkit as the
@@ -434,7 +436,7 @@ var getJibProfilesProfiles = function (input, common, data) {
         "windows-x64": {
             target_os: "windows",
             target_cpu: "x64",
-            dependencies: ["devkit", "gtest", "pandoc", "graalunit_lib"],
+            dependencies: ["devkit", "gtest", "pandoc"],
             configure_args: concat(common.configure_args_64bit),
         },
 
@@ -454,8 +456,6 @@ var getJibProfilesProfiles = function (input, common, data) {
             configure_args: [
                 "--openjdk-target=aarch64-linux-gnu",
 		"--disable-jvm-feature-jvmci",
-		"--disable-jvm-feature-graal",
-		"--disable-jvm-feature-aot",
             ],
         },
 
@@ -1149,15 +1149,6 @@ var getJibProfilesDependencies = function (input, common) {
             ext: "zip",
             revision: "1.7.1+1.0",
             configure_args: "",
-        },
-
-        graalunit_lib: {
-            organization: common.organization,
-            ext: "zip",
-            revision: "619_Apr_12_2018",
-            module: "graalunit-lib",
-            configure_args: "--with-graalunit-lib=" + input.get("graalunit_lib", "install_path"),
-            environment_name: "GRAALUNIT_LIB"
         },
 
         gtest: {

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IsCompilableTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IsCompilableTest.java
@@ -27,6 +27,7 @@
  * @requires vm.jvmci & vm.compMode == "Xmixed"
  * @library /test/lib /
  * @library ../common/patches
+ * @modules jdk.internal.vm.compiler
  * @modules java.base/jdk.internal.misc
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.org.objectweb.asm.tree
@@ -41,6 +42,23 @@
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:+UseJVMCICompiler
  *                   compiler.jvmci.compilerToVM.IsCompilableTest
+ */
+
+/**
+ * @test
+ * @requires vm.jvmci & vm.compMode == "Xmixed"
+ * @library /test/lib /
+ * @library ../common/patches
+ * @modules java.base/jdk.internal.misc
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.tree
+ *          jdk.internal.vm.ci/jdk.vm.ci.hotspot
+ *          jdk.internal.vm.ci/jdk.vm.ci.code
+ *          jdk.internal.vm.ci/jdk.vm.ci.meta
+ *          jdk.internal.vm.ci/jdk.vm.ci.runtime
+ *
+ * @build jdk.internal.vm.ci/jdk.vm.ci.hotspot.CompilerToVMHelper sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:.
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler

--- a/test/hotspot/jtreg/runtime/InvocationTests/invocationGraalTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invocationGraalTests.java
@@ -30,6 +30,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc
+ * @modules jdk.internal.vm.compiler
  * @compile shared/AbstractGenerator.java shared/AccessCheck.java shared/AccessType.java
  *          shared/Caller.java shared/ExecutorGenerator.java shared/Utils.java
  *          shared/ByteArrayClassLoader.java shared/Checker.java shared/GenericClassGenerator.java

--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -114,7 +114,7 @@
  *
  * @author Richard Reingruber richard DOT reingruber AT sap DOT com
  *
- * @requires ((vm.compMode == "Xmixed") & vm.jvmci)
+ * @requires ((vm.compMode == "Xmixed") & vm.graal.enabled)
  *
  * @library /test/lib /test/hotspot/jtreg
  *


### PR DESCRIPTION
We shipped Ahead-of-Time compilation (the jaotc tool) in JDK 9, as an experimental feature. We shipped Graal as an experimental JIT compiler in JDK 10. We haven't seen much use of these features, and the effort required to support and enhance them is significant. We therefore intend to disable these features in Oracle builds as of JDK 16. 

We'll leave the sources for these features in the repository, in case any one else is interested in building them. But we will not update or test them.

We'll continue to build and ship JVMCI as an experimental feature in Oracle builds.

Tested changes in all tiers.

I verified that with these changes I still able to build Graal in open repo and run graalunit testing: 

`open$ bash test/hotspot/jtreg/compiler/graalunit/downloadLibs.sh /mydir/graalunit_lib/`
`open$ bash configure --with-debug-level=fastdebug --with-graalunit-lib=/mydir/graalunit_lib/ --with-jtreg=/mydir/jtreg`
`open$ make jdk-image`
`open$ make test-image`
`open$ make run-test TEST=compiler/graalunit/HotspotTest.java`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255616](https://bugs.openjdk.java.net/browse/JDK-8255616): Disable AOT and Graal in Oracle OpenJDK


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/960/head:pull/960`
`$ git checkout pull/960`
