### PR TITLE
8255718: Zero: VM should know it runs in interpreter-only mode

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3213,6 +3213,11 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
     set_mode_flags(_int);
   }
 
+#ifdef ZERO
+  // Zero always runs in interpreted mode
+  set_mode_flags(_int);
+#endif
+
   // eventually fix up InitialTenuringThreshold if only MaxTenuringThreshold is set
   if (FLAG_IS_DEFAULT(InitialTenuringThreshold) && (InitialTenuringThreshold > MaxTenuringThreshold)) {
     FLAG_SET_ERGO(InitialTenuringThreshold, MaxTenuringThreshold);


### PR DESCRIPTION
There are many tests in tier1 that fail with Zero, because they supply -XX:+TieredCompilation, and that makes VM code believe it runs in "mixed" mode. 

Can be reproduced trivially by running anything with -XX:+TieredCompilation. Then Zero fails when runtime asks it to produce a native wrapper for MH intrinsics. That code is normally protected by Arguments::is_interpreter_only.

```
Method* SystemDictionary::find_method_handle_intrinsic(vmIntrinsics::ID iid,
                                                       Symbol* signature,
                                                       TRAPS) {
    ...
    if (!Arguments::is_interpreter_only()) {  // <--- checks here
      // Generate a compiled form of the MH intrinsic.
      AdapterHandlerLibrary::create_native_wrapper(m); // <--- fails through here
    }
```

Then in `sharedRuntime_zero.cpp`:

```
nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
                                                const methodHandle& method,
                                                int compile_id,
                                                BasicType *sig_bt,
                                                VMRegPair *regs,
                                                BasicType ret_type,
                                                address critical_entry) {
  ShouldNotCallThis();  // <--- crashes here
  return NULL;
}
```

...so:

```
$ build/linux-x86_64-zero-fastdebug/images/jdk/bin/java -XX:+TieredCompilation 
OpenJDK 64-Bit Zero VM warning: -XX:+TieredCompilation not supported in this VM
# To suppress the following error report, specify this argument
# after -XX: or in .hotspotrc:  SuppressErrorAt=/sharedRuntime_zero.cpp:80
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/home/shade/trunks/jdk/src/hotspot/cpu/zero/sharedRuntime_zero.cpp:80), pid=404967, tid=404968
#  Error: ShouldNotCall()
```

Additional testing:
 - [x] ad-hoc Hello World runs with Linux x86_64 Zero
 - [x] re-run some failed `tier1` tests with Linux x86_64 Zero, now passing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255718](https://bugs.openjdk.java.net/browse/JDK-8255718): Zero: VM should know it runs in interpreter-only mode


### Reviewers
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/985/head:pull/985`
`$ git checkout pull/985`
