### PR TITLE
8255694: memory leak in JDWP debug agent after calling JVMTI GetAllThreads

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -836,6 +836,7 @@ threadControl_onHook(void)
                  */
                 node->isStarted = JNI_TRUE;
             }
+            jvmtiDeallocate(threads);
         }
 
     } END_WITH_LOCAL_REFS(env)
@@ -1550,6 +1551,7 @@ threadControl_suspendAll(void)
         }
 
     err: ;
+        jvmtiDeallocate(threads);
 
     } END_WITH_LOCAL_REFS(env)
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -1550,7 +1550,7 @@ threadControl_suspendAll(void)
             suspendAllCount++;
         }
 
-    err: ;
+    err:
         jvmtiDeallocate(threads);
 
     } END_WITH_LOCAL_REFS(env)


### PR DESCRIPTION
The debug agent needs to deallocate memory that is allocated by calls to GetAllThreads. There were two places were this was not being done, resulting in a memory leak.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (1/9 failed) |

**Failed test task**
- [macOS x64 (hs/tier1 gc)](https://github.com/plummercj/jdk/runs/1343735842)

### Issue
 * [JDK-8255694](https://bugs.openjdk.java.net/browse/JDK-8255694): memory leak in JDWP debug agent after calling JVMTI GetAllThreads


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to 06063b7d84465f402449d6d5eca4e8885084b2e9
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to 06063b7d84465f402449d6d5eca4e8885084b2e9


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/968/head:pull/968`
`$ git checkout pull/968`
