### PR TITLE
8255799: AArch64: CPU_A53MAC feature may be set incorrectly

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -181,10 +181,6 @@ void VM_Version::initialize() {
   }
 
   if (_cpu == CPU_ARM && (_model == 0xd07 || _model2 == 0xd07)) _features |= CPU_STXR_PREFETCH;
-  // If an olde style /proc/cpuinfo (cores == 1) then if _model is an A57 (0xd07)
-  // we assume the worst and assume we could be on a big little system and have
-  // undisclosed A53 cores which we could be swapped to at any stage
-  if (_cpu == CPU_ARM && os::processor_count() == 1 && _model == 0xd07) _features |= CPU_A53MAC;
 
   char buf[512];
   sprintf(buf, "0x%02x:0x%x:0x%03x:%d", _cpu, _variant, _model, _revision);


### PR DESCRIPTION
Follow-up patch for PR #1039. As clarified by @nick-arm, CPU_A53MAC was set to workaround old Linux bug when A53 cores may be available if only a single A57 core is reported in /proc/cpuinfo. The workaround was broken recently but the bug is assumed to be fixed everywhere, so the workaround can be removed completely.

CCing old participants: @theRealAph @adinn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x86 (hs/tier1 gc)](https://github.com/AntonKozlov/jdk/runs/1360717076)

### Issue
 * [JDK-8255799](https://bugs.openjdk.java.net/browse/JDK-8255799): AArch64: CPU_A53MAC feature may be set incorrectly


### Reviewers
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - Committer)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1084/head:pull/1084`
`$ git checkout pull/1084`
