### PR TITLE
8255964: Add all details to jstack log in jtreg timeout handler

### DIFF
--- a/test/failure_handler/src/share/conf/common.properties
+++ b/test/failure_handler/src/share/conf/common.properties
@@ -29,7 +29,6 @@ args=%p
 ################################################################################
 onTimeout=\
   jinfo \
-  jcmd.thread.print \
   jcmd.compiler.codecache jcmd.compiler.codelist \
         jcmd.compiler.queue \
   jcmd.vm.classloader_stats jcmd.vm.stringtable \
@@ -46,8 +45,6 @@ jcmd.compiler.codecache.args=%p Compiler.codecache
 jcmd.compiler.codelist.args=%p Compiler.codelist
 jcmd.compiler.queue.args=%p Compiler.queue
 
-jcmd.thread.print.args=%p Thread.print
-
 jcmd.vm.classloader_stats.args=%p VM.classloader_stats
 jcmd.vm.stringtable.args=%p VM.stringtable
 jcmd.vm.symboltable.args=%p VM.symboltable
@@ -60,6 +57,7 @@ jcmd.gc.finalizer_info.args=%p GC.finalizer_info
 jcmd.gc.heap_info.args=%p GC.heap_info
 
 jstack.app=jstack
+jstack.args=-e -l %p
 jstack.params.repeat=6
 
 ################################################################################

--- a/test/failure_handler/src/share/conf/common.properties
+++ b/test/failure_handler/src/share/conf/common.properties
@@ -29,6 +29,7 @@ args=%p
 ################################################################################
 onTimeout=\
   jinfo \
+  jcmd.thread.print \
   jcmd.compiler.codecache jcmd.compiler.codelist \
         jcmd.compiler.queue \
   jcmd.vm.classloader_stats jcmd.vm.stringtable \
@@ -44,6 +45,8 @@ jcmd.app=jcmd
 jcmd.compiler.codecache.args=%p Compiler.codecache
 jcmd.compiler.codelist.args=%p Compiler.codelist
 jcmd.compiler.queue.args=%p Compiler.queue
+
+jcmd.thread.print.args=%p Thread.print
 
 jcmd.vm.classloader_stats.args=%p VM.classloader_stats
 jcmd.vm.stringtable.args=%p VM.stringtable


### PR DESCRIPTION
This patch adds jcmd Thread.print to the jtreg timeout handler.

Please review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255964](https://bugs.openjdk.java.net/browse/JDK-8255964): Add all details to jstack log in jtreg timeout handler


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1080/head:pull/1080`
`$ git checkout pull/1080`
