### PR TITLE
8255801: Race when building ct.sym build tools

### DIFF
--- a/make/modules/jdk.javadoc/Gendata.gmk
+++ b/make/modules/jdk.javadoc/Gendata.gmk
@@ -54,7 +54,7 @@ $(eval $(call SetupJavaCompilation, COMPILE_CREATE_SYMBOLS, \
     SRC := $(TOPDIR)/make/langtools/src/classes \
         $(TOPDIR)/src/jdk.jdeps/share/classes, \
     INCLUDES := build/tools/symbolgenerator com/sun/tools/classfile, \
-    BIN := $(BUILDTOOLS_OUTPUTDIR)/create_symbols, \
+    BIN := $(BUILDTOOLS_OUTPUTDIR)/create_symbols_javadoc, \
     DISABLED_WARNINGS := options, \
     JAVAC_FLAGS := \
         $(INTERIM_LANGTOOLS_ARGS) \
@@ -71,7 +71,7 @@ $(SUPPORT_OUTPUTDIR)/javadoc-symbols/symbols: \
 	$(ECHO) Creating javadoc element list
 	$(JAVA_SMALL) $(INTERIM_LANGTOOLS_ARGS) \
 	    $(COMPILECREATESYMBOLS_ADD_EXPORTS) \
-	    -classpath $(BUILDTOOLS_OUTPUTDIR)/create_symbols \
+	    -classpath $(BUILDTOOLS_OUTPUTDIR)/create_symbols_javadoc \
 	    build.tools.symbolgenerator.CreateSymbols \
 	    build-javadoc-data \
 	    $(CT_DATA_DESCRIPTION) \
@@ -79,7 +79,7 @@ $(SUPPORT_OUTPUTDIR)/javadoc-symbols/symbols: \
 	    11
 	$(JAVA_SMALL) $(INTERIM_LANGTOOLS_ARGS) \
 	    $(COMPILECREATESYMBOLS_ADD_EXPORTS) \
-	    -classpath $(BUILDTOOLS_OUTPUTDIR)/create_symbols \
+	    -classpath $(BUILDTOOLS_OUTPUTDIR)/create_symbols_javadoc \
 	    build.tools.symbolgenerator.JavadocElementList \
 	    $(JDK_OUTPUTDIR)/modules/jdk.javadoc/jdk/javadoc/internal/doclets/toolkit/resources/releases/element-list-$(JDK_SOURCE_TARGET_VERSION).txt \
 	    $(JAVADOC_MODULESOURCEPATH) \


### PR DESCRIPTION
There is a race when compiling build.tools.symbolgenerator.CreateSymbols:

[2020-11-03T07:21:12,118Z] Error: LinkageError occurred while loading main class build.tools.symbolgenerator.CreateSymbols
[2020-11-03T07:21:12,119Z] java.lang.ClassFormatError: Truncated class file
[2020-11-03T07:21:12,125Z] Gendata.gmk:69: recipe for target '/.../build/macosx-x64-open/support/javadoc-symbols/symbols' failed
[2020-11-03T07:21:12,125Z] make[3]: *** [/.../build/macosx-x64-open/support/javadoc-symbols/symbols] Error 1
[2020-11-03T07:21:12,127Z] make/Main.gmk:148: recipe for target 'jdk.javadoc-gendata' failed
[2020-11-03T07:21:12,127Z] make[2]: *** [jdk.javadoc-gendata] Error 2
[2020-11-03T07:21:12,127Z] make[2]: *** Waiting for unfinished jobs....

This was caused by https://bugs.openjdk.java.net/browse/JDK-8216497, which started compiling the same buildtool twic, in different, independent makefiles, to the same output directory.

The long term correct solution is to fix https://bugs.openjdk.java.net/browse/JDK-8241463.

For now, I opted to just make sure the output is placed in separate directories to avoid the race. We will still compile the build tool twice; it's annoying but not a major performance problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (2/9 running) | ⏳ (3/9 running) | ⏳ (8/9 running) | ⏳ (2/9 running) |

### Issue
 * [JDK-8255801](https://bugs.openjdk.java.net/browse/JDK-8255801): Race when building ct.sym build tools


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1037/head:pull/1037`
`$ git checkout pull/1037`
