### PR TITLE
8255920: J2DBench should support CS_PYCC color profile

### DIFF
--- a/src/demo/share/java2d/J2DBench/src/j2dbench/tests/cmm/CMMTests.java
+++ b/src/demo/share/java2d/J2DBench/src/j2dbench/tests/cmm/CMMTests.java
@@ -73,14 +73,16 @@ public class CMMTests extends Test {
             ColorSpace.CS_sRGB,
             ColorSpace.CS_GRAY,
             ColorSpace.CS_LINEAR_RGB,
-            ColorSpace.CS_CIEXYZ
+            ColorSpace.CS_CIEXYZ,
+            ColorSpace.CS_PYCC
         };
 
         String[] csNames = new String[]{
             "CS_sRGB",
             "CS_GRAY",
             "CS_LINEAR_RGB",
-            "CS_CIEXYZ"
+            "CS_CIEXYZ",
+            "CS_PYCC"
         };
 
         csList = new Option.IntList(cmmOptRoot,


### PR DESCRIPTION
Support of the CS_PYCC color profile is added to the J2DBench.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255920](https://bugs.openjdk.java.net/browse/JDK-8255920): J2DBench should support CS_PYCC color profile


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1072/head:pull/1072`
`$ git checkout pull/1072`
