### PR TITLE
8255766: Fix linux+arm64 build after 8254072

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1498,7 +1498,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // Generate stack overflow check
   if (UseStackBanging) {
-    assert(StackOverflow::stack_shadow_zone_size() == (int)StackOverflow::stack_shadow_zone_size(), "must be same");
+    assert(StackOverflow::stack_shadow_zone_size() == (size_t)(int)StackOverflow::stack_shadow_zone_size(), "must be same");
     __ bang_stack_with_offset((int)StackOverflow::stack_shadow_zone_size());
   } else {
     Unimplemented();

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1498,8 +1498,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // Generate stack overflow check
   if (UseStackBanging) {
-    assert(StackOverflow::stack_shadow_zone_size() == (size_t)(int)StackOverflow::stack_shadow_zone_size(), "must be same");
-    __ bang_stack_with_offset((int)StackOverflow::stack_shadow_zone_size());
+    __ bang_stack_with_offset(checked_cast<int>(StackOverflow::stack_shadow_zone_size()));
   } else {
     Unimplemented();
   }


### PR DESCRIPTION
Fixing this problem:
```
/home/beurba/work/jdk/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp:1501:52: error: comparison of integer expressions of different signedness: 'size_t' {aka 'long unsigned int'} and 'int' [-Werror=sign-compare]
 1501 | assert(StackOverflow::stack_shadow_zone_size() == (int)StackOverflow::stack_shadow_zone_size(), "must be same");
```
Verified via a linux+arm64 slowdebug build and a windows+arm64 slowdebug build.


/cc @magicus @theRealAph

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ⏳ (4/9 running) | ⏳ (1/9 running) |

### Issue
 * [JDK-8255766](https://bugs.openjdk.java.net/browse/JDK-8255766): Fix linux+arm64 build after 8254072


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to 30ef419079bc4a5b7aac6b6a2932e4ebe02e0b3b


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1013/head:pull/1013`
`$ git checkout pull/1013`
