### PR TITLE
8255909: Remove unused delayed_value methods

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -3220,13 +3220,6 @@ public:
   Assembler(CodeBuffer* code) : AbstractAssembler(code) {
   }
 
-  virtual RegisterOrConstant delayed_value_impl(intptr_t* delayed_value_addr,
-                                                Register tmp,
-                                                int offset) {
-    ShouldNotCallThis();
-    return RegisterOrConstant();
-  }
-
   // Stack overflow checking
   virtual void bang_stack_with_offset(int offset);
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -934,23 +934,6 @@ void MacroAssembler::check_and_handle_earlyret(Register java_thread) { }
 
 void MacroAssembler::check_and_handle_popframe(Register java_thread) { }
 
-
-RegisterOrConstant MacroAssembler::delayed_value_impl(intptr_t* delayed_value_addr,
-                                                      Register tmp,
-                                                      int offset) {
-  intptr_t value = *delayed_value_addr;
-  if (value != 0)
-    return RegisterOrConstant(value + offset);
-
-  // load indirectly to solve generation ordering problem
-  ldr(tmp, ExternalAddress((address) delayed_value_addr));
-
-  if (offset != 0)
-    add(tmp, tmp, offset);
-
-  return RegisterOrConstant(tmp);
-}
-
 // Look up the method for a megamorphic invokeinterface call.
 // The target method is determined by <intf_klass, itable_index>.
 // The receiver klass is in recv_klass.

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1013,10 +1013,6 @@ public:
   // Check for reserved stack access in method being exited (for JIT)
   void reserved_stack_check();
 
-  virtual RegisterOrConstant delayed_value_impl(intptr_t* delayed_value_addr,
-                                                Register tmp,
-                                                int offset);
-
   // Arithmetics
 
   void addptr(const Address &dst, int32_t src);

--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -85,20 +85,6 @@ void AddressLiteral::set_rspec(relocInfo::relocType rtype) {
   }
 }
 
-// Initially added to the Assembler interface as a pure virtual:
-//   RegisterConstant delayed_value(..)
-// for:
-//   6812678 macro assembler needs delayed binding of a few constants (for 6655638)
-// this was subsequently modified to its present name and return type
-RegisterOrConstant MacroAssembler::delayed_value_impl(intptr_t* delayed_value_addr,
-                                                      Register tmp,
-                                                      int offset) {
-  ShouldNotReachHere();
-  return RegisterOrConstant(-1);
-}
-
-
-
 
 // virtual method calling
 void MacroAssembler::lookup_virtual_method(Register recv_klass,

--- a/src/hotspot/cpu/arm/macroAssembler_arm.hpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.hpp
@@ -222,14 +222,6 @@ public:
   // returning false to preserve all relocation information.
   inline bool ignore_non_patchable_relocations() { return true; }
 
-  // Initially added to the Assembler interface as a pure virtual:
-  //   RegisterConstant delayed_value(..)
-  // for:
-  //   6812678 macro assembler needs delayed binding of a few constants (for 6655638)
-  // this was subsequently modified to its present name and return type
-  virtual RegisterOrConstant delayed_value_impl(intptr_t* delayed_value_addr, Register tmp, int offset);
-
-
   void align(int modulus);
 
   // Support for VM calls

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -382,25 +382,6 @@ AddressLiteral MacroAssembler::constant_oop_address(jobject obj) {
   return AddressLiteral(address(obj), oop_Relocation::spec(oop_index));
 }
 
-RegisterOrConstant MacroAssembler::delayed_value_impl(intptr_t* delayed_value_addr,
-                                                      Register tmp, int offset) {
-  intptr_t value = *delayed_value_addr;
-  if (value != 0) {
-    return RegisterOrConstant(value + offset);
-  }
-
-  // Load indirectly to solve generation ordering problem.
-  // static address, no relocation
-  int simm16_offset = load_const_optimized(tmp, delayed_value_addr, noreg, true);
-  ld(tmp, simm16_offset, tmp); // must be aligned ((xa & 3) == 0)
-
-  if (offset != 0) {
-    addi(tmp, tmp, offset);
-  }
-
-  return RegisterOrConstant(tmp);
-}
-
 #ifndef PRODUCT
 void MacroAssembler::pd_print_patched_instruction(address branch) {
   Unimplemented(); // TODO: PPC port

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -152,12 +152,6 @@ class MacroAssembler: public Assembler {
   // Same as load_address.
   inline void set_oop         (AddressLiteral obj_addr, Register d);
 
-  // Read runtime constant:  Issue load if constant not yet established,
-  // else use real constant.
-  virtual RegisterOrConstant delayed_value_impl(intptr_t* delayed_value_addr,
-                                                Register tmp,
-                                                int offset);
-
   //
   // branch, jump
   //

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -1810,34 +1810,6 @@ void MacroAssembler::c2bool(Register r, Register t) {
   z_srl(r, 31);  // Yields 0 if r was 0, 1 otherwise.
 }
 
-RegisterOrConstant MacroAssembler::delayed_value_impl(intptr_t* delayed_value_addr,
-                                                      Register tmp,
-                                                      int offset) {
-  intptr_t value = *delayed_value_addr;
-  if (value != 0) {
-    return RegisterOrConstant(value + offset);
-  }
-
-  BLOCK_COMMENT("delayed_value {");
-  // Load indirectly to solve generation ordering problem.
-  load_absolute_address(tmp, (address) delayed_value_addr); // tmp = a;
-  z_lg(tmp, 0, tmp);                   // tmp = *tmp;
-
-#ifdef ASSERT
-  NearLabel L;
-  compare64_and_branch(tmp, (intptr_t)0L, Assembler::bcondNotEqual, L);
-  z_illtrap();
-  bind(L);
-#endif
-
-  if (offset != 0) {
-    z_agfi(tmp, offset);               // tmp = tmp + offset;
-  }
-
-  BLOCK_COMMENT("} delayed_value");
-  return RegisterOrConstant(tmp);
-}
-
 // Patch instruction `inst' at offset `inst_pos' to refer to `dest_pos'
 // and return the resulting instruction.
 // Dest_pos and inst_pos are 32 bit only. These parms can only designate

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -350,9 +350,6 @@ class MacroAssembler: public Assembler {
   // Uses constant_metadata_address.
   inline bool set_metadata_constant(Metadata* md, Register d);
 
-  virtual RegisterOrConstant delayed_value_impl(intptr_t* delayed_value_addr,
-                                                Register tmp,
-                                                int offset);
   //
   // branch, jump
   //

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3929,44 +3929,6 @@ void MacroAssembler::vallones(XMMRegister dst, int vector_len) {
   }
 }
 
-RegisterOrConstant MacroAssembler::delayed_value_impl(intptr_t* delayed_value_addr,
-                                                      Register tmp,
-                                                      int offset) {
-  intptr_t value = *delayed_value_addr;
-  if (value != 0)
-    return RegisterOrConstant(value + offset);
-
-  // load indirectly to solve generation ordering problem
-  movptr(tmp, ExternalAddress((address) delayed_value_addr));
-
-#ifdef ASSERT
-  { Label L;
-    testptr(tmp, tmp);
-    if (WizardMode) {
-      const char* buf = NULL;
-      {
-        ResourceMark rm;
-        stringStream ss;
-        ss.print("DelayedValue=" INTPTR_FORMAT, delayed_value_addr[1]);
-        buf = code_string(ss.as_string());
-      }
-      jcc(Assembler::notZero, L);
-      STOP(buf);
-    } else {
-      jccb(Assembler::notZero, L);
-      hlt();
-    }
-    bind(L);
-  }
-#endif
-
-  if (offset != 0)
-    addptr(tmp, offset);
-
-  return RegisterOrConstant(tmp);
-}
-
-
 Address MacroAssembler::argument_address(RegisterOrConstant arg_slot,
                                          int extra_slot_offset) {
   // cf. TemplateTable::prepare_invoke(), if (load_receiver).

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -651,10 +651,6 @@ class MacroAssembler: public Assembler {
   // Check for reserved stack access in method being exited (for JIT)
   void reserved_stack_check();
 
-  virtual RegisterOrConstant delayed_value_impl(intptr_t* delayed_value_addr,
-                                                Register tmp,
-                                                int offset);
-
   void safepoint_poll(Label& slow_path, Register thread_reg, bool at_return, bool in_nmethod);
 
   void verify_tlab();

--- a/src/hotspot/cpu/zero/assembler_zero.cpp
+++ b/src/hotspot/cpu/zero/assembler_zero.cpp
@@ -66,12 +66,6 @@ void MacroAssembler::advance(int bytes) {
   code_section()->set_end(code_section()->end() + bytes);
 }
 
-RegisterOrConstant MacroAssembler::delayed_value_impl(
-  intptr_t* delayed_value_addr, Register tmpl, int offset) {
-  ShouldNotCallThis();
-  return RegisterOrConstant();
-}
-
 void MacroAssembler::store_oop(jobject obj) {
   code_section()->relocate(pc(), oop_Relocation::spec_for_immediate());
   emit_address((address) obj);

--- a/src/hotspot/cpu/zero/assembler_zero.hpp
+++ b/src/hotspot/cpu/zero/assembler_zero.hpp
@@ -54,9 +54,6 @@ class MacroAssembler : public Assembler {
   void bang_stack_with_offset(int offset);
   bool needs_explicit_null_check(intptr_t offset);
   bool uses_implicit_null_check(void* address);
-  RegisterOrConstant delayed_value_impl(intptr_t* delayed_value_addr,
-                                        Register tmp, int offset);
- public:
   void advance(int bytes);
   void store_oop(jobject obj);
   void store_Metadata(Metadata* obj);

--- a/src/hotspot/cpu/zero/interp_masm_zero.hpp
+++ b/src/hotspot/cpu/zero/interp_masm_zero.hpp
@@ -35,14 +35,6 @@
 class InterpreterMacroAssembler : public MacroAssembler {
  public:
   InterpreterMacroAssembler(CodeBuffer* code) : MacroAssembler(code) {}
-
- public:
-  RegisterOrConstant delayed_value_impl(intptr_t* delayed_value_addr,
-                                        Register  tmp,
-                                        int       offset) {
-    ShouldNotCallThis();
-    return RegisterOrConstant();
-  }
 };
 
 #endif // CPU_ZERO_INTERP_MASM_ZERO_HPP

--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -431,22 +431,6 @@ class AbstractAssembler : public ResourceObj  {
     return ptr;
   }
 
-  // Bootstrapping aid to cope with delayed determination of constants.
-  // Returns a static address which will eventually contain the constant.
-  // The value zero (NULL) stands instead of a constant which is still uncomputed.
-  // Thus, the eventual value of the constant must not be zero.
-  // This is fine, since this is designed for embedding object field
-  // offsets in code which must be generated before the object class is loaded.
-  // Field offsets are never zero, since an object's header (mark word)
-  // is located at offset zero.
-  RegisterOrConstant delayed_value(int(*value_fn)(), Register tmp, int offset = 0);
-  RegisterOrConstant delayed_value(address(*value_fn)(), Register tmp, int offset = 0);
-  virtual RegisterOrConstant delayed_value_impl(intptr_t* delayed_value_addr, Register tmp, int offset) = 0;
-  // Last overloading is platform-dependent; look in assembler_<arch>.cpp.
-  static intptr_t* delayed_value_addr(int(*constant_fn)());
-  static intptr_t* delayed_value_addr(address(*constant_fn)());
-  static void update_delayed_values();
-
   // Bang stack to trigger StackOverflowError at a safe location
   // implementation delegates to machine-specific bang_stack_with_offset
   void generate_stack_overflow_check( int frame_size_in_bytes );


### PR DESCRIPTION
Usage of and definitions of Assembler::delayed_value have been removed, but declarations linger along with various platform specific definitions of delayed_value_impl (all of which areunused) 

Clean up and remove. 

Untested on arm/aarch/ppc/s390, but as there are no mentions of delayed_value in the repository after this cleanup this is hopefully OK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255909](https://bugs.openjdk.java.net/browse/JDK-8255909): Remove unused delayed_value methods


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1065/head:pull/1065`
`$ git checkout pull/1065`
