### PR TITLE
JDK-8255850: Hotspot recompiled on first incremental build

### DIFF
--- a/make/common/JdkNativeCompilation.gmk
+++ b/make/common/JdkNativeCompilation.gmk
@@ -77,8 +77,10 @@ ifeq ($(STATIC_LIBS), true)
   FindStaticLib =
 endif
 
+# Returns the module specific java header dir if it exists.
+# Param 1 - module name
 GetJavaHeaderDir = \
-  $(wildcard $(SUPPORT_OUTPUTDIR)/headers/$(strip $1))
+  $(if $(strip $1),$(wildcard $(SUPPORT_OUTPUTDIR)/headers/$(strip $1)))
 
 # Process a dir description such as "java.base:headers" into a set of proper absolute paths.
 ProcessDir = \
@@ -123,15 +125,27 @@ JDK_RCFLAGS=$(RCFLAGS) \
 SetupJdkLibrary = $(NamedParamsMacroTemplate)
 define SetupJdkLibraryBody
   ifeq ($$($1_OUTPUT_DIR), )
-    $1_OUTPUT_DIR := $$(call FindLibDirForModule, $$(MODULE))
+    ifneq ($$(MODULE), )
+      $1_OUTPUT_DIR := $$(call FindLibDirForModule, $$(MODULE))
+    else
+      $$(error Must specify OUTPUT_DIR in a MODULE free context)
+    endif
   endif
 
   ifeq ($$($1_OBJECT_DIR), )
-    $1_OBJECT_DIR := $$(SUPPORT_OUTPUTDIR)/native/$$(MODULE)/lib$$($1_NAME)
+    ifneq ($$(MODULE), )
+      $1_OBJECT_DIR := $$(SUPPORT_OUTPUTDIR)/native/$$(MODULE)/lib$$($1_NAME)
+    else
+      $$(error Must specify OBJECT_DIR in a MODULE free context)
+    endif
   endif
 
   ifeq ($$($1_SRC), )
-    $1_SRC := $$(call FindSrcDirsForLib, $$(MODULE), $$($1_NAME))
+    ifneq ($$(MODULE), )
+      $1_SRC := $$(call FindSrcDirsForLib, $$(MODULE), $$($1_NAME))
+    else
+      $$(error Must specify SRC in a MODULE free context)
+    endif
   else
     $1_SRC := $$(foreach dir, $$($1_SRC), $$(call ProcessDir, $$(dir)))
   endif
@@ -165,7 +179,8 @@ define SetupJdkLibraryBody
   ifneq ($$($1_HEADERS_FROM_SRC), false)
     $1_SRC_HEADER_FLAGS := $$(addprefix -I, $$(wildcard $$($1_SRC)))
   endif
-  # Always add the java header dir
+
+  # Add the module specific java header dir
   $1_SRC_HEADER_FLAGS += $$(addprefix -I, $$(call GetJavaHeaderDir, $$(MODULE)))
 
   ifneq ($$($1_EXTRA_HEADER_DIRS), )
@@ -203,11 +218,19 @@ define SetupJdkExecutableBody
   $1_TYPE := EXECUTABLE
 
   ifeq ($$($1_OUTPUT_DIR), )
-    $1_OUTPUT_DIR := $$(call FindExecutableDirForModule, $$(MODULE))
+    ifneq ($$(MODULE), )
+      $1_OUTPUT_DIR := $$(call FindExecutableDirForModule, $$(MODULE))
+    else
+      $$(error Must specify OUTPUT_DIR in a MODULE free context)
+    endif
   endif
 
   ifeq ($$($1_OBJECT_DIR), )
-    $1_OBJECT_DIR := $$(SUPPORT_OUTPUTDIR)/native/$$(MODULE)/$$($1_NAME)
+    ifneq ($$(MODULE), )
+      $1_OBJECT_DIR := $$(SUPPORT_OUTPUTDIR)/native/$$(MODULE)/$$($1_NAME)
+    else
+      $$(error Must specify OBJECT_DIR in a MODULE free context)
+    endif
   endif
 
   ifeq ($$($1_VERSIONINFO_RESOURCE), )


### PR DESCRIPTION
After building the JDK from clean, the first incremental build of hotspot will recompile all of it. This is caused by a difference in the CFLAGS generated on the second go. The difference is generated in JdkNativeCompilation.gmk, where the module specific java header dir is always added to the list of include dirs. When compiling hotspot the first time, there is no such dir, and so nothing is added, but the second go, later compilation steps have created the base headers dir ($(SUPPORT_OUTPUTDIR)/headers), which is found and picked up in CFLAGS. This difference is then detected by the DependOnVariable construct for libjvm.

The fix here is to make sure SetupJdkLibrary is able to work in a context without a MODULE defined, since that is how libjvm is built. In that case, no java header dir should be added.

While fixing this I decided to go through the whole file and make sure all uses of MODULE were protected when needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255850](https://bugs.openjdk.java.net/browse/JDK-8255850): Hotspot recompiled on first incremental build


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1041/head:pull/1041`
`$ git checkout pull/1041`
