### PR TITLE
8255760: Shenandoah: match constants style in ShenandoahMarkTask fallback

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTaskqueue.hpp
@@ -225,10 +225,11 @@ public:
 class ShenandoahMarkTask
 {
 private:
-  enum {
-    chunk_bits  = 10,
-    pow_bits    = 5,
-  };
+  static const uint8_t chunk_bits  = 10;
+  static const uint8_t pow_bits    = 5;
+
+  static const int chunk_max       = nth_bit(chunk_bits) - 1;
+  static const int pow_max         = nth_bit(pow_bits) - 1;
 
   oop _obj;
   int _chunk;
@@ -237,8 +238,8 @@ private:
 public:
   ShenandoahMarkTask(oop o = NULL, int chunk = 0, int pow = 0):
     _obj(o), _chunk(chunk), _pow(pow) {
-    assert(0 <= chunk && chunk < nth_bit(chunk_bits), "chunk is sane: %d", chunk);
-    assert(0 <= pow && pow < nth_bit(pow_bits), "pow is sane: %d", pow);
+    assert(0 <= chunk && chunk <= chunk_max, "chunk is in range: %d", chunk);
+    assert(0 <= pow && pow <= pow_max, "pow is in range: %d", pow);
   }
 
   // Trivially copyable.


### PR DESCRIPTION
JDK-8255457 cleaned up the 64-bit version of ShenandoahMarkTask. However, there is also the 32-bit fallback without any tricky mechanics. Still, it should match the style of the optimized version by using `static const`-s instead of enums. I missed that during the JDK-8255457 work.

Additional testing:
 - [x] Linux x86_32 `hotspot_gc_shenandoah`