### PR TITLE
8255743: Relax SIGFPE match in in runtime/ErrorHandling/SecondaryErrorTest.java

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
@@ -60,7 +60,7 @@ public class SecondaryErrorTest {
 
     // we should have crashed with a SIGFPE
     output_detail.shouldMatch("# A fatal error has been detected by the Java Runtime Environment:.*");
-    output_detail.shouldMatch("# +SIGFPE.*");
+    output_detail.shouldMatch("#.+SIGFPE.*");
 
     // extract hs-err file
     String hs_err_file = output_detail.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);


### PR DESCRIPTION
After JDK-8255741, Zero prints the message below for the affected test:

```
# Internal Error (/home/shade/trunks/jdk/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp:257), pid=903938, tid=903939
# fatal error: caught unhandled signal: SIGFPE
```

Unfortunately, that still does not match the regexp in the test. Seems simple to relax the regexp a bit. @tstuefe, what do you think?

Additional testing:
 - [x] Affected test on Linux x86_64 Zero (together with JDK-8255741 fix)
 - [x] Affected test on Linux x86_64 server

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255743](https://bugs.openjdk.java.net/browse/JDK-8255743): Relax SIGFPE match in in runtime/ErrorHandling/SecondaryErrorTest.java


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1002/head:pull/1002`
`$ git checkout pull/1002`
