### PR TITLE
8255662: ZGC: Unify nmethod closures in the heap iterator

### DIFF
--- a/src/hotspot/share/gc/z/zHeapIterator.cpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.cpp
@@ -250,13 +250,15 @@ public:
       _bs_nm(BarrierSet::barrier_set()->barrier_set_nmethod()) {}
 
   virtual void do_nmethod(nmethod* nm) {
-    assert(!ClassUnloading, "Only used if class unloading is turned off");
+    if (!ClassUnloading) {
+      // ClassUnloading is turned off, all nmethods are considered strong,
+      // not only those on the call stacks. The heap iteration might happen
+      // before the concurrent processign of the code cache, make sure that
+      // all nmethods have been processed before visiting the oops.
+      _bs_nm->nmethod_entry_barrier(nm);
+    }
 
-    // ClassUnloading is turned off, all nmethods are considered strong,
-    // not only those on the call stacks. The heap iteration might happen
-    // before the concurrent processign of the code cache, make sure that
-    // all nmethods have been processed before visiting the oops.
-    _bs_nm->nmethod_entry_barrier(nm);
+    assert(!_bs_nm->is_armed(nm), "Must have been processed before oops are visited");
 
     ZNMethod::nmethod_oops_do(nm, _cl);
   }
@@ -264,27 +266,16 @@ public:
 
 class ZHeapIteratorThreadClosure : public ThreadClosure {
 private:
-  OopClosure* const _cl;
-
-  class NMethodVisitor : public CodeBlobToOopClosure {
-  public:
-    NMethodVisitor(OopClosure* cl) :
-        CodeBlobToOopClosure(cl, false /* fix_oop_relocations */) {}
-
-    void do_code_blob(CodeBlob* cb) {
-      assert(!cb->is_nmethod() || !ZNMethod::is_armed(cb->as_nmethod()),
-          "NMethods on stack should have been fixed and disarmed");
-
-      CodeBlobToOopClosure::do_code_blob(cb);
-    }
-  };
+  OopClosure* const        _cl;
+  CodeBlobToNMethodClosure _cb_cl;
 
 public:
-  ZHeapIteratorThreadClosure(OopClosure* cl) : _cl(cl) {}
+  ZHeapIteratorThreadClosure(OopClosure* cl, NMethodClosure* nm_cl) :
+      _cl(cl),
+      _cb_cl(nm_cl) {}
 
   void do_thread(Thread* thread) {
-    NMethodVisitor code_cl(_cl);
-    thread->oops_do(_cl, &code_cl);
+    thread->oops_do(_cl, &_cb_cl);
   }
 };
 
@@ -292,7 +283,7 @@ void ZHeapIterator::push_strong_roots(const ZHeapIteratorContext& context) {
   ZHeapIteratorRootOopClosure<false /* Weak */> cl(context);
   ZHeapIteratorCLDCLosure cld_cl(&cl);
   ZHeapIteratorNMethodClosure nm_cl(&cl);
-  ZHeapIteratorThreadClosure thread_cl(&cl);
+  ZHeapIteratorThreadClosure thread_cl(&cl, &nm_cl);
 
   _concurrent_roots.apply(&cl,
                           &cld_cl,

--- a/src/hotspot/share/gc/z/zHeapIterator.cpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.cpp
@@ -250,15 +250,11 @@ public:
       _bs_nm(BarrierSet::barrier_set()->barrier_set_nmethod()) {}
 
   virtual void do_nmethod(nmethod* nm) {
-    if (!ClassUnloading) {
-      // ClassUnloading is turned off, all nmethods are considered strong,
-      // not only those on the call stacks. The heap iteration might happen
-      // before the concurrent processign of the code cache, make sure that
-      // all nmethods have been processed before visiting the oops.
-      _bs_nm->nmethod_entry_barrier(nm);
-    }
-
-    assert(!_bs_nm->is_armed(nm), "Must have been processed before oops are visited");
+    // If ClassUnloading is turned off, all nmethods are considered strong,
+    // not only those on the call stacks. The heap iteration might happen
+    // before the concurrent processign of the code cache, make sure that
+    // all nmethods have been processed before visiting the oops.
+    _bs_nm->nmethod_entry_barrier(nm);
 
     ZNMethod::nmethod_oops_do(nm, _cl);
   }

--- a/src/hotspot/share/memory/iterator.cpp
+++ b/src/hotspot/share/memory/iterator.cpp
@@ -64,3 +64,10 @@ void MarkingCodeBlobClosure::do_code_blob(CodeBlob* cb) {
     do_nmethod(nm);
   }
 }
+
+void CodeBlobToNMethodClosure::do_code_blob(CodeBlob* cb) {
+  nmethod* nm = cb->as_nmethod_or_null();
+  if (nm != NULL) {
+    _nm_cl->do_nmethod(nm);
+  }
+}

--- a/src/hotspot/share/memory/iterator.hpp
+++ b/src/hotspot/share/memory/iterator.hpp
@@ -261,6 +261,15 @@ class NMethodClosure : public Closure {
   virtual void do_nmethod(nmethod* n) = 0;
 };
 
+class CodeBlobToNMethodClosure : public CodeBlobClosure {
+  NMethodClosure* const _nm_cl;
+
+ public:
+  CodeBlobToNMethodClosure(NMethodClosure* nm_cl) : _nm_cl(nm_cl) {}
+
+  virtual void do_code_blob(CodeBlob* cb);
+};
+
 // MonitorClosure is used for iterating over monitors in the monitors cache
 
 class ObjectMonitor;


### PR DESCRIPTION
In the heap iterator, we use different nmethod closures to visit the on-stack nmethods and the rest that are visited if class unloading is turned off.

The rational is that the first set have already been processed and does not have to be fixed, so the code simply verifies that the nmethod has been processed and visits all the oops. The second set contains nmethods of the kind that has been entered and processed, and those that have not. Before visiting oops in those nmethods, we apply an nmethod barrier to ensure that it's safe to visit the oops.

The proposal is to get rid of this separation and simply apply the nmethod entry barrier on all visited nmethods. This will make it easier to reason about the safeness of visiting the oops.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255662](https://bugs.openjdk.java.net/browse/JDK-8255662): ZGC: Unify nmethod closures in the heap iterator


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1011/head:pull/1011`
`$ git checkout pull/1011`
