### PR TITLE
8255671: Bidi.reorderVisually has misleading exception messages

### DIFF
--- a/src/java.base/share/classes/jdk/internal/icu/text/BidiBase.java
+++ b/src/java.base/share/classes/jdk/internal/icu/text/BidiBase.java
@@ -4590,13 +4590,13 @@ public class BidiBase {
         }
         if (0 > objectStart || objects.length <= objectStart) {
             throw new IllegalArgumentException("Value objectStart " +
-                      levelStart + " is out of range 0 to " +
+                      objectStart + " is out of range 0 to " +
                       (objects.length-1));
         }
         if (0 > count || objects.length < (objectStart+count)) {
             throw new IllegalArgumentException("Value count " +
-                      levelStart + " is out of range 0 to " +
-                      (objects.length - objectStart));
+                      count + " is less than zero, or objectStart + count" +
+                      " is beyond objects length " + objects.length);
         }
 
         byte[] reorderLevels = new byte[count];

--- a/test/jdk/java/text/Bidi/BidiConformance.java
+++ b/test/jdk/java/text/Bidi/BidiConformance.java
@@ -1246,6 +1246,11 @@ public class BidiConformance {
                 "when levelStart is -1.");
         }
         catch (IllegalArgumentException e) {
+            if (!e.getMessage().equals(
+                            "Value levelStart -1 is out of range 0 to " + (llen - 1))) {
+                errorHandling("reorderVisually() should throw an IAE" +
+                        " mentioning levelStart is beyond the levels range. Message: " + e.getMessage());
+            }
         }
         catch (ArrayIndexOutOfBoundsException e) {
             errorHandling("reorderVisually() should not throw an AIOoBE " +
@@ -1258,6 +1263,11 @@ public class BidiConformance {
                 "when levelStart is 6(levels.length).");
         }
         catch (IllegalArgumentException e) {
+            if (!e.getMessage().equals(
+                    "Value levelStart " + llen + " is out of range 0 to " + (llen - 1))) {
+                errorHandling("reorderVisually() should throw an IAE" +
+                        " mentioning levelStart is beyond the levels range. Message: " + e.getMessage());
+            }
         }
         catch (ArrayIndexOutOfBoundsException e) {
             errorHandling("reorderVisually() should not throw an AIOoBE " +
@@ -1278,6 +1288,11 @@ public class BidiConformance {
                 " when objectStart is -1.");
         }
         catch (IllegalArgumentException e) {
+            if (!e.getMessage().equals(
+                    "Value objectStart -1 is out of range 0 to " + (olen - 1))) {
+                errorHandling("reorderVisually() should throw an IAE" +
+                        " mentioning objectStart is beyond the objects range. Message: " + e.getMessage());
+            }
         }
         catch (ArrayIndexOutOfBoundsException e) {
             errorHandling("reorderVisually() should not throw an AIOoBE " +
@@ -1290,6 +1305,11 @@ public class BidiConformance {
                 "when objectStart is 6(objects.length).");
         }
         catch (IllegalArgumentException e) {
+            if (!e.getMessage().equals(
+                    "Value objectStart 6 is out of range 0 to " + (olen - 1))) {
+                errorHandling("reorderVisually() should throw an IAE" +
+                        " mentioning objectStart is beyond the objects range. Message: " + e.getMessage());
+            }
         }
 
         try {
@@ -1298,6 +1318,12 @@ public class BidiConformance {
                 "when count is -1.");
         }
         catch (IllegalArgumentException e) {
+            if (!e.getMessage().equals(
+                    "Value count -1 is less than zero, or objectStart + count " +
+                    "is beyond objects length " + olen)) {
+                errorHandling("reorderVisually() should throw an IAE" +
+                        " mentioning objectStart/count is beyond the objects range. Message: " + e.getMessage());
+            }
         }
         catch (NegativeArraySizeException e) {
             errorHandling("reorderVisually() should not throw an NASE " +
@@ -1310,6 +1336,12 @@ public class BidiConformance {
                 "when count is 7(objects.length+1).");
         }
         catch (IllegalArgumentException e) {
+            if (!e.getMessage().equals(
+                    "Value count " + (count + 1) + " is less than zero, or objectStart + count " +
+                    "is beyond objects length " + olen)) {
+                errorHandling("reorderVisually() should throw an IAE" +
+                        " mentioning objectStart/count is beyond the objects range. Message: " + e.getMessage());
+            }
         }
         catch (ArrayIndexOutOfBoundsException e) {
             errorHandling("reorderVisually() should not throw an AIOoBE " +


### PR DESCRIPTION
Hi,

Please review this simple message fix that follows JDK-8255242.

Naoto

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255671](https://bugs.openjdk.java.net/browse/JDK-8255671): Bidi.reorderVisually has misleading exception messages


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/973/head:pull/973`
`$ git checkout pull/973`
