### PR TITLE
8255214: Unsupported 'valign' attribute for 'th' tag used in j.u.l.LogManager

### DIFF
--- a/src/java.logging/share/classes/java/util/logging/LogManager.java
+++ b/src/java.logging/share/classes/java/util/logging/LogManager.java
@@ -1920,7 +1920,7 @@ public class LogManager {
      * </thead>
      * <tbody>
      * <tr>
-     * <th scope="row" valign="top">{@code <logger>.level}</th>
+     * <th scope="row" style="vertical-align:top">{@code <logger>.level}</th>
      * <td>
      * <ul>
      *   <li>If the resulting configuration defines a level for a logger and
@@ -1941,7 +1941,7 @@ public class LogManager {
      * </ul>
      * </td>
      * <tr>
-     * <th scope="row" valign="top">{@code <logger>.useParentHandlers}</th>
+     * <th scope="row" style="vertical-align:top">{@code <logger>.useParentHandlers}</th>
      * <td>
      * <ul>
      *   <li>If either the resulting or the old value for the useParentHandlers
@@ -1955,7 +1955,7 @@ public class LogManager {
      * </td>
      * </tr>
      * <tr>
-     * <th scope="row" valign="top">{@code <logger>.handlers}</th>
+     * <th scope="row" style="vertical-align:top">{@code <logger>.handlers}</th>
      * <td>
      * <ul>
      *   <li>If the resulting configuration defines a list of handlers for a
@@ -1979,7 +1979,7 @@ public class LogManager {
      * </td>
      * </tr>
      * <tr>
-     * <th scope="row" valign="top">{@code <handler-name>.*}</th>
+     * <th scope="row" style="vertical-align:top">{@code <handler-name>.*}</th>
      * <td>
      * <ul>
      *   <li>Properties configured/changed on handler classes will only affect
@@ -1991,7 +1991,7 @@ public class LogManager {
      * </td>
      * </tr>
      * <tr>
-     * <th scope="row" valign="top">{@code config} and any other property</th>
+     * <th scope="row" style="vertical-align:top">{@code config} and any other property</th>
      * <td>
      * <ul>
      *   <li>The resulting value for these property will be stored in the


### PR DESCRIPTION
Hello,

Request to review this small change, as HTML4 support has been dropped from javadoc.
Have replaced valign="top" with style="vertical-align:top".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (2/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Windows x64 (hs/tier1 gc)](https://github.com/rhyadav/jdk/runs/1355498496)
- [Windows x64 (hs/tier1 serviceability)](https://github.com/rhyadav/jdk/runs/1355498524)
- [macOS x64 (hs/tier1 gc)](https://github.com/rhyadav/jdk/runs/1355546318)

### Issue
 * [JDK-8255214](https://bugs.openjdk.java.net/browse/JDK-8255214): Unsupported 'valign' attribute for 'th' tag used in j.u.l.LogManager


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1064/head:pull/1064`
`$ git checkout pull/1064`
