### PR TITLE
8255697: LogTargetHandle::print should check if log level is enabled

### DIFF
--- a/src/hotspot/share/logging/logHandle.hpp
+++ b/src/hotspot/share/logging/logHandle.hpp
@@ -91,7 +91,9 @@ public:
   void print(const char* fmt, ...) ATTRIBUTE_PRINTF(2, 3) {
     va_list args;
     va_start(args, fmt);
-    _tagset->vwrite(_level, fmt, args);
+    if (is_enabled()) {
+      _tagset->vwrite(_level, fmt, args);
+    }
     va_end(args);
   }
 


### PR DESCRIPTION
An early check in LogTargetHandle::print like this can reduce overhead by not dropping into code that initialize LogDecorations et.c. This saves around 100k instructions on VM bootstrap, and can reduce cost of not logging in a few places.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255697](https://bugs.openjdk.java.net/browse/JDK-8255697): LogTargetHandle::print should check if log level is enabled


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/964/head:pull/964`
`$ git checkout pull/964`
