### PR TITLE
8255959: Timeouts in VectorConversion tests

### DIFF
--- a/test/jdk/jdk/incubator/vector/Vector128ConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/Vector128ConversionTests.java
@@ -34,7 +34,7 @@ import java.util.function.IntFunction;
  * @test
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
- * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ * @run testng/othervm/timeout=1800 -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      Vector128ConversionTests
  */
 

--- a/test/jdk/jdk/incubator/vector/Vector256ConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/Vector256ConversionTests.java
@@ -34,7 +34,7 @@ import java.util.function.IntFunction;
  * @test
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
- * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ * @run testng/othervm/timeout=1800 -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      Vector256ConversionTests
  */
 

--- a/test/jdk/jdk/incubator/vector/Vector512ConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/Vector512ConversionTests.java
@@ -34,7 +34,7 @@ import java.util.function.IntFunction;
  * @test
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
- * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ * @run testng/othervm/timeout=1800 -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      Vector512ConversionTests
  */
 

--- a/test/jdk/jdk/incubator/vector/Vector64ConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/Vector64ConversionTests.java
@@ -35,7 +35,7 @@ import java.util.function.IntFunction;
  * @test
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
- * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ * @run testng/othervm/timeout=1800 -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      Vector64ConversionTests
  */
 

--- a/test/jdk/jdk/incubator/vector/VectorMaxConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/VectorMaxConversionTests.java
@@ -34,7 +34,7 @@ import java.util.function.IntFunction;
  * @test
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
- * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ * @run testng/othervm/timeout=1800 -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      VectorMaxConversionTests
  */
 


### PR DESCRIPTION
We observed many timeouts in the following test/jdk/jdk/incubator/vector tests:
Vector128ConversionTests.java
Vector256ConversionTests.java
Vector512ConversionTests.java
Vector64ConversionTests.java
VectorMaxConversionTests.java
Some machines don't support vector instructions or fewer of them and C2 uses slower alternatives.

Maybe there are options to make the tests faster, but I just propose to use a larger timeout value for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255959](https://bugs.openjdk.java.net/browse/JDK-8255959): Timeouts in VectorConversion tests


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1079/head:pull/1079`
`$ git checkout pull/1079`
