### PR TITLE
8255672: Replace PhaseTransform::eqv by pointer equality check

### DIFF
--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -1150,10 +1150,9 @@ static void check_peepconstraints(FILE *fp, FormDict &globals, PeepMatch *pmatch
       //
       // Check for equivalence
       //
-      // fprintf(fp, "phase->eqv( ");
-      // fprintf(fp, "inst%d->in(%d+%d) /* %s */, inst%d->in(%d+%d) /* %s */",
-      //         left_index,  left_op_base,  left_op_index,  left_op,
-      //         right_index, right_op_base, right_op_index, right_op );
+      // fprintf(fp, "(inst%d->_opnds[%d]->reg(ra_,inst%d%s)  /* %d.%s */ == /* %d.%s */ inst%d->_opnds[%d]->reg(ra_,inst%d%s)",
+      //         left_index, left_op_index, left_index, left_reg_index, left_index, left_op
+      //         right_index, right_op, right_index, right_op_index, right_index, right_reg_index);
       // fprintf(fp, ")");
       //
       switch( left_interface_type ) {

--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -328,10 +328,9 @@ Node *AddINode::Ideal(PhaseGVN *phase, bool can_reshape) {
 //------------------------------Identity---------------------------------------
 // Fold (x-y)+y  OR  y+(x-y)  into  x
 Node* AddINode::Identity(PhaseGVN* phase) {
-  if( in(1)->Opcode() == Op_SubI && phase->eqv(in(1)->in(2),in(2)) ) {
+  if (in(1)->Opcode() == Op_SubI && in(1)->in(2) == in(2)) {
     return in(1)->in(1);
-  }
-  else if( in(2)->Opcode() == Op_SubI && phase->eqv(in(2)->in(2),in(1)) ) {
+  } else if (in(2)->Opcode() == Op_SubI && in(2)->in(2) == in(1)) {
     return in(2)->in(1);
   }
   return AddNode::Identity(phase);
@@ -445,10 +444,9 @@ Node *AddLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 //------------------------------Identity---------------------------------------
 // Fold (x-y)+y  OR  y+(x-y)  into  x
 Node* AddLNode::Identity(PhaseGVN* phase) {
-  if( in(1)->Opcode() == Op_SubL && phase->eqv(in(1)->in(2),in(2)) ) {
+  if (in(1)->Opcode() == Op_SubL && in(1)->in(2) == in(2)) {
     return in(1)->in(1);
-  }
-  else if( in(2)->Opcode() == Op_SubL && phase->eqv(in(2)->in(2),in(1)) ) {
+  } else if (in(2)->Opcode() == Op_SubL && in(2)->in(2) == in(1)) {
     return in(2)->in(1);
   }
   return AddNode::Identity(phase);
@@ -736,7 +734,7 @@ uint AddPNode::match_edge(uint idx) const {
 //------------------------------Identity---------------------------------------
 Node* OrINode::Identity(PhaseGVN* phase) {
   // x | x => x
-  if (phase->eqv(in(1), in(2))) {
+  if (in(1) == in(2)) {
     return in(1);
   }
 
@@ -823,7 +821,7 @@ const Type *OrINode::add_ring( const Type *t0, const Type *t1 ) const {
 //------------------------------Identity---------------------------------------
 Node* OrLNode::Identity(PhaseGVN* phase) {
   // x | x => x
-  if (phase->eqv(in(1), in(2))) {
+  if (in(1) == in(2)) {
     return in(1);
   }
 
@@ -1078,7 +1076,7 @@ Node *MinINode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
     // Transform MIN2(x + c0, MIN2(x + c1, z)) into MIN2(x + MIN2(c0, c1), z)
     // if x == y and the additions can't overflow.
-    if (phase->eqv(x,y) && tx != NULL &&
+    if (x == y && tx != NULL &&
         !can_overflow(tx, x_off) &&
         !can_overflow(tx, y_off)) {
       return new MinINode(phase->transform(new AddINode(x, phase->intcon(MIN2(x_off, y_off)))), r->in(2));
@@ -1086,7 +1084,7 @@ Node *MinINode::Ideal(PhaseGVN *phase, bool can_reshape) {
   } else {
     // Transform MIN2(x + c0, y + c1) into x + MIN2(c0, c1)
     // if x == y and the additions can't overflow.
-    if (phase->eqv(x,y) && tx != NULL &&
+    if (x == y && tx != NULL &&
         !can_overflow(tx, x_off) &&
         !can_overflow(tx, y_off)) {
       return new AddINode(x,phase->intcon(MIN2(x_off,y_off)));

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1224,8 +1224,12 @@ Node* SafePointNode::Identity(PhaseGVN* phase) {
 
 //------------------------------Value------------------------------------------
 const Type* SafePointNode::Value(PhaseGVN* phase) const {
-  if( phase->type(in(0)) == Type::TOP ) return Type::TOP;
-  if( phase->eqv( in(0), this ) ) return Type::TOP; // Dead infinite loop
+  if (phase->type(in(0)) == Type::TOP) {
+    return Type::TOP;
+  }
+  if (in(0) == this) {
+    return Type::TOP; // Dead infinite loop
+  }
   return Type::CONTROL;
 }
 

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -344,7 +344,7 @@ bool RegionNode::is_possible_unsafe_loop(const PhaseGVN* phase) const {
     Node* n = raw_out(i);
     if (n != NULL && n->is_Phi()) {
       PhiNode* phi = n->as_Phi();
-      assert(phase->eqv(phi->in(0), this), "sanity check phi");
+      assert(phi->in(0) == this, "sanity check phi");
       if (phi->outcnt() == 0) {
         continue; // Safe case - no loops
       }
@@ -383,7 +383,7 @@ bool RegionNode::is_unreachable_from_root(const PhaseGVN* phase) const {
     for (uint i = 0; i < max; i++) {
       Node* m = n->raw_out(i);
       if (m != NULL && m->is_CFG()) {
-        if (phase->eqv(m, this)) {
+        if (m == this) {
           return false; // We reached the Region node - it is not dead.
         }
         if (!visited.test_set(m->_idx))
@@ -568,7 +568,7 @@ Node *RegionNode::Ideal(PhaseGVN *phase, bool can_reshape) {
         for (j = outs(); has_out(j); j++) {
           Node *n = out(j);
           if( n->is_Phi() ) {
-            assert( igvn->eqv(n->in(0), this), "" );
+            assert(n->in(0) == this, "");
             assert( n->req() == 2 &&  n->in(1) != NULL, "Only one data input expected" );
             // Break dead loop data path.
             // Eagerly replace phis with top to avoid regionless phis.
@@ -619,7 +619,7 @@ Node *RegionNode::Ideal(PhaseGVN *phase, bool can_reshape) {
         // The fallthrough case since we already checked dead loops above.
         parent_ctrl = in(1);
         assert(parent_ctrl != NULL, "Region is a copy of some non-null control");
-        assert(!igvn->eqv(parent_ctrl, this), "Close dead loop");
+        assert(parent_ctrl != this, "Close dead loop");
       }
       if (!add_to_worklist)
         igvn->add_users_to_worklist(this); // Check for further allowed opts
@@ -641,7 +641,7 @@ Node *RegionNode::Ideal(PhaseGVN *phase, bool can_reshape) {
           igvn->replace_node(n, in);
         }
         else if( n->is_Region() ) { // Update all incoming edges
-          assert( !igvn->eqv(n, this), "Must be removed from DefUse edges");
+          assert(n != this, "Must be removed from DefUse edges");
           uint uses_found = 0;
           for( uint k=1; k < n->req(); k++ ) {
             if( n->in(k) == this ) {
@@ -654,12 +654,12 @@ Node *RegionNode::Ideal(PhaseGVN *phase, bool can_reshape) {
           }
         }
         else {
-          assert( igvn->eqv(n->in(0), this), "Expect RegionNode to be control parent");
+          assert(n->in(0) == this, "Expect RegionNode to be control parent");
           n->set_req(0, parent_ctrl);
         }
 #ifdef ASSERT
         for( uint k=0; k < n->req(); k++ ) {
-          assert( !igvn->eqv(n->in(k), this), "All uses of RegionNode should be gone");
+          assert(n->in(k) != this, "All uses of RegionNode should be gone");
         }
 #endif
       }
@@ -2078,7 +2078,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   if (can_reshape) {
     opt = split_flow_path(phase, this);
     // This optimization only modifies phi - don't need to check for dead loop.
-    assert(opt == NULL || phase->eqv(opt, this), "do not elide phi");
+    assert(opt == NULL || opt == this, "do not elide phi");
     if (opt != NULL)  return opt;
   }
 
@@ -2194,7 +2194,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       if (ii->is_MergeMem()) {
         MergeMemNode* n = ii->as_MergeMem();
         merge_width = MAX2(merge_width, n->req());
-        saw_self = saw_self || phase->eqv(n->base_memory(), this);
+        saw_self = saw_self || (n->base_memory() == this);
       }
     }
 

--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -505,8 +505,9 @@ const Type* DivINode::Value(PhaseGVN* phase) const {
   if( t2 == Type::TOP ) return Type::TOP;
 
   // x/x == 1 since we always generate the dynamic divisor check for 0.
-  if( phase->eqv( in(1), in(2) ) )
+  if (in(1) == in(2)) {
     return TypeInt::ONE;
+  }
 
   // Either input is BOTTOM ==> the result is the local BOTTOM
   const Type *bot = bottom_type();
@@ -610,8 +611,9 @@ const Type* DivLNode::Value(PhaseGVN* phase) const {
   if( t2 == Type::TOP ) return Type::TOP;
 
   // x/x == 1 since we always generate the dynamic divisor check for 0.
-  if( phase->eqv( in(1), in(2) ) )
+  if (in(1) == in(2)) {
     return TypeLong::ONE;
+  }
 
   // Either input is BOTTOM ==> the result is the local BOTTOM
   const Type *bot = bottom_type();
@@ -685,9 +687,10 @@ const Type* DivFNode::Value(PhaseGVN* phase) const {
   // x/x == 1, we ignore 0/0.
   // Note: if t1 and t2 are zero then result is NaN (JVMS page 213)
   // Does not work for variables because of NaN's
-  if( phase->eqv( in(1), in(2) ) && t1->base() == Type::FloatCon)
-    if (!g_isnan(t1->getf()) && g_isfinite(t1->getf()) && t1->getf() != 0.0) // could be negative ZERO or NaN
-      return TypeF::ONE;
+  if (in(1) == in(2) && t1->base() == Type::FloatCon &&
+      !g_isnan(t1->getf()) && g_isfinite(t1->getf()) && t1->getf() != 0.0) { // could be negative ZERO or NaN
+    return TypeF::ONE;
+  }
 
   if( t2 == TypeF::ONE )
     return t1;
@@ -773,9 +776,10 @@ const Type* DivDNode::Value(PhaseGVN* phase) const {
   // x/x == 1, we ignore 0/0.
   // Note: if t1 and t2 are zero then result is NaN (JVMS page 213)
   // Does not work for variables because of NaN's
-  if( phase->eqv( in(1), in(2) ) && t1->base() == Type::DoubleCon)
-    if (!g_isnan(t1->getd()) && g_isfinite(t1->getd()) && t1->getd() != 0.0) // could be negative ZERO or NaN
-      return TypeD::ONE;
+  if (in(1) == in(2) && t1->base() == Type::DoubleCon &&
+      !g_isnan(t1->getd()) && g_isfinite(t1->getd()) && t1->getd() != 0.0) { // could be negative ZERO or NaN
+    return TypeD::ONE;
+  }
 
   if( t2 == TypeD::ONE )
     return t1;
@@ -990,7 +994,9 @@ const Type* ModINode::Value(PhaseGVN* phase) const {
   // 0 MOD X is 0
   if( t1 == TypeInt::ZERO ) return TypeInt::ZERO;
   // X MOD X is 0
-  if( phase->eqv( in(1), in(2) ) ) return TypeInt::ZERO;
+  if (in(1) == in(2)) {
+    return TypeInt::ZERO;
+  }
 
   // Either input is BOTTOM ==> the result is the local BOTTOM
   const Type *bot = bottom_type();
@@ -1163,7 +1169,9 @@ const Type* ModLNode::Value(PhaseGVN* phase) const {
   // 0 MOD X is 0
   if( t1 == TypeLong::ZERO ) return TypeLong::ZERO;
   // X MOD X is 0
-  if( phase->eqv( in(1), in(2) ) ) return TypeLong::ZERO;
+  if (in(1) == in(2)) {
+    return TypeLong::ZERO;
+  }
 
   // Either input is BOTTOM ==> the result is the local BOTTOM
   const Type *bot = bottom_type();

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1074,7 +1074,7 @@ Node* MemNode::can_see_stored_value(Node* st, PhaseTransform* phase) const {
 
     if (st->is_Store()) {
       Node* st_adr = st->in(MemNode::Address);
-      if (!phase->eqv(st_adr, ld_adr)) {
+      if (st_adr != ld_adr) {
         // Try harder before giving up. Unify base pointers with casts (e.g., raw/non-raw pointers).
         intptr_t st_off = 0;
         Node* st_base = AddPNode::Ideal_base_and_offset(st_adr, phase, st_off);
@@ -1523,7 +1523,7 @@ Node *LoadNode::split_through_phi(PhaseGVN *phase) {
 
   // Do nothing here if Identity will find a value
   // (to avoid infinite chain of value phis generation).
-  if (!phase->eqv(this, this->Identity(phase))) {
+  if (this != Identity(phase)) {
     return NULL;
   }
 
@@ -2737,7 +2737,7 @@ Node* StoreNode::Identity(PhaseGVN* phase) {
       // Steps (a), (b):  Walk past independent stores to find an exact match.
       if (prev_mem != NULL) {
         Node* prev_val = can_see_stored_value(prev_mem, phase);
-        if (prev_val != NULL && phase->eqv(prev_val, val)) {
+        if (prev_val != NULL && prev_val == val) {
           // prev_val and val might differ by a cast; it would be good
           // to keep the more informative of the two.
           result = mem;

--- a/src/hotspot/share/opto/movenode.cpp
+++ b/src/hotspot/share/opto/movenode.cpp
@@ -78,9 +78,9 @@ Node *CMoveNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   if( in(0) && remove_dead_region(phase, can_reshape) ) return this;
   // Don't bother trying to transform a dead node
   if( in(0) && in(0)->is_top() )  return NULL;
-  assert( !phase->eqv(in(Condition), this) &&
-         !phase->eqv(in(IfFalse), this) &&
-         !phase->eqv(in(IfTrue), this), "dead loop in CMoveNode::Ideal" );
+  assert(in(Condition) != this &&
+         in(IfFalse) != this &&
+         in(IfTrue) != this, "dead loop in CMoveNode::Ideal" );
   if( phase->type(in(Condition)) == Type::TOP )
   return NULL; // return NULL when Condition is dead
 
@@ -98,11 +98,9 @@ Node *CMoveNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 // Helper function to check for CMOVE identity.  Shared with PhiNode::Identity
 Node *CMoveNode::is_cmove_id( PhaseTransform *phase, Node *cmp, Node *t, Node *f, BoolNode *b ) {
   // Check for Cmp'ing and CMove'ing same values
-  if( (phase->eqv(cmp->in(1),f) &&
-       phase->eqv(cmp->in(2),t)) ||
-     // Swapped Cmp is OK
-     (phase->eqv(cmp->in(2),f) &&
-      phase->eqv(cmp->in(1),t)) ) {
+  if ((cmp->in(1) == f && cmp->in(2) == t) ||
+      // Swapped Cmp is OK
+      (cmp->in(2) == f && cmp->in(1) == t)) {
        // Give up this identity check for floating points because it may choose incorrect
        // value around 0.0 and -0.0
        if ( cmp->Opcode()==Op_CmpF || cmp->Opcode()==Op_CmpD )
@@ -122,12 +120,16 @@ Node *CMoveNode::is_cmove_id( PhaseTransform *phase, Node *cmp, Node *t, Node *f
 // Conditional-move is an identity if both inputs are the same, or the test
 // true or false.
 Node* CMoveNode::Identity(PhaseGVN* phase) {
-  if( phase->eqv(in(IfFalse),in(IfTrue)) ) // C-moving identical inputs?
-  return in(IfFalse);         // Then it doesn't matter
-  if( phase->type(in(Condition)) == TypeInt::ZERO )
-  return in(IfFalse);         // Always pick left(false) input
-  if( phase->type(in(Condition)) == TypeInt::ONE )
-  return in(IfTrue);          // Always pick right(true) input
+  // C-moving identical inputs?
+  if (in(IfFalse) == in(IfTrue)) {
+    return in(IfFalse); // Then it doesn't matter
+  }
+  if (phase->type(in(Condition)) == TypeInt::ZERO) {
+    return in(IfFalse); // Always pick left(false) input
+  }
+  if (phase->type(in(Condition)) == TypeInt::ONE) {
+    return in(IfTrue);  // Always pick right(true) input
+  }
 
   // Check for CMove'ing a constant after comparing against the constant.
   // Happens all the time now, since if we compare equality vs a constant in

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -87,12 +87,13 @@ Node *MulNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     Node *mul1 = in(1);
 #ifdef ASSERT
     // Check for dead loop
-    int   op1 = mul1->Opcode();
-    if( phase->eqv( mul1, this ) || phase->eqv( in(2), this ) ||
-        ( ( op1 == mul_opcode() || op1 == add_opcode() ) &&
-          ( phase->eqv( mul1->in(1), this ) || phase->eqv( mul1->in(2), this ) ||
-            phase->eqv( mul1->in(1), mul1 ) || phase->eqv( mul1->in(2), mul1 ) ) ) )
+    int op1 = mul1->Opcode();
+    if ((mul1 == this) || (in(2) == this) ||
+        ((op1 == mul_opcode() || op1 == add_opcode()) &&
+         ((mul1->in(1) == this) || (mul1->in(2) == this) ||
+          (mul1->in(1) == mul1) || (mul1->in(2) == mul1)))) {
       assert(false, "dead loop in MulNode::Ideal");
+    }
 #endif
 
     if( mul1->Opcode() == mul_opcode() ) {  // Left input is a multiply?
@@ -436,7 +437,9 @@ const Type *AndINode::mul_ring( const Type *t0, const Type *t1 ) const {
 Node* AndINode::Identity(PhaseGVN* phase) {
 
   // x & x => x
-  if (phase->eqv(in(1), in(2))) return in(1);
+  if (in(1) == in(2)) {
+    return in(1);
+  }
 
   Node* in1 = in(1);
   uint op = in1->Opcode();
@@ -558,7 +561,9 @@ const Type *AndLNode::mul_ring( const Type *t0, const Type *t1 ) const {
 Node* AndLNode::Identity(PhaseGVN* phase) {
 
   // x & x => x
-  if (phase->eqv(in(1), in(2))) return in(1);
+  if (in(1) == in(2)) {
+    return in(1);
+  }
 
   Node *usr = in(1);
   const TypeLong *t2 = phase->type( in(2) )->isa_long();

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -282,11 +282,6 @@ public:
   // in a faster or cheaper fashion.
   virtual Node *transform( Node *n ) = 0;
 
-  // Return whether two Nodes are equivalent.
-  // Must not be recursive, since the recursive version is built from this.
-  // For pessimistic optimizations this is simply pointer equivalence.
-  bool eqv(const Node* n1, const Node* n2) const { return n1 == n2; }
-
   // For pessimistic passes, the return type must monotonically narrow.
   // For optimistic  passes, the return type must monotonically widen.
   // It is possible to get into a "death march" in either type of pass,

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -454,7 +454,7 @@ Node *SubFNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   if (IdealizedNumerics && !phase->C->method()->is_strict() &&
       in(2)->is_Add() && in(1) == in(2)->in(1)) {
     // Convert "x - (x+y)" into "-y"
-    return new SubFNode(phase->makecon(TypeF::ZERO),in(2)->in(2));
+    return new SubFNode(phase->makecon(TypeF::ZERO), in(2)->in(2));
   }
 
   // Cannot replace 0.0-X with -X because a 'fsub' bytecode computes

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -61,20 +61,22 @@ Node* SubNode::Identity(PhaseGVN* phase) {
   }
 
   // Convert "(X+Y) - Y" into X and "(X+Y) - X" into Y
-  if( in(1)->Opcode() == Op_AddI ) {
-    if( phase->eqv(in(1)->in(2),in(2)) )
+  if (in(1)->Opcode() == Op_AddI) {
+    if (in(1)->in(2) == in(2)) {
       return in(1)->in(1);
-    if (phase->eqv(in(1)->in(1),in(2)))
+    }
+    if (in(1)->in(1) == in(2)) {
       return in(1)->in(2);
+    }
 
     // Also catch: "(X + Opaque2(Y)) - Y".  In this case, 'Y' is a loop-varying
     // trip counter and X is likely to be loop-invariant (that's how O2 Nodes
     // are originally used, although the optimizer sometimes jiggers things).
     // This folding through an O2 removes a loop-exit use of a loop-varying
     // value and generally lowers register pressure in and around the loop.
-    if( in(1)->in(2)->Opcode() == Op_Opaque2 &&
-        phase->eqv(in(1)->in(2)->in(1),in(2)) )
+    if (in(1)->in(2)->Opcode() == Op_Opaque2 && in(1)->in(2)->in(1) == in(2)) {
       return in(1)->in(1);
+    }
   }
 
   return ( phase->type( in(2) )->higher_equal( zero ) ) ? in(1) : this;
@@ -154,11 +156,12 @@ Node *SubINode::Ideal(PhaseGVN *phase, bool can_reshape){
 
 #ifdef ASSERT
   // Check for dead loop
-  if( phase->eqv( in1, this ) || phase->eqv( in2, this ) ||
-      ( ( op1 == Op_AddI || op1 == Op_SubI ) &&
-        ( phase->eqv( in1->in(1), this ) || phase->eqv( in1->in(2), this ) ||
-          phase->eqv( in1->in(1), in1  ) || phase->eqv( in1->in(2), in1 ) ) ) )
+  if ((in1 == this) || (in2 == this) ||
+      ((op1 == Op_AddI || op1 == Op_SubI) &&
+       ((in1->in(1) == this) || (in1->in(2) == this) ||
+        (in1->in(1) == in1)  || (in1->in(2) == in1)))) {
     assert(false, "dead loop in SubINode::Ideal");
+  }
 #endif
 
   const Type *t2 = phase->type( in2 );
@@ -200,24 +203,25 @@ Node *SubINode::Ideal(PhaseGVN *phase, bool can_reshape){
 
 #ifdef ASSERT
   // Check for dead loop
-  if( ( op2 == Op_AddI || op2 == Op_SubI ) &&
-      ( phase->eqv( in2->in(1), this ) || phase->eqv( in2->in(2), this ) ||
-        phase->eqv( in2->in(1), in2  ) || phase->eqv( in2->in(2), in2  ) ) )
+  if ((op2 == Op_AddI || op2 == Op_SubI) &&
+      ((in2->in(1) == this) || (in2->in(2) == this) ||
+       (in2->in(1) == in2)  || (in2->in(2) == in2))) {
     assert(false, "dead loop in SubINode::Ideal");
+  }
 #endif
 
   // Convert "x - (x+y)" into "-y"
-  if( op2 == Op_AddI &&
-      phase->eqv( in1, in2->in(1) ) )
-    return new SubINode( phase->intcon(0),in2->in(2));
+  if (op2 == Op_AddI && in1 == in2->in(1)) {
+    return new SubINode(phase->intcon(0), in2->in(2));
+  }
   // Convert "(x-y) - x" into "-y"
-  if( op1 == Op_SubI &&
-      phase->eqv( in1->in(1), in2 ) )
-    return new SubINode( phase->intcon(0),in1->in(2));
+  if (op1 == Op_SubI && in1->in(1) == in2) {
+    return new SubINode(phase->intcon(0), in1->in(2));
+  }
   // Convert "x - (y+x)" into "-y"
-  if( op2 == Op_AddI &&
-      phase->eqv( in1, in2->in(2) ) )
-    return new SubINode( phase->intcon(0),in2->in(1));
+  if (op2 == Op_AddI && in1 == in2->in(2)) {
+    return new SubINode(phase->intcon(0), in2->in(1));
+  }
 
   // Convert "0 - (x-y)" into "y-x"
   if( t1 == TypeInt::ZERO && op2 == Op_SubI )
@@ -296,11 +300,12 @@ Node *SubLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
 #ifdef ASSERT
   // Check for dead loop
-  if( phase->eqv( in1, this ) || phase->eqv( in2, this ) ||
-      ( ( op1 == Op_AddL || op1 == Op_SubL ) &&
-        ( phase->eqv( in1->in(1), this ) || phase->eqv( in1->in(2), this ) ||
-          phase->eqv( in1->in(1), in1  ) || phase->eqv( in1->in(2), in1  ) ) ) )
+  if ((in1 == this) || (in2 == this) ||
+      ((op1 == Op_AddL || op1 == Op_SubL) &&
+       ((in1->in(1) == this) || (in1->in(2) == this) ||
+        (in1->in(1) == in1)  || (in1->in(2) == in1)))) {
     assert(false, "dead loop in SubLNode::Ideal");
+  }
 #endif
 
   if( phase->type( in2 ) == Type::TOP ) return NULL;
@@ -340,20 +345,21 @@ Node *SubLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
 #ifdef ASSERT
   // Check for dead loop
-  if( ( op2 == Op_AddL || op2 == Op_SubL ) &&
-      ( phase->eqv( in2->in(1), this ) || phase->eqv( in2->in(2), this ) ||
-        phase->eqv( in2->in(1), in2  ) || phase->eqv( in2->in(2), in2  ) ) )
+  if ((op2 == Op_AddL || op2 == Op_SubL) &&
+      ((in2->in(1) == this) || (in2->in(2) == this) ||
+       (in2->in(1) == in2)  || (in2->in(2) == in2))) {
     assert(false, "dead loop in SubLNode::Ideal");
+  }
 #endif
 
   // Convert "x - (x+y)" into "-y"
-  if( op2 == Op_AddL &&
-      phase->eqv( in1, in2->in(1) ) )
-    return new SubLNode( phase->makecon(TypeLong::ZERO), in2->in(2));
+  if (op2 == Op_AddL && in1 == in2->in(1)) {
+    return new SubLNode(phase->makecon(TypeLong::ZERO), in2->in(2));
+  }
   // Convert "x - (y+x)" into "-y"
-  if( op2 == Op_AddL &&
-      phase->eqv( in1, in2->in(2) ) )
-    return new SubLNode( phase->makecon(TypeLong::ZERO),in2->in(1));
+  if (op2 == Op_AddL && in1 == in2->in(2)) {
+    return new SubLNode(phase->makecon(TypeLong::ZERO), in2->in(1));
+  }
 
   // Convert "0 - (x-y)" into "y-x"
   if( phase->type( in1 ) == TypeLong::ZERO && op2 == Op_SubL )
@@ -421,8 +427,8 @@ const Type* SubFPNode::Value(PhaseGVN* phase) const {
 
   // if both operands are infinity of same sign, the result is NaN; do
   // not replace with zero
-  if( (t1->is_finite() && t2->is_finite()) ) {
-    if( phase->eqv(in1, in2) ) return add_id();
+  if (t1->is_finite() && t2->is_finite() && in1 == in2) {
+    return add_id();
   }
 
   // Either input is BOTTOM ==> the result is the local BOTTOM
@@ -445,11 +451,10 @@ Node *SubFNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
 
   // Not associative because of boundary conditions (infinity)
-  if( IdealizedNumerics && !phase->C->method()->is_strict() ) {
+  if (IdealizedNumerics && !phase->C->method()->is_strict() &&
+      in(2)->is_Add() && in(1) == in(2)->in(1)) {
     // Convert "x - (x+y)" into "-y"
-    if( in(2)->is_Add() &&
-        phase->eqv(in(1),in(2)->in(1) ) )
-      return new SubFNode( phase->makecon(TypeF::ZERO),in(2)->in(2));
+    return new SubFNode(phase->makecon(TypeF::ZERO),in(2)->in(2));
   }
 
   // Cannot replace 0.0-X with -X because a 'fsub' bytecode computes
@@ -488,11 +493,10 @@ Node *SubDNode::Ideal(PhaseGVN *phase, bool can_reshape){
   }
 
   // Not associative because of boundary conditions (infinity)
-  if( IdealizedNumerics && !phase->C->method()->is_strict() ) {
+  if (IdealizedNumerics && !phase->C->method()->is_strict() &&
+      in(2)->is_Add() && in(1) == in(2)->in(1)) {
     // Convert "x - (x+y)" into "-y"
-    if( in(2)->is_Add() &&
-        phase->eqv(in(1),in(2)->in(1) ) )
-      return new SubDNode( phase->makecon(TypeD::ZERO),in(2)->in(2));
+    return new SubDNode(phase->makecon(TypeD::ZERO), in(2)->in(2));
   }
 
   // Cannot replace 0.0-X with -X because a 'dsub' bytecode computes


### PR DESCRIPTION
`PhaseTransform::eqv(n1, n2)` can be replaced by `n1 == n2`. Code in adlc also refers to it but already uses `==` instead.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255672](https://bugs.openjdk.java.net/browse/JDK-8255672): Replace PhaseTransform::eqv by pointer equality check


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/999/head:pull/999`
`$ git checkout pull/999`
