### PR TITLE
7124397: [macosx] JSpinner serialiazation - deserialization issue

### DIFF
--- a/test/jdk/javax/swing/JSpinner/SerializationTest.java
+++ b/test/jdk/javax/swing/JSpinner/SerializationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import javax.swing.JSpinner;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import static javax.swing.UIManager.getInstalledLookAndFeels;
+
+/**
+ * @test
+ * @bug 7124397
+ */
+public final class SerializationTest {
+
+    public static void main(String[] argv) throws Exception {
+        for (UIManager.LookAndFeelInfo laf : getInstalledLookAndFeels()) {
+            EventQueue.invokeAndWait(() -> setLookAndFeel(laf));
+            EventQueue.invokeAndWait(() -> {
+                JSpinner spinner = new JSpinner();
+                JSpinner firstCopy = (JSpinner) createCopy(spinner);
+                JSpinner secondCopy = (JSpinner) createCopy(firstCopy);
+            });
+        }
+    }
+
+    private static Object createCopy(Serializable objectToCopy) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(objectToCopy);
+            InputStream bais = new ByteArrayInputStream(baos.toByteArray());
+            ObjectInputStream ois = new ObjectInputStream(bais);
+            return ois.readObject();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported LookAndFeel: " + laf.getClassName());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/jdk/javax/swing/JSpinner/SerializationTest.java
+++ b/test/jdk/javax/swing/JSpinner/SerializationTest.java
@@ -38,6 +38,7 @@ import static javax.swing.UIManager.getInstalledLookAndFeels;
 /**
  * @test
  * @bug 7124397
+ * @summary Verifies that JSpinner can be serialized/deserialized correctly.
  */
 public final class SerializationTest {
 


### PR DESCRIPTION
The serialization was broken because different listeners are leaked in the case of compound components. 
That listeners also caused memory leaks which were fixed by a few fixes here and there, and in jdk16 the serialization start to work fine. But I would like to contribute the test which will prove that serialization works fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (2/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-7124397](https://bugs.openjdk.java.net/browse/JDK-7124397): [macosx] JSpinner serialiazation - deserialization issue


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/989/head:pull/989`
`$ git checkout pull/989`
