### PR TITLE
8255215: Unsupported 'valign' attribute for 'tr' tag used in j.s.t.h.HTMLDocument

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -194,7 +194,7 @@ import static sun.swing.SwingUtilities2.IMPLIED_CR;
  *     <th><code>setInnerHTML</code></th>
  *     <th><code>setOuterHTML</code></th>
  *   </tr>
- *   <tr valign="top">
+ *   <tr style="vertical-align:top">
  *     <td style="white-space:nowrap">
  *       <div style="background-color: silver;">
  *         <p>Paragraph 1</p>


### PR DESCRIPTION
Since HTML4 support has been dropped from javadoc by JDK-8187793.
HTMLDocument.java containing the valign attribute in the table element, `valign="top"` 
needs to be replaced with `style="vertical-align:top"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x86 (hs/tier1 gc)](https://github.com/prsadhuk/jdk/runs/1341099859)

### Issue
 * [JDK-8255215](https://bugs.openjdk.java.net/browse/JDK-8255215): Unsupported 'valign' attribute for 'tr' tag used in j.s.t.h.HTMLDocument


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/995/head:pull/995`
`$ git checkout pull/995`
