### PR TITLE
8255598: [PPC64] assert(Universe::heap()->is_in(result)) failed: object not in heap

### DIFF
--- a/src/hotspot/cpu/ppc/nativeInst_ppc.cpp
+++ b/src/hotspot/cpu/ppc/nativeInst_ppc.cpp
@@ -197,7 +197,10 @@ intptr_t NativeMovConstReg::data() const {
   CodeBlob* cb = CodeCache::find_blob_unsafe(addr);
   if (MacroAssembler::is_set_narrow_oop(addr, cb->content_begin())) {
     narrowOop no = MacroAssembler::get_narrow_oop(addr, cb->content_begin());
-    if (no == narrowOop::null) return 0;
+    // We can reach here during GC with 'no' pointing to new object location
+    // while 'heap()->is_in' still reports false (e.g. with SerialGC).
+    // Therefore we use raw decoding.
+    if (CompressedOops::is_null(no)) return 0;
     return cast_from_oop<intptr_t>(CompressedOops::decode_raw(no));
   } else {
     assert(MacroAssembler::is_load_const_from_method_toc_at(addr), "must be load_const_from_pool");

--- a/src/hotspot/cpu/ppc/nativeInst_ppc.cpp
+++ b/src/hotspot/cpu/ppc/nativeInst_ppc.cpp
@@ -197,7 +197,8 @@ intptr_t NativeMovConstReg::data() const {
   CodeBlob* cb = CodeCache::find_blob_unsafe(addr);
   if (MacroAssembler::is_set_narrow_oop(addr, cb->content_begin())) {
     narrowOop no = MacroAssembler::get_narrow_oop(addr, cb->content_begin());
-    return cast_from_oop<intptr_t>(CompressedOops::decode(no));
+    if (no == narrowOop::null) return 0;
+    return cast_from_oop<intptr_t>(CompressedOops::decode_raw(no));
   } else {
     assert(MacroAssembler::is_load_const_from_method_toc_at(addr), "must be load_const_from_pool");
 


### PR DESCRIPTION
JDK-8237363 introduced "assert(Universe::heap()->is_in..." check in CompressedOops::decode functions.
This assertion restricts the usability of the decode functions. There are periods of time (during GC) at which we can't use " Universe::heap()->is_in" because the pointer gets switched between old and new location, but "Universe::heap()->is_in" is not yet accurate.
PPC64 code has a usage of CompressedOops::decode which is affected by this problem. (It was observed with SerialGC, see JBS.)
We could also use a weaker assertion, but seems like other people value the stronger assertion more. So I suggest to use decode_raw as workaround for PPC64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255598](https://bugs.openjdk.java.net/browse/JDK-8255598): [PPC64] assert(Universe::heap()->is_in(result)) failed: object not in heap


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1078/head:pull/1078`
`$ git checkout pull/1078`
