### PR TITLE
6816284: Notepad class should be public

### DIFF
--- a/src/demo/share/jfc/Notepad/Notepad.java
+++ b/src/demo/share/jfc/Notepad/Notepad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -60,7 +60,7 @@ import javax.swing.UIManager.LookAndFeelInfo;
  * @author  Timothy Prinzing
  */
 @SuppressWarnings("serial")
-class Notepad extends JPanel {
+public class Notepad extends JPanel {
 
     protected static Properties properties;
     private static ResourceBundle resources;


### PR DESCRIPTION
The main class in the Notepad demo made public

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-6816284](https://bugs.openjdk.java.net/browse/JDK-6816284): Notepad class should be public


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/980/head:pull/980`
`$ git checkout pull/980`
