### PR TITLE
8255665: C2 should aggressively remove temporary hook nodes

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -2358,7 +2358,7 @@ void MemoryGraphFixer::collect_memory_nodes() {
   while (dead_phis.size() > 0) {
     Node* n = dead_phis.pop();
     n->replace_by(_phase->C->top());
-    n->destruct();
+    n->destruct(&_phase->igvn());
   }
   for (int i = rpo_list.size() - 1; i >= 0; i--) {
     Node* c = rpo_list.at(i);

--- a/src/hotspot/share/opto/arraycopynode.hpp
+++ b/src/hotspot/share/opto/arraycopynode.hpp
@@ -100,12 +100,12 @@ private:
                                bool disjoint_bases, int count,
                                Node*& forward_ctl, Node*& backward_ctl);
   Node* array_copy_forward(PhaseGVN *phase, bool can_reshape, Node*& ctl,
-                           MergeMemNode* mm,
+                           Node* mem,
                            const TypePtr* atp_src, const TypePtr* atp_dest,
                            Node* adr_src, Node* base_src, Node* adr_dest, Node* base_dest,
                            BasicType copy_type, const Type* value_type, int count);
   Node* array_copy_backward(PhaseGVN *phase, bool can_reshape, Node*& ctl,
-                            MergeMemNode* mm,
+                            Node* mem,
                             const TypePtr* atp_src, const TypePtr* atp_dest,
                             Node* adr_src, Node* base_src, Node* adr_dest, Node* base_dest,
                             BasicType copy_type, const Type* value_type, int count);

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2302,10 +2302,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
           Node* phi = mms.memory();
           mms.set_memory(phase->transform(phi));
         }
-        if (igvn) { // Unhook.
-          igvn->_worklist.remove(hook);
-        }
-        hook->destruct();
+        hook->destruct(igvn);
         // Replace self with the result.
         return result;
       }

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2303,11 +2303,9 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
           mms.set_memory(phase->transform(phi));
         }
         if (igvn) { // Unhook.
-          igvn->hash_delete(hook);
-          for (uint i = 1; i < hook->req(); i++) {
-            hook->set_req(i, NULL);
-          }
+          igvn->_worklist.remove(hook);
         }
+        hook->destruct();
         // Replace self with the result.
         return result;
       }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1128,8 +1128,7 @@ void Compile::print_missing_nodes() {
   }
 }
 void Compile::record_modified_node(Node* n) {
-  if (_modified_nodes != NULL && !_inlining_incrementally &&
-      n->outcnt() != 0 && !n->is_Con()) {
+  if (_modified_nodes != NULL && !_inlining_incrementally && !n->is_Con()) {
     _modified_nodes->push(n);
   }
 }

--- a/src/hotspot/share/opto/convertnode.cpp
+++ b/src/hotspot/share/opto/convertnode.cpp
@@ -403,7 +403,7 @@ Node *ConvI2LNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     Node *hook = new Node(1);
     hook->init_req(0, cx);  // Add a use to cx to prevent him from dying
     Node* cy = phase->C->constrained_convI2L(phase, y, TypeInt::make(rylo, ryhi, widen), NULL);
-    hook->destruct();
+    hook->destruct(phase);
     switch (op) {
       case Op_AddI:  return new AddLNode(cx, cy);
       case Op_SubI:  return new SubLNode(cx, cy);

--- a/src/hotspot/share/opto/convertnode.cpp
+++ b/src/hotspot/share/opto/convertnode.cpp
@@ -403,7 +403,6 @@ Node *ConvI2LNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     Node *hook = new Node(1);
     hook->init_req(0, cx);  // Add a use to cx to prevent him from dying
     Node* cy = phase->C->constrained_convI2L(phase, y, TypeInt::make(rylo, ryhi, widen), NULL);
-    hook->del_req(0);  // Just yank bogus edge
     hook->destruct();
     switch (op) {
       case Op_AddI:  return new AddLNode(cx, cy);

--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -326,11 +326,7 @@ static Node* long_by_long_mulhi(PhaseGVN* phase, Node* dividend, jlong magic_con
   Node* temp2 = phase->transform(new RShiftLNode(w1, phase->intcon(N / 2)));
 
   // Remove the bogus extra edges used to keep things alive
-  PhaseIterGVN* igvn = phase->is_IterGVN();
-  if (igvn != NULL) {
-    igvn->_worklist.remove(hook);
-  }
-  hook->destruct();
+  hook->destruct(phase);
 
   return new AddLNode(temp1, temp2);
 }
@@ -909,10 +905,7 @@ Node *ModINode::Ideal(PhaseGVN *phase, bool can_reshape) {
       // cmov2 is now the mod
 
       // Now remove the bogus extra edges used to keep things alive
-      if (can_reshape) {
-        phase->is_IterGVN()->_worklist.remove(hook);
-      }
-      hook->destruct();
+      hook->destruct(phase);
       return cmov2;
     }
   }
@@ -964,10 +957,7 @@ Node *ModINode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
 
   // Now remove the bogus extra edges used to keep things alive
-  if (can_reshape) {
-    phase->is_IterGVN()->_worklist.remove(hook);
-  }
-  hook->destruct();
+  hook->destruct(phase);
 
   // return the value
   return result;
@@ -1080,10 +1070,7 @@ Node *ModLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       // cmov2 is now the mod
 
       // Now remove the bogus extra edges used to keep things alive
-      if (can_reshape) {
-        phase->is_IterGVN()->_worklist.remove(hook);
-      }
-      hook->destruct();
+      hook->destruct(phase);
       return cmov2;
     }
   }
@@ -1135,10 +1122,7 @@ Node *ModLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
 
   // Now remove the bogus extra edges used to keep things alive
-  if (can_reshape) {
-    phase->is_IterGVN()->_worklist.remove(hook);
-  }
-  hook->destruct();
+  hook->destruct(phase);
 
   // return the value
   return result;

--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -328,12 +328,9 @@ static Node* long_by_long_mulhi(PhaseGVN* phase, Node* dividend, jlong magic_con
   // Remove the bogus extra edges used to keep things alive
   PhaseIterGVN* igvn = phase->is_IterGVN();
   if (igvn != NULL) {
-    igvn->remove_dead_node(hook);
-  } else {
-    for (int i = 0; i < 4; i++) {
-      hook->set_req(i, NULL);
-    }
+    igvn->_worklist.remove(hook);
   }
+  hook->destruct();
 
   return new AddLNode(temp1, temp2);
 }
@@ -913,10 +910,9 @@ Node *ModINode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
       // Now remove the bogus extra edges used to keep things alive
       if (can_reshape) {
-        phase->is_IterGVN()->remove_dead_node(hook);
-      } else {
-        hook->set_req(0, NULL);   // Just yank bogus edge during Parse phase
+        phase->is_IterGVN()->_worklist.remove(hook);
       }
+      hook->destruct();
       return cmov2;
     }
   }
@@ -969,10 +965,9 @@ Node *ModINode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
   // Now remove the bogus extra edges used to keep things alive
   if (can_reshape) {
-    phase->is_IterGVN()->remove_dead_node(hook);
-  } else {
-    hook->set_req(0, NULL);       // Just yank bogus edge during Parse phase
+    phase->is_IterGVN()->_worklist.remove(hook);
   }
+  hook->destruct();
 
   // return the value
   return result;
@@ -1086,10 +1081,9 @@ Node *ModLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
       // Now remove the bogus extra edges used to keep things alive
       if (can_reshape) {
-        phase->is_IterGVN()->remove_dead_node(hook);
-      } else {
-        hook->set_req(0, NULL);   // Just yank bogus edge during Parse phase
+        phase->is_IterGVN()->_worklist.remove(hook);
       }
+      hook->destruct();
       return cmov2;
     }
   }
@@ -1142,10 +1136,9 @@ Node *ModLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
   // Now remove the bogus extra edges used to keep things alive
   if (can_reshape) {
-    phase->is_IterGVN()->remove_dead_node(hook);
-  } else {
-    hook->set_req(0, NULL);       // Just yank bogus edge during Parse phase
+    phase->is_IterGVN()->_worklist.remove(hook);
   }
+  hook->destruct();
 
   // return the value
   return result;

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -999,7 +999,6 @@ bool IfNode::fold_compares_helper(ProjNode* proj, ProjNode* success, ProjNode* f
     if (adjusted_lim == NULL) {
       adjusted_lim = igvn->transform(new SubINode(hi, lo));
     }
-    hook->del_req(0); // Just yank bogus edge
     hook->destruct();
     Node* newcmp = igvn->transform(new CmpUNode(adjusted_val, adjusted_lim));
     Node* newbool = igvn->transform(new BoolNode(newcmp, cond));

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -999,7 +999,7 @@ bool IfNode::fold_compares_helper(ProjNode* proj, ProjNode* success, ProjNode* f
     if (adjusted_lim == NULL) {
       adjusted_lim = igvn->transform(new SubINode(hi, lo));
     }
-    hook->destruct();
+    hook->destruct(igvn);
     Node* newcmp = igvn->transform(new CmpUNode(adjusted_val, adjusted_lim));
     Node* newbool = igvn->transform(new BoolNode(newcmp, cond));
 

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -430,7 +430,7 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
     tmp1->replace_by(tmp);
     tmp2->replace_by(tmp1);
     tmp->replace_by(tmp2);
-    tmp->destruct();
+    tmp->destruct(NULL);
   }
 
   // Remove the existing null check; use a new implicit null check instead.

--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -727,7 +727,7 @@ BoolNode* PhaseIdealLoop::rc_predicate(IdealLoopTree *loop, Node* ctrl,
     idx_type = (TypeInt*)mul->mul_ring(idx_type, scale_type);
     if (overflow || TypeInt::INT->higher_equal(idx_type)) {
       // May overflow
-      mul->destruct();
+      mul->destruct(&_igvn);
       if (!overflow) {
         max_idx_expr = new ConvI2LNode(max_idx_expr);
         register_new_node(max_idx_expr, ctrl);

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2651,7 +2651,7 @@ void IdealLoopTree::split_fall_in( PhaseIdealLoop *phase, int fall_in_cnt ) {
       // with the CSE to avoid O(N^2) node blow-up.
       Node *p2 = igvn.hash_find_insert(p); // Look for a CSE
       if( p2 ) {                // Found CSE
-        p->destruct();          // Recover useless new node
+        p->destruct(&igvn);     // Recover useless new node
         p = p2;                 // Use old node
       } else {
         igvn.register_new_node_with_optimizer(p, old_phi);

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1400,8 +1400,6 @@ bool PhaseIdealLoop::is_counted_loop(Node* x, IdealLoopTree*& loop) {
   assert(x->Opcode() == Op_Loop, "regular loops only");
   C->print_method(PHASE_BEFORE_CLOOPS, 3);
 
-  Node *hook = new Node(6);
-
   // ===================================================
   // Generate loop limit check to avoid integer overflow
   // in cases like next (cyclic loops):
@@ -1690,9 +1688,6 @@ bool PhaseIdealLoop::is_counted_loop(Node* x, IdealLoopTree*& loop) {
       }
     }
   }
-
-  // Free up intermediate goo
-  _igvn.remove_dead_node(hook);
 
 #ifdef ASSERT
   assert(l->is_valid_counted_loop(), "counted loop shape is messed up");

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -329,7 +329,7 @@ Node* PhaseMacroExpand::make_arraycopy_load(ArrayCopyNode* ac, intptr_t offset, 
     Node* base = ac->in(ArrayCopyNode::Src);
     Node* adr = _igvn.transform(new AddPNode(base, base, MakeConX(offset)));
     const TypePtr* adr_type = _igvn.type(base)->is_ptr()->add_offset(offset);
-    MergeMemNode* mergemen = MergeMemNode::make(mem);
+    MergeMemNode* mergemen = _igvn.transform(MergeMemNode::make(mem))->as_MergeMem();
     BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
     res = ArrayCopyNode::load(bs, &_igvn, ctl, mergemen, adr, adr_type, type, bt);
   } else {
@@ -369,7 +369,7 @@ Node* PhaseMacroExpand::make_arraycopy_load(ArrayCopyNode* ac, intptr_t offset, 
           return NULL;
         }
       }
-      MergeMemNode* mergemen = MergeMemNode::make(mem);
+      MergeMemNode* mergemen = _igvn.transform(MergeMemNode::make(mem))->as_MergeMem();
       BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
       res = ArrayCopyNode::load(bs, &_igvn, ctl, mergemen, adr, adr_type, type, bt);
     }

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -581,8 +581,11 @@ void Node::setup_is_top() {
 
 //------------------------------~Node------------------------------------------
 // Fancy destructor; eagerly attempt to reclaim Node numberings and storage
-void Node::destruct() {
-  Compile* compile = Compile::current();
+void Node::destruct(PhaseValues* phase) {
+  Compile* compile = (phase != NULL) ? phase->C : Compile::current();
+  if (phase != NULL && phase->is_IterGVN()) {
+    phase->is_IterGVN()->_worklist.remove(this);
+  }
   // If this is the most recently created node, reclaim its index. Otherwise,
   // record the node as dead to keep liveness information accurate.
   if ((uint)_idx+1 == compile->unique()) {

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1399,7 +1399,6 @@ static void kill_dead_code( Node *dead, PhaseIterGVN *igvn ) {
       // Done with outputs.
       igvn->hash_delete(dead);
       igvn->_worklist.remove(dead);
-      igvn->C->remove_modified_node(dead);
       igvn->set_type(dead, Type::TOP);
       if (dead->is_macro()) {
         igvn->C->remove_macro_node(dead);
@@ -1435,6 +1434,7 @@ static void kill_dead_code( Node *dead, PhaseIterGVN *igvn ) {
           }
         }
       }
+      igvn->C->remove_modified_node(dead);
     } // (dead->outcnt() == 0)
   }   // while (nstack.size() > 0) for outputs
   return;

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -236,7 +236,7 @@ public:
   // Delete is a NOP
   void operator delete( void *ptr ) {}
   // Fancy destructor; eagerly attempt to reclaim Node numberings and storage
-  void destruct();
+  void destruct(PhaseValues* phase);
 
   // Create a new Node.  Required is the number is of inputs required for
   // semantic correctness.

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1069,7 +1069,7 @@ void PhaseIterGVN::init_verifyPhaseIterGVN() {
   Unique_Node_List* modified_list = C->modified_nodes();
   while (modified_list != NULL && modified_list->size()) {
     Node* n = modified_list->pop();
-    if (!_worklist.member(n)) {
+    if (!n->is_Con() && !_worklist.member(n)) {
       n->dump();
       fatal("modified node is not on IGVN._worklist");
     }
@@ -1083,8 +1083,10 @@ void PhaseIterGVN::verify_PhaseIterGVN() {
   Unique_Node_List* modified_list = C->modified_nodes();
   while (modified_list != NULL && modified_list->size()) {
     Node* n = modified_list->pop();
-    n->dump();
-    fatal("modified node was not processed by IGVN.transform_old()");
+    if (!n->is_Con()) { // skip Con nodes
+      n->dump();
+      fatal("modified node was not processed by IGVN.transform_old()");
+    }
   }
 #endif
 

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -749,7 +749,7 @@ ConNode* PhaseValues::uncached_makecon(const Type *t) {
       loc->clear(); // do not put debug info on constants
     }
   } else {
-    x->destruct();              // Hit, destroy duplicate constant
+    x->destruct(this);          // Hit, destroy duplicate constant
     x = k;                      // use existing constant
   }
   return x;
@@ -1472,8 +1472,7 @@ void PhaseIterGVN::subsume_node( Node *old, Node *nn ) {
     }
   }
 #endif
-  _worklist.remove(temp);   // this can be necessary
-  temp->destruct();         // reuse the _idx of this little guy
+  temp->destruct(this);     // reuse the _idx of this little guy
 }
 
 //------------------------------add_users_to_worklist--------------------------

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1069,9 +1069,9 @@ void PhaseIterGVN::init_verifyPhaseIterGVN() {
   Unique_Node_List* modified_list = C->modified_nodes();
   while (modified_list != NULL && modified_list->size()) {
     Node* n = modified_list->pop();
-    if (n->outcnt() != 0 && !n->is_Con() && !_worklist.member(n)) {
+    if (!_worklist.member(n)) {
       n->dump();
-      assert(false, "modified node is not on IGVN._worklist");
+      fatal("modified node is not on IGVN._worklist");
     }
   }
 #endif
@@ -1083,10 +1083,8 @@ void PhaseIterGVN::verify_PhaseIterGVN() {
   Unique_Node_List* modified_list = C->modified_nodes();
   while (modified_list != NULL && modified_list->size()) {
     Node* n = modified_list->pop();
-    if (n->outcnt() != 0 && !n->is_Con()) { // skip dead and Con nodes
-      n->dump();
-      assert(false, "modified node was not processed by IGVN.transform_old()");
-    }
+    n->dump();
+    fatal("modified node was not processed by IGVN.transform_old()");
   }
 #endif
 

--- a/src/hotspot/share/opto/split_if.cpp
+++ b/src/hotspot/share/opto/split_if.cpp
@@ -337,7 +337,7 @@ Node *PhaseIdealLoop::spinup( Node *iff_dom, Node *new_false, Node *new_true, No
       if( t ) {                 // See if we already have this one
         // phi_post will not be used, so kill it
         _igvn.remove_dead_node(phi_post);
-        phi_post->destruct();
+        phi_post->destruct(&_igvn);
         phi_post = t;
       } else {
         register_new_node( phi_post, prior_n );


### PR DESCRIPTION
C2 often creates temporary "hook" nodes to keep other nodes alive. Although dead, these are sometimes not removed because they don't end up on the IGVN worklist. JDK-8040213 added detection of modified nodes that are not re-processed by IGVN but currently ignores dead nodes.

This patch includes the following changes:
- Adjust detection of modified nodes such that dead nodes are includes as well. This revealed several locations were dead nodes are not eagerly destructed (or not even added to the worklist for later removal). I've fixed all of these.
- No need to yank node inputs before calling `destruct`.
- `kill_dead_code` accidentally re-adds dead nodes to the `_modified_nodes` list. `Compile::remove_modified_node` should be called at the end to avoid this.
- Some removal of dead code.

Tested with tier1-3, higher tiers are running.

JDK-8255670 will further improve detection.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255665](https://bugs.openjdk.java.net/browse/JDK-8255665): C2 should aggressively remove temporary hook nodes


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/994/head:pull/994`
`$ git checkout pull/994`
