### PR TITLE
8255937: Better cleanup for test/jdk/javax/imageio/stream/StreamFlush.java

### DIFF
--- a/test/jdk/javax/imageio/stream/StreamFlush.java
+++ b/test/jdk/javax/imageio/stream/StreamFlush.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageOutputStream;
@@ -44,14 +46,20 @@ public class StreamFlush {
         ImageIO.setUseCache(true);
 
         // Create a FileImageOutputStream from a FileOutputStream
-        File temp1 = File.createTempFile("imageio", ".tmp");
-        temp1.deleteOnExit();
-        ImageOutputStream fios = ImageIO.createImageOutputStream(temp1);
-
+        File temp1 = File.createTempFile("StreamFlush_fis_", ".tmp");
         // Create a FileCacheImageOutputStream from a BufferedOutputStream
-        File temp2 = File.createTempFile("imageio", ".tmp");
-        temp2.deleteOnExit();
-        FileOutputStream fos2 = new FileOutputStream(temp2);
+        File temp2 = File.createTempFile("StreamFlush_bos_", ".tmp");
+        try (ImageOutputStream fios = ImageIO.createImageOutputStream(temp1);
+             FileOutputStream fos2 = new FileOutputStream(temp2)) {
+            test(temp1, fios, temp2, fos2);
+        } finally {
+            Files.delete(Paths.get(temp1.getAbsolutePath()));
+            Files.delete(Paths.get(temp2.getAbsolutePath()));
+        }
+    }
+
+    private static void test(File temp1, ImageOutputStream fios, File temp2,
+                             FileOutputStream fos2) throws IOException {
         BufferedOutputStream bos = new BufferedOutputStream(fos2);
         ImageOutputStream fcios1 = ImageIO.createImageOutputStream(bos);
 


### PR DESCRIPTION
The test leaves two temporary files due to unclosed file streams.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255937](https://bugs.openjdk.java.net/browse/JDK-8255937): Better cleanup for test/jdk/javax/imageio/stream/StreamFlush.java


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1074/head:pull/1074`
`$ git checkout pull/1074`
