### PR TITLE
8255690:  &nbsp in StringBuilder.subSequence

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -1028,12 +1028,12 @@ abstract class AbstractStringBuilder implements Appendable, CharSequence {
      * <p> An invocation of this method of the form
      *
      * <pre>{@code
-     * sb.subSequence(begin,&nbsp;end)}</pre>
+     * sb.subSequence(begin, end)}</pre>
      *
      * behaves in exactly the same way as the invocation
      *
      * <pre>{@code
-     * sb.substring(begin,&nbsp;end)}</pre>
+     * sb.substring(begin, end)}</pre>
      *
      * This method is provided so that this class can
      * implement the {@link CharSequence} interface.


### PR DESCRIPTION
There are a couple of stray "&nbsp"'s in the StringBuilder.subSequence() documentation, which should be removed.  The updated doc build looks good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (4/9 running) | ⏳ (8/9 running) | ⏳ (9/9 running) | ⏳ (6/9 running) |

### Issue
 * [JDK-8255690](https://bugs.openjdk.java.net/browse/JDK-8255690): &nbsp in StringBuilder.subSequence


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/963/head:pull/963`
`$ git checkout pull/963`
