### PR TITLE
JDK-8255732: OpenJDK fails to build if $A is set to a value with spaces

### DIFF
--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -311,9 +311,11 @@ define SetupJavaCompilationBody
   ifneq ($$($1_KEEP_DUPS), true)
     # Remove duplicate source files by keeping the first found of each duplicate.
     # This allows for automatic overrides with custom or platform specific versions
-    # source files.
+    # source files. Need to call DoubleDollar as we have java classes with '$' in
+    # their names.
     $1_SRCS := $$(strip $$(foreach s, $$($1_SRCS), \
-        $$(eval relative_src := $$(call remove-prefixes, $$($1_SRC), $$(s))) \
+        $$(eval relative_src := $$(call remove-prefixes, $$($1_SRC), \
+            $$(call DoubleDollar, $$(s)))) \
         $$(if $$($1_$$(relative_src)), \
           , \
           $$(eval $1_$$(relative_src) := 1) $$(s))))


### PR DESCRIPTION
We have at least one java file with a '$' in the name. As we have learned over the years, having $ in unexpected places quickly leads to unexpected behavior in a shell/make based build. In this case it's our override mechanism of java files that needs protection against expanding such occurrences of $.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255732](https://bugs.openjdk.java.net/browse/JDK-8255732): OpenJDK fails to build if $A is set to a value with spaces


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1007/head:pull/1007`
`$ git checkout pull/1007`
