### PR TITLE
8255785: X11 libraries should not be required by configure for headless only

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -43,9 +43,11 @@ AC_DEFUN_ONCE([LIB_DETERMINE_DEPENDENCIES],
   if test "x$OPENJDK_TARGET_OS" = xwindows || test "x$OPENJDK_TARGET_OS" = xmacosx; then
     # No X11 support on windows or macosx
     NEEDS_LIB_X11=false
+  elif test "x$ENABLE_HEADLESS_ONLY" = xtrue; then
+    # No X11 support needed when building headless only
+    NEEDS_LIB_X11=false
   else
-    # All other instances need X11, even if building headless only, libawt still
-    # needs X11 headers.
+    # All other instances need X11
     NEEDS_LIB_X11=true
   fi
 


### PR DESCRIPTION
If we build a headless only JDK, configure will require X11 libraries and headers to be present. This used to be necessary, but thanks to massive cleanups in the AWT headless code, this is no longer the case.

We should fix configure so that headless can be built without X11 libraries and headers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (9/9 running) | ⏳ (7/9 running) |    |  ⏳ (8/9 running) |

### Issue
 * [JDK-8255785](https://bugs.openjdk.java.net/browse/JDK-8255785): X11 libraries should not be required by configure for headless only


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1025/head:pull/1025`
`$ git checkout pull/1025`
