### PR TITLE
8233562: [TESTBUG] Swing StyledEditorKit test bug4506788.java fails on MacOS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -779,7 +779,6 @@ javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JTree/6263446/bug6263446.java 8213125 macosx-all
 javax/swing/text/View/8014863/bug8014863.java 8233561 macosx-all
-javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233562 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java 8233555 macosx-all
 javax/swing/JRadioButton/8075609/bug8075609.java 8233555 macosx-all

--- a/test/jdk/javax/swing/text/StyledEditorKit/4506788/bug4506788.java
+++ b/test/jdk/javax/swing/text/StyledEditorKit/4506788/bug4506788.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,6 +65,7 @@ public class bug4506788 {
         Robot robot;
         try {
             robot = new Robot();
+            robot.setAutoDelay(100);
         } catch (AWTException e) {
             throw new RuntimeException("Robot could not be created");
         }
@@ -78,7 +79,6 @@ public class bug4506788 {
             throw new RuntimeException("Could not get JEditorPane location on screen");
         }
 
-        robot.setAutoDelay(50);
         robot.mouseMove(p.x, p.y);
         robot.mousePress(InputEvent.BUTTON1_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_MASK);


### PR DESCRIPTION
This issue is related to not giving permission for terminal to control things in System Preferences -> Security & privacy -> Privacy -> Accessibility.

I have verified the test in our CI and removed it from problemlist. There are small tweaks in test also.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (5/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8233562](https://bugs.openjdk.java.net/browse/JDK-8233562): [TESTBUG] Swing StyledEditorKit test bug4506788.java fails on MacOS


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to 83fef1fa427da42735815516b5eb22cb612d4e48


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1028/head:pull/1028`
`$ git checkout pull/1028`
