### PR TITLE
Add shebang support for Jar files

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarOutputStream.java
+++ b/src/java.base/share/classes/java/util/jar/JarOutputStream.java
@@ -58,6 +58,7 @@ public class JarOutputStream extends ZipOutputStream {
         if (man == null) {
             throw new NullPointerException("man");
         }
+        writeShebang(out);
         ZipEntry e = new ZipEntry(JarFile.MANIFEST_NAME);
         putNextEntry(e);
         man.write(new BufferedOutputStream(this));
@@ -71,6 +72,24 @@ public class JarOutputStream extends ZipOutputStream {
      */
     public JarOutputStream(OutputStream out) throws IOException {
         super(out);
+        writeShebang(out);
+    }
+
+    /**
+     * Writes a "shebang" to the output stream.
+     * <p>
+     * This is used on unix systems to identify how to execute a
+     * binary file, in this case using the java executable on the
+     * path, passing this file as a -jar argument.
+     */
+    private void writeShebang(OutputStream out) throws IOException {
+        // shebang = "#!java -jar\n"
+        byte[] shebangBytes = new byte[]{
+            0x23, 0x21, 0x6A, 0x61, // #!ja
+            0x76, 0x61, 0x20, 0x2D, // va -
+            0x6A, 0x61, 0x72, 0x0A  // jar\n
+        };
+        out.write(shebangBytes);
     }
 
     /**


### PR DESCRIPTION
This pull request modifies JarOutputStream to write a "shebang" at the start of the output.

This is used on unix systems to identify how to execute a binary file, in this case using the java executable on the path, passing the jar file as a -jar argument.

Benefits:
- Increased security, executing jar files using the shebang will require the jar file to have executable file permissions
- Better usability - for users who do not know how to use java, when downloading a jar file they may simply try to execute it in the command line, this change will support this and either run the jar file if they have java installed, or tell them they are missing a `java` executable and they will know to install one

Side Affects:
- Outputted jar files will be slightly different. For most cases this shouldn't matter - the zip specification allows the zip header to be present at any point in the file, extra bytes at the beginning does not affect the validity of a zip file

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/976/head:pull/976`
`$ git checkout pull/976`
