### PR TITLE
8255965: LogCompilation: add sort by nmethod code size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ test/nashorn/lib
 NashornProfile.txt
 **/JTreport/**
 **/JTwork/**
+/src/utils/LogCompilation/target/

--- a/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/Compilation.java
+++ b/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/Compilation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -221,8 +221,17 @@ public class Compilation implements LogEvent {
                     stream.print(" " + nmethod.getLevel());
                 }
             }
+
+            String codeSize = "";
+            if (nmethod != null) {
+                long nmethodSize = nmethod.getInstSize();
+                if (nmethodSize > 0) {
+                    codeSize = "(code size: " + nmethodSize + ")";
+                }
+            }
+
             int bc = isOsr() ? getBCI() : -1;
-            stream.print(getMethod().decodeFlags(bc) + " " + getCompiler() + " " + getMethod().format(bc));
+            stream.print(getMethod().decodeFlags(bc) + " " + getCompiler() + " " + getMethod().format(bc) + codeSize);
             stream.println();
             if (getFailureReason() != null) {
                 stream.println("COMPILE SKIPPED: " + getFailureReason() + " (not retryable)");

--- a/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogCompilation.java
+++ b/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogCompilation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,6 +94,9 @@ public class LogCompilation extends DefaultHandler implements ErrorHandler {
                 index++;
             } else if (a.equals("-s")) {
                 sort = LogParser.sortByStart;
+                index++;
+            } else if (a.equals("-z")) {
+                sort = LogParser.sortByNMethodSize;
                 index++;
             } else if (a.equals("-t")) {
                 printTimeStamps = true;

--- a/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/NMethod.java
+++ b/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/NMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,11 @@ public class NMethod extends BasicLogEvent {
     private long size;
 
     /**
+     * The nmethod's insts size in bytes.
+     */
+    private long instSize;
+
+    /**
      * The nmethod's compilation level.
      */
     private long level;
@@ -77,6 +82,14 @@ public class NMethod extends BasicLogEvent {
 
     public void setSize(long size) {
         this.size = size;
+    }
+
+    public long getInstSize() {
+        return instSize;
+    }
+
+    public void setInstSize(long size) {
+        this.instSize = size;
     }
 
     /**

--- a/src/utils/LogCompilation/src/test/java/com/sun/hotspot/tools/compiler/TestLogCompilation.java
+++ b/src/utils/LogCompilation/src/test/java/com/sun/hotspot/tools/compiler/TestLogCompilation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,6 +172,15 @@ public class TestLogCompilation {
     @Test
     public void testDashn() throws Exception {
         String[] args = {"-n",
+            logFile
+        };
+
+        LogCompilation.main(args);
+    }
+
+    @Test
+    public void testDashz() throws Exception {
+        String[] args = {"-z",
             logFile
         };
 


### PR DESCRIPTION
While profiling an issue I added this sort by code size to LogCompilation, using  -z

$ java -ea -jar target/LogCompilation-1.0-SNAPSHOT.jar -z 2000-2.log | head

879 4 com.fee.fi.fo.Fum::foobar (3076 bytes)(code size: 57344)
853 make_not_entrant
853 3 com.fee.fi.fo.Fum::foobar (3076 bytes)(code size: 55968)
895 4 com.fee.fi.fo.Fum::baz (2238 bytes)(code size: 46112)
888 4 com.fee.fi.fo.Fum::quux (2165 bytes)(code size: 43200)

The code size = stub_offset - insts_offset from what is in the log. 
This makes it easier to see, for example, if changing compiler XX options make huge differences in inlining.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255965](https://bugs.openjdk.java.net/browse/JDK-8255965): LogCompilation: add sort by nmethod code size


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1085/head:pull/1085`
`$ git checkout pull/1085`
