### PR TITLE
8254742: InputStream::readNBytes(int) result may contain zeros not in input

### DIFF
--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -415,6 +415,9 @@ public abstract class InputStream implements Closeable {
             if (nread > 0) {
                 if (MAX_BUFFER_SIZE - total < nread) {
                     throw new OutOfMemoryError("Required array size too large");
+                }
+                if (nread < buf.length) {
+                    buf = Arrays.copyOfRange(buf, 0, nread);
                 }
                 total += nread;
                 if (result == null) {


### PR DESCRIPTION
InputStream::readNBytes() invokes read(byte[],int,int) repeatedly to load bytes into a sequence of intermediate arrays. If an intermediate array is not completely filled before being added to the list of arrays the contents of which are eventually concatenated to produce the result, then the unfilled part of the intermediate array will contribute zeros to the result which are not actually in the input. This can occur for example if n < 8192 bytes are read into an intermediate array without filling it, and the next read() returns zero. It is proposed to detect when an intermediate array is only partially full, and to copy the valid range of the array into a new array which is instead appended to the list of component arrays.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254742](https://bugs.openjdk.java.net/browse/JDK-8254742): InputStream::readNBytes(int) result may contain zeros not in input


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1024/head:pull/1024`
`$ git checkout pull/1024`
