### PR TITLE
8233561: [TESTBUG] Swing text test bug8014863.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -778,7 +778,6 @@ javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-al
 javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JTree/6263446/bug6263446.java 8213125 macosx-all
-javax/swing/text/View/8014863/bug8014863.java 8233561 macosx-all
 javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233562 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java 8233555 macosx-all

--- a/test/jdk/javax/swing/text/View/8014863/bug8014863.java
+++ b/test/jdk/javax/swing/text/View/8014863/bug8014863.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ public class bug8014863 {
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
         glyphViews = new ArrayList<GlyphView>();
 
         createAndShowGUI(text1);
@@ -152,6 +152,7 @@ public class bug8014863 {
 
                 frame.add(editorPane);
                 frame.setSize(200, 200);
+                frame.setLocationRelativeTo(null);
                 frame.setVisible(true);
             }
         });


### PR DESCRIPTION
This issue is related to not giving permission for terminal to control things in System Preferences -> Security & privacy -> Privacy -> Accessibility.

I have verified the test in our CI and removed it from problemlist. There are small tweaks in test also.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (9/9 running) | ⏳ (6/9 running) |    |  ⏳ (9/9 running) |

### Issue
 * [JDK-8233561](https://bugs.openjdk.java.net/browse/JDK-8233561): [TESTBUG] Swing text test bug8014863.java fails on macos


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1027/head:pull/1027`
`$ git checkout pull/1027`
