### PR TITLE
8255782: Turn UseTLAB and ResizeTLAB from product_pd to product, defaulting to "true"

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_globals_aarch64.hpp
@@ -34,8 +34,6 @@
 
 #ifndef TIERED
 define_pd_global(bool, BackgroundCompilation,        true );
-define_pd_global(bool, UseTLAB,                      true );
-define_pd_global(bool, ResizeTLAB,                   true );
 define_pd_global(bool, InlineIntrinsics,             true );
 define_pd_global(bool, PreferInterpreterNativeStubs, false);
 define_pd_global(bool, ProfileTraps,                 false);

--- a/src/hotspot/cpu/aarch64/c2_globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_globals_aarch64.hpp
@@ -33,8 +33,6 @@
 // (see c2_globals.hpp).  Alpha-sorted.
 
 define_pd_global(bool, BackgroundCompilation,        true);
-define_pd_global(bool, UseTLAB,                      true);
-define_pd_global(bool, ResizeTLAB,                   true);
 define_pd_global(bool, CICompileOSR,                 true);
 define_pd_global(bool, InlineIntrinsics,             true);
 define_pd_global(bool, PreferInterpreterNativeStubs, false);

--- a/src/hotspot/cpu/arm/c1_globals_arm.hpp
+++ b/src/hotspot/cpu/arm/c1_globals_arm.hpp
@@ -35,8 +35,6 @@
 
 #ifndef COMPILER2 // avoid duplicated definitions, favoring C2 version
 define_pd_global(bool, BackgroundCompilation,        true );
-define_pd_global(bool, UseTLAB,                      true );
-define_pd_global(bool, ResizeTLAB,                   true );
 define_pd_global(bool, InlineIntrinsics,             false); // TODO: ARM
 define_pd_global(bool, PreferInterpreterNativeStubs, false);
 define_pd_global(bool, ProfileTraps,                 false);

--- a/src/hotspot/cpu/arm/c2_globals_arm.hpp
+++ b/src/hotspot/cpu/arm/c2_globals_arm.hpp
@@ -54,8 +54,6 @@ define_pd_global(size_t, NewSizeThreadIncrease,      ScaleForWordSize(4*K));
 // (For _228_jack 16/16 is 2% better than 4/4, 16/4, 32/32, 32/16, or 16/32.)
 //define_pd_global(intx, OptoLoopAlignment,            16);  // = 4*wordSize
 define_pd_global(intx, RegisterCostAreaRatio,        16000);
-define_pd_global(bool, UseTLAB,                      true);
-define_pd_global(bool, ResizeTLAB,                   true);
 define_pd_global(intx, LoopUnrollLimit,              60); // Design center runs on 1.3.1
 define_pd_global(intx, LoopPercentProfileLimit,      10);
 define_pd_global(intx, MinJumpTableSize,             16);

--- a/src/hotspot/cpu/ppc/c1_globals_ppc.hpp
+++ b/src/hotspot/cpu/ppc/c1_globals_ppc.hpp
@@ -43,9 +43,7 @@ define_pd_global(bool,     TieredCompilation,            false);
 define_pd_global(intx,     CompileThreshold,             1000);
 
 define_pd_global(intx,     OnStackReplacePercentage,     1400);
-define_pd_global(bool,     UseTLAB,                      true);
 define_pd_global(bool,     ProfileInterpreter,           false);
-define_pd_global(bool,     ResizeTLAB,                   true);
 define_pd_global(uintx,    ReservedCodeCacheSize,        32*M);
 define_pd_global(uintx,    NonProfiledCodeHeapSize,      13*M );
 define_pd_global(uintx,    ProfiledCodeHeapSize,         14*M );

--- a/src/hotspot/cpu/ppc/c2_globals_ppc.hpp
+++ b/src/hotspot/cpu/ppc/c2_globals_ppc.hpp
@@ -51,8 +51,6 @@ define_pd_global(intx, INTPRESSURE,                  26);
 define_pd_global(intx, InteriorEntryAlignment,       16);
 define_pd_global(size_t, NewSizeThreadIncrease,      ScaleForWordSize(4*K));
 define_pd_global(intx, RegisterCostAreaRatio,        16000);
-define_pd_global(bool, UseTLAB,                      true);
-define_pd_global(bool, ResizeTLAB,                   true);
 define_pd_global(intx, LoopUnrollLimit,              60);
 define_pd_global(intx, LoopPercentProfileLimit,      10);
 

--- a/src/hotspot/cpu/s390/c1_globals_s390.hpp
+++ b/src/hotspot/cpu/s390/c1_globals_s390.hpp
@@ -43,9 +43,7 @@ define_pd_global(bool,     TieredCompilation,            false);
 define_pd_global(intx,     CompileThreshold,             1000);
 
 define_pd_global(intx,     OnStackReplacePercentage,     1400);
-define_pd_global(bool,     UseTLAB,                      true);
 define_pd_global(bool,     ProfileInterpreter,           false);
-define_pd_global(bool,     ResizeTLAB,                   true);
 define_pd_global(uintx,    ReservedCodeCacheSize,        32*M);
 define_pd_global(uintx,    NonProfiledCodeHeapSize,      13*M);
 define_pd_global(uintx,    ProfiledCodeHeapSize,         14*M);

--- a/src/hotspot/cpu/s390/c2_globals_s390.hpp
+++ b/src/hotspot/cpu/s390/c2_globals_s390.hpp
@@ -51,8 +51,6 @@ define_pd_global(intx, INTPRESSURE,                  10); // Medium size registe
 define_pd_global(intx, InteriorEntryAlignment,       2);
 define_pd_global(size_t, NewSizeThreadIncrease,      ScaleForWordSize(4*K));
 define_pd_global(intx, RegisterCostAreaRatio,        12000);
-define_pd_global(bool, UseTLAB,                      true);
-define_pd_global(bool, ResizeTLAB,                   true);
 define_pd_global(intx, LoopUnrollLimit,              60);
 define_pd_global(intx, LoopPercentProfileLimit,      10);
 define_pd_global(intx, MinJumpTableSize,             18);

--- a/src/hotspot/cpu/x86/c1_globals_x86.hpp
+++ b/src/hotspot/cpu/x86/c1_globals_x86.hpp
@@ -33,8 +33,6 @@
 
 #ifndef TIERED
 define_pd_global(bool, BackgroundCompilation,          true );
-define_pd_global(bool, UseTLAB,                        true );
-define_pd_global(bool, ResizeTLAB,                     true );
 define_pd_global(bool, InlineIntrinsics,               true );
 define_pd_global(bool, PreferInterpreterNativeStubs,   false);
 define_pd_global(bool, ProfileTraps,                   false);

--- a/src/hotspot/cpu/x86/c2_globals_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_globals_x86.hpp
@@ -31,8 +31,6 @@
 // Sets the default values for platform dependent flags used by the server compiler.
 // (see c2_globals.hpp).  Alpha-sorted.
 define_pd_global(bool, BackgroundCompilation,        true);
-define_pd_global(bool, UseTLAB,                      true);
-define_pd_global(bool, ResizeTLAB,                   true);
 define_pd_global(bool, CICompileOSR,                 true);
 define_pd_global(bool, InlineIntrinsics,             true);
 define_pd_global(bool, PreferInterpreterNativeStubs, false);

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -38,7 +38,6 @@
 
 #if !defined(COMPILER1) && !defined(COMPILER2) && !INCLUDE_JVMCI
 define_pd_global(bool, BackgroundCompilation,        false);
-define_pd_global(bool, UseTLAB,                      false);
 define_pd_global(bool, CICompileOSR,                 false);
 define_pd_global(bool, UseTypeProfile,               false);
 define_pd_global(bool, UseOnStackReplacement,        false);
@@ -51,7 +50,6 @@ define_pd_global(bool, TieredCompilation,            false);
 define_pd_global(intx, CompileThreshold,             0);
 
 define_pd_global(intx,   OnStackReplacePercentage,   0);
-define_pd_global(bool,   ResizeTLAB,                 false);
 define_pd_global(size_t, NewSizeThreadIncrease,      4*K);
 define_pd_global(bool,   InlineClassNatives,         true);
 define_pd_global(bool,   InlineUnsafeOps,            true);

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -293,9 +293,10 @@
   product(bool, ExecutingUnitTests, false,                                  \
           "Whether the JVM is running unit tests or not")                   \
                                                                             \
-  product_pd(bool, UseTLAB, "Use thread-local object allocation")           \
+  product(bool, UseTLAB, true,                                              \
+          "Use thread-local object allocation")                             \
                                                                             \
-  product_pd(bool, ResizeTLAB,                                              \
+  product(bool, ResizeTLAB, true,                                           \
           "Dynamically resize TLAB size for threads")                       \
                                                                             \
   product(bool, ZeroTLAB, false,                                            \


### PR DESCRIPTION
When doing Zero VM performance investigations, I realized that `UseTLAB` is disabled there by default. 

That is effectively because `UseTLAB` is currently `product_pd` (defined in `gc_globals.hpp`), and it is enabled for every platform with C1 and C2 ports (in their respective `c1/c2_globals.hpp`). `compiler_globals.hpp` has a block that defines `UseTLAB` to `false` when no C1/C2/JVMCI is present.

Not only this is awkward -- GC flag is managed by Compiler globals! -- it makes Zero awkward to opt-in to `UseTLAB` in `*_zero_globals.hpp`, because `compiler_globals.hpp` already defines it. I think we can make this all better by turning TLAB flags from `product_pd` to `product`, and defaulting them to `true`. This matches what every current Server/Minimal VM config has, and would implicitly enable `UseTLAB` and `ResizeTLAB` for Zero, as well as for builds with `--with-jvm-features=-compiler1,-compiler-2,-jvmci` (in case anyone actually builds it, that is only with template interpreter).

On the downside, this shuts the door for new platform ports to disable TLAB flags by default to ease porting. But I believe the same can be achieved by turning these flags off in `arguments.cpp` under the special platform defines, while TLAB enablement work is in progress.

Additional testing:
  - [x] Linux x86_64 Zero ad-hoc runs
  - [x] Linux x86_64 `--with-jvm-features=-compiler1,-compiler-2,-jvmci,*` builds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255782](https://bugs.openjdk.java.net/browse/JDK-8255782): Turn UseTLAB and ResizeTLAB from product_pd to product, defaulting to "true"


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1019/head:pull/1019`
`$ git checkout pull/1019`
