### PR TITLE
8233569: [TESTBUG] JTextComponent test bug6361367.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -783,7 +783,6 @@ javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JTree/6263446/bug6263446.java 8213125 macosx-all
 javax/swing/text/View/8014863/bug8014863.java 8233561 macosx-all
 javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233562 macosx-all
-javax/swing/text/JTextComponent/6361367/bug6361367.java 8233569 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java 8233555 macosx-all
 javax/swing/JRadioButton/8075609/bug8075609.java 8233555 macosx-all

--- a/test/jdk/javax/swing/text/JTextComponent/6361367/bug6361367.java
+++ b/test/jdk/javax/swing/text/JTextComponent/6361367/bug6361367.java
@@ -79,7 +79,7 @@ public class bug6361367 {
         waitForFocus(textComponent);
         Robot robot = new Robot();
         robot.setAutoWaitForIdle(true);
-        robot.setAutoDelay(250);
+        robot.setAutoDelay(100);
         robot.keyPress(KeyEvent.VK_END);
         robot.keyRelease(KeyEvent.VK_END);
         robot.keyPress(KeyEvent.VK_SHIFT);


### PR DESCRIPTION
Please review deproblemlisting an issue which is not failing in latest build.  I have made the delay time consistent with other test.
Resultant test is green on all platforms for mach5 test run.
Mach5 job has been run for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8233569](https://bugs.openjdk.java.net/browse/JDK-8233569): [TESTBUG] JTextComponent test bug6361367.java fails on macos


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/977/head:pull/977`
`$ git checkout pull/977`
