### PR TITLE
JDK-8255681: print callstack in error case in runAWTLoopWithApp

### DIFF
--- a/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.m
+++ b/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,6 +334,7 @@ AWT_ASSERT_APPKIT_THREAD;
             [app run];
         } @catch (NSException* e) {
             NSLog(@"Apple AWT Startup Exception: %@", [e description]);
+            NSLog(@"Apple AWT Startup Exception callstack: %@", [e callStackSymbols]);
             NSLog(@"Apple AWT Restarting Native Event Thread");
 
             [app stop:app];


### PR DESCRIPTION
Currently in case of occurences of an NSException in runAWTLoopWithApp we catch the exception just print a simple error message like this :

2020-10-30 15:28:33.027 java[634:8435] Apple AWT Startup Exception: Cannot lock focus on image <NSImage 0x7fd350d7f9f0 Size={0, 0} RepProvider=(null)>, because it is size zero.
2020-10-30 15:28:33.306 java[634:8435] Apple AWT Restarting Native Event Thread

But we omit the callstack and loose valuable information. This change  adds the callstack to the output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255681](https://bugs.openjdk.java.net/browse/JDK-8255681): print callstack in error case in runAWTLoopWithApp


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1032/head:pull/1032`
`$ git checkout pull/1032`
