### PR TITLE
8255913: Decrease number of iterations in TestMaxCachedBufferSize

### DIFF
--- a/test/jdk/sun/nio/ch/TestMaxCachedBufferSize.java
+++ b/test/jdk/sun/nio/ch/TestMaxCachedBufferSize.java
@@ -54,7 +54,7 @@ import jdk.test.lib.RandomFactory;
  * @key randomness
  */
 public class TestMaxCachedBufferSize {
-    private static final int DEFAULT_ITERS = 10 * 1000;
+    private static final int DEFAULT_ITERS = 5 * 1000;
     private static final int DEFAULT_THREAD_NUM = 4;
 
     private static final int SMALL_BUFFER_MIN_SIZE =  4 * 1024;


### PR DESCRIPTION
Please review this test-only change to TestMaxCachedBufferSize. The test times out frequently, primarily on older hardware. The proposed change is to decrease the number of iterations in the test, which should not compromise its value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255913](https://bugs.openjdk.java.net/browse/JDK-8255913): Decrease number of iterations in TestMaxCachedBufferSize


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1066/head:pull/1066`
`$ git checkout pull/1066`
