### PR TITLE
8255798: Remove dead headless code in CompileJavaModules.gmk

### DIFF
--- a/make/CompileJavaModules.gmk
+++ b/make/CompileJavaModules.gmk
@@ -184,10 +184,6 @@ ifeq ($(call isTargetOs, windows), true)
   java.desktop_EXCLUDES += com/sun/java/swing/plaf/gtk
 endif
 
-ifdef BUILD_HEADLESS_ONLY
-  java.desktop_EXCLUDES += sun/applet
-endif
-
 ifeq ($(call isTargetOs, windows macosx), false)
   java.desktop_EXCLUDE_FILES += sun/awt/AWTCharset.java
 endif


### PR DESCRIPTION
The variable BUILD_HEADLESS_ONLY is no longer set. And sun/applet does not exist anymore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255798](https://bugs.openjdk.java.net/browse/JDK-8255798): Remove dead headless code in CompileJavaModules.gmk


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1031/head:pull/1031`
`$ git checkout pull/1031`
