### PR TITLE
8255894: Remove unused StubRoutines::_zero_aligned_words

### DIFF
--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -111,8 +111,6 @@ address StubRoutines::_arrayof_jlong_disjoint_arraycopy  = CAST_FROM_FN_PTR(addr
 address StubRoutines::_arrayof_oop_disjoint_arraycopy    = CAST_FROM_FN_PTR(address, StubRoutines::arrayof_oop_copy);
 address StubRoutines::_arrayof_oop_disjoint_arraycopy_uninit  = CAST_FROM_FN_PTR(address, StubRoutines::arrayof_oop_copy_uninit);
 
-address StubRoutines::_zero_aligned_words = CAST_FROM_FN_PTR(address, Copy::zero_to_words);
-
 address StubRoutines::_data_cache_writeback              = NULL;
 address StubRoutines::_data_cache_writeback_sync         = NULL;
 

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -207,9 +207,6 @@ class StubRoutines: AllStatic {
   static address _arrayof_jshort_fill;
   static address _arrayof_jint_fill;
 
-  // zero heap space aligned to jlong (8 bytes)
-  static address _zero_aligned_words;
-
   static address _aescrypt_encryptBlock;
   static address _aescrypt_decryptBlock;
   static address _cipherBlockChaining_encryptAESCrypt;
@@ -441,8 +438,6 @@ class StubRoutines: AllStatic {
   static address dtan()                { return _dtan; }
 
   static address select_fill_function(BasicType t, bool aligned, const char* &name);
-
-  static address zero_aligned_words()  { return _zero_aligned_words; }
 
   //
   // Safefetch stub support


### PR DESCRIPTION
_zero_aligned_words was a SPARC-only optimization added by JDK-7059037

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (2/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Windows x64 (hs/tier1 gc)](https://github.com/cl4es/jdk/runs/1352882200)
- [Windows x64 (hs/tier1 serviceability)](https://github.com/cl4es/jdk/runs/1352882231)
- [macOS x64 (hs/tier1 gc)](https://github.com/cl4es/jdk/runs/1352793621)

### Issue
 * [JDK-8255894](https://bugs.openjdk.java.net/browse/JDK-8255894): Remove unused StubRoutines::_zero_aligned_words


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1053/head:pull/1053`
`$ git checkout pull/1053`
