### PR TITLE
8255716: AArch64: Regression: JVM crashes if manually offline a core

### DIFF
--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -142,7 +142,6 @@ void VM_Version::get_os_cpu_info() {
     _zva_length = 4 << (dczid_el0 & 0xf);
   }
 
-  int cpu_lines = 0;
   if (FILE *f = fopen("/proc/cpuinfo", "r")) {
     // need a large buffer as the flags line may include lots of text
     char buf[1024], *p;
@@ -151,7 +150,6 @@ void VM_Version::get_os_cpu_info() {
         long v = strtol(p+1, NULL, 0);
         if (strncmp(buf, "CPU implementer", sizeof "CPU implementer" - 1) == 0) {
           _cpu = v;
-          cpu_lines++;
         } else if (strncmp(buf, "CPU variant", sizeof "CPU variant" - 1) == 0) {
           _variant = v;
         } else if (strncmp(buf, "CPU part", sizeof "CPU part" - 1) == 0) {
@@ -168,5 +166,4 @@ void VM_Version::get_os_cpu_info() {
     }
     fclose(f);
   }
-  guarantee(cpu_lines == os::processor_count(), "core count should be consistent");
 }


### PR DESCRIPTION
Please review this change that removed the unnecessary check **cpu_lines == os::processor_count()** from VM_Version::get_os_cpu_info inside src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp. 

This **assertion** is practically not needed. While a test system with some cores intentionally turned off, e.g. via echo 0 > /sys/devices/system/cpu/cpu1/online, **java -version** would crash, building openjdk on this system would fail too. 

This regression issue was introduced by https://github.com/openjdk/jdk/commit/ec9bee68

Testing:
- java -version, building openjdk as smoke tests
- jtreg tier1 as sanity check

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255716](https://bugs.openjdk.java.net/browse/JDK-8255716): AArch64: Regression: JVM crashes if manually offline a core


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)
 * akozlov - no project role ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/983/head:pull/983`
`$ git checkout pull/983`
