### PR TITLE
8255895: Submit workflow artifacts miss hs_errs/replays due to ZIP include mismatch

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -368,8 +368,8 @@ jobs:
           "$HOME/linux-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip"
           .
           -i *.jtr
-          -i hs_err*
-          -i replay*
+          -i */hs_err*.log
+          -i */replay*.log
         continue-on-error: true
 
       - name: Persist test results
@@ -655,8 +655,8 @@ jobs:
           "$HOME/linux-x86${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip"
           .
           -i *.jtr
-          -i hs_err*
-          -i replay*
+          -i */hs_err*.log
+          -i */replay*.log
         continue-on-error: true
 
       - name: Persist test results
@@ -971,8 +971,8 @@ jobs:
           "$HOME/windows-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip"
           .
           -i *.jtr
-          -i hs_err*
-          -i replay*
+          -i */hs_err*.log
+          -i */replay*.log
         continue-on-error: true
 
       - name: Persist test results
@@ -1253,8 +1253,8 @@ jobs:
           "$HOME/macos-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip"
           .
           -i *.jtr
-          -i hs_err*
-          -i replay*
+          -i */hs_err*.log
+          -i */replay*.log
         continue-on-error: true
 
       - name: Persist test results


### PR DESCRIPTION
Current submit workflow omits `hs_err*.log` and `replay*.log` files, because zip matches the paths, and so only the hs_errs/replays in the current dir are picked up (and there are none). It should be preceded with `*` to match files in subdirs. Incidentally, this is why `*.jtr` match works.

Observe:

```
$ mkdir 1/2 -p
$ touch 1/2/hs_err_213123.log
$ zip -r9 test.zip . -i hs_err*
	zip warning: zip file empty
$ zip -r9 test.zip . -i */hs_err*
  adding: 1/2/hs_err_213123.log (stored 0%)
```

This was introduced in the initial implementation in JDK-8255352.

Additional testing:
 - [x] Observing current Windows failures package hs_err into archive

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (2/9 failed) | ❌ (1/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Linux x86 (hs/tier1 compiler)](https://github.com/shipilev/jdk/runs/1353057408)
- [Linux x86 (hs/tier1 gc)](https://github.com/shipilev/jdk/runs/1353057428)
- [Windows x64 (hs/tier1 serviceability)](https://github.com/shipilev/jdk/runs/1353182278)
- [macOS x64 (hs/tier1 gc)](https://github.com/shipilev/jdk/runs/1353084081)

### Issue
 * [JDK-8255895](https://bugs.openjdk.java.net/browse/JDK-8255895): Submit workflow artifacts miss hs_errs/replays due to ZIP include mismatch


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1055/head:pull/1055`
`$ git checkout pull/1055`
