### PR TITLE
8255848: -Xlog:gc+heap+exit shows "used 0K"

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2437,10 +2437,11 @@ void G1CollectedHeap::print_heap_regions() const {
 }
 
 void G1CollectedHeap::print_on(outputStream* st) const {
+  size_t heap_used = Heap_lock->owned_by_self() ? used() : used_unlocked();
   st->print(" %-20s", "garbage-first heap");
   if (_hrm != NULL) {
     st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
-              capacity()/K, used_unlocked()/K);
+              capacity()/K, heap_used/K);
     st->print(" [" PTR_FORMAT ", " PTR_FORMAT ")",
               p2i(_hrm->reserved().start()),
               p2i(_hrm->reserved().end()));


### PR DESCRIPTION
Please review this small change to improve the exit heap-log for G1.

Currently if all allocations fit into one region the exit log will faulty state that the usage is 0K:
```
$ java -Xlog:gc+heap+exit -Xshare:off -Xmx16g -version
[0.072s][info][gc,heap,exit] garbage-first heap total 1032192K, used 0K [0x00000003c0000000, 0x00000007c0000000)
[0.072s][info][gc,heap,exit] region size 8192K, 1 young (8192K), 0 survivors (0K)
```

This is cause by G1 using `used_unlocked()`, which doesn't take the current allocation region(s) into account. My proposed change is to check if the `Heap_lock` is taken and if so use `used()` instead of `used_unlocked()`. For the exit logging the lock will be held, but this log is printed using `G1CollectedHeap::print_on()` and we might want to allow calling this without requiring holding the heap lock.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255848](https://bugs.openjdk.java.net/browse/JDK-8255848): -Xlog:gc+heap+exit shows "used 0K"


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1051/head:pull/1051`
`$ git checkout pull/1051`
