### PR TITLE
8211958: Broken links in java.desktop files

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -207,7 +207,7 @@ import static sun.java2d.pipe.hw.ExtendedBufferCapabilities.VSyncType.VSYNC_ON;
  * <a href="https://docs.oracle.com/javase/tutorial/uiswing/misc/focus.html">
  * How to Use the Focus Subsystem</a>,
  * a section in <em>The Java Tutorial</em>, and the
- * <a href="../../java/awt/doc-files/FocusSpec.html">Focus Specification</a>
+ * <a href="doc-files/FocusSpec.html">Focus Specification</a>
  * for more information.
  *
  * @author      Arthur van Hoff
@@ -7651,7 +7651,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * @param temporary true if the focus change is temporary,
      *        such as when the window loses the focus; for
      *        more information on temporary focus changes see the
-     *<a href="../../java/awt/doc-files/FocusSpec.html">Focus Specification</a>
+     *<a href="doc-files/FocusSpec.html">Focus Specification</a>
      * @return {@code false} if the focus change request is guaranteed to
      *         fail; {@code true} if it is likely to succeed
      * @see java.awt.event.FocusEvent
@@ -7719,7 +7719,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * @param temporary true if the focus change is temporary,
      *        such as when the window loses the focus; for
      *        more information on temporary focus changes see the
-     *<a href="../../java/awt/doc-files/FocusSpec.html">Focus Specification</a>
+     *<a href="doc-files/FocusSpec.html">Focus Specification</a>
      *
      * @param  cause the cause why the focus is requested
      * @return {@code false} if the focus change request is guaranteed to
@@ -7886,7 +7886,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * @param temporary true if the focus change is temporary,
      *        such as when the window loses the focus; for
      *        more information on temporary focus changes see the
-     *<a href="../../java/awt/doc-files/FocusSpec.html">Focus Specification</a>
+     *<a href="doc-files/FocusSpec.html">Focus Specification</a>
      * @return {@code false} if the focus change request is guaranteed to
      *         fail; {@code true} if it is likely to succeed
      * @see #requestFocus

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -83,7 +83,7 @@ import sun.util.logging.PlatformLogger;
  * <a href="https://docs.oracle.com/javase/tutorial/uiswing/misc/focus.html">
  * How to Use the Focus Subsystem</a>,
  * a section in <em>The Java Tutorial</em>, and the
- * <a href="../../java/awt/doc-files/FocusSpec.html">Focus Specification</a>
+ * <a href="doc-files/FocusSpec.html">Focus Specification</a>
  * for more information.
  *
  * @author      Arthur van Hoff

--- a/src/java.desktop/share/classes/java/awt/DefaultFocusTraversalPolicy.java
+++ b/src/java.desktop/share/classes/java/awt/DefaultFocusTraversalPolicy.java
@@ -57,7 +57,7 @@ import java.awt.peer.ComponentPeer;
  * <a href="https://docs.oracle.com/javase/tutorial/uiswing/misc/focus.html">
  * How to Use the Focus Subsystem</a>,
  * a section in <em>The Java Tutorial</em>, and the
- * <a href="../../java/awt/doc-files/FocusSpec.html">Focus Specification</a>
+ * <a href="doc-files/FocusSpec.html">Focus Specification</a>
  * for more information.
  *
  * @author David Mendenhall

--- a/src/java.desktop/share/classes/java/awt/DefaultKeyboardFocusManager.java
+++ b/src/java.desktop/share/classes/java/awt/DefaultKeyboardFocusManager.java
@@ -52,7 +52,7 @@ import sun.util.logging.PlatformLogger;
  * <a href="https://docs.oracle.com/javase/tutorial/uiswing/misc/focus.html">
  * How to Use the Focus Subsystem</a>,
  * a section in <em>The Java Tutorial</em>, and the
- * <a href="../../java/awt/doc-files/FocusSpec.html">Focus Specification</a>
+ * <a href="doc-files/FocusSpec.html">Focus Specification</a>
  * for more information.
  *
  * @author David Mendenhall

--- a/src/java.desktop/share/classes/java/awt/FocusTraversalPolicy.java
+++ b/src/java.desktop/share/classes/java/awt/FocusTraversalPolicy.java
@@ -52,7 +52,7 @@ package java.awt;
  * <a href="https://docs.oracle.com/javase/tutorial/uiswing/misc/focus.html">
  * How to Use the Focus Subsystem</a>,
  * a section in <em>The Java Tutorial</em>, and the
- * <a href="../../java/awt/doc-files/FocusSpec.html">Focus Specification</a>
+ * <a href="doc-files/FocusSpec.html">Focus Specification</a>
  * for more information.
  *
  * @author David Mendenhall

--- a/src/java.desktop/share/classes/java/awt/KeyboardFocusManager.java
+++ b/src/java.desktop/share/classes/java/awt/KeyboardFocusManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,7 +88,7 @@ import sun.awt.AWTAccessor;
  * <a href="https://docs.oracle.com/javase/tutorial/uiswing/misc/focus.html">
  * How to Use the Focus Subsystem</a>,
  * a section in <em>The Java Tutorial</em>, and the
- * <a href="../../java/awt/doc-files/FocusSpec.html">Focus Specification</a>
+ * <a href="doc-files/FocusSpec.html">Focus Specification</a>
  * for more information.
  *
  * @author David Mendenhall

--- a/src/java.desktop/share/classes/java/awt/doc-files/DesktopProperties.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/DesktopProperties.html
@@ -36,8 +36,8 @@
 
 The following refers to standard AWT desktop properties that
 may be obtained via the
-<a href="../Toolkit.html#getDesktopProperty(java.lang.String)">
-<code>Toolkit.getDesktopProperty</code></a> method.
+{@link java.awt.Toolkit#getDesktopProperty(java.lang.String)
+Toolkit.getDesktopProperty} method.
 <p>
 Each desktop property is named by a unique string, which
 is the "name" of that property.
@@ -86,9 +86,9 @@ Modern desktops support various forms of text antialiasing (font smoothing).
 These are applied by platform-specific heavyweight components.
 However an application may want to render text using the same text
 antialiasing on a drawing surface or lightweight (non-platform) component using
-<a href="../Graphics2D.html"> <code>Graphics2D</code></a> methods.
+{@link java.awt.Graphics2D Graphics2D} methods.
 This is particularly important when creating
-<a href="../../../javax/swing/JComponent.html"> Swing components</a> which
+{@link javax.swing.JComponent Swing components} which
 are required to appear consistent with native desktop components or other
 Swing components.
 
@@ -97,9 +97,8 @@ The standard desktop property named
 <b>"awt.font.desktophints"</b>
 can be used to obtain the rendering hints that best match the desktop settings.
 
-The return value is a
-<a href="../../util/Map.html"> Map</a> of
-<a href="../RenderingHints.html"> <code>RenderingHints</code></a> which
+The return value is a {@link java.util.Map Map} of
+{@link java.awt.RenderingHints RenderingHints} which
 can be directly applied to a <code>Graphics2D</code>.
 <p>
 It is a <code>Map</code> as more than one hint may be needed.
@@ -116,8 +115,7 @@ if (map != null) {
 <h4>Listening for changes</h4>
 <p>
 An application can listen for changes in the property
-using a <a href="../../beans/PropertyChangeListener.html">
-<code>PropertyChangeListener</code></a> :
+using a {@link java.beans.PropertyChangeListener PropertyChangeListener}:
 <pre><code>
 tk.addPropertyChangeListener("awt.font.desktophints", pcl);
 </code></pre>
@@ -134,10 +132,10 @@ do provide this capability.
 <h4>Text Measurement</h4>
 <p>
 Text always needs to be measured using the same
-<a href="../font/FontRenderContext.html"> <code>FontRenderContext</code></a>
+{@link java.awt.font.FontRenderContext FontRenderContext}
 as used for rendering. The text anti-aliasing hint is a component of
 the <code>FontRenderContext</code>.
-A <a href="../FontMetrics.html"> <code>FontMetrics</code></a>
+A {@link java.awt.FontMetrics FontMetrics}
 obtained from the <code>Graphics</code> object on which the hint
 has been set will measure text appropriately.
 This is not a unique requirement for clients that specify this hint

--- a/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/doc-files/tiff_metadata.html
@@ -5,7 +5,7 @@
     <title>TIFF Metadata Format Specification and Usage Notes</title>
 </head>
 <!--
-Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -72,9 +72,9 @@ questions.
 
 <h2><a id="Reading">Reading Images</a></h2>
 
-TIFF images are read by an <a href="../../ImageReader.html">ImageReader</a>
+TIFF images are read by an {@link javax.imageio.ImageReader ImageReader}
 which may be controlled by its public interface as well as via a supplied
-<a href="../../plugins/tiff/TIFFImageReadParam.html">TIFFImageReadParam</a>.
+{@link javax.imageio.plugins.tiff.TIFFImageReadParam TIFFImageReadParam}.
 
 <!-- <h3>Supported Image Types</h3> -->
 
@@ -90,7 +90,7 @@ RGB using an internal color converter.</p>
 <h3><a id="ColorSpacesRead">Color Spaces</a></h3>
 
 The raw color space assigned by default, i.e., in the absence of a
-user-supplied <a href="../../ImageTypeSpecifier.html">ImageTypeSpecifier</a>,
+user-supplied {@link javax.imageio.ImageTypeSpecifier ImageTypeSpecifier},
 will be the first among the following which applies:
 
 <ul>
@@ -158,8 +158,8 @@ for the data in question.</p>
 <h3><a id="ICCProfilesRead">ICC Profiles</a></h3>
 
 If an ICC profile is contained in the image metadata
-(<a href="../../plugins/tiff/BaselineTIFFTagSet.html">
-BaselineTIFFTagSet</a>.TAG_ICC_PROFILE, tag number 34675),
+({@link javax.imageio.plugins.tiff.BaselineTIFFTagSet BaselineTIFFTagSet}.
+TAG_ICC_PROFILE, tag number 34675),
 an attempt will be made to use it to create the color space
 of the loaded image. It will be used if the data layout is of component type
 and the number of samples per pixel equals or is one greater than the number
@@ -174,15 +174,13 @@ it may be used manually by following this procedure:
 <li>Obtain the image metadata from
 <code>ImageReader.getImageMetadata</code></li>
 <li>Extract the ICC profile field and its value.</li>
-<li>Create an <a href="../../../../java/awt/color/ICC_ColorSpace.html">
-ICC_ColorSpace</a> from an
-<a href="../../../../java/awt/color/ICC_Profile.html">
-ICC_Profile</a> created from the ICC profile field data
+<li>Create an {@link java.awt.color.ICC_ColorSpace ICC_ColorSpace} from an
+{@link java.awt.color.ICC_Profile ICC_Profile} created from the ICC profile field data
 using <code>ICC_Profile.getInstance(byte[])</code>.</li>
 <li>Create an <code>ImageTypeSpecifier</code> from the new color
 space using one of its factory methods which accepts an
 <code>ICC_ColorSpace</code>.
-<li>Create a compatible <a href="../../ImageReadParam.html">ImageReadParam</a>
+<li>Create a compatible {@link javax.imageio.ImageReadParam ImageReadParam}
 and set the <code>ImageTypeSpecifier</code> using
 <code>ImageReadParam.setDestinationType</code>.</li>
 <li>Pass the parameter object to the appropriate <code>read</code> method.</li>
@@ -206,7 +204,7 @@ whether to read fields with unrecognized tags, and whether to ignore all
 metadata. The reader is informed to disregard all metadata as usual via the
 <code>ignoreMetadata</code> parameter of
 <code>ImageReader.setInput(Object,boolean,boolean)</code>. It is
-informed of which <a href="../../plugins/tiff/TIFFTag.html">TIFFTag</a>s to
+informed of which {@link javax.imageio.plugins.tiff.TIFFTag TIFFTag}s to
 recognize or not to recognize via
 <code>TIFFImageReadParam.addAllowedTagSet(TIFFTagSet)</code> and
 <code>TIFFImageReadParam.removeAllowedTagSet(TIFFTagSet)</code>.
@@ -221,7 +219,7 @@ by passing in a <code>TIFFImageReadParam</code> on which
 <code>TIFFImageReadParam.setReadUnknownTags(boolean)</code> has been
 invoked with parameter <code>true</code>.
 
-<p>Use of a <a href="../../plugins/tiff/TIFFDirectory.html">TIFFDirectory</a>
+<p>Use of a {@link javax.imageio.plugins.tiff.TIFFDirectory TIFFDirectory}
 object may simplify gaining access to metadata values. An instance of
 <code>TIFFDirectory</code> may be created from the <code>IIOMetadata</code>
 object returned by the TIFF reader using the
@@ -481,9 +479,9 @@ empty; the primary image should be obtained using the JPEG reader itself.
 
 <h2><a id="Writing">Writing Images</a></h2>
 
-TIFF images are written by a <a href="../../ImageWriter.html">ImageWriter</a> which may be
+TIFF images are written by a {@link javax.imageio.ImageWriter ImageWriter} which may be
 controlled by its public interface as well as via a supplied
-<a href="../../ImageWriteParam.html">ImageWriteParam</a>.  For an <code>ImageWriteParam</code> returned
+{@link javax.imageio.ImageWriteParam ImageWriteParam}.  For an <code>ImageWriteParam</code> returned
 by the <code>getDefaultWriteParam()</code> method of the TIFF <code>ImageWriter</code>,
 the <code>canWriteTiles()</code> and <code>canWriteCompressed()</code> methods
 will return <code>true</code>; the <code>canOffsetTiles()</code> and
@@ -631,9 +629,9 @@ RGB using an internal color converter.</p>
 An <code>ICC Profile</code> field will be written if either:
 <ul>
 <li>one is present in the native image metadata
-<a href="../IIOMetadata.html">IIOMetadata</a> instance supplied to the writer,
+{@link javax.imageio.metadata.IIOMetadata IIOMetadata} instance supplied to the writer,
 or</li>
-<li>the <a href="../../../../java/awt/color/ColorSpace.html">ColorSpace</a>
+<li>the {@link java.awt.color.ColorSpace ColorSpace}
 of the destination <code>ImageTypeSpecifier</code> is an instance of
 <code>ICC_ColorSpace</code> which is not one of the standard
 color spaces defined by the <code>CS_*</code> constants in the
@@ -748,7 +746,7 @@ specification.</p>
 <p>Setting up the image metadata to write to a TIFF stream may be simplified
 by using the <code>TIFFDirectory</code> class
 which represents a TIFF IFD. A field in a TIFF IFD is represented by an
-instance of <a href="../../plugins/tiff/TIFFField.html">TIFFField</a>. For each
+instance of {@link javax.imageio.plugins.tiff.TIFFField TIFFField}. For each
 field to be written a <code>TIFFField</code> may be added to the
 <code>TIFFDirectory</code> and the latter converted to an
 <code>IIOMetadata</code> object by invoking

--- a/src/java.desktop/share/classes/javax/print/DocFlavor.java
+++ b/src/java.desktop/share/classes/javax/print/DocFlavor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,9 +156,9 @@ import java.io.Serializable;
  * the primary IANA name but is guaranteed to be understood by this VM. For
  * common flavors, the pre-defined *HOST {@code DocFlavors} may be used.
  * <p>
- * See <a href="../../java/lang/package-summary.html#charenc">character
- * encodings</a> for more information on the character encodings supported on
- * the Java platform.
+ * See <a href="../../../java.base/java/lang/package-summary.html#charenc">
+ * character encodings</a> for more information on the character encodings
+ * supported on the Java platform.
  *
  * <hr>
  * <h2>Recommended DocFlavors</h2>


### PR DESCRIPTION
Most of the broken links were fixed already by the JDK-8225368 and JDK-8214817
This change fix just a few.

Also two cleanups are applied:
 - The `../../java/awt/doc-files/` in some cases simplified to `doc-files/`
 - The html links to the java classes via `<a href>` replaced by the `{@link }`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (1/9 failed) |

**Failed test task**
- [macOS x64 (jdk/tier1 part 3)](https://github.com/mrserb/jdk/runs/1341279495)

### Issue
 * [JDK-8211958](https://bugs.openjdk.java.net/browse/JDK-8211958): Broken links in java.desktop files


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/998/head:pull/998`
`$ git checkout pull/998`
