### PR TITLE
8254864: vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java timed out

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/Helper.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,17 +22,28 @@
  */
 package nsk.jvmti.ResourceExhausted;
 
+import jtreg.SkippedException;
+
 public class Helper {
 
-    static native boolean gotExhaustedEvent();
+    static native int getExhaustedEventFlags();
     static native void resetExhaustedEvent();
 
-    static boolean checkResult(String eventName) {
-        if ( ! gotExhaustedEvent() ) {
+    static final int JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR = 1;
+    static final int JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP = 2;
+    static final int JVMTI_RESOURCE_EXHAUSTED_THREADS = 4;
+
+    static boolean checkResult(int expectedFlag, String eventName) {
+        int got = getExhaustedEventFlags();
+        if (got == 0) {
             System.err.println("Failure: Expected ResourceExhausted event after " + eventName + " did not occur");
             return false;
         }
 
+        if ((got & expectedFlag) == 0) {
+            System.err.println("Warning: did not get expected flag bit (expected: "+ expectedFlag + ", got: " + got + ")");
+            throw new SkippedException("Test did not get expected flag value");
+        }
         System.out.println("Got expected ResourceExhausted event");
         return true;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@
 extern "C" {
 
 static jvmtiEnv* gJvmti = NULL;
-static volatile jboolean gGotEvent = JNI_FALSE;
+static volatile jint gEventFlags = 0;
 
 void JNICALL
 resourceExhausted(jvmtiEnv *jvmti_env,
@@ -46,19 +46,19 @@ resourceExhausted(jvmtiEnv *jvmti_env,
     if (flags & JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR) NSK_DISPLAY0("Agent:    JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR\n");
     if (flags & JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP) NSK_DISPLAY0("Agent:    JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP\n");
     if (flags & JVMTI_RESOURCE_EXHAUSTED_THREADS)   NSK_DISPLAY0("Agent:    JVMTI_RESOURCE_EXHAUSTED_THREADS\n");
-    gGotEvent = JNI_TRUE;
+    gEventFlags = flags;
 }
 
-JNIEXPORT jboolean JNICALL
-Java_nsk_jvmti_ResourceExhausted_Helper_gotExhaustedEvent(JNIEnv* env, jclass cls)
+JNIEXPORT jint JNICALL
+Java_nsk_jvmti_ResourceExhausted_Helper_getExhaustedEventFlags(JNIEnv* env, jclass cls)
 {
-    return gGotEvent;
+    return gEventFlags;
 }
 
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_ResourceExhausted_Helper_resetExhaustedEvent(JNIEnv* env, jclass cls)
 {
-    gGotEvent = JNI_FALSE;
+    gEventFlags = 0;
 }
 
 #ifdef STATIC_BUILD

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java
@@ -40,6 +40,8 @@
  * @run main/othervm/native/timeout=240
  *      -agentlib:resexhausted=-waittime=5
  *      -XX:-UseGCOverheadLimit
+ *      -Xms16m
+ *      -Xmx16m
  *      nsk.jvmti.ResourceExhausted.resexhausted001
  *      -stressTime 220
  */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted002.java
@@ -64,8 +64,9 @@ public class resexhausted002 {
         }
 
         System.gc();
-        if ( ! Helper.checkResult("creating " + count + " objects") )
+        if (!Helper.checkResult(Helper.JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP, "creating " + count + " objects")) {
             return Consts.TEST_FAILED;
+        }
 
         return Consts.TEST_PASSED;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003.java
@@ -125,8 +125,10 @@ public class resexhausted003 {
         }
 
         System.gc();
-        if ( ! Helper.checkResult("loading " + count + " classes of " + bloatBytes.length + " bytes") )
+        if (!Helper.checkResult(Helper.JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR,
+                                "loading " + count + " classes of " + bloatBytes.length + " bytes")) {
             return Consts.TEST_FAILED;
+        }
 
         return Consts.TEST_PASSED;
     }


### PR DESCRIPTION
- Fixed synchronization logic in resexhausted001;
- On Windows JVM cannot produce OOM caused by thread creation failure. Massive thread creation causes big system (not VM) memory consumption, as a result test host dramatically slows down up to hang. Specifying small heap size we can get RESOURCE_EXHAUSTED_JAVA_HEAP, but this is not the goal of resexhausted001.
So I disabled resexhausted001 on Windows.
Had to implement runtime check (instead of using @requires) because resexhausted001 is also called by resexhausted004.
- Additionally resexhausted001-resexhausted003 test were improved to verify JVMTI generates ResourceExhausted event with correct flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254864](https://bugs.openjdk.java.net/browse/JDK-8254864): vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java timed out


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1046/head:pull/1046`
`$ git checkout pull/1046`
