### PR TITLE
JDK-8255780: Remove unused overloads of VMError::report_and_die()

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1321,19 +1321,6 @@ void VMError::report_and_die(Thread* thread, unsigned int sig, address pc, void*
   report_and_die(thread, sig, pc, siginfo, context, "%s", "");
 }
 
-void VMError::report_and_die(const char* message, const char* detail_fmt, ...)
-{
-  va_list detail_args;
-  va_start(detail_args, detail_fmt);
-  report_and_die(INTERNAL_ERROR, message, detail_fmt, detail_args, NULL, NULL, NULL, NULL, NULL, 0, 0);
-  va_end(detail_args);
-}
-
-void VMError::report_and_die(const char* message)
-{
-  report_and_die(message, "%s", "");
-}
-
 void VMError::report_and_die(Thread* thread, void* context, const char* filename, int lineno, const char* message,
                              const char* detail_fmt, va_list detail_args)
 {

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -118,7 +118,6 @@ class VMError : public AllStatic {
 
   static void report_and_die(Thread* thread, unsigned int sig, address pc, void* siginfo,
                              void* context, const char* detail_fmt, ...) ATTRIBUTE_PRINTF(6, 7);
-  static void report_and_die(const char* message, const char* detail_fmt, ...) ATTRIBUTE_PRINTF(2, 3);
 
   // Timeout handling.
   // Hook functions for platform dependend functionality:
@@ -160,8 +159,6 @@ public:
   static void report_and_die(Thread* thread, const char* filename, int lineno, size_t size,
                              VMErrorType vm_err_type, const char* detail_fmt,
                              va_list detail_args) ATTRIBUTE_PRINTF(6, 0);
-
-  static void report_and_die(const char* message);
 
   // reporting OutOfMemoryError
   static void report_java_out_of_memory(const char* message);


### PR DESCRIPTION
VMError::report_and_die() comes in a lot of overloads. These are unused:

```
void report_and_die(const char* message, const char* detail_fmt, ...)
void report_and_die(const char* message);
```

and can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255780](https://bugs.openjdk.java.net/browse/JDK-8255780): Remove unused overloads of VMError::report_and_die()


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1018/head:pull/1018`
`$ git checkout pull/1018`
