### PR TITLE
8255796: Zero: CASE(_new) should replenish TLABs properly

### DIFF
--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -2069,30 +2069,13 @@ run:
           if (ik->is_initialized() && ik->can_be_fastpath_allocated() ) {
             size_t obj_size = ik->size_helper();
             oop result = NULL;
-            // If the TLAB isn't pre-zeroed then we'll have to do it
-            bool need_zero = !ZeroTLAB;
             if (UseTLAB) {
               result = (oop) THREAD->tlab().allocate(obj_size);
             }
-            // Disable non-TLAB-based fast-path, because profiling requires that all
-            // allocations go through InterpreterRuntime::_new() if THREAD->tlab().allocate
-            // returns NULL.
-            if (result == NULL) {
-              need_zero = true;
-              // Try allocate in shared eden
-            retry:
-              HeapWord* compare_to = *Universe::heap()->top_addr();
-              HeapWord* new_top = compare_to + obj_size;
-              if (new_top <= *Universe::heap()->end_addr()) {
-                if (Atomic::cmpxchg(Universe::heap()->top_addr(), compare_to, new_top) != compare_to) {
-                  goto retry;
-                }
-                result = (oop) compare_to;
-              }
-            }
             if (result != NULL) {
-              // Initialize object (if nonzero size and need) and then the header
-              if (need_zero ) {
+              // Initialize object (if nonzero size and need) and then the header.
+              // If the TLAB isn't pre-zeroed then we'll have to do it.
+              if (!ZeroTLAB) {
                 HeapWord* to_zero = cast_from_oop<HeapWord*>(result) + sizeof(oopDesc) / oopSize;
                 obj_size -= sizeof(oopDesc) / oopSize;
                 if (obj_size > 0 ) {


### PR DESCRIPTION
If you look at how current `CASE(_new)` is structured, then you will notice an odd thing:

```
if (ik->is_initialized() && ik->can_be_fastpath_allocated() ) {
  size_t obj_size = ik->size_helper();
  oop result = NULL;
  if (UseTLAB) {
    result = (oop) THREAD->tlab().allocate(obj_size);
  }
  if (result == NULL) {
    // allocate from inline contiguous alloc
  }
  if (result != NULL) {
    // initialize the object and return
  }
}
// Slow case allocation
CALL_VM(InterpreterRuntime::_new(THREAD, METHOD->constants(), index),
        handle_exception);
// return
``` 

The oddity here is: when TLAB is depleted and rejects the allocation, we fall through to inline contiguous alloc block that allocates the object in shared eden. That allocation is likely to succeed, and then we return from this path. But TLAB would never get replenished! Because to do that, we need to hit the slowpath allocation in `Interpreter::_new`, let in enter the runtime, and ask GC for a new TLAB!

So in the end, when +UseTLAB is enabled for Zero, the code only uses the very first issued TLAB, and then always falls through to inline contiguous allocation, until eden is completely depleted. Inline contiguous block makes the shared CAS increment that could be heavily contended under allocations. 

I have observed this with supplying +UseTLAB to my adhoc Zero runs -- it was still slow. I think we can just remove the inline contiguous allocation block, and let the whole thing slide to slowpath on failure. This would also resolve the issue of enabling Zero for GCs that do not support inline contiguous allocs (anything beyond Serial and Parallel).

I think giving up that block and make use +UseTLAB is enabled (JDK-8255782) would give us sensible improvements:

|     | Original | Original +UseTLAB | Patched +UseTLAB |
| --- | ----- | ----- | ----- |
| Simple alloc, ns/op | 302 +- 5 | 291 +- 5 | 233 +- 3 | 
| Linux x86_64 Zero release `make images` | 9m35s | ----- | 9m10s |

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255796](https://bugs.openjdk.java.net/browse/JDK-8255796): Zero: CASE(_new) should replenish TLABs properly


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1029/head:pull/1029`
`$ git checkout pull/1029`
