### PR TITLE
8255914: [AOT] Using AOT flag should give warning when AOT is not included in build

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3284,6 +3284,25 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
   }
 #endif
 
+#if !INCLUDE_AOT
+  UNSUPPORTED_OPTION(UseAOT);
+  UNSUPPORTED_OPTION(PrintAOT);
+  UNSUPPORTED_OPTION(UseAOTStrictLoading);
+  UNSUPPORTED_OPTION_NULL(AOTLibrary);
+
+  UNSUPPORTED_OPTION_INIT(Tier3AOTInvocationThreshold, 0);
+  UNSUPPORTED_OPTION_INIT(Tier3AOTMinInvocationThreshold, 0);
+  UNSUPPORTED_OPTION_INIT(Tier3AOTCompileThreshold, 0);
+  UNSUPPORTED_OPTION_INIT(Tier3AOTBackEdgeThreshold, 0);
+  UNSUPPORTED_OPTION_INIT(Tier0AOTInvocationThreshold, 0);
+  UNSUPPORTED_OPTION_INIT(Tier0AOTMinInvocationThreshold, 0);
+  UNSUPPORTED_OPTION_INIT(Tier0AOTCompileThreshold, 0);
+  UNSUPPORTED_OPTION_INIT(Tier0AOTBackEdgeThreshold, 0);
+#ifndef PRODUCT
+  UNSUPPORTED_OPTION(PrintAOTStatistics);
+#endif
+#endif
+
 #ifndef CAN_SHOW_REGISTERS_ON_ASSERT
   UNSUPPORTED_OPTION(ShowRegistersOnAssert);
 #endif // CAN_SHOW_REGISTERS_ON_ASSERT

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -684,5 +684,14 @@ do {                                                     \
   }                                                      \
 } while(0)
 
+// Initialize options not supported in this release, with a warning
+// if they were explicitly requested on the command-line
+#define UNSUPPORTED_OPTION_INIT(opt, value)              \
+do {                                                     \
+  if (FLAG_IS_CMDLINE(opt)) {                            \
+    warning("-XX flag " #opt " not supported in this VM"); \
+  }                                                      \
+  FLAG_SET_DEFAULT(opt, value);                          \
+} while(0)
 
 #endif // SHARE_RUNTIME_ARGUMENTS_HPP


### PR DESCRIPTION
Currently if AOT feature is not included in a build AOT flags specified on command line are silently ignored: 
```
$ java -XX:+UnlockExperimentalVMOptions -XX:+UseAOT -version 
java version "16-internal" 2021-03-16
```

It should give warning:

```
$ java -XX:+UnlockExperimentalVMOptions -XX:+UseAOT -version
Java HotSpot(TM) 64-Bit Server VM warning: -XX:+UseAOT not supported in this VM
java version "16-internal" 2021-03-16
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255914](https://bugs.openjdk.java.net/browse/JDK-8255914): [AOT] Using AOT flag should give warning when AOT is not included in build


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1071/head:pull/1071`
`$ git checkout pull/1071`
