### PR TITLE
8255128: linux x86 build failure with libJNIPoint.c

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -664,9 +664,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
       -D$FLAGS_CPU_LEGACY"
 
   if test "x$FLAGS_CPU_BITS" = x64; then
-    # -D_LP64=1 is only set on linux and mac. Setting on windows causes diff in
-    # unpack200.exe.
-    if test "x$FLAGS_OS" = xlinux || test "x$FLAGS_OS" = xmacosx; then
+    if test "x$FLAGS_OS" = xlinux || test "x$FLAGS_OS" = xmacosx || test "x$FLAGS_OS" = xwindows; then
       $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -D_LP64=1"
     fi
     if test "x$FLAGS_OS" != xaix; then

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -663,14 +663,10 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
   $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -DARCH='\"$FLAGS_CPU_LEGACY\"' \
       -D$FLAGS_CPU_LEGACY"
 
-  if test "x$FLAGS_CPU_BITS" = x64; then
-    if test "x$FLAGS_OS" = xlinux || test "x$FLAGS_OS" = xmacosx || test "x$FLAGS_OS" = xwindows; then
-      $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -D_LP64=1"
-    fi
-    if test "x$FLAGS_OS" != xaix; then
-      # xlc on AIX defines _LP64=1 by default and issues a warning if we redefine it.
-      $1_DEFINES_CPU_JVM="${$1_DEFINES_CPU_JVM} -D_LP64=1"
-    fi
+  if test "x$FLAGS_CPU_BITS" = x64 && test "x$FLAGS_OS" != xaix; then
+    # xlc on AIX defines _LP64=1 by default and issues a warning if we redefine it.
+    $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -D_LP64=1"
+    $1_DEFINES_CPU_JVM="${$1_DEFINES_CPU_JVM} -D_LP64=1"
   fi
 
   # toolchain dependend, per-cpu

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/libJNIPoint.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/libJNIPoint.c
@@ -25,37 +25,45 @@
 
 #include "points.h"
 
+#ifdef _LP64
+#define JLONG_TO_PTR(value, type) ((type*) (value))
+#define PTR_TO_JLONG(value) ((jlong) (value))
+#else
+#define JLONG_TO_PTR(value, type) ((type*) (jint) (value))
+#define PTR_TO_JLONG(value) ((jlong) (jint) (value))
+#endif
+
 JNIEXPORT jlong JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_allocate
   (JNIEnv *env, jclass nativePointClass) {
     Point* p = malloc(sizeof *p);
-    return (jlong) p;
+    return PTR_TO_JLONG(p);
 }
 
 JNIEXPORT void JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_free
   (JNIEnv *env, jclass cls, jlong thisPoint) {
-    free((Point*) thisPoint);
+    free(JLONG_TO_PTR(thisPoint, Point));
 }
 
 JNIEXPORT jint JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_getX
   (JNIEnv *env, jclass cls, jlong thisPoint) {
-    Point* point = (Point*) thisPoint;
+    Point* point = JLONG_TO_PTR(thisPoint, Point);
     return point->x;
 }
 
 JNIEXPORT void JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_setX
   (JNIEnv *env, jclass cls, jlong thisPoint, jint value) {
-    Point* point = (Point*) thisPoint;
+    Point* point = JLONG_TO_PTR(thisPoint, Point);
     point->x = value;
 }
 
 JNIEXPORT jint JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_getY
   (JNIEnv *env, jclass cls, jlong thisPoint) {
-    Point* point = (Point*) thisPoint;
+    Point* point = JLONG_TO_PTR(thisPoint, Point);
     return point->y;
 }
 
 JNIEXPORT void JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_setY
   (JNIEnv *env, jclass cls, jlong thisPoint, jint value) {
-    Point* point = (Point*) thisPoint;
+    Point* point = JLONG_TO_PTR(thisPoint, Point);
     point->y = value;
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/libJNIPoint.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/libJNIPoint.c
@@ -22,48 +22,41 @@
  */
 #include <jni.h>
 #include <stdlib.h>
+#include "jlong.h"
 
 #include "points.h"
-
-#ifdef _LP64
-#define JLONG_TO_PTR(value, type) ((type*) (value))
-#define PTR_TO_JLONG(value) ((jlong) (value))
-#else
-#define JLONG_TO_PTR(value, type) ((type*) (jint) (value))
-#define PTR_TO_JLONG(value) ((jlong) (jint) (value))
-#endif
 
 JNIEXPORT jlong JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_allocate
   (JNIEnv *env, jclass nativePointClass) {
     Point* p = malloc(sizeof *p);
-    return PTR_TO_JLONG(p);
+    return ptr_to_jlong(p);
 }
 
 JNIEXPORT void JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_free
   (JNIEnv *env, jclass cls, jlong thisPoint) {
-    free(JLONG_TO_PTR(thisPoint, Point));
+    free(jlong_to_ptr(thisPoint));
 }
 
 JNIEXPORT jint JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_getX
   (JNIEnv *env, jclass cls, jlong thisPoint) {
-    Point* point = JLONG_TO_PTR(thisPoint, Point);
+    Point* point = jlong_to_ptr(thisPoint);
     return point->x;
 }
 
 JNIEXPORT void JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_setX
   (JNIEnv *env, jclass cls, jlong thisPoint, jint value) {
-    Point* point = JLONG_TO_PTR(thisPoint, Point);
+    Point* point = jlong_to_ptr(thisPoint);
     point->x = value;
 }
 
 JNIEXPORT jint JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_getY
   (JNIEnv *env, jclass cls, jlong thisPoint) {
-    Point* point = JLONG_TO_PTR(thisPoint, Point);
+    Point* point = jlong_to_ptr(thisPoint);
     return point->y;
 }
 
 JNIEXPORT void JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_setY
   (JNIEnv *env, jclass cls, jlong thisPoint, jint value) {
-    Point* point = JLONG_TO_PTR(thisPoint, Point);
+    Point* point = jlong_to_ptr(thisPoint);
     point->y = value;
 }


### PR DESCRIPTION
Add 32-bit-safe version of jlong <-> casts to libJNIPoint.c

This removes the reported warning.

Note that the _LP64 macro was not being propagated to the benchmark native libraries on Windows. The comment says that this is due to pack200, but since this has been removed [1], it seemed safe to propagate the macro now (backed up by testing).

CC'ing hotspot-runtime since I know some people there were looking forward to having this fixed.

Testing: tier1-3

[1] https://bugs.openjdk.java.net/browse/JDK-8232022

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255128](https://bugs.openjdk.java.net/browse/JDK-8255128): linux x86 build failure with libJNIPoint.c


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1017/head:pull/1017`
`$ git checkout pull/1017`
