### PR TITLE
8214561: Use {@systemProperty} for definition of "java.util.prefs.PreferencesFactory" system property

### DIFF
--- a/src/java.prefs/share/classes/java/util/prefs/Preferences.java
+++ b/src/java.prefs/share/classes/java/util/prefs/Preferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -194,7 +194,7 @@ import java.lang.Double;
  * <ol>
  *
  * <li><p>If the system property
- * {@code java.util.prefs.PreferencesFactory} is defined, then it is
+ * {@systemProperty java.util.prefs.PreferencesFactory} is defined, then it is
  * taken to be the fully-qualified name of a class implementing the
  * {@code PreferencesFactory} interface.  The class is loaded and
  * instantiated; if this process fails then an unspecified error is


### PR DESCRIPTION
Using the {@systemProperty} tag for the "java.util.prefs.PreferencesFactory" system property will allow it to be found in the main javadoc search index.

The updated doc build looks good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (9/9 running) | ⏳ (8/9 running) |    |  ⏳ (9/9 running) |

### Issue
 * [JDK-8214561](https://bugs.openjdk.java.net/browse/JDK-8214561): Use {@systemProperty} for definition of "java.util.prefs.PreferencesFactory" system property


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/965/head:pull/965`
`$ git checkout pull/965`
