### PR TITLE
8253892: Disable misleading-indentation on clang as well as gcc

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -91,7 +91,7 @@ DISABLED_WARNINGS_clang := tautological-compare \
     undefined-var-template sometimes-uninitialized unknown-pragmas \
     delete-non-virtual-dtor missing-braces char-subscripts \
     ignored-qualifiers missing-field-initializers mismatched-tags \
-    shift-negative-value
+    shift-negative-value misleading-indentation
 
 DISABLED_WARNINGS_xlc := tautological-compare shift-negative-value
 

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -49,7 +49,7 @@ $(eval $(call SetupNativeCompilation, BUILD_LIBFDLIBM, \
     CFLAGS_windows_debug := -DLOGGING, \
     CFLAGS_aix := -qfloat=nomaf, \
     DISABLED_WARNINGS_gcc := sign-compare misleading-indentation array-bounds, \
-    DISABLED_WARNINGS_clang := sign-compare, \
+    DISABLED_WARNINGS_clang := sign-compare misleading-indentation, \
     DISABLED_WARNINGS_microsoft := 4146 4244 4018, \
     ARFLAGS := $(ARFLAGS), \
     OBJECT_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libfdlibm, \


### PR DESCRIPTION
With clang 10.0, the compiler now detects a new class of warnings. The `misleading-indentation` warning has previously been disabled on gcc for hotspot and libfdlibm.  Now we need to disable it for clang as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (2/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Windows x64 (hs/tier1 gc)](https://github.com/magicus/openjdk-sandbox/runs/1350301484)
- [Windows x64 (hs/tier1 serviceability)](https://github.com/magicus/openjdk-sandbox/runs/1350301500)
- [macOS x64 (hs/tier1 gc)](https://github.com/magicus/openjdk-sandbox/runs/1350205945)

### Issue
 * [JDK-8253892](https://bugs.openjdk.java.net/browse/JDK-8253892): Disable misleading-indentation on clang as well as gcc


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1044/head:pull/1044`
`$ git checkout pull/1044`
