### PR TITLE
8255862: Remove @SuppressWarnings from sun.misc.Unsafe

### DIFF
--- a/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
+++ b/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
@@ -636,7 +636,6 @@ public final class Unsafe {
      * @see #getInt(Object, long)
      */
     @ForceInline
-    @SuppressWarnings("preview")
     public long objectFieldOffset(Field f) {
         if (f == null) {
             throw new NullPointerException();
@@ -646,7 +645,7 @@ public final class Unsafe {
             throw new UnsupportedOperationException("can't get field offset on a hidden class: " + f);
         }
         if (declaringClass.isRecord()) {
-            throw new UnsupportedOperationException("can't get field offset on a record (preview): " + f);
+            throw new UnsupportedOperationException("can't get field offset on a record class: " + f);
         }
         return theInternalUnsafe.objectFieldOffset(f);
     }
@@ -669,7 +668,6 @@ public final class Unsafe {
      * @see #getInt(Object, long)
      */
     @ForceInline
-    @SuppressWarnings("preview")
     public long staticFieldOffset(Field f) {
         if (f == null) {
             throw new NullPointerException();
@@ -679,7 +677,7 @@ public final class Unsafe {
             throw new UnsupportedOperationException("can't get field offset on a hidden class: " + f);
         }
         if (declaringClass.isRecord()) {
-            throw new UnsupportedOperationException("can't get field offset on a record (preview): " + f);
+            throw new UnsupportedOperationException("can't get field offset on a record class: " + f);
         }
         return theInternalUnsafe.staticFieldOffset(f);
     }
@@ -695,7 +693,6 @@ public final class Unsafe {
      * this class.
      */
     @ForceInline
-    @SuppressWarnings("preview")
     public Object staticFieldBase(Field f) {
         if (f == null) {
             throw new NullPointerException();
@@ -705,7 +702,7 @@ public final class Unsafe {
             throw new UnsupportedOperationException("can't get base address on a hidden class: " + f);
         }
         if (declaringClass.isRecord()) {
-            throw new UnsupportedOperationException("can't get base address on a record (preview): " + f);
+            throw new UnsupportedOperationException("can't get base address on a record class: " + f);
         }
         return theInternalUnsafe.staticFieldBase(f);
     }


### PR DESCRIPTION
Record classes are now a standard feature in 16. @SuppressWarnings can be
removed from sun.misc.Unsafe.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (2/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Windows x64 (hs/tier1 gc)](https://github.com/mlchung/jdk/runs/1350573888)
- [Windows x64 (hs/tier1 serviceability)](https://github.com/mlchung/jdk/runs/1350573909)
- [macOS x64 (hs/tier1 gc)](https://github.com/mlchung/jdk/runs/1350514917)

### Issue
 * [JDK-8255862](https://bugs.openjdk.java.net/browse/JDK-8255862): Remove @SuppressWarnings from sun.misc.Unsafe


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1049/head:pull/1049`
`$ git checkout pull/1049`
