### PR TITLE
8196302: javax/swing/JFileChooser/8041694/bug8041694.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -746,7 +746,6 @@ javax/swing/JTable/4235420/bug4235420.java     8079127 generic-all
 javax/swing/JSplitPane/4201995/bug4201995.java 8079127 generic-all
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all
-javax/swing/JFileChooser/8041694/bug8041694.java 8196302 windows-all,macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
 javax/swing/Action/8133039/bug8133039.java 8196089 windows-all,macosx-all
 javax/swing/JComboBox/6559152/bug6559152.java 8196090 windows-all,macosx-all

--- a/test/jdk/javax/swing/JFileChooser/8041694/bug8041694.java
+++ b/test/jdk/javax/swing/JFileChooser/8041694/bug8041694.java
@@ -57,6 +57,7 @@ public class bug8041694 {
             // Set Metal L&F to make the test compatible with OS X.
             UIManager.setLookAndFeel(new MetalLookAndFeel());
             Robot robot = new Robot();
+            robot.setAutoDelay(100);
 
             dir1 = Files.createTempDirectory("bug8041694").toFile();
             if (Platform.isWindows()) {
@@ -83,15 +84,17 @@ public class bug8041694 {
                 }
             });
 
-            robot.setAutoDelay(50);
             robot.delay(1000);
             robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_D);
             robot.keyRelease(KeyEvent.VK_D);
+            robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_SPACE);
             robot.keyRelease(KeyEvent.VK_SPACE);
+            robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_ENTER);
             robot.keyRelease(KeyEvent.VK_ENTER);
+            robot.waitForIdle();
 
             fChooserClosedSignal.await();
             if (selectedDir == null) {


### PR DESCRIPTION
Another one of timing issue in mach5 windows solved by adjusted timing in setAutoDelay() and added waitForIdle().
Mach5 job has been run for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8196302](https://bugs.openjdk.java.net/browse/JDK-8196302): javax/swing/JFileChooser/8041694/bug8041694.java


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/975/head:pull/975`
`$ git checkout pull/975`
