### PR TITLE
8255741: Zero: print signal name in unhandled signal handler

### DIFF
--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -244,9 +244,9 @@ JVM_handle_linux_signal(int sig,
   char exc_buf[32];
 
   if (os::exception_name(sig, exc_buf, sizeof(exc_buf))) {
+    bool sent_by_kill = (info != NULL && os::signal_sent_by_kill(info));
     snprintf(buf, sizeof(buf), "caught unhandled signal: %s %s",
-            exc_buf,
-            (info != NULL && os::signal_sent_by_kill(info)) ? "(sent by kill)" : "");
+             exc_buf, sent_by_kill ? "(sent by kill)" : "");
   } else {
     snprintf(buf, sizeof(buf), "caught unhandled signal: %d", sig);
   }

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -240,9 +240,16 @@ JVM_handle_linux_signal(int sig,
   }
 #endif // !PRODUCT
 
-  char buf[64];
+  char buf[128];
+  char exc_buf[32];
 
-  sprintf(buf, "caught unhandled signal %d", sig);
+  if (os::exception_name(sig, exc_buf, sizeof(exc_buf))) {
+    snprintf(buf, sizeof(buf), "caught unhandled signal: %s %s",
+            exc_buf,
+            (info != NULL && os::signal_sent_by_kill(info)) ? "(sent by kill)" : "");
+  } else {
+    snprintf(buf, sizeof(buf), "caught unhandled signal: %d", sig);
+  }
 
 // Silence -Wformat-security warning for fatal()
 PRAGMA_DIAG_PUSH


### PR DESCRIPTION
At least one test -- `runtime/Safepoint/TestAbortVMOnSafepointTimeout.java` -- fails on Zero with:

```
# Internal Error (/home/shade/trunks/jdk/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp:250), pid=560280, tid=560281
# fatal error: caught unhandled signal 4
```

The test expects "SIGKILL (sent by kill)" in the test output.

Additional testing:
 - [x] `TestAbortVMOnSafepointTimeout.java` now passes on Linux x86_64 Zero.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255741](https://bugs.openjdk.java.net/browse/JDK-8255741): Zero: print signal name in unhandled signal handler


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 89de8c271c279c9b39bd3b85770d43375314be85


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1001/head:pull/1001`
`$ git checkout pull/1001`
