### PR TITLE
8255578: [JVMCI] be more careful about reflective reads of Class.componentType.

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -322,6 +322,8 @@ class java_lang_Class : AllStatic {
   static oop  class_data(oop java_class);
   static void set_class_data(oop java_class, oop classData);
 
+  static int component_mirror_offset() { return _component_mirror_offset; }
+
   static oop class_loader(oop java_class);
   static void set_module(oop java_class, oop module);
   static oop module(oop java_class);

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJDKReflection.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJDKReflection.java
@@ -404,6 +404,14 @@ final class HotSpotJDKReflection extends HotSpotJVMCIReflection {
         assert obj != null;
         assert !field.isStatic() || obj instanceof Class;
         long displacement = field.getOffset();
+        if (obj instanceof Class && field.getName().equals("componentType")) {
+            Class<?> clazz = (Class<?>) obj;
+            if (!clazz.isArray()) {
+                // Class.componentType for non-array classes can transiently contain an int[] that's
+                // used for locking so always return null to mimic Class.getComponentType()
+                return JavaConstant.NULL_POINTER;
+            }
+        }
 
         assert checkRead(field.getJavaKind(), displacement,
                         (HotSpotResolvedObjectType) runtime().getHostJVMCIBackend().getMetaAccess().lookupJavaType(field.isStatic() ? (Class<?>) obj : obj.getClass()),


### PR DESCRIPTION
cc @vnkozlov

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255578](https://bugs.openjdk.java.net/browse/JDK-8255578): [JVMCI] be more careful about reflective reads of Class.componentType.


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/962/head:pull/962`
`$ git checkout pull/962`
