### PR TITLE
JDK-8255734: VM should ignore SIGXFSZ on ppc64, s390 too

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -184,7 +184,7 @@ JVM_handle_aix_signal(int sig, siginfo_t* info, void* ucVoid, int abort_if_unrec
   // avoid unnecessary crash when libjsig is not preloaded, try handle signals
   // that do not require siginfo/ucontext first.
 
-  if (sig == SIGPIPE) {
+  if (sig == SIGPIPE || sig == SIGXFSZ) {
     if (PosixSignals::chained_handler(sig, info, ucVoid)) {
       return 1;
     } else {

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -206,7 +206,7 @@ JVM_handle_linux_signal(int sig,
   // avoid unnecessary crash when libjsig is not preloaded, try handle signals
   // that do not require siginfo/ucontext first.
 
-  if (sig == SIGPIPE) {
+  if (sig == SIGPIPE || sig == SIGXFSZ) {
     if (PosixSignals::chained_handler(sig, info, ucVoid)) {
       return true;
     } else {

--- a/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
@@ -227,7 +227,7 @@ JVM_handle_linux_signal(int sig,
   // avoid unnecessary crash when libjsig is not preloaded, try handle signals
   // that do not require siginfo/ucontext first.
 
-  if (sig == SIGPIPE) {
+  if (sig == SIGPIPE || sig == SIGXFSZ) {
     if (PosixSignals::chained_handler(sig, info, ucVoid)) {
       return true;
     } else {


### PR DESCRIPTION
Hi,

may I have reviews please for this small fix.

We willfully ignore SIGPIPE and SIGXFSZ, since their default action is to terminate the VM. However, SIGXFSZ handling was missing for linux ppc64, s390 and AIX. 

Note that this is a minimal patch, with the explicit aim of making backporting simple. This whole coding will change a lot with JDK-8255711, so I did refrain from changing much more code.

Thanks, Thomas

/issue: JDK-8255734
/cc: ppc-aix-port-dev
/cc: s390x-port-dev
/cc: hotspot-runtime-dev

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255734](https://bugs.openjdk.java.net/browse/JDK-8255734): VM should ignore SIGXFSZ on ppc64, s390 too


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/996/head:pull/996`
`$ git checkout pull/996`
