### PR TITLE
8180352: Add Stream.toList() method

### DIFF
--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -196,9 +196,10 @@ class ImmutableCollections {
      * elements.
      *
      * <p>A trusted array has no references retained by the caller. It can therefore be
-     * safely reused as the List's internal storage, avoiding a defensive copy. Declared
-     * with Object... instead of E... as the parameter type so that varargs calls don't
-     * accidentally create an array of type other than Object[].
+     * safely reused as the List's internal storage, avoiding a defensive copy. The array's
+     * class must be Object[].class. This method is declared with a parameter type of
+     * Object... instead of E... so that a varargs call doesn't accidentally create an array
+     * of some class other than Object[].class.
      *
      * @param <E> the List's element type
      * @param input the input array
@@ -206,29 +207,27 @@ class ImmutableCollections {
      */
     @SuppressWarnings("unchecked")
     static <E> List<E> listFromTrustedArray(Object... input) {
+        assert input.getClass() == Object[].class;
         for (Object o : input) { // implicit null check of 'input' array
             Objects.requireNonNull(o);
         }
 
-        switch (input.length) {
-            case 0:
-                return (List<E>) ImmutableCollections.EMPTY_LIST;
-            case 1:
-                return (List<E>) new List12<>(input[0]);
-            case 2:
-                return (List<E>) new List12<>(input[0], input[1]);
-            default:
-                return (List<E>) new ListN<>(input, false);
-        }
+        return switch (input.length) {
+            case 0  -> (List<E>) ImmutableCollections.EMPTY_LIST;
+            case 1  -> (List<E>) new List12<>(input[0]);
+            case 2  -> (List<E>) new List12<>(input[0], input[1]);
+            default -> (List<E>) new ListN<>(input, false);
+        };
     }
 
     /**
      * Creates a new List from a trusted array, allowing null elements.
      *
      * <p>A trusted array has no references retained by the caller. It can therefore be
-     * safely reused as the List's internal storage, avoiding a defensive copy. Declared
-     * with Object... instead of E... as the parameter type so that varargs calls don't
-     * accidentally create an array of type other than Object[].
+     * safely reused as the List's internal storage, avoiding a defensive copy. The array's
+     * class must be Object[].class. This method is declared with a parameter type of
+     * Object... instead of E... so that a varargs call doesn't accidentally create an array
+     * of some class other than Object[].class.
      *
      * <p>Avoids creating a List12 instance, as it cannot accommodate null elements.
      *
@@ -238,6 +237,7 @@ class ImmutableCollections {
      */
     @SuppressWarnings("unchecked")
     static <E> List<E> listFromTrustedArrayNullsAllowed(Object... input) {
+        assert input.getClass() == Object[].class;
         if (input.length == 0) {
             return (List<E>) EMPTY_LIST_NULLS;
         } else {

--- a/src/java.base/share/classes/java/util/List.java
+++ b/src/java.base/share/classes/java/util/List.java
@@ -842,7 +842,7 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3) {
-        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3);
+        return ImmutableCollections.listFromTrustedArray(e1, e2, e3);
     }
 
     /**
@@ -861,7 +861,7 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4) {
-        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4);
+        return ImmutableCollections.listFromTrustedArray(e1, e2, e3, e4);
     }
 
     /**
@@ -881,7 +881,7 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4, E e5) {
-        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4, e5);
+        return ImmutableCollections.listFromTrustedArray(e1, e2, e3, e4, e5);
     }
 
     /**
@@ -902,8 +902,8 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
-        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4, e5,
-                                                           e6);
+        return ImmutableCollections.listFromTrustedArray(e1, e2, e3, e4, e5,
+                                                         e6);
     }
 
     /**
@@ -925,8 +925,8 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
-        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4, e5,
-                                                           e6, e7);
+        return ImmutableCollections.listFromTrustedArray(e1, e2, e3, e4, e5,
+                                                         e6, e7);
     }
 
     /**
@@ -949,8 +949,8 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
-        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4, e5,
-                                                           e6, e7, e8);
+        return ImmutableCollections.listFromTrustedArray(e1, e2, e3, e4, e5,
+                                                         e6, e7, e8);
     }
 
     /**
@@ -974,8 +974,8 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
-        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4, e5,
-                                                           e6, e7, e8, e9);
+        return ImmutableCollections.listFromTrustedArray(e1, e2, e3, e4, e5,
+                                                         e6, e7, e8, e9);
     }
 
     /**
@@ -1000,8 +1000,8 @@ public interface List<E> extends Collection<E> {
      * @since 9
      */
     static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
-        return ImmutableCollections.ListN.fromTrustedArray(e1, e2, e3, e4, e5,
-                                                           e6, e7, e8, e9, e10);
+        return ImmutableCollections.listFromTrustedArray(e1, e2, e3, e4, e5,
+                                                         e6, e7, e8, e9, e10);
     }
 
     /**
@@ -1042,7 +1042,7 @@ public interface List<E> extends Collection<E> {
             case 2:
                 return new ImmutableCollections.List12<>(elements[0], elements[1]);
             default:
-                return ImmutableCollections.ListN.fromArray(elements);
+                return ImmutableCollections.listFromArray(elements);
         }
     }
 

--- a/src/java.base/share/classes/java/util/stream/ReferencePipeline.java
+++ b/src/java.base/share/classes/java/util/stream/ReferencePipeline.java
@@ -26,6 +26,7 @@ package java.util.stream;
 
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Spliterator;
@@ -44,6 +45,7 @@ import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToIntFunction;
 import java.util.function.ToLongFunction;
+import jdk.internal.access.SharedSecrets;
 
 /**
  * Abstract base class for an intermediate pipeline stage or pipeline source
@@ -618,6 +620,11 @@ abstract class ReferencePipeline<P_IN, P_OUT>
     @Override
     public final Object[] toArray() {
         return toArray(Object[]::new);
+    }
+
+    @Override
+    public List<P_OUT> toList() {
+        return SharedSecrets.getJavaUtilCollectionAccess().listFromTrustedArrayNullsAllowed(this.toArray());
     }
 
     @Override

--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -1164,9 +1164,10 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
 
     /**
      * Accumulates the elements of this stream into a {@code List}. The elements in
-     * the list will be in this stream's encounter order, if one exists. There are no
-     * guarantees on the implementation type, mutability, serializability, or
-     * thread-safety of the returned List.
+     * the list will be in this stream's encounter order, if one exists. The returned List
+     * is unmodifiable; calls to any mutator method will always cause
+     * {@code UnsupportedOperationException} to be thrown. There are no
+     * guarantees on the implementation type or serializability of the returned List.
      *
      * <p>The returned instance may be <a href="../lang/doc-files/ValueBased.html">value-based</a>.
      * Callers should make no assumptions about the identity of the returned instances.
@@ -1175,13 +1176,16 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
      *
      * <p>This is a <a href="package-summary.html#StreamOps">terminal operation</a>.
      *
-     * @implSpec The default implementation returns a List produced as if by the following:
+     * @apiNote If more control over the returned object is required, use
+     * {@link Collectors#toCollection(Supplier)}.
+     *
+     * @implSpec The implementation in this interface returns a List produced as if by the following:
      * <pre>{@code
      * Collections.unmodifiableList(new ArrayList<>(Arrays.asList(this.toArray())))
      * }</pre>
      *
-     * @apiNote If more control over the returned object is required, use
-     * {@link Collectors#toCollection(Supplier)}.
+     * @implNote Most instances of Stream will override this method and provide an implementation
+     * that is highly optimized compared to the implementation in this interface.
      *
      * @return a List containing the stream elements
      *

--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -1163,6 +1163,36 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
     <R, A> R collect(Collector<? super T, A, R> collector);
 
     /**
+     * Accumulates the elements of this stream into a {@code List}. The elements in
+     * the list will be in this stream's encounter order, if one exists. There are no
+     * guarantees on the implementation type, mutability, serializability, or
+     * thread-safety of the returned List.
+     *
+     * <p>The returned instance may be <a href="../lang/doc-files/ValueBased.html">value-based</a>.
+     * Callers should make no assumptions about the identity of the returned instances.
+     * Identity-sensitive operations on these instances (reference equality ({@code ==}),
+     * identity hash code, and synchronization) are unreliable and should be avoided.
+     *
+     * <p>This is a <a href="package-summary.html#StreamOps">terminal operation</a>.
+     *
+     * @implSpec The default implementation returns a List produced as if by the following:
+     * <pre>{@code
+     * Collections.unmodifiableList(new ArrayList<>(Arrays.asList(this.toArray())))
+     * }</pre>
+     *
+     * @apiNote If more control over the returned object is required, use
+     * {@link Collectors#toCollection(Supplier)}.
+     *
+     * @return a List containing the stream elements
+     *
+     * @since 16
+     */
+    @SuppressWarnings("unchecked")
+    default List<T> toList() {
+        return (List<T>) Collections.unmodifiableList(new ArrayList<>(Arrays.asList(this.toArray())));
+    }
+
+    /**
      * Returns the minimum element of this stream according to the provided
      * {@code Comparator}.  This is a special case of a
      * <a href="package-summary.html#Reduction">reduction</a>.

--- a/src/java.base/share/classes/jdk/internal/access/JavaUtilCollectionAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaUtilCollectionAccess.java
@@ -29,4 +29,5 @@ import java.util.List;
 
 public interface JavaUtilCollectionAccess {
     <E> List<E> listFromTrustedArray(Object[] array);
+    <E> List<E> listFromTrustedArrayNullsAllowed(Object[] array);
 }

--- a/test/jdk/java/util/List/ListFactories.java
+++ b/test/jdk/java/util/List/ListFactories.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.stream.Stream;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -357,6 +358,19 @@ public class ListFactories {
     @Test(expectedExceptions=NullPointerException.class)
     public void copyOfRejectsNullElements() {
         List<Integer> list = List.copyOf(Arrays.asList(1, null, 3));
+    }
+
+    @Test(expectedExceptions=NullPointerException.class)
+    public void copyOfRejectsNullElements2() {
+        List<String> list = List.copyOf(Stream.of("a", null, "c").toList());
+    }
+
+    @Test
+    public void copyOfCopiesNullAllowingList() {
+        List<String> orig = Stream.of("a", "b", "c").toList();
+        List<String> copy = List.copyOf(orig);
+
+        assertNotSame(orig, copy);
     }
 
     @Test

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/ToListOpTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/ToListOpTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.tests.java.util.stream;
+
+import org.testng.annotations.Test;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.*;
+
+import static java.util.Comparator.*;
+import static java.util.stream.LambdaTestHelpers.*;
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * ToListOpTest
+ */
+@Test
+public class ToListOpTest extends OpTestCase {
+
+    public void testToList() {
+        assertCountSum(countTo(0).stream().toList(), 0, 0);
+        assertCountSum(countTo(10).stream().toList(), 10, 55);
+    }
+
+    private void checkUnmodifiable(List<Integer> list) {
+        try {
+            list.add(Integer.MIN_VALUE);
+            fail("List.add did not throw UnsupportedOperationException");
+        } catch (UnsupportedOperationException ignore) { }
+
+        if (list.size() > 0) {
+            try {
+                list.set(0, Integer.MAX_VALUE);
+                fail("List.set did not throw UnsupportedOperationException");
+            } catch (UnsupportedOperationException ignore) { }
+        }
+    }
+
+    @Test(dataProvider = "withNull:StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
+    public void testOps(String name, TestData.OfRef<Integer> data) {
+        List<Integer> objects = exerciseTerminalOps(data, s -> s.toList());
+        checkUnmodifiable(objects);
+    }
+
+    @Test(dataProvider = "withNull:StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
+    public void testDefaultOps(String name, TestData.OfRef<Integer> data) {
+        List<Integer> objects = exerciseTerminalOps(data, s -> DefaultMethodStreams.delegateTo(s).toList());
+        checkUnmodifiable(objects);
+    }
+
+    @Test(dataProvider = "withNull:StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
+    public void testOpsWithMap(String name, TestData.OfRef<Integer> data) {
+        // Retain the size of the source
+        // This should kick in the parallel evaluation optimization for tasks stuffing elements into a shared array
+
+        List<Integer> objects = exerciseTerminalOps(data, s -> s.map(i -> i == null ? 0 : (Integer) (i + i)), s -> s.toList());
+        assertTrue(objects.size() == data.size());
+    }
+
+    @Test(dataProvider = "withNull:StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
+    public void testOpsWithSorted(String name, TestData.OfRef<Integer> data) {
+        // Retain the size of the source
+        // This should kick in the parallel evaluation optimization for tasks stuffing elements into a shared array
+
+        List<Integer> objects = exerciseTerminalOps(data, s -> s.sorted(nullsLast(naturalOrder())), s -> s.toList());
+        assertTrue(objects.size() == data.size());
+    }
+
+    @Test(dataProvider = "withNull:StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
+    public void testOpsWithFlatMap(String name, TestData.OfRef<Integer> data) {
+        // Double the size of the source
+        // Fixed size optimizations will not be used
+
+        List<Object> objects = exerciseTerminalOps(data,
+                                                   s -> s.flatMap(e -> Arrays.stream(new Object[] { e, e })),
+                                                   s -> s.toList());
+        assertTrue(objects.size() == data.size() * 2);
+    }
+
+    @Test(dataProvider = "withNull:StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
+    public void testOpsWithFilter(String name, TestData.OfRef<Integer> data) {
+        // Reduce the size of the source
+        // Fixed size optimizations will not be used
+
+        exerciseTerminalOps(data, s -> s.filter(i -> i == null ? false : LambdaTestHelpers.pEven.test(i)), s -> s.toList());
+    }
+
+    private List<Function<Stream<Integer>, Stream<Integer>>> uniqueAndSortedPermutations =
+            LambdaTestHelpers.permuteStreamFunctions(Arrays.asList(
+                    s -> s.distinct(),
+                    s -> s.distinct(),
+                    s -> s.sorted(),
+                    s -> s.sorted()
+            ));
+
+    @Test(dataProvider = "StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
+    public void testDistinctAndSortedPermutations(String name, TestData.OfRef<Integer> data) {
+        for (Function<Stream<Integer>, Stream<Integer>> f : uniqueAndSortedPermutations) {
+            exerciseTerminalOps(data, f, s -> s.toList());
+        }
+    }
+
+    private List<Function<Stream<Integer>, Stream<Integer>>> statefulOpPermutations =
+            LambdaTestHelpers.permuteStreamFunctions(Arrays.asList(
+                    s -> s.limit(10),
+                    s -> s.distinct(),
+                    s -> s.sorted()
+            ));
+
+    private <T extends Object> ResultAsserter<List<T>> statefulOpResultAsserter(TestData.OfRef<Integer> data) {
+        return (act, exp, ord, par) -> {
+            if (par) {
+                if (!data.isOrdered()) {
+                    // Relax the checking if the data source is unordered
+                    // It is not exactly possible to determine if the limit
+                    // operation is present and if it is before or after
+                    // the sorted operation
+                    // If the limit operation is present and before the sorted
+                    // operation then the sub-set output after limit is a
+                    // non-deterministic sub-set of the source
+                    List<Integer> expected = new ArrayList<>();
+                    data.forEach(expected::add);
+
+                    assertEquals(act.size(), exp.size());
+                    assertTrue(expected.containsAll(act));
+                    return;
+                }
+                else if (!ord) {
+                    LambdaTestHelpers.assertContentsUnordered(act, exp);
+                    return;
+                }
+            }
+            assertEquals(act, exp);
+        };
+    }
+
+    @Test(dataProvider = "StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class,
+          groups = { "serialization-hostile" })
+    public void testStatefulOpPermutations(String name, TestData.OfRef<Integer> data) {
+        for (Function<Stream<Integer>, Stream<Integer>> f : statefulOpPermutations) {
+            withData(data).terminal(f, s -> s.toList())
+                    .resultAsserter(statefulOpResultAsserter(data))
+                    .exercise();
+        }
+    }
+
+}

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/ToListOpTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/ToListOpTest.java
@@ -25,12 +25,12 @@ package org.openjdk.tests.java.util.stream;
 import org.testng.annotations.Test;
 
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.*;
 
-import static java.util.Comparator.*;
 import static java.util.stream.LambdaTestHelpers.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 
 /**
@@ -58,112 +58,32 @@ public class ToListOpTest extends OpTestCase {
         }
     }
 
-    @Test(dataProvider = "withNull:StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
+    @Test(dataProvider = "StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
     public void testOps(String name, TestData.OfRef<Integer> data) {
         List<Integer> objects = exerciseTerminalOps(data, s -> s.toList());
         checkUnmodifiable(objects);
+        assertFalse(objects.contains(null));
     }
 
     @Test(dataProvider = "withNull:StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
+    public void testOpsWithNull(String name, TestData.OfRef<Integer> data) {
+        List<Integer> objects = exerciseTerminalOps(data, s -> s.toList());
+        checkUnmodifiable(objects);
+        assertTrue(objects.contains(null));
+    }
+
+    @Test(dataProvider = "StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
     public void testDefaultOps(String name, TestData.OfRef<Integer> data) {
         List<Integer> objects = exerciseTerminalOps(data, s -> DefaultMethodStreams.delegateTo(s).toList());
         checkUnmodifiable(objects);
+        assertFalse(objects.contains(null));
     }
 
     @Test(dataProvider = "withNull:StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
-    public void testOpsWithMap(String name, TestData.OfRef<Integer> data) {
-        // Retain the size of the source
-        // This should kick in the parallel evaluation optimization for tasks stuffing elements into a shared array
-
-        List<Integer> objects = exerciseTerminalOps(data, s -> s.map(i -> i == null ? 0 : (Integer) (i + i)), s -> s.toList());
-        assertTrue(objects.size() == data.size());
-    }
-
-    @Test(dataProvider = "withNull:StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
-    public void testOpsWithSorted(String name, TestData.OfRef<Integer> data) {
-        // Retain the size of the source
-        // This should kick in the parallel evaluation optimization for tasks stuffing elements into a shared array
-
-        List<Integer> objects = exerciseTerminalOps(data, s -> s.sorted(nullsLast(naturalOrder())), s -> s.toList());
-        assertTrue(objects.size() == data.size());
-    }
-
-    @Test(dataProvider = "withNull:StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
-    public void testOpsWithFlatMap(String name, TestData.OfRef<Integer> data) {
-        // Double the size of the source
-        // Fixed size optimizations will not be used
-
-        List<Object> objects = exerciseTerminalOps(data,
-                                                   s -> s.flatMap(e -> Arrays.stream(new Object[] { e, e })),
-                                                   s -> s.toList());
-        assertTrue(objects.size() == data.size() * 2);
-    }
-
-    @Test(dataProvider = "withNull:StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
-    public void testOpsWithFilter(String name, TestData.OfRef<Integer> data) {
-        // Reduce the size of the source
-        // Fixed size optimizations will not be used
-
-        exerciseTerminalOps(data, s -> s.filter(i -> i == null ? false : LambdaTestHelpers.pEven.test(i)), s -> s.toList());
-    }
-
-    private List<Function<Stream<Integer>, Stream<Integer>>> uniqueAndSortedPermutations =
-            LambdaTestHelpers.permuteStreamFunctions(Arrays.asList(
-                    s -> s.distinct(),
-                    s -> s.distinct(),
-                    s -> s.sorted(),
-                    s -> s.sorted()
-            ));
-
-    @Test(dataProvider = "StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class)
-    public void testDistinctAndSortedPermutations(String name, TestData.OfRef<Integer> data) {
-        for (Function<Stream<Integer>, Stream<Integer>> f : uniqueAndSortedPermutations) {
-            exerciseTerminalOps(data, f, s -> s.toList());
-        }
-    }
-
-    private List<Function<Stream<Integer>, Stream<Integer>>> statefulOpPermutations =
-            LambdaTestHelpers.permuteStreamFunctions(Arrays.asList(
-                    s -> s.limit(10),
-                    s -> s.distinct(),
-                    s -> s.sorted()
-            ));
-
-    private <T extends Object> ResultAsserter<List<T>> statefulOpResultAsserter(TestData.OfRef<Integer> data) {
-        return (act, exp, ord, par) -> {
-            if (par) {
-                if (!data.isOrdered()) {
-                    // Relax the checking if the data source is unordered
-                    // It is not exactly possible to determine if the limit
-                    // operation is present and if it is before or after
-                    // the sorted operation
-                    // If the limit operation is present and before the sorted
-                    // operation then the sub-set output after limit is a
-                    // non-deterministic sub-set of the source
-                    List<Integer> expected = new ArrayList<>();
-                    data.forEach(expected::add);
-
-                    assertEquals(act.size(), exp.size());
-                    assertTrue(expected.containsAll(act));
-                    return;
-                }
-                else if (!ord) {
-                    LambdaTestHelpers.assertContentsUnordered(act, exp);
-                    return;
-                }
-            }
-            assertEquals(act, exp);
-        };
-    }
-
-    @Test(dataProvider = "StreamTestData<Integer>", dataProviderClass = StreamTestDataProvider.class,
-          groups = { "serialization-hostile" })
-    public void testStatefulOpPermutations(String name, TestData.OfRef<Integer> data) {
-        for (Function<Stream<Integer>, Stream<Integer>> f : statefulOpPermutations) {
-            withData(data).terminal(f, s -> s.toList())
-                    .resultAsserter(statefulOpResultAsserter(data))
-                    .exercise();
-        }
+    public void testDefaultOpsWithNull(String name, TestData.OfRef<Integer> data) {
+        List<Integer> objects = exerciseTerminalOps(data, s -> DefaultMethodStreams.delegateTo(s).toList());
+        checkUnmodifiable(objects);
+        assertTrue(objects.contains(null));
     }
 
 }


### PR DESCRIPTION
This change introduces a new terminal operation on Stream. This looks like a convenience method for Stream.collect(Collectors.toList()) or Stream.collect(Collectors.toUnmodifiableList()), but it's not. Having this method directly on Stream enables it to do what can't easily by done by a Collector. In particular, it allows the stream to deposit results directly into a destination array (even in parallel) and have this array be wrapped in an unmodifiable List without copying.

In the past we've kept most things from the Collections Framework as implementations of Collector, not directly on Stream, whereas only fundamental things (like toArray) appear directly on Stream. This is true of most Collections, but it does seem that List is special. It can be a thin wrapper around an array; it can handle generics better than arrays; and unlike an array, it can be made unmodifiable (shallowly immutable); and it can be value-based. See John Rose's comments in the bug report:

https://bugs.openjdk.java.net/browse/JDK-8180352?focusedCommentId=14133065&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14133065

This operation is null-tolerant, which matches the rest of Streams. This isn't specified, though; a general statement about null handling in Streams is probably warranted at some point.

Finally, this method is indeed quite convenient (if the caller can deal with what this operation returns), as collecting into a List is the most common stream terminal operation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8180352](https://bugs.openjdk.java.net/browse/JDK-8180352): Add Stream.toList() method


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1026/head:pull/1026`
`$ git checkout pull/1026`
