### PR TITLE
8255744: Zero: handle JVM_CONSTANT_DynamicInError

### DIFF
--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -2266,6 +2266,7 @@ run:
             break;
 
           case JVM_CONSTANT_Dynamic:
+          case JVM_CONSTANT_DynamicInError:
             {
               CALL_VM(InterpreterRuntime::resolve_ldc(THREAD, (Bytecodes::Code) opcode), handle_exception);
               oop result = THREAD->vm_result();
@@ -2307,6 +2308,7 @@ run:
             break;
 
           case JVM_CONSTANT_Dynamic:
+          case JVM_CONSTANT_DynamicInError:
             {
               CALL_VM(InterpreterRuntime::resolve_ldc(THREAD, (Bytecodes::Code) opcode), handle_exception);
               oop result = THREAD->vm_result();


### PR DESCRIPTION
JDK-8186211 introduced a few negative tests for Condy, and Zero seem to fail them:

```
$ CONF=linux-x86_64-zero-fastdebug make run-test TEST=java/lang/invoke/condy/CondyRepeatFailedResolution.java
# Internal Error (/home/shade/trunks/jdk/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp:2289), pid=574573, tid=581749
# Error: ShouldNotReachHere()
```

After some debugging, I think Zero misses to handle `JVM_CONSTANT_DynamicInError`. I believe we can just do the same thing as `JVM_CONSTANT_Dynamic`, and then let `CALL_VM` to go to `handle_exception` on another resolution failure.

Additional testing:
 - [x] `CondyRepeatFailedResolution` test now passes on Linux x86_64 Zero

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (4/4 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255744](https://bugs.openjdk.java.net/browse/JDK-8255744): Zero: handle JVM_CONSTANT_DynamicInError


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1004/head:pull/1004`
`$ git checkout pull/1004`
