### PR TITLE
8255719: Zero: on return path, check for pending exception before attempting to clear it

### DIFF
--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -2902,7 +2902,9 @@ run:
     // a NULL oop in it and then overwrite the oop later as needed. This isn't
     // unfortunately isn't possible.
 
-    THREAD->clear_pending_exception();
+    if (THREAD->has_pending_exception()) {
+      THREAD->clear_pending_exception();
+    }
 
     //
     // As far as we are concerned we have returned. If we have a pending exception


### PR DESCRIPTION
Profiling shows we spend a lot of time trying to clear the pending exception at _return path, whereas it seldom is pending. 

The additional problem with calling into `clear_pending_exception` is that inlining budget is depleted completely at that point in the compilation unit, and so we do the full outbound call.

There are other places where we clear pending exception unconditionally, but those places do seem to expect the exceptions to be there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255719](https://bugs.openjdk.java.net/browse/JDK-8255719): Zero: on return path, check for pending exception before attempting to clear it


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/986/head:pull/986`
`$ git checkout pull/986`
