### PR TITLE
8248191: [PPC64] Replace lxvd2x/stxvd2x with lxvx/stxvx for Power10

### DIFF
--- a/src/hotspot/cpu/ppc/assembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.hpp
@@ -519,6 +519,8 @@ class Assembler : public AbstractAssembler {
     LVSR_OPCODE    = (31u << OPCODE_SHIFT |   38u << 1),
 
     // Vector-Scalar (VSX) instruction support.
+    LXVX_OPCODE    = (31u << OPCODE_SHIFT |  268u << 1),
+    STXVX_OPCODE   = (31u << OPCODE_SHIFT |  396u << 1),
     LXVD2X_OPCODE  = (31u << OPCODE_SHIFT |  844u << 1),
     STXVD2X_OPCODE = (31u << OPCODE_SHIFT |  972u << 1),
     MTVSRD_OPCODE  = (31u << OPCODE_SHIFT |  179u << 1),
@@ -2235,6 +2237,10 @@ class Assembler : public AbstractAssembler {
   inline void mfvscr(   VectorRegister d);
 
   // Vector-Scalar (VSX) instructions.
+  inline void lxvx(     VectorSRegister d, Register a);
+  inline void lxvx(     VectorSRegister d, Register a, Register b);
+  inline void stxvx(    VectorSRegister d, Register b);
+  inline void stxvx(    VectorSRegister d, Register a, Register b);
   inline void lxvd2x(   VectorSRegister d, Register a);
   inline void lxvd2x(   VectorSRegister d, Register a, Register b);
   inline void stxvd2x(  VectorSRegister d, Register a);

--- a/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
@@ -776,6 +776,10 @@ inline void Assembler::lvsl(  VectorRegister d, Register s1, Register s2) { emit
 inline void Assembler::lvsr(  VectorRegister d, Register s1, Register s2) { emit_int32( LVSR_OPCODE   | vrt(d) | ra0mem(s1) | rb(s2)); }
 
 // Vector-Scalar (VSX) instructions.
+inline void Assembler::lxvx(    VectorSRegister d, Register s1)              { emit_int32( LXVX_OPCODE    | vsrt(d) | ra(0) | rb(s1)); }
+inline void Assembler::lxvx(    VectorSRegister d, Register s1, Register s2) { emit_int32( LXVX_OPCODE    | vsrt(d) | ra0mem(s1) | rb(s2)); }
+inline void Assembler::stxvx(   VectorSRegister d, Register s1)              { emit_int32( STXVX_OPCODE   | vsrs(d) | ra(0) | rb(s1)); }
+inline void Assembler::stxvx(   VectorSRegister d, Register s1, Register s2) { emit_int32( STXVX_OPCODE   | vsrs(d) | ra0mem(s1) | rb(s2)); }
 inline void Assembler::lxvd2x(  VectorSRegister d, Register s1)              { emit_int32( LXVD2X_OPCODE  | vsrt(d) | ra(0) | rb(s1)); }
 inline void Assembler::lxvd2x(  VectorSRegister d, Register s1, Register s2) { emit_int32( LXVD2X_OPCODE  | vsrt(d) | ra0mem(s1) | rb(s2)); }
 inline void Assembler::stxvd2x( VectorSRegister d, Register s1)              { emit_int32( STXVD2X_OPCODE | vsrs(d) | ra(0) | rb(s1)); }

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -1706,7 +1706,11 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
       if (cbuf) {
         C2_MacroAssembler _masm(cbuf);
         __ addi(R0, R1_SP, dst_offset);
-        __ stxvd2x(Rsrc, R0);
+        if (VM_Version::has_brw()) {
+          __ stxvx(Rsrc, R0);
+        } else {
+          __ stxvd2x(Rsrc, R0);
+        }
       }
       size += 8;
     }
@@ -1717,7 +1721,11 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
       if (cbuf) {
         C2_MacroAssembler _masm(cbuf);
         __ addi(R0, R1_SP, src_offset);
-        __ lxvd2x(Rdst, R0);
+        if (VM_Version::has_brw()) {
+          __ lxvx(Rdst, R0);
+        } else {
+          __ lxvd2x(Rdst, R0);
+        }
       }
       size += 8;
     }
@@ -5560,7 +5568,7 @@ instruct loadV8(iRegLdst dst, memoryAlg4 mem) %{
 
 // Load Aligned Packed Byte
 instruct loadV16(vecX dst, indirect mem) %{
-  predicate(n->as_LoadVector()->memory_size() == 16);
+  predicate(n->as_LoadVector()->memory_size() == 16 && !VM_Version::has_brw());
   match(Set dst (LoadVector mem));
   ins_cost(MEMORY_REF_COST);
 
@@ -5568,6 +5576,19 @@ instruct loadV16(vecX dst, indirect mem) %{
   size(4);
   ins_encode %{
     __ lxvd2x($dst$$VectorSRegister, $mem$$Register);
+  %}
+  ins_pipe(pipe_class_default);
+%}
+
+instruct loadV16_lxvx(vecX dst, indirect mem) %{
+  predicate(n->as_LoadVector()->memory_size() == 16 && VM_Version::has_brw());
+  match(Set dst (LoadVector mem));
+  ins_cost(MEMORY_REF_COST);
+
+  format %{ "LXVX     $dst, $mem \t// load 16 byte Vector" %}
+  size(4);
+  ins_encode %{
+    __ lxvx($dst$$VectorSRegister, $mem$$Register);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -6538,7 +6559,7 @@ instruct storeA8B(memoryAlg4 mem, iRegLsrc src) %{
 
 // Store Packed Byte long register to memory
 instruct storeV16(indirect mem, vecX src) %{
-  predicate(n->as_StoreVector()->memory_size() == 16);
+  predicate(n->as_StoreVector()->memory_size() == 16 && !VM_Version::has_brw());
   match(Set mem (StoreVector mem src));
   ins_cost(MEMORY_REF_COST);
 
@@ -6546,6 +6567,19 @@ instruct storeV16(indirect mem, vecX src) %{
   size(4);
   ins_encode %{
     __ stxvd2x($src$$VectorSRegister, $mem$$Register);
+  %}
+  ins_pipe(pipe_class_default);
+%}
+
+instruct storeV16_stxvx(indirect mem, vecX src) %{
+  predicate(n->as_StoreVector()->memory_size() == 16 && VM_Version::has_brw());
+  match(Set mem (StoreVector mem src));
+  ins_cost(MEMORY_REF_COST);
+
+  format %{ "STXVX     $mem, $src \t// store 16-byte Vector" %}
+  size(4);
+  ins_encode %{
+    __ stxvx($src$$VectorSRegister, $mem$$Register);
   %}
   ins_pipe(pipe_class_default);
 %}

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -1097,10 +1097,18 @@ class StubGenerator: public StubCodeGenerator {
         __ bind(l_10);
         // Use loop with VSX load/store instructions to
         // copy 32 elements a time.
-        __ lxvd2x(tmp_vsr1, R3_ARG1);        // Load src
-        __ stxvd2x(tmp_vsr1, R4_ARG2);       // Store to dst
-        __ lxvd2x(tmp_vsr2, tmp1, R3_ARG1);  // Load src + 16
-        __ stxvd2x(tmp_vsr2, tmp1, R4_ARG2); // Store to dst + 16
+        if (VM_Version::has_brw()) {
+          __ lxvx(tmp_vsr1, R3_ARG1);        // Load src
+          __ stxvx(tmp_vsr1, R4_ARG2);       // Store to dst
+          __ lxvx(tmp_vsr2, tmp1, R3_ARG1);  // Load src + 16
+          __ stxvx(tmp_vsr2, tmp1, R4_ARG2); // Store to dst + 16
+        }
+        else {
+          __ lxvd2x(tmp_vsr1, R3_ARG1);        // Load src
+          __ stxvd2x(tmp_vsr1, R4_ARG2);       // Store to dst
+          __ lxvd2x(tmp_vsr2, tmp1, R3_ARG1);  // Load src + 16
+          __ stxvd2x(tmp_vsr2, tmp1, R4_ARG2); // Store to dst + 16
+        }
         __ addi(R3_ARG1, R3_ARG1, 32);       // Update src+=32
         __ addi(R4_ARG2, R4_ARG2, 32);       // Update dsc+=32
         __ bdnz(l_10);                       // Dec CTR and loop if not zero.
@@ -1368,10 +1376,17 @@ class StubGenerator: public StubCodeGenerator {
           __ bind(l_9);
           // Use loop with VSX load/store instructions to
           // copy 16 elements a time.
-          __ lxvd2x(tmp_vsr1, R3_ARG1);        // Load from src.
-          __ stxvd2x(tmp_vsr1, R4_ARG2);       // Store to dst.
-          __ lxvd2x(tmp_vsr2, R3_ARG1, tmp1);  // Load from src + 16.
-          __ stxvd2x(tmp_vsr2, R4_ARG2, tmp1); // Store to dst + 16.
+          if (VM_Version::has_brw()) {
+            __ lxvx(tmp_vsr1, R3_ARG1);        // Load from src.
+            __ stxvx(tmp_vsr1, R4_ARG2);       // Store to dst.
+            __ lxvx(tmp_vsr2, R3_ARG1, tmp1);  // Load from src + 16.
+            __ stxvx(tmp_vsr2, R4_ARG2, tmp1); // Store to dst + 16.
+          } else {
+            __ lxvd2x(tmp_vsr1, R3_ARG1);        // Load from src.
+            __ stxvd2x(tmp_vsr1, R4_ARG2);       // Store to dst.
+            __ lxvd2x(tmp_vsr2, R3_ARG1, tmp1);  // Load from src + 16.
+            __ stxvd2x(tmp_vsr2, R4_ARG2, tmp1); // Store to dst + 16.
+          }
           __ addi(R3_ARG1, R3_ARG1, 32);       // Update src+=32.
           __ addi(R4_ARG2, R4_ARG2, 32);       // Update dsc+=32.
           __ bdnz(l_9);                        // Dec CTR and loop if not zero.
@@ -1564,10 +1579,17 @@ class StubGenerator: public StubCodeGenerator {
       __ bind(l_7);
       // Use loop with VSX load/store instructions to
       // copy 8 elements a time.
-      __ lxvd2x(tmp_vsr1, R3_ARG1);        // Load src
-      __ stxvd2x(tmp_vsr1, R4_ARG2);       // Store to dst
-      __ lxvd2x(tmp_vsr2, tmp1, R3_ARG1);  // Load src + 16
-      __ stxvd2x(tmp_vsr2, tmp1, R4_ARG2); // Store to dst + 16
+      if (VM_Version::has_brw()) {
+        __ lxvx(tmp_vsr1, R3_ARG1);        // Load src
+        __ stxvx(tmp_vsr1, R4_ARG2);       // Store to dst
+        __ lxvx(tmp_vsr2, tmp1, R3_ARG1);  // Load src + 16
+        __ stxvx(tmp_vsr2, tmp1, R4_ARG2); // Store to dst + 16
+      } else {
+        __ lxvd2x(tmp_vsr1, R3_ARG1);        // Load src
+        __ stxvd2x(tmp_vsr1, R4_ARG2);       // Store to dst
+        __ lxvd2x(tmp_vsr2, tmp1, R3_ARG1);  // Load src + 16
+        __ stxvd2x(tmp_vsr2, tmp1, R4_ARG2); // Store to dst + 16
+      }
       __ addi(R3_ARG1, R3_ARG1, 32);       // Update src+=32
       __ addi(R4_ARG2, R4_ARG2, 32);       // Update dsc+=32
       __ bdnz(l_7);                        // Dec CTR and loop if not zero.
@@ -1719,10 +1741,17 @@ class StubGenerator: public StubCodeGenerator {
       // copy 8 elements a time.
       __ addi(R3_ARG1, R3_ARG1, -32);      // Update src-=32
       __ addi(R4_ARG2, R4_ARG2, -32);      // Update dsc-=32
-      __ lxvd2x(tmp_vsr2, tmp1, R3_ARG1);  // Load src+16
-      __ lxvd2x(tmp_vsr1, R3_ARG1);        // Load src
-      __ stxvd2x(tmp_vsr2, tmp1, R4_ARG2); // Store to dst+16
-      __ stxvd2x(tmp_vsr1, R4_ARG2);       // Store to dst
+      if (VM_Version::has_brw()) {
+        __ lxvx(tmp_vsr2, tmp1, R3_ARG1);  // Load src+16
+        __ lxvx(tmp_vsr1, R3_ARG1);        // Load src
+        __ stxvx(tmp_vsr2, tmp1, R4_ARG2); // Store to dst+16
+        __ stxvx(tmp_vsr1, R4_ARG2);       // Store to dst
+      } else {
+        __ lxvd2x(tmp_vsr2, tmp1, R3_ARG1);  // Load src+16
+        __ lxvd2x(tmp_vsr1, R3_ARG1);        // Load src
+        __ stxvd2x(tmp_vsr2, tmp1, R4_ARG2); // Store to dst+16
+        __ stxvd2x(tmp_vsr1, R4_ARG2);       // Store to dst
+      }
       __ bdnz(l_4);
 
       // Restore DSCR pre-fetch value.
@@ -1843,10 +1872,17 @@ class StubGenerator: public StubCodeGenerator {
       __ bind(l_5);
       // Use loop with VSX load/store instructions to
       // copy 4 elements a time.
-      __ lxvd2x(tmp_vsr1, R3_ARG1);        // Load src
-      __ stxvd2x(tmp_vsr1, R4_ARG2);       // Store to dst
-      __ lxvd2x(tmp_vsr2, tmp1, R3_ARG1);  // Load src + 16
-      __ stxvd2x(tmp_vsr2, tmp1, R4_ARG2); // Store to dst + 16
+      if (VM_Version::has_brw()) {
+        __ lxvx(tmp_vsr1, R3_ARG1);        // Load src
+        __ stxvx(tmp_vsr1, R4_ARG2);       // Store to dst
+        __ lxvx(tmp_vsr2, tmp1, R3_ARG1);  // Load src + 16
+        __ stxvx(tmp_vsr2, tmp1, R4_ARG2); // Store to dst + 16
+      } else {
+        __ lxvd2x(tmp_vsr1, R3_ARG1);        // Load src
+        __ stxvd2x(tmp_vsr1, R4_ARG2);       // Store to dst
+        __ lxvd2x(tmp_vsr2, tmp1, R3_ARG1);  // Load src + 16
+        __ stxvd2x(tmp_vsr2, tmp1, R4_ARG2); // Store to dst + 16
+      }
       __ addi(R3_ARG1, R3_ARG1, 32);       // Update src+=32
       __ addi(R4_ARG2, R4_ARG2, 32);       // Update dsc+=32
       __ bdnz(l_5);                        // Dec CTR and loop if not zero.
@@ -1976,10 +2012,17 @@ class StubGenerator: public StubCodeGenerator {
       // copy 4 elements a time.
       __ addi(R3_ARG1, R3_ARG1, -32);      // Update src-=32
       __ addi(R4_ARG2, R4_ARG2, -32);      // Update dsc-=32
-      __ lxvd2x(tmp_vsr2, tmp1, R3_ARG1);  // Load src+16
-      __ lxvd2x(tmp_vsr1, R3_ARG1);        // Load src
-      __ stxvd2x(tmp_vsr2, tmp1, R4_ARG2); // Store to dst+16
-      __ stxvd2x(tmp_vsr1, R4_ARG2);       // Store to dst
+      if (VM_Version::has_brw()) {
+        __ lxvx(tmp_vsr2, tmp1, R3_ARG1);  // Load src+16
+        __ lxvx(tmp_vsr1, R3_ARG1);        // Load src
+        __ stxvx(tmp_vsr2, tmp1, R4_ARG2); // Store to dst+16
+        __ stxvx(tmp_vsr1, R4_ARG2);       // Store to dst
+      } else {
+        __ lxvd2x(tmp_vsr2, tmp1, R3_ARG1);  // Load src+16
+        __ lxvd2x(tmp_vsr1, R3_ARG1);        // Load src
+        __ stxvd2x(tmp_vsr2, tmp1, R4_ARG2); // Store to dst+16
+        __ stxvd2x(tmp_vsr1, R4_ARG2);       // Store to dst
+      }
       __ bdnz(l_4);
 
       // Restore DSCR pre-fetch value.


### PR DESCRIPTION
The pair lxvx/stxvx are more modern VSX instructions to load/store data.
These should benefit the Vector API because lxvd2x/stxvd2x may require
xxswapd, leading to a more difficult code generation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (8/8 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8248191](https://bugs.openjdk.java.net/browse/JDK-8248191): [PPC64] Replace lxvd2x/stxvd2x with lxvx/stxvx for Power10


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1086/head:pull/1086`
`$ git checkout pull/1086`
