### PR TITLE
8246741: NetworkInterface/UniqueMacAddressesTest: mac address uniqueness test failed

### DIFF
--- a/test/jdk/java/net/NetworkInterface/UniqueMacAddressesTest.java
+++ b/test/jdk/java/net/NetworkInterface/UniqueMacAddressesTest.java
@@ -35,7 +35,7 @@ import jdk.test.lib.NetworkConfiguration;
 /*
  * @test
  * @bug 8021372
- * @summary Tests that the MAC addresses returned by NetworkConfiguration.probe() are unique for each adapter.
+ * @summary Tests that the MAC addresses returned by NetworkInterface.getNetworkInterfaces are unique for each adapter.
  * @library /test/lib
  * @build jdk.test.lib.NetworkConfiguration
  * @run main/othervm UniqueMacAddressesTest
@@ -43,6 +43,7 @@ import jdk.test.lib.NetworkConfiguration;
 public class UniqueMacAddressesTest {
 
     static PrintStream log = System.err;
+    record NetIfPair(String interfaceName, byte[] address) {}
 
     public static void main(String[] args) throws Exception {
         new UniqueMacAddressesTest().execute();
@@ -104,6 +105,4 @@ public class UniqueMacAddressesTest {
                 .collect(Collectors.filtering(netIfPair -> netIfPair.address != null,
                         Collectors.toCollection(ArrayList::new)));
     }
-
-    record NetIfPair(String interfaceName, byte[] address) {}
 }

--- a/test/jdk/java/net/NetworkInterface/UniqueMacAddressesTest.java
+++ b/test/jdk/java/net/NetworkInterface/UniqueMacAddressesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,87 +21,65 @@
  * questions.
  */
 
-import java.net.InetAddress;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Enumeration;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import jdk.test.lib.NetworkConfiguration;
 
 /*
  * @test
  * @bug 8021372
- * @summary Tests that the MAC addresses returned by NetworkInterface.getNetworkInterfaces are unique for each adapter.
- *
+ * @summary Tests that the MAC addresses returned by NetworkConfiguration.probe() are unique for each adapter.
+ * @library /test/lib
+ * @build jdk.test.lib.NetworkConfiguration
+ * @run main/othervm UniqueMacAddressesTest
  */
 public class UniqueMacAddressesTest {
 
+    static PrintStream log = System.err;
+
     public static void main(String[] args) throws Exception {
         new UniqueMacAddressesTest().execute();
-        System.out.println("UniqueMacAddressesTest: OK");
+        log.println("UniqueMacAddressesTest: OK");
     }
 
     public UniqueMacAddressesTest() {
-        System.out.println("UniqueMacAddressesTest: start ");
+        log.println("UniqueMacAddressesTest: start");
     }
 
     public void execute() throws Exception {
-        Enumeration<NetworkInterface> networkInterfaces;
-        boolean areMacAddressesUnique = false;
-        List<NetworkInterface> networkInterfaceList = new ArrayList<NetworkInterface>();
-            networkInterfaces = NetworkInterface.getNetworkInterfaces();
-
-        // build a list of NetworkInterface objects to test MAC address
-        // uniqueness
-        createNetworkInterfaceList(networkInterfaces, networkInterfaceList);
-        areMacAddressesUnique = checkMacAddressesAreUnique(networkInterfaceList);
-        if (!areMacAddressesUnique) {
+        // build a list of NetworkInterface name address pairs
+        // to test MAC address uniqueness
+        List<NetIfPair> netIfList = createNetworkInterfaceList(NetworkConfiguration.probe());
+        if (!macAddressesAreUnique(netIfList))
             throw new RuntimeException("mac address uniqueness test failed");
-        }
     }
 
-    private boolean checkMacAddressesAreUnique (
-            List<NetworkInterface> networkInterfaces) throws Exception {
-        boolean uniqueMacAddresses = true;
-        for (NetworkInterface networkInterface : networkInterfaces) {
-            for (NetworkInterface comparisonNetIf : networkInterfaces) {
-                System.out.println("Comparing netif "
-                        + networkInterface.getName() + " and netif "
-                        + comparisonNetIf.getName());
-                if (testMacAddressesEqual(networkInterface, comparisonNetIf)) {
-                    uniqueMacAddresses = false;
-                    break;
-                }
+    private boolean macAddressesAreUnique(List<NetIfPair> netIfPairs) {
+        for (NetIfPair netIfPair : netIfPairs) {
+            for (NetIfPair compNetIfPair : netIfPairs) {
+                if (!netIfPair.interfaceName.equals(compNetIfPair.interfaceName) &&
+                        testMacAddressesEqual(netIfPair, compNetIfPair))
+                    return false;
             }
-            if (uniqueMacAddresses != true)
-                break;
         }
-        return uniqueMacAddresses;
+        return true;
     }
 
-    private boolean testMacAddressesEqual(NetworkInterface netIf1,
-            NetworkInterface netIf2) throws Exception {
-
-        byte[] rawMacAddress1 = null;
-        byte[] rawMacAddress2 = null;
-        boolean macAddressesEqual = false;
-        if (!netIf1.getName().equals(netIf2.getName())) {
-            System.out.println("compare hardware addresses "
-                +  createMacAddressString(netIf1) + " and " + createMacAddressString(netIf2));
-            rawMacAddress1 = netIf1.getHardwareAddress();
-            rawMacAddress2 = netIf2.getHardwareAddress();
-            macAddressesEqual = Arrays.equals(rawMacAddress1, rawMacAddress2);
-        } else {
-            // same interface
-            macAddressesEqual = false;
-        }
-        return macAddressesEqual;
+    private boolean testMacAddressesEqual(NetIfPair if1, NetIfPair if2) {
+        log.println("Compare hardware addresses of " + if1.interfaceName + " ("
+                +  createMacAddressString(if1.address) + ")" + " and " + if2.interfaceName
+                + " (" + createMacAddressString(if2.address) + ")");
+        return (Arrays.equals(if1.address, if2.address));
     }
 
-    private String createMacAddressString (NetworkInterface netIf) throws Exception {
-        byte[] macAddr = netIf.getHardwareAddress();
+    private String createMacAddressString(byte[] macAddr) {
         StringBuilder sb =  new StringBuilder();
         if (macAddr != null) {
             for (int i = 0; i < macAddr.length; i++) {
@@ -112,21 +90,20 @@ public class UniqueMacAddressesTest {
         return sb.toString();
     }
 
-    private void createNetworkInterfaceList(Enumeration<NetworkInterface> nis,
-            List<NetworkInterface> networkInterfaceList) throws Exception {
-        byte[] macAddr = null;
-        NetworkInterface netIf = null;
-        while (nis.hasMoreElements()) {
-            netIf = (NetworkInterface) nis.nextElement();
-            if (netIf.isUp()) {
-                macAddr = netIf.getHardwareAddress();
-                if (macAddr != null) {
-                    System.out.println("Adding NetworkInterface "
-                            + netIf.getName() + " with mac address "
-                            + createMacAddressString(netIf));
-                    networkInterfaceList.add(netIf);
-                }
-            }
+    private byte[] getNetworkInterfaceHardwareAddress(NetworkInterface inf) {
+        try {
+            return inf.getHardwareAddress();
+        } catch (SocketException se) {
+            throw new UncheckedIOException(se);
         }
     }
+
+    private List<NetIfPair> createNetworkInterfaceList(NetworkConfiguration netConf) {
+        return netConf.interfaces()
+                .map(netIf -> new NetIfPair(netIf.getName(), getNetworkInterfaceHardwareAddress(netIf)))
+                .collect(Collectors.filtering(netIfPair -> netIfPair.address != null,
+                        Collectors.toCollection(ArrayList::new)));
+    }
+
+    record NetIfPair(String interfaceName, byte[] address) {}
 }

--- a/test/jdk/java/net/NetworkInterface/UniqueMacAddressesTest.java
+++ b/test/jdk/java/net/NetworkInterface/UniqueMacAddressesTest.java
@@ -43,6 +43,8 @@ import jdk.test.lib.NetworkConfiguration;
 public class UniqueMacAddressesTest {
 
     static PrintStream log = System.err;
+
+    // A record pair (NetworkInterface::name,  NetworkInterface::hardwareAddress)
     record NetIfPair(String interfaceName, byte[] address) {}
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
The primary goal of this fix was to refactor NetworkInterface/UniqueMacAddressesTest.java to make use of the jdk.test.lib.NetworkConfiguration class instead of java.net.NetworkInterface. This was due to the original failure being related to the use of the 'awdl' interface on macOS, which should be skipped for functional tests. The NetworkConfiguration class accounts for this when returning the list of present interfaces (originally retrieved using NetworkInterface.getNetworkInterfaces()) as well as for other OS specific properties. The effects of these changes can be seen on L59 and L101-106.

In addition to these changes, some modifications were made to the test in the interest of keeping it concise and readable but were made bearing in mind the original logging of the test was already up to a good standard (and I sought to keep it that way). To summarize the other changes:

- When using NetworkConfiguration::interfaces to read in a stream of NetworkInterface objects, the objects are collected into a list of records (see [JEP 395](https://openjdk.java.net/jeps/395)) to avoid multiple calls to NetworkInterface::getHardwareAddress  (which can throw a SocketException) throughout the test.
- When checking if the MAC addresses are unique, the testMacAddressesEqual() method is not called unless the interface names are different. If testMacAddressesEqual() returns true, the calling method will simply return instead of updating the value of a boolean variable.
- Majority of logging was moved to the testMacAddressesEqualMethod() so that only logs for comparisons are carried out. There is scope for additional logging of, for example, the list of present interfaces returned by createNetworkInterfaceList() if deemed necessary by review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8246741](https://bugs.openjdk.java.net/browse/JDK-8246741): NetworkInterface/UniqueMacAddressesTest: mac address uniqueness test failed


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to 3e086804477fa105d3b4a2367d9e948804de963c
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1076/head:pull/1076`
`$ git checkout pull/1076`
