### PR TITLE
8255799: AArch64: CPU_A53MAC feature may be set incorrectly

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -41,6 +41,8 @@ int VM_Version::_variant;
 int VM_Version::_revision;
 int VM_Version::_stepping;
 
+int VM_Version::_max_cpu_cores;
+
 int VM_Version::_zva_length;
 int VM_Version::_dcache_line_size;
 int VM_Version::_icache_line_size;
@@ -181,10 +183,11 @@ void VM_Version::initialize() {
   }
 
   if (_cpu == CPU_ARM && (_model == 0xd07 || _model2 == 0xd07)) _features |= CPU_STXR_PREFETCH;
-  // If an olde style /proc/cpuinfo (cores == 1) then if _model is an A57 (0xd07)
+  // If max number of cores (on Linux reported in /proc/cpuinfo) then if _model is an A57 (0xd07)
   // we assume the worst and assume we could be on a big little system and have
   // undisclosed A53 cores which we could be swapped to at any stage
-  if (_cpu == CPU_ARM && os::processor_count() == 1 && _model == 0xd07) _features |= CPU_A53MAC;
+  assert(_max_cpu_cores != 0, "should be initialized");
+  if (_cpu == CPU_ARM && _max_cpu_cores == 1 && _model == 0xd07) _features |= CPU_A53MAC;
 
   char buf[512];
   sprintf(buf, "0x%02x:0x%x:0x%03x:%d", _cpu, _variant, _model, _revision);

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -40,6 +40,11 @@ protected:
   static int _revision;
   static int _stepping;
 
+  // Used to decide CPU_A53MAC feature of some single-core CPUs. Note this
+  // value may be bigger than os::processor_count, which is number of online
+  // cores on Linux, see JDK-8255716.
+  static int _max_cpu_cores;
+
   static int _zva_length;
   static int _dcache_line_size;
   static int _icache_line_size;

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -142,6 +142,7 @@ void VM_Version::get_os_cpu_info() {
     _zva_length = 4 << (dczid_el0 & 0xf);
   }
 
+  int cpu_lines = 0;
   if (FILE *f = fopen("/proc/cpuinfo", "r")) {
     // need a large buffer as the flags line may include lots of text
     char buf[1024], *p;
@@ -150,6 +151,7 @@ void VM_Version::get_os_cpu_info() {
         long v = strtol(p+1, NULL, 0);
         if (strncmp(buf, "CPU implementer", sizeof "CPU implementer" - 1) == 0) {
           _cpu = v;
+          cpu_lines++;
         } else if (strncmp(buf, "CPU variant", sizeof "CPU variant" - 1) == 0) {
           _variant = v;
         } else if (strncmp(buf, "CPU part", sizeof "CPU part" - 1) == 0) {
@@ -166,4 +168,5 @@ void VM_Version::get_os_cpu_info() {
     }
     fclose(f);
   }
+  _max_cpu_cores = cpu_lines;
 }

--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -96,4 +96,6 @@ void VM_Version::get_os_cpu_info() {
       _revision = si.wProcessorRevision & 0xFF;
     }
   }
+
+  _max_cpu_cores = os::processor_count();
 }


### PR DESCRIPTION
JDK-8255716 (#983) uncovered that os::processor_count on Linux can be not equal to number of cores reported in /proc/cpuinfo. The latter historically was used to decide CPU_A53MAC feature. This patch restores feature detection based on /proc/cpuinfo.

Testing: linux -version
Unfortunately I cannot test windows/aarch64, CC: @lewurm @luhenry

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (2/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Windows x64 (hs/tier1 gc)](https://github.com/AntonKozlov/jdk/runs/1349004097)
- [Windows x64 (hs/tier1 serviceability)](https://github.com/AntonKozlov/jdk/runs/1349004141)
- [macOS x64 (hs/tier1 gc)](https://github.com/AntonKozlov/jdk/runs/1348878853)

### Issue
 * [JDK-8255799](https://bugs.openjdk.java.net/browse/JDK-8255799): AArch64: CPU_A53MAC feature may be set incorrectly


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1039/head:pull/1039`
`$ git checkout pull/1039`
