### PR TITLE
8255575: java.awt.color.ICC_ColorSpace is not thread-safe

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -198,7 +198,7 @@ public class ICC_ColorSpace extends ColorSpace {
             synchronized (this) {
                 if (this2srgb == null) {
                     ColorTransform[] transforms = new ColorTransform[2];
-                    var srgb = (ICC_ColorSpace) ColorSpace.getInstance(CS_sRGB);
+                    var srgb = (ICC_ColorSpace) getInstance(CS_sRGB);
                     PCMM mdl = CMSManager.getModule();
                     transforms[0] = mdl.createTransform(thisProfile,
                                     ColorTransform.Any, ColorTransform.In);
@@ -250,7 +250,7 @@ public class ICC_ColorSpace extends ColorSpace {
             synchronized (this) {
                 if (srgb2this == null) {
                     ColorTransform[] transforms = new ColorTransform[2];
-                    var srgb = (ICC_ColorSpace) ColorSpace.getInstance(CS_sRGB);
+                    var srgb = (ICC_ColorSpace) getInstance(CS_sRGB);
                     PCMM mdl = CMSManager.getModule();
                     transforms[0] = mdl.createTransform(srgb.getProfile(),
                                     ColorTransform.Any, ColorTransform.In);
@@ -382,7 +382,7 @@ public class ICC_ColorSpace extends ColorSpace {
             synchronized (this) {
                 if (this2xyz == null) {
                     ColorTransform[] transforms = new ColorTransform[2];
-                    var xyz = (ICC_ColorSpace)ColorSpace.getInstance(CS_CIEXYZ);
+                    var xyz = (ICC_ColorSpace) getInstance(CS_CIEXYZ);
                     PCMM mdl = CMSManager.getModule();
                     try {
                         transforms[0] = mdl.createTransform(thisProfile,
@@ -522,7 +522,7 @@ public class ICC_ColorSpace extends ColorSpace {
             synchronized (this) {
                 if (xyz2this == null) {
                     ColorTransform[] transforms = new ColorTransform[2];
-                    var xyz = (ICC_ColorSpace)ColorSpace.getInstance(CS_CIEXYZ);
+                    var xyz = (ICC_ColorSpace) getInstance(CS_CIEXYZ);
                     PCMM mdl = CMSManager.getModule();
                     transforms[0] = mdl.createTransform(xyz.getProfile(),
                                     ColorTransform.Any, ColorTransform.In);

--- a/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -115,10 +115,10 @@ public class ICC_ColorSpace extends ColorSpace {
     private boolean needScaleInit = true;
 
     // {to,from}{RGB,CIEXYZ} methods create and cache these when needed
-    private transient ColorTransform this2srgb;
-    private transient ColorTransform srgb2this;
-    private transient ColorTransform this2xyz;
-    private transient ColorTransform xyz2this;
+    private transient volatile ColorTransform this2srgb;
+    private transient volatile ColorTransform srgb2this;
+    private transient volatile ColorTransform this2xyz;
+    private transient volatile ColorTransform xyz2this;
 
     /**
      * Constructs a new {@code ICC_ColorSpace} from an {@code ICC_Profile}
@@ -193,20 +193,22 @@ public class ICC_ColorSpace extends ColorSpace {
      * @throws ArrayIndexOutOfBoundsException if array length is not at least
      *         the number of components in this {@code ColorSpace}
      */
-    public float[]    toRGB (float[] colorvalue) {
-
+    public float[] toRGB(float[] colorvalue) {
         if (this2srgb == null) {
-            ColorTransform[] transformList = new ColorTransform [2];
-            ICC_ColorSpace srgbCS =
-                (ICC_ColorSpace) ColorSpace.getInstance (CS_sRGB);
-            PCMM mdl = CMSManager.getModule();
-            transformList[0] = mdl.createTransform(
-                thisProfile, ColorTransform.Any, ColorTransform.In);
-            transformList[1] = mdl.createTransform(
-                srgbCS.getProfile(), ColorTransform.Any, ColorTransform.Out);
-            this2srgb = mdl.createTransform(transformList);
-            if (needScaleInit) {
-                setComponentScaling();
+            synchronized (this) {
+                if (this2srgb == null) {
+                    ColorTransform[] transformList = new ColorTransform[2];
+                    var srgb = (ICC_ColorSpace) ColorSpace.getInstance(CS_sRGB);
+                    PCMM mdl = CMSManager.getModule();
+                    transformList[0] = mdl.createTransform(thisProfile,
+                                       ColorTransform.Any, ColorTransform.In);
+                    transformList[1] = mdl.createTransform(srgb.getProfile(),
+                                       ColorTransform.Any, ColorTransform.Out);
+                    if (needScaleInit) {
+                        setComponentScaling();
+                    }
+                    this2srgb = mdl.createTransform(transformList);
+                }
             }
         }
 
@@ -243,20 +245,22 @@ public class ICC_ColorSpace extends ColorSpace {
      *         this {@code ColorSpace}
      * @throws ArrayIndexOutOfBoundsException if array length is not at least 3
      */
-    public float[]    fromRGB(float[] rgbvalue) {
-
+    public float[] fromRGB(float[] rgbvalue) {
         if (srgb2this == null) {
-            ColorTransform[] transformList = new ColorTransform [2];
-            ICC_ColorSpace srgbCS =
-                (ICC_ColorSpace) ColorSpace.getInstance (CS_sRGB);
-            PCMM mdl = CMSManager.getModule();
-            transformList[0] = mdl.createTransform(
-                srgbCS.getProfile(), ColorTransform.Any, ColorTransform.In);
-            transformList[1] = mdl.createTransform(
-                thisProfile, ColorTransform.Any, ColorTransform.Out);
-            srgb2this = mdl.createTransform(transformList);
-            if (needScaleInit) {
-                setComponentScaling();
+            synchronized (this) {
+                if (srgb2this == null) {
+                    ColorTransform[] transformList = new ColorTransform[2];
+                    var srgb = (ICC_ColorSpace) ColorSpace.getInstance(CS_sRGB);
+                    PCMM mdl = CMSManager.getModule();
+                    transformList[0] = mdl.createTransform(srgb.getProfile(),
+                                       ColorTransform.Any, ColorTransform.In);
+                    transformList[1] = mdl.createTransform(thisProfile,
+                                       ColorTransform.Any, ColorTransform.Out);
+                    if (needScaleInit) {
+                        setComponentScaling();
+                    }
+                    srgb2this = mdl.createTransform(transformList);
+                }
             }
         }
 
@@ -373,26 +377,29 @@ public class ICC_ColorSpace extends ColorSpace {
      * @throws ArrayIndexOutOfBoundsException if array length is not at least
      *         the number of components in this {@code ColorSpace}
      */
-    public float[]    toCIEXYZ(float[] colorvalue) {
-
+    public float[] toCIEXYZ(float[] colorvalue) {
         if (this2xyz == null) {
-            ColorTransform[] transformList = new ColorTransform [2];
-            ICC_ColorSpace xyzCS =
-                (ICC_ColorSpace) ColorSpace.getInstance (CS_CIEXYZ);
-            PCMM mdl = CMSManager.getModule();
-            try {
-                transformList[0] = mdl.createTransform(
-                    thisProfile, ICC_Profile.icRelativeColorimetric,
-                    ColorTransform.In);
-            } catch (CMMException e) {
-                transformList[0] = mdl.createTransform(
-                    thisProfile, ColorTransform.Any, ColorTransform.In);
-            }
-            transformList[1] = mdl.createTransform(
-                xyzCS.getProfile(), ColorTransform.Any, ColorTransform.Out);
-            this2xyz = mdl.createTransform (transformList);
-            if (needScaleInit) {
-                setComponentScaling();
+            synchronized (this) {
+                if (this2xyz == null) {
+                    ColorTransform[] transformList = new ColorTransform[2];
+                    var xyz = (ICC_ColorSpace)ColorSpace.getInstance(CS_CIEXYZ);
+                    PCMM mdl = CMSManager.getModule();
+                    try {
+                        transformList[0] = mdl.createTransform(thisProfile,
+                                           ICC_Profile.icRelativeColorimetric,
+                                           ColorTransform.In);
+                    } catch (CMMException e) {
+                        transformList[0] = mdl.createTransform(thisProfile,
+                                           ColorTransform.Any,
+                                           ColorTransform.In);
+                    }
+                    transformList[1] = mdl.createTransform(xyz.getProfile(),
+                                       ColorTransform.Any, ColorTransform.Out);
+                    if (needScaleInit) {
+                        setComponentScaling();
+                    }
+                    this2xyz = mdl.createTransform(transformList);
+                }
             }
         }
 
@@ -511,26 +518,29 @@ public class ICC_ColorSpace extends ColorSpace {
      *         this {@code ColorSpace}
      * @throws ArrayIndexOutOfBoundsException if array length is not at least 3
      */
-    public float[]    fromCIEXYZ(float[] colorvalue) {
-
+    public float[] fromCIEXYZ(float[] colorvalue) {
         if (xyz2this == null) {
-            ColorTransform[] transformList = new ColorTransform [2];
-            ICC_ColorSpace xyzCS =
-                (ICC_ColorSpace) ColorSpace.getInstance (CS_CIEXYZ);
-            PCMM mdl = CMSManager.getModule();
-            transformList[0] = mdl.createTransform (
-                xyzCS.getProfile(), ColorTransform.Any, ColorTransform.In);
-            try {
-                transformList[1] = mdl.createTransform(
-                    thisProfile, ICC_Profile.icRelativeColorimetric,
-                    ColorTransform.Out);
-            } catch (CMMException e) {
-                transformList[1] = CMSManager.getModule().createTransform(
-                thisProfile, ColorTransform.Any, ColorTransform.Out);
-            }
-            xyz2this = mdl.createTransform(transformList);
-            if (needScaleInit) {
-                setComponentScaling();
+            synchronized (this) {
+                if (xyz2this == null) {
+                    ColorTransform[] transformList = new ColorTransform[2];
+                    var xyz = (ICC_ColorSpace)ColorSpace.getInstance(CS_CIEXYZ);
+                    PCMM mdl = CMSManager.getModule();
+                    transformList[0] = mdl.createTransform(xyz.getProfile(),
+                                       ColorTransform.Any, ColorTransform.In);
+                    try {
+                        transformList[1] = mdl.createTransform(thisProfile,
+                                           ICC_Profile.icRelativeColorimetric,
+                                           ColorTransform.Out);
+                    } catch (CMMException e) {
+                        transformList[1] = mdl.createTransform(thisProfile,
+                                           ColorTransform.Any,
+                                           ColorTransform.Out);
+                    }
+                    if (needScaleInit) {
+                        setComponentScaling();
+                    }
+                    xyz2this = mdl.createTransform(transformList);
+                }
             }
         }
 

--- a/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -197,17 +197,17 @@ public class ICC_ColorSpace extends ColorSpace {
         if (this2srgb == null) {
             synchronized (this) {
                 if (this2srgb == null) {
-                    ColorTransform[] transformList = new ColorTransform[2];
+                    ColorTransform[] transforms = new ColorTransform[2];
                     var srgb = (ICC_ColorSpace) ColorSpace.getInstance(CS_sRGB);
                     PCMM mdl = CMSManager.getModule();
-                    transformList[0] = mdl.createTransform(thisProfile,
-                                       ColorTransform.Any, ColorTransform.In);
-                    transformList[1] = mdl.createTransform(srgb.getProfile(),
-                                       ColorTransform.Any, ColorTransform.Out);
+                    transforms[0] = mdl.createTransform(thisProfile,
+                                    ColorTransform.Any, ColorTransform.In);
+                    transforms[1] = mdl.createTransform(srgb.getProfile(),
+                                    ColorTransform.Any, ColorTransform.Out);
                     if (needScaleInit) {
                         setComponentScaling();
                     }
-                    this2srgb = mdl.createTransform(transformList);
+                    this2srgb = mdl.createTransform(transforms);
                 }
             }
         }
@@ -249,17 +249,17 @@ public class ICC_ColorSpace extends ColorSpace {
         if (srgb2this == null) {
             synchronized (this) {
                 if (srgb2this == null) {
-                    ColorTransform[] transformList = new ColorTransform[2];
+                    ColorTransform[] transforms = new ColorTransform[2];
                     var srgb = (ICC_ColorSpace) ColorSpace.getInstance(CS_sRGB);
                     PCMM mdl = CMSManager.getModule();
-                    transformList[0] = mdl.createTransform(srgb.getProfile(),
-                                       ColorTransform.Any, ColorTransform.In);
-                    transformList[1] = mdl.createTransform(thisProfile,
-                                       ColorTransform.Any, ColorTransform.Out);
+                    transforms[0] = mdl.createTransform(srgb.getProfile(),
+                                    ColorTransform.Any, ColorTransform.In);
+                    transforms[1] = mdl.createTransform(thisProfile,
+                                    ColorTransform.Any, ColorTransform.Out);
                     if (needScaleInit) {
                         setComponentScaling();
                     }
-                    srgb2this = mdl.createTransform(transformList);
+                    srgb2this = mdl.createTransform(transforms);
                 }
             }
         }
@@ -381,24 +381,23 @@ public class ICC_ColorSpace extends ColorSpace {
         if (this2xyz == null) {
             synchronized (this) {
                 if (this2xyz == null) {
-                    ColorTransform[] transformList = new ColorTransform[2];
+                    ColorTransform[] transforms = new ColorTransform[2];
                     var xyz = (ICC_ColorSpace)ColorSpace.getInstance(CS_CIEXYZ);
                     PCMM mdl = CMSManager.getModule();
                     try {
-                        transformList[0] = mdl.createTransform(thisProfile,
-                                           ICC_Profile.icRelativeColorimetric,
-                                           ColorTransform.In);
+                        transforms[0] = mdl.createTransform(thisProfile,
+                                        ICC_Profile.icRelativeColorimetric,
+                                        ColorTransform.In);
                     } catch (CMMException e) {
-                        transformList[0] = mdl.createTransform(thisProfile,
-                                           ColorTransform.Any,
-                                           ColorTransform.In);
+                        transforms[0] = mdl.createTransform(thisProfile,
+                                        ColorTransform.Any, ColorTransform.In);
                     }
-                    transformList[1] = mdl.createTransform(xyz.getProfile(),
-                                       ColorTransform.Any, ColorTransform.Out);
+                    transforms[1] = mdl.createTransform(xyz.getProfile(),
+                                    ColorTransform.Any, ColorTransform.Out);
                     if (needScaleInit) {
                         setComponentScaling();
                     }
-                    this2xyz = mdl.createTransform(transformList);
+                    this2xyz = mdl.createTransform(transforms);
                 }
             }
         }
@@ -522,24 +521,23 @@ public class ICC_ColorSpace extends ColorSpace {
         if (xyz2this == null) {
             synchronized (this) {
                 if (xyz2this == null) {
-                    ColorTransform[] transformList = new ColorTransform[2];
+                    ColorTransform[] transforms = new ColorTransform[2];
                     var xyz = (ICC_ColorSpace)ColorSpace.getInstance(CS_CIEXYZ);
                     PCMM mdl = CMSManager.getModule();
-                    transformList[0] = mdl.createTransform(xyz.getProfile(),
-                                       ColorTransform.Any, ColorTransform.In);
+                    transforms[0] = mdl.createTransform(xyz.getProfile(),
+                                    ColorTransform.Any, ColorTransform.In);
                     try {
-                        transformList[1] = mdl.createTransform(thisProfile,
-                                           ICC_Profile.icRelativeColorimetric,
-                                           ColorTransform.Out);
+                        transforms[1] = mdl.createTransform(thisProfile,
+                                        ICC_Profile.icRelativeColorimetric,
+                                        ColorTransform.Out);
                     } catch (CMMException e) {
-                        transformList[1] = mdl.createTransform(thisProfile,
-                                           ColorTransform.Any,
-                                           ColorTransform.Out);
+                        transforms[1] = mdl.createTransform(thisProfile,
+                                        ColorTransform.Any, ColorTransform.Out);
                     }
                     if (needScaleInit) {
                         setComponentScaling();
                     }
-                    xyz2this = mdl.createTransform(transformList);
+                    xyz2this = mdl.createTransform(transforms);
                 }
             }
         }

--- a/test/jdk/java/awt/color/MTICC_ColorSpaceToFrom.java
+++ b/test/jdk/java/awt/color/MTICC_ColorSpaceToFrom.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_ColorSpace;
+import java.awt.color.ICC_Profile;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @test
+ * @bug 8254370
+ * @summary Verifies MT safety of ICC_ColorSpace#To/From methods
+ */
+public final class MTICC_ColorSpaceToFrom {
+
+    private enum Method {
+        FROM_RGB, FROM_XYZ, TO_RGB, TO_XYZ;
+    }
+
+    static volatile long endtime;
+    static volatile boolean failed;
+
+    public static void main(String[] args) throws Exception {
+        ICC_Profile srgb = ICC_Profile.getInstance(ColorSpace.CS_sRGB);
+        ICC_Profile gray = ICC_Profile.getInstance(ColorSpace.CS_GRAY);
+        ICC_Profile xyz = ICC_Profile.getInstance(ColorSpace.CS_CIEXYZ);
+        ICC_Profile lrgb = ICC_Profile.getInstance(ColorSpace.CS_LINEAR_RGB);
+        ICC_Profile pycc = ICC_Profile.getInstance(ColorSpace.CS_PYCC);
+
+        // Will run the test no more than 15 seconds
+        endtime = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        for (int i = 0; i < 1000 && !isComplete(); i++) {
+            for (Method method : new Method[]{
+                    Method.FROM_RGB,
+                    Method.FROM_XYZ,
+                    Method.TO_RGB,
+                    Method.TO_XYZ
+            }) {
+                test(new ICC_ColorSpace(srgb), method);
+                test(new ICC_ColorSpace(gray), method);
+                test(new ICC_ColorSpace(xyz), method);
+                test(new ICC_ColorSpace(lrgb), method);
+                test(new ICC_ColorSpace(pycc), method);
+            }
+        }
+        if (failed) {
+            throw new RuntimeException();
+        }
+    }
+
+    private static void test(ColorSpace cs, Method method) throws Exception {
+        Thread[] ts = new Thread[10];
+        CountDownLatch latch = new CountDownLatch(ts.length);
+        for (int i = 0; i < ts.length; i++) {
+            ts[i] = new Thread(() -> {
+                latch.countDown();
+                try {
+                    latch.await();
+                } catch (InterruptedException ex) {
+                }
+                try {
+                    switch (method) {
+                        case TO_RGB -> cs.toRGB(new float[3]);
+                        case FROM_RGB -> cs.fromRGB(new float[3]);
+                        case TO_XYZ -> cs.toCIEXYZ(new float[3]);
+                        case FROM_XYZ -> cs.fromCIEXYZ(new float[3]);
+                    }
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                    failed = true;
+                }
+            });
+        }
+        for (Thread t : ts) {
+            t.start();
+        }
+        for (Thread t : ts) {
+            t.join();
+        }
+    }
+
+    private static boolean isComplete() {
+        return endtime - System.nanoTime() < 0 || failed;
+    }
+}

--- a/test/jdk/java/awt/color/MTICC_ColorSpaceToFrom.java
+++ b/test/jdk/java/awt/color/MTICC_ColorSpaceToFrom.java
@@ -51,12 +51,8 @@ public final class MTICC_ColorSpaceToFrom {
         // Will run the test no more than 15 seconds
         endtime = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
         for (int i = 0; i < 1000 && !isComplete(); i++) {
-            for (Method method : new Method[]{
-                    Method.FROM_RGB,
-                    Method.FROM_XYZ,
-                    Method.TO_RGB,
-                    Method.TO_XYZ
-            }) {
+            for (Method method : new Method[]{Method.FROM_RGB, Method.FROM_XYZ,
+                                              Method.TO_RGB, Method.TO_XYZ}) {
                 test(new ICC_ColorSpace(srgb), method);
                 test(new ICC_ColorSpace(gray), method);
                 test(new ICC_ColorSpace(xyz), method);


### PR DESCRIPTION
The ICC_ColorSpace class uses a couple of internal data caches that might be used w/o any synchronization by different threads.

The solution is to wrap the initialization of the cached data by the DLC. I have checked performance impact by the J2DBench and it seems no big difference before/after the fix.

BTW jdk16 in some cases x10 times faster than 8u and 11u. Probably we should backport something, will check that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255575](https://bugs.openjdk.java.net/browse/JDK-8255575): java.awt.color.ICC_ColorSpace is not thread-safe


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1069/head:pull/1069`
`$ git checkout pull/1069`
