### PR TITLE
8251177: [macosx] The text "big" is truncated

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -891,7 +891,6 @@ java/awt/Frame/FrameStateTest/FrameStateTest.html 8203920 macosx-all,linux-all
 javax/swing/SwingUtilities/TestTextPosInPrint.java 8227025 windows-all
 java/awt/print/PrinterJob/ScaledText/ScaledText.java 8231226 macosx-all
 java/awt/font/TextLayout/TestJustification.html 8250791 macosx-all
-javax/swing/JTabbedPane/4209065/bug4209065.java 8251177 macosx-all
 java/awt/TrayIcon/DragEventSource/DragEventSource.java 8252242 macosx-all
 
 ############################################################################

--- a/test/jdk/javax/swing/JTabbedPane/4209065/bug4209065.java
+++ b/test/jdk/javax/swing/JTabbedPane/4209065/bug4209065.java
@@ -49,7 +49,9 @@ public final class bug4209065 extends JApplet {
         JTabbedPane tp = new JTabbedPane();
         getContentPane().add(tp);
         String text = "<html><center>If the style of the text on the tabs matches"
-                      + "<br>the descriptions, press <em><b>PASS</b></em></center></html>";
+                      + "<br>the descriptions, press <em><b>PASS</b></em>"
+                      + "<br><b>Note:</b> On Mac, text \"big\" may be truncated,"
+                      + " it should be ignored</center></html>";
         tp.addTab("<html><center><font size=+3>big</font></center></html>", new JLabel(text));
         tp.addTab("<html><center><font color=red>red</font></center></html>", new JLabel(text));
         tp.addTab("<html><center><em><b>Bold Italic!</b></em></center></html>", new JLabel(text));

--- a/test/jdk/javax/swing/JTabbedPane/4209065/bug4209065.java
+++ b/test/jdk/javax/swing/JTabbedPane/4209065/bug4209065.java
@@ -49,10 +49,8 @@ public final class bug4209065 extends JApplet {
         JTabbedPane tp = new JTabbedPane();
         getContentPane().add(tp);
         String text = "<html><center>If the style of the text on the tabs matches"
-                      + "<br>the descriptions, press <em><b>PASS</b></em>"
-                      + "<br><b>Note:</b> On Mac, text \"big\" may be truncated,"
-                      + " it should be ignored</center></html>";
-        tp.addTab("<html><center><font size=+3>big</font></center></html>", new JLabel(text));
+                      + "<br>the descriptions, press <em><b>PASS</b></em></center></html>";
+        tp.addTab("<html><center><font size=+1>big</font></center></html>", new JLabel(text));
         tp.addTab("<html><center><font color=red>red</font></center></html>", new JLabel(text));
         tp.addTab("<html><center><em><b>Bold Italic!</b></em></center></html>", new JLabel(text));
     }


### PR DESCRIPTION
The manual test creates a JTabbedPane and add tabs with text with different html styles. For the tab with text "big", a bigger text size is used and it is expected that this should result in making the tab height bigger.

For AquaLookAndFeel, inside class AquaJTabbedPaneUI and AquaTabbedPaneCopyFromBasicUI, the tabs height is constraint and there is upper/lower limit set for tab height. So the tab height is less than expected and the text looks truncated. I do not see this issue in other L&Fs.

It looks like this is done deliberately for AquaL&F and this is not a bug. but the test instructions do not specify this and result in confusion. So updating the test instructions to specify that the text "big" may be truncated in MacOS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8251177](https://bugs.openjdk.java.net/browse/JDK-8251177): [macosx] The text "big" is truncated


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/984/head:pull/984`
`$ git checkout pull/984`
