### PR TITLE
JDK-8255885: Metaspace: freelist commit counter is not updated when purging

### DIFF
--- a/src/hotspot/share/memory/metaspace/chunkManager.hpp
+++ b/src/hotspot/share/memory/metaspace/chunkManager.hpp
@@ -107,6 +107,9 @@ class ChunkManager : public CHeapObj<mtMetaspace> {
   // See return_chunk().
   void return_chunk_locked(Metachunk* c);
 
+  // Calculates the total number of committed words over all chunks. Walks chunks.
+  size_t calc_committed_word_size_locked() const;
+
 public:
 
   // Creates a chunk manager with a given name (which is for debug purposes only)
@@ -167,8 +170,8 @@ public:
   // Returns number of words in all free chunks (regardless of commit state).
   size_t total_word_size() const            { return _chunks.word_size(); }
 
-  // Returns number of committed words in all free chunks.
-  size_t total_committed_word_size() const  { return _chunks.committed_word_size(); }
+  // Calculates the total number of committed words over all chunks. Walks chunks.
+  size_t calc_committed_word_size() const;
 
   // Update statistics.
   void add_to_statistics(ChunkManagerStats* out) const;

--- a/src/hotspot/share/memory/metaspace/freeChunkList.cpp
+++ b/src/hotspot/share/memory/metaspace/freeChunkList.cpp
@@ -31,6 +31,15 @@
 
 namespace metaspace {
 
+// Calculates total number of committed words over all chunks (walks chunks).
+size_t FreeChunkList::calc_committed_word_size() const {
+  size_t s = 0;
+  for (const Metachunk* c = _first; c != NULL; c = c->next()) {
+    s += c->committed_words();
+  }
+  return s;
+}
+
 void FreeChunkList::print_on(outputStream* st) const {
   if (_num_chunks.get() > 0) {
     for (const Metachunk* c = _first; c != NULL; c = c->next()) {
@@ -60,7 +69,6 @@ void FreeChunkList::verify() const {
     assert(_last == NULL, "Sanity");
   } else {
     assert(_last != NULL, "Sanity");
-    size_t committed = 0;
     int num = 0;
     bool uncommitted = (_first->committed_words() == 0);
     for (Metachunk* c = _first; c != NULL; c = c->next()) {
@@ -71,11 +79,9 @@ void FreeChunkList::verify() const {
       assert(c->prev() == NULL || c->prev()->next() == c, "back link broken");
       assert(c != c->prev() && c != c->next(), "circle");
       c->verify();
-      committed += c->committed_words();
       num++;
     }
     _num_chunks.check(num);
-    _committed_word_size.check(committed);
   }
 }
 
@@ -90,13 +96,17 @@ size_t FreeChunkListVector::word_size() const {
   return sum;
 }
 
-// Returns total committed size in all lists
-size_t FreeChunkListVector::committed_word_size() const {
+// Calculates total number of committed words over all chunks (walks chunks).
+size_t FreeChunkListVector::calc_committed_word_size() const {
   size_t sum = 0;
   for (chunklevel_t l = chunklevel::LOWEST_CHUNK_LEVEL; l <= chunklevel::HIGHEST_CHUNK_LEVEL; l++) {
-    sum += list_for_level(l)->committed_word_size();
+    sum += calc_committed_word_size_at_level(l);
   }
   return sum;
+}
+
+size_t FreeChunkListVector::calc_committed_word_size_at_level(chunklevel_t lvl) const {
+  return list_for_level(lvl)->calc_committed_word_size();
 }
 
 // Returns total committed size in all lists
@@ -146,8 +156,8 @@ void FreeChunkListVector::print_on(outputStream* st) const {
     list_for_level(l)->print_on(st);
     st->cr();
   }
-  st->print_cr("total chunks: %d, total word size: " SIZE_FORMAT ", committed word size: " SIZE_FORMAT ".",
-               num_chunks(), word_size(), committed_word_size());
+  st->print_cr("total chunks: %d, total word size: " SIZE_FORMAT ".",
+               num_chunks(), word_size());
 }
 
 #ifdef ASSERT

--- a/test/hotspot/gtest/metaspace/test_metachunklist.cpp
+++ b/test/hotspot/gtest/metaspace/test_metachunklist.cpp
@@ -112,7 +112,7 @@ TEST_VM(metaspace, freechunklist) {
 
     EXPECT_EQ(lst.num_chunks(), (int)cnt.count());
     EXPECT_EQ(lst.word_size(), cnt.total_size());
-    EXPECT_EQ(lst.committed_word_size(), committed_cnt.total_size());
+    EXPECT_EQ(lst.calc_committed_word_size(), committed_cnt.total_size());
   }
 
   // Drain each list separately, front to back. While draining observe the order
@@ -137,7 +137,7 @@ TEST_VM(metaspace, freechunklist) {
 
       EXPECT_EQ(lst.num_chunks(), (int)cnt.count());
       EXPECT_EQ(lst.word_size(), cnt.total_size());
-      EXPECT_EQ(lst.committed_word_size(), committed_cnt.total_size());
+      EXPECT_EQ(lst.calc_committed_word_size(), committed_cnt.total_size());
 
       context.return_chunk(c);
 

--- a/test/hotspot/gtest/metaspace/test_metaspacearena.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspacearena.cpp
@@ -504,7 +504,7 @@ static void test_recover_from_commit_limit_hit() {
   EXPECT_LE(allocated_from_3, Settings::commit_granule_words() * 2);
 
   // We expect the freelist to be empty of committed space...
-  EXPECT_0(context.cm().total_committed_word_size());
+  EXPECT_0(context.cm().calc_committed_word_size());
 
   //msthelper.cm().print_on(tty);
 
@@ -515,7 +515,7 @@ static void test_recover_from_commit_limit_hit() {
 
   // Should have populated the freelist with committed space
   // We expect the freelist to be empty of committed space...
-  EXPECT_GT(context.cm().total_committed_word_size(), (size_t)0);
+  EXPECT_GT(context.cm().calc_committed_word_size(), (size_t)0);
 
   // Repeat allocation from helper3, should now work.
   helper3.allocate_from_arena_with_tests_expect_success(1);


### PR DESCRIPTION
Metaspace chunks are uncommitted, under certain conditions, when being returned to the Metaspace by a dying class loader.

There are two places where this happens:
1) when individual chunks are returned (see ChunkManager::return_chunk_locked())
2) later, when CLDG::purge()->Metaspace::purge()->ChunkManager::purge() is called - all free chunks are again checked and potentially uncommitted.

Free chunks are kept in FreeChunkList. FreeChunkList has a counter for words-comitted. That counter gets updated when chunks are added and removed. However, path (2) does not change the list, it just uncommits chunks residing in that list. That passes under the FreeChunkList's radar and now the counter is off.

-----

Review note: `ChunkManager` keeps free chunks. It has an instance of `FreeChunkListVector`, which has a series (one per chunk size) of `FreeChunkList` instances. The commit counter value is handed up from `FreeChunkList` to, eventually, `ChunkManager`.

What changed:

- I removed the counter (_committed_word_size) from FreeChunkList. This seemed the simplest and safest measure. Keeping this counter up-to-date is a hassle, since chunks may get committed and uncommitted while being in this list.

- Now we calculate the number of committed words on the fly if asked, by iterating all chunks in the list and accumulating. To reflect this change, I change the name of "FreeChunkList::committed_word_size()" to "FreeChunkList::calc_committed_word_size()". In metaspace, anything named "calc_" is potentially expensive.

- Same renamings in FreeChunkListVector and ChunkManager::total_committed_word_size() - to ChunkManager::calc_committed_word_size()

Now these functions always deliver the correct result. However, they are potentially slower and now require the central metaspace lock. That is not a problem: the only user of this function is when collecting the statistics for the "VM.metaspace" jcmd report, and that happens under lock protection and walks all kind of stuff anyway, so walking the freelists won't hurt.

Just to be sure, I removed the use of these functions from ChunkManager::print_on(), even though that was just a debug function.

-----

Tests:

This patch has been tested in our nightlies for a week now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255885](https://bugs.openjdk.java.net/browse/JDK-8255885): Metaspace: freelist commit counter is not updated when purging


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1057/head:pull/1057`
`$ git checkout pull/1057`
