### PR TITLE
JDK-8254893: Fix display of search tag results without holder information

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js
@@ -161,7 +161,7 @@ $.widget("custom.catcomplete", $.ui.autocomplete, {
         }
         var li = $("<li/>").appendTo(ul);
         var div = $("<div/>").appendTo(li);
-        if (item.category === catSearchTags) {
+        if (item.category === catSearchTags && item.h) {
             if (item.d) {
                 div.html(label + "<span class=\"search-tag-holder-result\"> (" + item.h + ")</span><br><span class=\"search-tag-desc-result\">"
                                 + item.d + "</span><br>");


### PR DESCRIPTION
This is a trivial fix to only display holder information for index items in search results if it is available.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254893](https://bugs.openjdk.java.net/browse/JDK-8254893): Fix display of search tag results without holder information


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1077/head:pull/1077`
`$ git checkout pull/1077`
