### PR TITLE
8255838: Use 32-bit immediate movslq in macro assembler if 64-bit value fits in 32 bits on x86_64

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -714,8 +714,12 @@ void MacroAssembler::movptr(Register dst, ArrayAddress src) {
 
 // src should NEVER be a real pointer. Use AddressLiteral for true pointers
 void MacroAssembler::movptr(Address dst, intptr_t src) {
-  mov64(rscratch1, src);
-  movq(dst, rscratch1);
+  if (is_simm32(src)) {
+    movptr(dst, checked_cast<int32_t>(src));
+  } else {
+    mov64(rscratch1, src);
+    movq(dst, rscratch1);
+  }
 }
 
 // These are mostly for initializing NULL


### PR DESCRIPTION
Currently, Macro::Assembler(Address dst, intprt_t src) on x64 uses an intermediate scratch register to store the 64-bit immediate.

```
void MacroAssembler::movptr(Address dst, intptr_t src) {
  mov64(rscratch1, src);
  movq(dst, rscratch1);
}
```

But, if the value fits into 32-bits, we can also explicitly use the 32-bit immediate overload, which saves an instruction and a register use, by using movslq/movabs instead (sig extended move).

This ends up saving about 90k instructions on hello world. It also reduces the size of the interpreter by about 4k.

Special thanks to Claes for prior discussion and help with testing.

Testing: tier1-3, local startup profiling

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255838](https://bugs.openjdk.java.net/browse/JDK-8255838): Use 32-bit immediate movslq in macro assembler if 64-bit value fits in 32 bits on x86_64


### Reviewers
 * [Azeem Jiva](https://openjdk.java.net/census#azeemj) (@AzeemJiva - Author)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1038/head:pull/1038`
`$ git checkout pull/1038`
