### PR TITLE
8255703: jaotc: Add Windows+Arm64 support

### DIFF
--- a/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/BinaryContainer.java
+++ b/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/BinaryContainer.java
@@ -586,7 +586,7 @@ public final class BinaryContainer implements SymbolTable {
                 break;
             default:
                 if (osName.startsWith("Windows")) {
-                    JPECoffRelocObject pecoffobj = new JPECoffRelocObject(this, outputFileName);
+                    JPECoffRelocObject pecoffobj = JPECoffRelocObject.newInstance(this, outputFileName);
                     pecoffobj.createPECoffRelocObject(relocationTable, symbolTable.values());
                     break;
                 } else {

--- a/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/pecoff/AArch64JPECoffRelocObject.java
+++ b/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/pecoff/AArch64JPECoffRelocObject.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+
+package jdk.tools.jaotc.binformat.pecoff;
+
+import jdk.tools.jaotc.binformat.BinaryContainer;
+import jdk.tools.jaotc.binformat.Relocation;
+import jdk.tools.jaotc.binformat.Relocation.RelocType;
+import jdk.tools.jaotc.binformat.Symbol;
+import jdk.tools.jaotc.binformat.pecoff.PECoff.IMAGE_FILE_HEADER;
+import jdk.tools.jaotc.binformat.pecoff.PECoff.IMAGE_RELOCATION;
+
+public class AArch64JPECoffRelocObject extends JPECoffRelocObject {
+
+    AArch64JPECoffRelocObject(BinaryContainer binContainer, String outputFileName) {
+        super (binContainer, outputFileName);
+    }
+
+    @Override
+    protected void createRelocation(Symbol symbol, Relocation reloc, PECoffRelocTable pecoffRelocTable) {
+        RelocType relocType = reloc.getType();
+
+        PECoffSymbol sym = (PECoffSymbol) symbol.getNativeSymbol();
+        int symno = sym.getIndex();
+        int sectindex = reloc.getSection().getSectionId();
+        int offset = reloc.getOffset();
+
+        switch (relocType) {
+            case STUB_CALL_DIRECT:
+            case JAVA_CALL_DIRECT: {
+                break;
+            }
+            case EXTERNAL_PLT_TO_GOT:
+                offset -= 16;
+                pecoffRelocTable.createRelocationEntry(sectindex, offset, symno, IMAGE_RELOCATION.IMAGE_REL_ARM64_PAGEBASE_REL21);
+                pecoffRelocTable.createRelocationEntry(sectindex, offset + 4, symno, IMAGE_RELOCATION.IMAGE_REL_ARM64_PAGEOFFSET_12A);
+                return;
+
+            case FOREIGN_CALL_INDIRECT_GOT: {
+                break;
+            }
+            case METASPACE_GOT_REFERENCE: {
+                offset -= 4;
+
+                pecoffRelocTable.createRelocationEntry(sectindex, offset, symno, IMAGE_RELOCATION.IMAGE_REL_ARM64_PAGEBASE_REL21);
+                pecoffRelocTable.createRelocationEntry(sectindex, offset + 4, symno, IMAGE_RELOCATION.IMAGE_REL_ARM64_PAGEOFFSET_12A);
+                return;
+            }
+            // break;
+            case JAVA_CALL_INDIRECT: {
+                offset -= 4;
+                break;
+            }
+            case EXTERNAL_GOT_TO_PLT: {
+                // this is load time relocations
+                break;
+            }
+            default:
+                throw new InternalError("Unhandled relocation type: " + relocType);
+        }
+        int pecoffRelocType = getPECoffRelocationType(relocType);
+        pecoffRelocTable.createRelocationEntry(sectindex, offset, symno, pecoffRelocType);
+    }
+
+    // Return IMAGE_RELOCATION Type based on relocType
+    private static int getPECoffRelocationType(RelocType relocType) {
+        int pecoffRelocType = 0; // R_<ARCH>_NONE if #define'd to 0 for all values of ARCH
+        switch (PECoffTargetInfo.getPECoffArch()) {
+            case IMAGE_FILE_HEADER.IMAGE_FILE_MACHINE_ARM64:
+                if (relocType == RelocType.JAVA_CALL_DIRECT) {
+                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_ARM64_BRANCH26;
+                } else if (relocType == RelocType.FOREIGN_CALL_INDIRECT_GOT) {
+                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_ARM64_BRANCH26;
+                } else if (relocType == RelocType.STUB_CALL_DIRECT) {
+                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_ARM64_BRANCH26;
+                } else if (relocType == RelocType.JAVA_CALL_INDIRECT) {
+                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_ARM64_BRANCH26;
+                } else if (relocType == RelocType.METASPACE_GOT_REFERENCE || relocType == RelocType.EXTERNAL_PLT_TO_GOT) {
+                    assert false : "Should have been handled already";
+                    // pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_ARM64_ABSOLUTE;
+                } else if (relocType == RelocType.EXTERNAL_GOT_TO_PLT) {
+                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_ARM64_ADDR64;
+                } else {
+                    assert false : "Unhandled relocation type: " + relocType;
+                }
+                break;
+            default:
+                System.out.println("Relocation Type mapping: Unhandled architecture");
+        }
+        return pecoffRelocType;
+    }
+}

--- a/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/pecoff/AMD64JPECoffRelocObject.java
+++ b/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/pecoff/AMD64JPECoffRelocObject.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+
+package jdk.tools.jaotc.binformat.pecoff;
+
+import jdk.tools.jaotc.binformat.BinaryContainer;
+import jdk.tools.jaotc.binformat.Relocation;
+import jdk.tools.jaotc.binformat.Relocation.RelocType;
+import jdk.tools.jaotc.binformat.Symbol;
+import jdk.tools.jaotc.binformat.pecoff.PECoff.IMAGE_FILE_HEADER;
+import jdk.tools.jaotc.binformat.pecoff.PECoff.IMAGE_RELOCATION;
+
+public class AMD64JPECoffRelocObject extends JPECoffRelocObject {
+
+    AMD64JPECoffRelocObject(BinaryContainer binContainer, String outputFileName) {
+        super (binContainer, outputFileName);
+    }
+
+    @Override
+    protected void createRelocation(Symbol symbol, Relocation reloc, PECoffRelocTable pecoffRelocTable) {
+        RelocType relocType = reloc.getType();
+
+        int pecoffRelocType = getPECoffRelocationType(relocType);
+        PECoffSymbol sym = (PECoffSymbol) symbol.getNativeSymbol();
+        int symno = sym.getIndex();
+        int sectindex = reloc.getSection().getSectionId();
+        int offset = reloc.getOffset();
+        int addend = 0;
+
+        switch (relocType) {
+            case JAVA_CALL_DIRECT:
+            case STUB_CALL_DIRECT:
+            case FOREIGN_CALL_INDIRECT_GOT: {
+                // Create relocation entry
+                addend = -4; // Size in bytes of the patch location
+                // Relocation should be applied at the location after call operand
+                offset = offset + reloc.getSize() + addend;
+                break;
+            }
+            case JAVA_CALL_INDIRECT: {
+                // Do nothing.
+                return;
+            }
+            case METASPACE_GOT_REFERENCE:
+            case EXTERNAL_PLT_TO_GOT: {
+                addend = -4; // Size of 32-bit address of the GOT
+                /*
+                 * Relocation should be applied before the test instruction to the move instruction.
+                 * reloc.getOffset() points to the test instruction after the instruction that loads
+                 * the address of polling page. So set the offset appropriately.
+                 */
+                offset = offset + addend;
+                break;
+            }
+            case EXTERNAL_GOT_TO_PLT: {
+                // this is load time relocations
+                break;
+            }
+            default:
+                throw new InternalError("Unhandled relocation type: " + relocType);
+        }
+        pecoffRelocTable.createRelocationEntry(sectindex, offset, symno, pecoffRelocType);
+    }
+
+    // Return IMAGE_RELOCATION Type based on relocType
+    private static int getPECoffRelocationType(RelocType relocType) {
+        int pecoffRelocType = 0; // R_<ARCH>_NONE if #define'd to 0 for all values of ARCH
+        switch (PECoffTargetInfo.getPECoffArch()) {
+            case IMAGE_FILE_HEADER.IMAGE_FILE_MACHINE_AMD64:
+                if (relocType == RelocType.JAVA_CALL_DIRECT ||
+                                relocType == RelocType.FOREIGN_CALL_INDIRECT_GOT) {
+                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_AMD64_REL32;
+                } else if (relocType == RelocType.STUB_CALL_DIRECT) {
+                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_AMD64_REL32;
+                } else if (relocType == RelocType.JAVA_CALL_INDIRECT) {
+                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_AMD64_ABSOLUTE;
+                } else if (relocType == RelocType.METASPACE_GOT_REFERENCE ||
+                                relocType == RelocType.EXTERNAL_PLT_TO_GOT) {
+                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_AMD64_REL32;
+                } else if (relocType == RelocType.EXTERNAL_GOT_TO_PLT) {
+                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_AMD64_ADDR64;
+                } else {
+                    assert false : "Unhandled relocation type: " + relocType;
+                }
+                break;
+            default:
+                System.out.println("Relocation Type mapping: Unhandled architecture");
+        }
+        return pecoffRelocType;
+    }
+}

--- a/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/pecoff/JPECoffRelocObject.java
+++ b/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/pecoff/JPECoffRelocObject.java
@@ -45,7 +45,7 @@ import jdk.tools.jaotc.binformat.pecoff.PECoff.IMAGE_RELOCATION;
 import jdk.tools.jaotc.binformat.pecoff.PECoff.IMAGE_SECTION_HEADER;
 import jdk.tools.jaotc.binformat.pecoff.PECoff.IMAGE_SYMBOL;
 
-public class JPECoffRelocObject {
+public abstract class JPECoffRelocObject {
 
     private final BinaryContainer binContainer;
 
@@ -57,6 +57,16 @@ public class JPECoffRelocObject {
         this.binContainer = binContainer;
         this.pecoffContainer = new PECoffContainer(outputFileName);
         this.sectionAlignment = binContainer.getCodeSegmentSize();
+    }
+
+    public static JPECoffRelocObject newInstance(BinaryContainer binContainer, String outputFileName) {
+        String archStr = System.getProperty("os.arch").toLowerCase();
+        if (archStr.equals("amd64") || archStr.equals("x86_64")) {
+            return new AMD64JPECoffRelocObject(binContainer, outputFileName);
+        } else if (archStr.equals("aarch64")) {
+            return new AArch64JPECoffRelocObject(binContainer, outputFileName);
+        }
+        throw new InternalError("Unsupported platform: " + archStr);
     }
 
     private static PECoffSection createByteSection(ArrayList<PECoffSection> sections, String sectName, byte[] scnData,
@@ -291,75 +301,5 @@ public class JPECoffRelocObject {
         return (pecoffRelocTable);
     }
 
-    private static void createRelocation(Symbol symbol, Relocation reloc, PECoffRelocTable pecoffRelocTable) {
-        RelocType relocType = reloc.getType();
-
-        int pecoffRelocType = getPECoffRelocationType(relocType);
-        PECoffSymbol sym = (PECoffSymbol) symbol.getNativeSymbol();
-        int symno = sym.getIndex();
-        int sectindex = reloc.getSection().getSectionId();
-        int offset = reloc.getOffset();
-        int addend = 0;
-
-        switch (relocType) {
-            case JAVA_CALL_DIRECT:
-            case STUB_CALL_DIRECT:
-            case FOREIGN_CALL_INDIRECT_GOT: {
-                // Create relocation entry
-                addend = -4; // Size in bytes of the patch location
-                // Relocation should be applied at the location after call operand
-                offset = offset + reloc.getSize() + addend;
-                break;
-            }
-            case JAVA_CALL_INDIRECT: {
-                // Do nothing.
-                return;
-            }
-            case METASPACE_GOT_REFERENCE:
-            case EXTERNAL_PLT_TO_GOT: {
-                addend = -4; // Size of 32-bit address of the GOT
-                /*
-                 * Relocation should be applied before the test instruction to the move instruction.
-                 * reloc.getOffset() points to the test instruction after the instruction that loads
-                 * the address of polling page. So set the offset appropriately.
-                 */
-                offset = offset + addend;
-                break;
-            }
-            case EXTERNAL_GOT_TO_PLT: {
-                // this is load time relocations
-                break;
-            }
-            default:
-                throw new InternalError("Unhandled relocation type: " + relocType);
-        }
-        pecoffRelocTable.createRelocationEntry(sectindex, offset, symno, pecoffRelocType);
-    }
-
-    // Return IMAGE_RELOCATION Type based on relocType
-    private static int getPECoffRelocationType(RelocType relocType) {
-        int pecoffRelocType = 0; // R_<ARCH>_NONE if #define'd to 0 for all values of ARCH
-        switch (PECoffTargetInfo.getPECoffArch()) {
-            case IMAGE_FILE_HEADER.IMAGE_FILE_MACHINE_AMD64:
-                if (relocType == RelocType.JAVA_CALL_DIRECT ||
-                                relocType == RelocType.FOREIGN_CALL_INDIRECT_GOT) {
-                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_AMD64_REL32;
-                } else if (relocType == RelocType.STUB_CALL_DIRECT) {
-                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_AMD64_REL32;
-                } else if (relocType == RelocType.JAVA_CALL_INDIRECT) {
-                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_AMD64_ABSOLUTE;
-                } else if (relocType == RelocType.METASPACE_GOT_REFERENCE ||
-                                relocType == RelocType.EXTERNAL_PLT_TO_GOT) {
-                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_AMD64_REL32;
-                } else if (relocType == RelocType.EXTERNAL_GOT_TO_PLT) {
-                    pecoffRelocType = IMAGE_RELOCATION.IMAGE_REL_AMD64_ADDR64;
-                } else {
-                    assert false : "Unhandled relocation type: " + relocType;
-                }
-                break;
-            default:
-                System.out.println("Relocation Type mapping: Unhandled architecture");
-        }
-        return pecoffRelocType;
-    }
+    abstract void createRelocation(Symbol symbol, Relocation reloc, PECoffRelocTable pecoffRelocTable);
 }

--- a/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/pecoff/PECoff.java
+++ b/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/pecoff/PECoff.java
@@ -27,7 +27,7 @@ package jdk.tools.jaotc.binformat.pecoff;
 
 /**
  *
- * Support for the creation of Coff files. Current support is limited to 64 bit x86_64.
+ * Support for the creation of Coff files. Current support is limited to 64 bit x86_64 and ARM64.
  *
  */
 
@@ -64,6 +64,7 @@ final class PECoff {
          */
         static final char IMAGE_FILE_MACHINE_UNKNOWN = 0x0;
         static final char IMAGE_FILE_MACHINE_AMD64   = 0x8664;
+        static final char IMAGE_FILE_MACHINE_ARM64   = 0xaa64;
 
     }
 
@@ -202,6 +203,12 @@ final class PECoff {
         static final int IMAGE_REL_AMD64_REL32_4  = 0x8;
         static final int IMAGE_REL_AMD64_REL32_5  = 0x9;
 
+        static final int IMAGE_REL_ARM64_ABSOLUTE       = 0x0;
+        static final int IMAGE_REL_ARM64_BRANCH26       = 0x3;
+        static final int IMAGE_REL_ARM64_PAGEBASE_REL21 = 0x4;
+        static final int IMAGE_REL_ARM64_REL21          = 0x5;
+        static final int IMAGE_REL_ARM64_PAGEOFFSET_12A = 0x6;
+        static final int IMAGE_REL_ARM64_ADDR64         = 0xe;
     }
     //@formatter:on
 }

--- a/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/pecoff/PECoffHeader.java
+++ b/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/pecoff/PECoffHeader.java
@@ -35,7 +35,7 @@ final class PECoffHeader {
     PECoffHeader() {
         header = PECoffByteBuffer.allocate(IMAGE_FILE_HEADER.totalsize);
 
-        header.putChar(IMAGE_FILE_HEADER.Machine.off, IMAGE_FILE_HEADER.IMAGE_FILE_MACHINE_AMD64);
+        header.putChar(IMAGE_FILE_HEADER.Machine.off, PECoffTargetInfo.getPECoffArch());
         header.putInt(IMAGE_FILE_HEADER.TimeDateStamp.off, (int) (System.currentTimeMillis() / 1000));
         header.putInt(IMAGE_FILE_HEADER.PointerToSymbolTable.off, 0);
         header.putInt(IMAGE_FILE_HEADER.NumberOfSymbols.off, 0);

--- a/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/pecoff/PECoffTargetInfo.java
+++ b/src/jdk.aot/share/classes/jdk.tools.jaotc.binformat/src/jdk/tools/jaotc/binformat/pecoff/PECoffTargetInfo.java
@@ -52,6 +52,8 @@ final class PECoffTargetInfo {
 
         if (archStr.equals("amd64") || archStr.equals("x86_64")) {
             arch = IMAGE_FILE_HEADER.IMAGE_FILE_MACHINE_AMD64;
+        } else if (archStr.equals("aarch64")) {
+            arch = IMAGE_FILE_HEADER.IMAGE_FILE_MACHINE_ARM64;
         } else {
             System.out.println("Unsupported architecture " + archStr);
             arch = IMAGE_FILE_HEADER.IMAGE_FILE_MACHINE_UNKNOWN;

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotConstantRetrievalOp.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotConstantRetrievalOp.java
@@ -116,7 +116,7 @@ public final class AArch64HotSpotConstantRetrievalOp extends AArch64LIRInstructi
         }
 
         final int before = masm.position();
-        masm.bl(before);
+        masm.bl(0);
         final int after = masm.position();
         crb.recordDirectCall(before, after, callLinkage, frameState);
     }


### PR DESCRIPTION
Quite bad timing given https://github.com/openjdk/jdk/pull/960 is happening, but I'm gonna publish those changes anyway.

Tests aren't passing yet, that's the current result of `test/hotspot/jtreg:tier1_compiler_aot_jvmci`:
```
Test results: passed: 120; failed: 22; error: 8
```

Depends on https://github.com/openjdk/jdk/pull/685.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255703](https://bugs.openjdk.java.net/browse/JDK-8255703): jaotc: Add Windows+Arm64 support


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/972/head:pull/972`
`$ git checkout pull/972`
