### PR TITLE
8255949: AArch64: Add support for vectorized shift right and accumulate

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -18922,6 +18922,216 @@ instruct vsrl2L_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
+instruct vsraa8B_imm(vecD dst, vecD src, immI shift) %{
+  predicate(n->as_Vector()->length() == 8);
+  match(Set dst (AddVB dst (RShiftVB src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "ssra    $dst, $src, $shift\t# vector (8B)" %}
+  ins_encode %{
+    int sh = (int)$shift$$constant;
+    if (sh >= 8) sh = 7;
+    __ ssra(as_FloatRegister($dst$$reg), __ T8B,
+           as_FloatRegister($src$$reg), sh);
+  %}
+  ins_pipe(vshift64_imm);
+%}
+
+instruct vsraa16B_imm(vecX dst, vecX src, immI shift) %{
+  predicate(n->as_Vector()->length() == 16);
+  match(Set dst (AddVB dst (RShiftVB src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "ssra    $dst, $src, $shift\t# vector (16B)" %}
+  ins_encode %{
+    int sh = (int)$shift$$constant;
+    if (sh >= 8) sh = 7;
+    __ ssra(as_FloatRegister($dst$$reg), __ T16B,
+           as_FloatRegister($src$$reg), sh);
+  %}
+  ins_pipe(vshift128_imm);
+%}
+
+instruct vsraa4S_imm(vecD dst, vecD src, immI shift) %{
+  predicate(n->as_Vector()->length() == 4);
+  match(Set dst (AddVS dst (RShiftVS src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "ssra    $dst, $src, $shift\t# vector (4H)" %}
+  ins_encode %{
+    int sh = (int)$shift$$constant;
+    if (sh >= 16) sh = 15;
+    __ ssra(as_FloatRegister($dst$$reg), __ T4H,
+           as_FloatRegister($src$$reg), sh);
+  %}
+  ins_pipe(vshift64_imm);
+%}
+
+instruct vsraa8S_imm(vecX dst, vecX src, immI shift) %{
+  predicate(n->as_Vector()->length() == 8);
+  match(Set dst (AddVS dst (RShiftVS src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "ssra    $dst, $src, $shift\t# vector (8H)" %}
+  ins_encode %{
+    int sh = (int)$shift$$constant;
+    if (sh >= 16) sh = 15;
+    __ ssra(as_FloatRegister($dst$$reg), __ T8H,
+           as_FloatRegister($src$$reg), sh);
+  %}
+  ins_pipe(vshift128_imm);
+%}
+
+instruct vsraa2I_imm(vecD dst, vecD src, immI shift) %{
+  predicate(n->as_Vector()->length() == 2);
+  match(Set dst (AddVI dst (RShiftVI src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "ssra    $dst, $src, $shift\t# vector (2S)" %}
+  ins_encode %{
+    __ ssra(as_FloatRegister($dst$$reg), __ T2S,
+            as_FloatRegister($src$$reg),
+            (int)$shift$$constant);
+  %}
+  ins_pipe(vshift64_imm);
+%}
+
+instruct vsraa4I_imm(vecX dst, vecX src, immI shift) %{
+  predicate(n->as_Vector()->length() == 4);
+  match(Set dst (AddVI dst (RShiftVI src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "ssra    $dst, $src, $shift\t# vector (4S)" %}
+  ins_encode %{
+    __ ssra(as_FloatRegister($dst$$reg), __ T4S,
+            as_FloatRegister($src$$reg),
+            (int)$shift$$constant);
+  %}
+  ins_pipe(vshift128_imm);
+%}
+
+instruct vsraa2L_imm(vecX dst, vecX src, immI shift) %{
+  predicate(n->as_Vector()->length() == 2);
+  match(Set dst (AddVL dst (RShiftVL src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "ssra    $dst, $src, $shift\t# vector (2D)" %}
+  ins_encode %{
+    __ ssra(as_FloatRegister($dst$$reg), __ T2D,
+            as_FloatRegister($src$$reg),
+            (int)$shift$$constant);
+  %}
+  ins_pipe(vshift128_imm);
+%}
+
+instruct vsrla8B_imm(vecD dst, vecD src, immI shift) %{
+  predicate(n->as_Vector()->length() == 8);
+  match(Set dst (AddVB dst (URShiftVB src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "usra    $dst, $src, $shift\t# vector (8B)" %}
+  ins_encode %{
+    int sh = (int)$shift$$constant;
+    if (sh >= 8) {
+      __ eor(as_FloatRegister($src$$reg), __ T8B,
+             as_FloatRegister($src$$reg),
+             as_FloatRegister($src$$reg));
+    } else {
+      __ usra(as_FloatRegister($dst$$reg), __ T8B,
+             as_FloatRegister($src$$reg), sh);
+    }
+  %}
+  ins_pipe(vshift64_imm);
+%}
+
+instruct vsrla16B_imm(vecX dst, vecX src, immI shift) %{
+  predicate(n->as_Vector()->length() == 16);
+  match(Set dst (AddVB dst (URShiftVB src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "usra    $dst, $src, $shift\t# vector (16B)" %}
+  ins_encode %{
+    int sh = (int)$shift$$constant;
+    if (sh >= 8) {
+      __ eor(as_FloatRegister($src$$reg), __ T16B,
+             as_FloatRegister($src$$reg),
+             as_FloatRegister($src$$reg));
+    } else {
+      __ usra(as_FloatRegister($dst$$reg), __ T16B,
+             as_FloatRegister($src$$reg), sh);
+    }
+  %}
+  ins_pipe(vshift128_imm);
+%}
+
+instruct vsrla4S_imm(vecD dst, vecD src, immI shift) %{
+  predicate(n->as_Vector()->length() == 4);
+  match(Set dst (AddVS dst (URShiftVS src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "usra    $dst, $src, $shift\t# vector (4H)" %}
+  ins_encode %{
+    int sh = (int)$shift$$constant;
+    if (sh >= 16) {
+      __ eor(as_FloatRegister($src$$reg), __ T8B,
+             as_FloatRegister($src$$reg),
+             as_FloatRegister($src$$reg));
+    } else {
+      __ ushr(as_FloatRegister($dst$$reg), __ T4H,
+             as_FloatRegister($src$$reg), sh);
+    }
+  %}
+  ins_pipe(vshift64_imm);
+%}
+
+instruct vsrla8S_imm(vecX dst, vecX src, immI shift) %{
+  predicate(n->as_Vector()->length() == 8);
+  match(Set dst (AddVS dst (URShiftVS src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "usra    $dst, $src, $shift\t# vector (8H)" %}
+  ins_encode %{
+    int sh = (int)$shift$$constant;
+    if (sh >= 16) {
+      __ eor(as_FloatRegister($src$$reg), __ T16B,
+             as_FloatRegister($src$$reg),
+             as_FloatRegister($src$$reg));
+    } else {
+      __ usra(as_FloatRegister($dst$$reg), __ T8H,
+             as_FloatRegister($src$$reg), sh);
+    }
+  %}
+  ins_pipe(vshift128_imm);
+%}
+
+instruct vsrla2I_imm(vecD dst, vecD src, immI shift) %{
+  predicate(n->as_Vector()->length() == 2);
+  match(Set dst (AddVI dst (URShiftVI src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "usra    $dst, $src, $shift\t# vector (2S)" %}
+  ins_encode %{
+    __ usra(as_FloatRegister($dst$$reg), __ T2S,
+            as_FloatRegister($src$$reg),
+            (int)$shift$$constant);
+  %}
+  ins_pipe(vshift64_imm);
+%}
+
+instruct vsrla4I_imm(vecX dst, vecX src, immI shift) %{
+  predicate(n->as_Vector()->length() == 4);
+  match(Set dst (AddVI dst (URShiftVI src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "usra    $dst, $src, $shift\t# vector (4S)" %}
+  ins_encode %{
+    __ usra(as_FloatRegister($dst$$reg), __ T4S,
+            as_FloatRegister($src$$reg),
+            (int)$shift$$constant);
+  %}
+  ins_pipe(vshift128_imm);
+%}
+
+instruct vsrla2L_imm(vecX dst, vecX src, immI shift) %{
+  predicate(n->as_Vector()->length() == 2);
+  match(Set dst (AddVL dst (URShiftVL src (RShiftCntV shift))));
+  ins_cost(INSN_COST);
+  format %{ "usra    $dst, $src, $shift\t# vector (2D)" %}
+  ins_encode %{
+    __ usra(as_FloatRegister($dst$$reg), __ T2D,
+            as_FloatRegister($src$$reg),
+            (int)$shift$$constant);
+  %}
+  ins_pipe(vshift128_imm);
+%}
+
 instruct vmax2F(vecD dst, vecD src1, vecD src2)
 %{
   predicate(n->as_Vector()->length() == 2 && n->bottom_type()->is_vect()->element_basic_type() == T_FLOAT);

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -2688,6 +2688,8 @@ public:
   INSN(shl,  0, 0b010101, /* isSHR = */ false);
   INSN(sshr, 0, 0b000001, /* isSHR = */ true);
   INSN(ushr, 1, 0b000001, /* isSHR = */ true);
+  INSN(usra, 1, 0b000101, /* isSHR = */ true);
+  INSN(ssra, 0, 0b000101, /* isSHAR =*/ true);
 
 #undef INSN
 

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorShiftAccumulate.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorShiftAccumulate.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.Random;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class VectorShiftAccumulate {
+    @Param({"1028"})
+    public int count;
+
+    private byte[]  bytesA,  bytesB,  bytesD;
+    private short[] shortsA, shortsB, shortsD;
+    private char[]  charsA,  charsB,  charsD;
+    private int[]   intsA,   intsB,   intsD;
+    private long[]  longsA,  longsB,  longsD;
+
+    @Param("0")
+    private int seed;
+    private Random r = new Random(seed);
+
+    @Setup
+    public void init() {
+        bytesA  = new byte[count];
+        shortsA = new short[count];
+        charsA  = new char[count];
+        intsA   = new int[count];
+        longsA  = new long[count];
+
+        bytesB  = new byte[count];
+        shortsB = new short[count];
+        charsB  = new char[count];
+        intsB   = new int[count];
+        longsB  = new long[count];
+
+        bytesD  = new byte[count];
+        shortsD = new short[count];
+        charsD  = new char[count];
+        intsD   = new int[count];
+        longsD  = new long[count];
+
+        for (int i = 0; i < count; i++) {
+            bytesA[i]  = (byte) r.nextInt();
+            shortsA[i] = (short) r.nextInt();
+            intsA[i]   = r.nextInt();
+            longsA[i]  = r.nextLong();
+
+            bytesB[i]  = (byte) r.nextInt();
+            shortsB[i] = (short) r.nextInt();
+            intsB[i]   = r.nextInt();
+            longsB[i]  = r.nextLong();
+        }
+    }
+
+    @Benchmark
+    public void shiftRightAccumulateByte() {
+        for (int i = 0; i < count; i++) {
+            bytesD[i] = (byte) (bytesA[i] + (bytesB[i] >> 1));
+        }
+    }
+
+    @Benchmark
+    public void shiftURightAccumulateByte() {
+        for (int i = 0; i < count; i++) {
+            bytesD[i] = (byte) (bytesA[i] + (((byte) (bytesB[i] >>> 3))));
+        }
+    }
+
+    @Benchmark
+    public void shiftRightAccumulateShort() {
+        for (int i = 0; i < count; i++) {
+            shortsD[i] = (short) (shortsA[i] + (shortsB[i] >> 5));
+        }
+    }
+
+    @Benchmark
+    public void shiftURightAccumulateChar() {
+        for (int i = 0; i < count; i++) {
+            charsD[i] = (char) (charsA[i] + (charsB[i] >>> 4));
+        }
+    }
+
+    @Benchmark
+    public void shiftRightAccumulateInt() {
+        for (int i = 0; i < count; i++) {
+            intsD[i] = intsA[i] + (intsB[i] >> 2);
+        }
+    }
+
+    @Benchmark
+    public void shiftURightAccumulateInt() {
+        for (int i = 0; i < count; i++) {
+            intsD[i] = (intsB[i] >>> 2) + intsA[i];
+        }
+    }
+
+    @Benchmark
+    public void shiftRightAccumulateLong() {
+        for (int i = 0; i < count; i++) {
+            longsD[i] = longsA[i] + (longsB[i] >> 5);
+        }
+    }
+
+    @Benchmark
+    public void shiftURightAccumulateLong() {
+        for (int i = 0; i < count; i++) {
+            longsD[i] = (longsB[i] >>> 2) + longsA[i];
+        }
+    }
+}
+


### PR DESCRIPTION
This supports missing NEON shift right and accumulate instructions, i.e. SSRA and USRA, for AArch64 backend.

Verified with linux-aarch64-server-release, tier1-3.

Added a JMH micro `test/micro/org/openjdk/bench/vm/compiler/VectorShiftAccumulate.java` for performance test.
We witness about ~20% with different basic types on Kunpeng916. The JMH results:
```
Benchmark                                         (count)  (seed)  Mode  Cnt    Score   Error  Units
# before, Kunpeng 916
VectorShiftAccumulate.shiftRightAccumulateByte      1028       0  avgt   10  146.259 ±  0.123  ns/op
VectorShiftAccumulate.shiftRightAccumulateInt       1028       0  avgt   10  454.781 ±  3.856  ns/op
VectorShiftAccumulate.shiftRightAccumulateLong      1028       0  avgt   10  938.842 ± 23.288  ns/op
VectorShiftAccumulate.shiftRightAccumulateShort     1028       0  avgt   10  205.493 ±  4.938  ns/op
VectorShiftAccumulate.shiftURightAccumulateByte     1028       0  avgt   10  905.483 ±  0.309  ns/op (not vectorized)
VectorShiftAccumulate.shiftURightAccumulateChar     1028       0  avgt   10  220.847 ±  5.868  ns/op
VectorShiftAccumulate.shiftURightAccumulateInt      1028       0  avgt   10  442.587 ±  6.980  ns/op
VectorShiftAccumulate.shiftURightAccumulateLong     1028       0  avgt   10  936.289 ± 21.458  ns/op
# after shift right and accumulate, Kunpeng 916
VectorShiftAccumulate.shiftRightAccumulateByte      1028       0  avgt   10  125.586 ±  0.204  ns/op
VectorShiftAccumulate.shiftRightAccumulateInt       1028       0  avgt   10  365.973 ±  6.466  ns/op
VectorShiftAccumulate.shiftRightAccumulateLong      1028       0  avgt   10  804.605 ± 12.336  ns/op
VectorShiftAccumulate.shiftRightAccumulateShort     1028       0  avgt   10  170.123 ±  4.678  ns/op
VectorShiftAccumulate.shiftURightAccumulateByte     1028       0  avgt   10  905.779 ±  0.587  ns/op (not vectorized)
VectorShiftAccumulate.shiftURightAccumulateChar     1028       0  avgt   10  185.799 ±  4.764  ns/op
VectorShiftAccumulate.shiftURightAccumulateInt      1028       0  avgt   10  364.360 ±  6.522  ns/op
VectorShiftAccumulate.shiftURightAccumulateLong     1028       0  avgt   10  800.737 ± 13.735  ns/op
```

We checked the shiftURightAccumulateByte test, the performance stays same since it is not vectorized with or without this patch, due to:
```
src/hotspot/share/opto/vectornode.cpp, line 226:
  case Op_URShiftI:
    switch (bt) {
    case T_BOOLEAN:return Op_URShiftVB;
    case T_CHAR:   return Op_URShiftVS;
    case T_BYTE:
    case T_SHORT:  return 0; // Vector logical right shift for signed short
                             // values produces incorrect Java result for
                             // negative data because java code should convert
                             // a short value into int value with sign
                             // extension before a shift.
    case T_INT:    return Op_URShiftVI;
    default:       ShouldNotReachHere(); return 0;
    }
```
We also tried the existing vector operation micro urShiftB, i.e.:
```
test/micro/org/openjdk/bench/vm/compiler/TypeVectorOperations.java, line 116
    @Benchmark
    public void urShiftB() {
        for (int i = 0; i < COUNT; i++) {
            resB[i] = (byte) (bytesA[i] >>> 3);
        }
    }
```
It is not vectorlized too. Seems it's hard to match JAVA code with the URShiftVB node.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255949](https://bugs.openjdk.java.net/browse/JDK-8255949): AArch64: Add support for vectorized shift right and accumulate


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1087/head:pull/1087`
`$ git checkout pull/1087`
