### PR TITLE
8254270: linux 32 bit build doesn't compile libjdwp/log_messages.c

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -78,11 +78,12 @@ get_time_stamp(char *tbuf, size_t ltbuf)
                 "%d.%m.%Y %T", localtime(&t));
     (void)strftime(timestamp_timezone, TZ_SIZE,
                 "%Z", localtime(&t));
+
     // Truncate milliseconds in buffer large enough to hold the
-    // value which is always < 1000
+    // value which is always < 1000 (and so a maximum of 3 digits for "%.3s")
     char tmp[10 + 1];
-    snprintf(tmp, sizeof(tmp), "%d", millisecs);
-    snprintf(tbuf, ltbuf, "%s.%.3s %s", timestamp_date_time, tmp, timestamp_timezone);
+    snprintf(tmp, sizeof(tmp), "%.3d", millisecs);
+    snprintf(tbuf, ltbuf, "%s.%s %s", timestamp_date_time, tmp, timestamp_timezone);
 }
 
 /* Get basename of filename */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -80,8 +80,8 @@ get_time_stamp(char *tbuf, size_t ltbuf)
                 "%Z", localtime(&t));
 
     // Truncate milliseconds in buffer large enough to hold the
-    // value which is always < 1000 (and so a maximum of 3 digits for "%.3s")
-    char tmp[10 + 1];
+    // value which is always < 1000 (and so a maximum of 3 digits for "%.3d")
+    char tmp[20];
     snprintf(tmp, sizeof(tmp), "%.3d", millisecs);
     snprintf(tbuf, ltbuf, "%s.%s %s", timestamp_date_time, tmp, timestamp_timezone);
 }

--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -78,16 +78,11 @@ get_time_stamp(char *tbuf, size_t ltbuf)
                 "%d.%m.%Y %T", localtime(&t));
     (void)strftime(timestamp_timezone, TZ_SIZE,
                 "%Z", localtime(&t));
-#if 0
-    (void)snprintf(tbuf, ltbuf,
-                   "%.19s.%.3d %.50s", timestamp_date_time,
-                   (int)(millisecs), timestamp_timezone);
-#endif
-     // Truncate milliseconds in buffer large enough to hold the
-     // value which is always < 1000
-     char tmp[10 + 1];
-     snprintf(tmp, sizeof(tmp), "%d", millisecs);
-     snprintf(tbuf, ltbuf, "%s.%.3s %s", timestamp_date_time, tmp, timestamp_timezone);
+    // Truncate milliseconds in buffer large enough to hold the
+    // value which is always < 1000
+    char tmp[10 + 1];
+    snprintf(tmp, sizeof(tmp), "%d", millisecs);
+    snprintf(tbuf, ltbuf, "%s.%.3s %s", timestamp_date_time, tmp, timestamp_timezone);
 }
 
 /* Get basename of filename */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -83,7 +83,7 @@ get_time_stamp(char *tbuf, size_t ltbuf)
     // value which is always < 1000 (and so a maximum of 3 digits for "%.3d")
     char tmp[20];
     snprintf(tmp, sizeof(tmp), "%.3d", millisecs);
-    snprintf(tbuf, ltbuf, "%s.%s %s", timestamp_date_time, tmp, timestamp_timezone);
+    snprintf(tbuf, ltbuf, "%s.%.3s %s", timestamp_date_time, tmp, timestamp_timezone);
 }
 
 /* Get basename of filename */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ get_time_stamp(char *tbuf, size_t ltbuf)
     (void)strftime(timestamp_timezone, TZ_SIZE,
                 "%Z", localtime(&t));
     (void)snprintf(tbuf, ltbuf,
-                   "%s.%.3d %s", timestamp_date_time,
+                   "%.19s.%.3d %.50s", timestamp_date_time,
                    (int)(millisecs), timestamp_timezone);
 }
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -78,9 +78,16 @@ get_time_stamp(char *tbuf, size_t ltbuf)
                 "%d.%m.%Y %T", localtime(&t));
     (void)strftime(timestamp_timezone, TZ_SIZE,
                 "%Z", localtime(&t));
+#if 0
     (void)snprintf(tbuf, ltbuf,
                    "%.19s.%.3d %.50s", timestamp_date_time,
                    (int)(millisecs), timestamp_timezone);
+#endif
+     // Truncate milliseconds in buffer large enough to hold the
+     // value which is always < 1000
+     char tmp[10 + 1];
+     snprintf(tmp, sizeof(tmp), "%d", millisecs);
+     snprintf(tbuf, ltbuf, "%s.%.3s %s", timestamp_date_time, tmp, timestamp_timezone);
 }
 
 /* Get basename of filename */


### PR DESCRIPTION
Apply patch suggested by @cl4es in the bug report.  Passes linux-x86-open,linux-x64-open,linux-s390x-open,linux-arm32-debug,linux-ppc64le-debug builds with this patch, and tier1.

thanks,
Coleen

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254270](https://bugs.openjdk.java.net/browse/JDK-8254270): linux 32 bit build doesn't compile libjdwp/log_messages.c


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 245c7f7f059de2792659564c6fa38b427dd9ccfc
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1067/head:pull/1067`
`$ git checkout pull/1067`
