### PR TITLE
8255529:  Remove unused methods from java.util.zip.ZipFile

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1335,18 +1335,6 @@ public class ZipFile implements ZipConstants, Closeable {
             }
         }
 
-        private static final int hashN(byte[] a, int off, int len) {
-            int h = 1;
-            while (len-- > 0) {
-                h = 31 * h + a[off++];
-            }
-            return h;
-        }
-
-        private static final int hash_append(int hash, byte b) {
-            return hash * 31 + b;
-        }
-
         private static class End {
             int  centot;     // 4 bytes
             long cenlen;     // 4 bytes


### PR DESCRIPTION
Please review this fix for JDK-8255529 which removes methods that were unused and were added back merge in July

Mach5 jdk-tier1, jdk-tier2, jdk-tier3 ran clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (6/9 running) | ⏳ (7/9 running) |    |  ⏳ (8/9 running) |

### Issue
 * [JDK-8255529](https://bugs.openjdk.java.net/browse/JDK-8255529): Remove unused methods from java.util.zip.ZipFile


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1015/head:pull/1015`
`$ git checkout pull/1015`
