### PR TITLE
8255239: The timezone of the hs_err_pid log file is corrupted in Japanese locale

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1002,8 +1002,14 @@ void os::print_date_and_time(outputStream *st, char* buf, size_t buflen) {
 
   struct tm tz;
   if (localtime_pd(&tloc, &tz) != NULL) {
-    ::strftime(buf, buflen, "%Z", &tz);
-    st->print("Time: %s %s", timestring, buf);
+    wchar_t w_buf[80];
+    size_t n = ::wcsftime(w_buf, 80, L"%Z", &tz);
+    if (n > 0) {
+      ::wcstombs(buf, w_buf, buflen);
+      st->print("Time: %s %s", timestring, buf);
+    } else {
+      st->print("Time: %s", timestring);
+    }
   } else {
     st->print("Time: %s", timestring);
   }


### PR DESCRIPTION
Please review this simple fix by using the wide char version of strftime, i.e. wcsftime, to convert the timezone into a wide character string. After that, converting the wide character string back to multi-byte string before printing out the time and timezone.

Testing: ran the test case in the bug report manually on:

- Windows with ja, zh-tw, and en locales;

- Linux and Mac OS with en locale.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255239](https://bugs.openjdk.java.net/browse/JDK-8255239): The timezone of the hs_err_pid log file is corrupted in Japanese locale


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1023/head:pull/1023`
`$ git checkout pull/1023`
