### PR TITLE
8255400: Shenandoah: C2 failures after JDK-8255000

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestBarrierExpansionDeadMemPhi.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestBarrierExpansionDeadMemPhi.java
@@ -29,7 +29,7 @@
  * @modules java.base/jdk.internal.misc:+open
  *
  * @run main/othervm -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:+UseShenandoahGC TestBarrierExpansionDeadMemPhi
- *                   
+ *
  *
  */
 
@@ -67,7 +67,7 @@ public class TestBarrierExpansionDeadMemPhi {
     static public void main(String[] args) {
         Object[] array = new Object[100];
         Arrays.fill(array, new A());
-        
+
         for (int i = 0; i < 20000; i++) {
             test(array);
         }

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestBarrierExpansionDeadMemPhi.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestBarrierExpansionDeadMemPhi.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary
+ * @requires vm.gc.Shenandoah
+ * @modules java.base/jdk.internal.misc:+open
+ *
+ * @run main/othervm -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:+UseShenandoahGC TestBarrierExpansionDeadMemPhi
+ *                   
+ *
+ */
+
+import jdk.internal.misc.Unsafe;
+import java.util.Arrays;
+import java.lang.reflect.Field;
+
+public class TestBarrierExpansionDeadMemPhi {
+
+    static final jdk.internal.misc.Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    static final long F_OFFSET;
+
+    static class A {
+        int f;
+    }
+
+    static {
+        try {
+            Field fField = A.class.getDeclaredField("f");
+            F_OFFSET = UNSAFE.objectFieldOffset(fField);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static int test(Object[] array) {
+        int f = 0;
+        for (int i = 0; i < 100; i++) {
+            f += UNSAFE.getInt(array[i], F_OFFSET);
+        }
+        return f;
+    }
+
+    static public void main(String[] args) {
+        Object[] array = new Object[100];
+        Arrays.fill(array, new A());
+        
+        for (int i = 0; i < 20000; i++) {
+            test(array);
+        }
+    }
+}

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestBarrierExpansionDeadMemPhi.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestBarrierExpansionDeadMemPhi.java
@@ -23,7 +23,8 @@
 
 /**
  * @test
- * @summary
+ * @bug 8255400
+ * @summary C2 failures after JDK-8255000
  * @requires vm.gc.Shenandoah
  * @modules java.base/jdk.internal.misc:+open
  *


### PR DESCRIPTION
At barrier expansion time, the IR graph may contain a Halt node whose
control is a region. In that case, code that wires raw memory creates
a memory Phi at the region. But that Phi has no use because the Halt
node doesn't consume any memory. That dead Phi causes the assert to
trigger. I propose some adjustments so a Phi is not created in that
case.

/cc shenandoah,hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255400](https://bugs.openjdk.java.net/browse/JDK-8255400): Shenandoah: C2 failures after JDK-8255000


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1000/head:pull/1000`
`$ git checkout pull/1000`
