### PR TITLE
8255721: Remove no-op clean_weak_method_links methods

### DIFF
--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1786,27 +1786,7 @@ void MethodData::clean_method_data(bool always_clean) {
 // methods out of MethodData for all methods.
 void MethodData::clean_weak_method_links() {
   ResourceMark rm;
-  for (ProfileData* data = first_data();
-       is_valid(data);
-       data = next_data(data)) {
-    data->clean_weak_method_links();
-  }
-
   CleanExtraDataMethodClosure cl;
   clean_extra_data(&cl);
   verify_extra_data_clean(&cl);
 }
-
-#ifdef ASSERT
-void MethodData::verify_clean_weak_method_links() {
-  ResourceMark rm;
-  for (ProfileData* data = first_data();
-       is_valid(data);
-       data = next_data(data)) {
-    data->verify_clean_weak_method_links();
-  }
-
-  CleanExtraDataMethodClosure cl;
-  verify_extra_data_clean(&cl);
-}
-#endif // ASSERT

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -238,10 +238,6 @@ public:
 
   // GC support
   void clean_weak_klass_links(bool always_clean);
-
-  // Redefinition support
-  void clean_weak_method_links();
-  DEBUG_ONLY(void verify_clean_weak_method_links();)
 };
 
 
@@ -454,10 +450,6 @@ public:
 
   // GC support
   virtual void clean_weak_klass_links(bool always_clean) {}
-
-  // Redefinition support
-  virtual void clean_weak_method_links() {}
-  DEBUG_ONLY(virtual void verify_clean_weak_method_links() {})
 
   // CI translation: ProfileData can represent both MethodDataOop data
   // as well as CIMethodData data. This function is provided for translating

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -2407,7 +2407,6 @@ public:
 
   void clean_method_data(bool always_clean);
   void clean_weak_method_links();
-  DEBUG_ONLY(void verify_clean_weak_method_links();)
   Mutex* extra_data_lock() { return &_extra_data_lock; }
 };
 


### PR DESCRIPTION
ProfileData:: and DataLayout::clean_weak_method_links are both virtual but empty methods with no overrides, so removing them and simplifying MethodData::clean_weak_method_links should be a minor clean-up and possibly speed-up redefinition a notch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255721](https://bugs.openjdk.java.net/browse/JDK-8255721): Remove no-op clean_weak_method_links methods


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 4d5c18f4ab2aa21522ec00cc73684a54e20ad889
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/990/head:pull/990`
`$ git checkout pull/990`
