### PR TITLE
    8255706: The JDWP debug agent unecessarily checks for JVMTI_ERROR_INTERRUPT after calling RawMonitorEnter

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.c
@@ -1008,16 +1008,9 @@ void
 debugMonitorEnter(jrawMonitorID monitor)
 {
     jvmtiError error;
-    while (JNI_TRUE) {
-        error = JVMTI_FUNC_PTR(gdata->jvmti,RawMonitorEnter)
-                        (gdata->jvmti, monitor);
-        error = ignore_vm_death(error);
-        if (error == JVMTI_ERROR_INTERRUPT) {
-            handleInterrupt();
-        } else {
-            break;
-        }
-    }
+    error = JVMTI_FUNC_PTR(gdata->jvmti,RawMonitorEnter)
+            (gdata->jvmti, monitor);
+    error = ignore_vm_death(error);
     if (error != JVMTI_ERROR_NONE) {
         EXIT_ERROR(error, "on raw monitor enter");
     }


### PR DESCRIPTION
Remove code that retries if RawMonitorEnter is interrupted since that can't happen:

https://docs.oracle.com/en/java/javase/14/docs/specs/jvmti.html#RawMonitorEnter

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255706](https://bugs.openjdk.java.net/browse/JDK-8255706): The JDWP debug agent unecessarily checks for JVMTI_ERROR_INTERRUPT after calling RawMonitorEnter


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1022/head:pull/1022`
`$ git checkout pull/1022`
