### PR TITLE
8255860: Clean up CDS logging related to lambda

### DIFF
--- a/src/hotspot/share/classfile/classListParser.cpp
+++ b/src/hotspot/share/classfile/classListParser.cpp
@@ -461,7 +461,6 @@ bool ClassListParser::is_matching_cp_entry(constantPoolHandle &pool, int cp_inde
 }
 
 void ClassListParser::resolve_indy(Symbol* class_name_symbol, TRAPS) {
-
   Handle class_loader(THREAD, SystemDictionary::java_system_loader());
   Handle protection_domain;
   Klass* klass = SystemDictionary::resolve_or_fail(class_name_symbol, class_loader, protection_domain, true, THREAD); // FIXME should really be just a lookup
@@ -482,8 +481,8 @@ void ClassListParser::resolve_indy(Symbol* class_name_symbol, TRAPS) {
         BootstrapInfo bootstrap_specifier(pool, pool_index, indy_index);
         Handle bsm = bootstrap_specifier.resolve_bsm(THREAD);
         if (!SystemDictionaryShared::is_supported_invokedynamic(&bootstrap_specifier)) {
-           tty->print_cr("is_supported_invokedynamic check failed for cp_index %d", pool_index);
-           continue;
+          log_debug(cds, lambda)("is_supported_invokedynamic check failed for cp_index %d", pool_index);
+          continue;
         }
         if (is_matching_cp_entry(pool, pool_index, THREAD)) {
           found = true;

--- a/src/hotspot/share/classfile/lambdaFormInvokers.cpp
+++ b/src/hotspot/share/classfile/lambdaFormInvokers.cpp
@@ -147,5 +147,5 @@ void LambdaFormInvokers::reload_class(char* name, ClassFileStream& st, TRAPS) {
 
   // exclude the existing class from dump
   SystemDictionaryShared::set_excluded(InstanceKlass::cast(klass));
-  log_info(cds)("Replaced class %s, old: %p  new: %p", name, klass, result);
+  log_info(cds, lambda)("Replaced class %s, old: %p  new: %p", name, klass, result);
 }

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -40,6 +40,7 @@
 #include "interpreter/bootstrapInfo.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "logging/log.hpp"
+#include "logging/logStream.hpp"
 #include "memory/allocation.hpp"
 #include "memory/archiveUtils.hpp"
 #include "memory/dynamicArchive.hpp"
@@ -1924,26 +1925,28 @@ bool SystemDictionaryShared::check_linking_constraints(InstanceKlass* klass, TRA
 }
 
 bool SystemDictionaryShared::is_supported_invokedynamic(BootstrapInfo* bsi) {
+  LogTarget(Debug, cds, lambda) log;
   if (bsi->arg_values() == NULL || !bsi->arg_values()->is_objArray()) {
-    DEBUG_ONLY(
-      tty->print_cr("bsi check failed");
-      tty->print_cr("    bsi->arg_values().not_null() %d", bsi->arg_values().not_null());
+    if (log.is_enabled()) {
+      LogStream log_stream(log);
+      log.print("bsi check failed");
+      log.print("    bsi->arg_values().not_null() %d", bsi->arg_values().not_null());
       if (bsi->arg_values().not_null()) {
-        tty->print_cr("    bsi->arg_values()->is_objArray() %d", bsi->arg_values()->is_objArray());
-        bsi->print();
+        log.print("    bsi->arg_values()->is_objArray() %d", bsi->arg_values()->is_objArray());
+        bsi->print_msg_on(&log_stream);
       }
-    )
+    }
     return false;
   }
 
   Handle bsm = bsi->bsm();
   if (bsm.is_null() || !java_lang_invoke_DirectMethodHandle::is_instance(bsm())) {
-    DEBUG_ONLY(
-      tty->print_cr("bsm check failed");
-      tty->print_cr("    bsm.is_null() %d", bsm.is_null());
-      tty->print_cr("    java_lang_invoke_DirectMethodHandle::is_instance(bsm()) %d",
+    if (log.is_enabled()) {
+      log.print("bsm check failed");
+      log.print("    bsm.is_null() %d", bsm.is_null());
+      log.print("    java_lang_invoke_DirectMethodHandle::is_instance(bsm()) %d",
         java_lang_invoke_DirectMethodHandle::is_instance(bsm()));
-    )
+    }
     return false;
   }
 
@@ -1954,13 +1957,13 @@ bool SystemDictionaryShared::is_supported_invokedynamic(BootstrapInfo* bsi) {
       method->signature()->equals("(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;")) {
       return true;
   } else {
-    DEBUG_ONLY(
+    if (log.is_enabled()) {
       ResourceMark rm;
-      tty->print_cr("method check failed");
-      tty->print_cr("    klass_name() %s", method->klass_name()->as_C_string());
-      tty->print_cr("    name() %s", method->name()->as_C_string());
-      tty->print_cr("    signature() %s", method->signature()->as_C_string());
-    )
+      log.print("method check failed");
+      log.print("    klass_name() %s", method->klass_name()->as_C_string());
+      log.print("    name() %s", method->name()->as_C_string());
+      log.print("    signature() %s", method->signature()->as_C_string());
+    }
   }
 
   return false;

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -95,6 +95,7 @@
   LOG_TAG(jit) \
   LOG_TAG(jni) \
   LOG_TAG(jvmti) \
+  LOG_TAG(lambda) \
   LOG_TAG(library) \
   LOG_TAG(liveness) \
   LOG_TAG(load) /* Trace all classes loaded */ \

--- a/test/hotspot/jtreg/runtime/cds/appcds/BadBSM.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/BadBSM.java
@@ -42,7 +42,8 @@ public class BadBSM {
 
     OutputAnalyzer out = TestCommon.dump(appJar,
         TestCommon.list("WrongBSM",
-                        "@lambda-proxy WrongBSM 7"));
+                        "@lambda-proxy WrongBSM 7"),
+        "-Xlog:cds+lambda=debug");
     out.shouldHaveExitValue(0);
     out.shouldContain( "is_supported_invokedynamic check failed for cp_index 7");
   }

--- a/test/hotspot/jtreg/runtime/cds/appcds/ClassListFormatBase.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ClassListFormatBase.java
@@ -41,7 +41,7 @@ public class ClassListFormatBase {
         System.out.println("------------------------------");
 
         try {
-            OutputAnalyzer output = TestCommon.dump(appJar, appClasses);
+            OutputAnalyzer output = TestCommon.dump(appJar, appClasses, "-Xlog:cds+lambda=debug");
             output.shouldHaveExitValue(1);
             for (String s : expected_errors) {
                 output.shouldContain(s);
@@ -63,7 +63,7 @@ public class ClassListFormatBase {
         System.out.println("------------------------------");
 
         try {
-            OutputAnalyzer output = TestCommon.dump(appJar, appClasses, "-Xlog:cds");
+            OutputAnalyzer output = TestCommon.dump(appJar, appClasses, "-Xlog:cds", "-Xlog:cds+lambda=debug");
             output.shouldHaveExitValue(0);
             output.shouldContain("Dumping");
             for (String s : expected_msgs) {


### PR DESCRIPTION
A small clean up to make the logging more manageable.

[1] Moved some debug printing from `tty->print_cr()` to `-Xlog:cds+lambda=debug`
[2] Moved some logs from `-Xlog:cds` to `-Xlog:cds+lambda`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255860](https://bugs.openjdk.java.net/browse/JDK-8255860): Clean up CDS logging related to lambda


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1062/head:pull/1062`
`$ git checkout pull/1062`
