### PR TITLE
8255863: Clean up test/jdk/java/lang/invoke/defineHiddenClass/BasicTest.java

### DIFF
--- a/test/jdk/java/lang/invoke/defineHiddenClass/BasicTest.java
+++ b/test/jdk/java/lang/invoke/defineHiddenClass/BasicTest.java
@@ -31,7 +31,7 @@
  *          BadClassFileVersion.jcod
  * @build jdk.test.lib.Utils
  *        jdk.test.lib.compiler.CompilerUtils
- * @run testng/othervm --enable-preview BasicTest
+ * @run testng/othervm BasicTest
  */
 
 import java.io.File;
@@ -77,8 +77,7 @@ public class BasicTest {
 
     @BeforeTest
     static void setup() throws IOException {
-        compileSources(SRC_DIR, CLASSES_DIR,
-                "--enable-preview", "-source", String.valueOf(Runtime.version().feature()));
+        compileSources(SRC_DIR, CLASSES_DIR);
         hiddenClassBytes = Files.readAllBytes(CLASSES_DIR.resolve("HiddenClass.class"));
 
         // compile with --release 10 with no NestHost and NestMembers attribute


### PR DESCRIPTION
test/jdk/java/lang/invoke/defineHiddenClass/BasicTest.java tests a record class.
This test no longer needs to be run with --enable-preview.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (2/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Windows x64 (hs/tier1 gc)](https://github.com/mlchung/jdk/runs/1350597068)
- [Windows x64 (hs/tier1 serviceability)](https://github.com/mlchung/jdk/runs/1350597093)
- [macOS x64 (hs/tier1 gc)](https://github.com/mlchung/jdk/runs/1350517630)

### Issue
 * [JDK-8255863](https://bugs.openjdk.java.net/browse/JDK-8255863): Clean up test/jdk/java/lang/invoke/defineHiddenClass/BasicTest.java 


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1048/head:pull/1048`
`$ git checkout pull/1048`
