### PR TITLE
Updated the comment in getResponseCode method as per JDK-8255675

### DIFF
--- a/src/java.base/share/classes/java/net/HttpURLConnection.java
+++ b/src/java.base/share/classes/java/net/HttpURLConnection.java
@@ -511,7 +511,7 @@ public abstract class HttpURLConnection extends URLConnection {
      */
     public int getResponseCode() throws IOException {
         /*
-         * We're got the response code already
+         * We'v got the response code already
          */
         if (responseCode != -1) {
             return responseCode;
@@ -530,7 +530,7 @@ public abstract class HttpURLConnection extends URLConnection {
         }
 
         /*
-         * If we can't a status-line then re-throw any exception
+         * If we can't find a status-line then re-throw any exception
          * that getInputStream threw.
          */
         String statusLine = getHeaderField(0);


### PR DESCRIPTION
Inside comments in the method getResponseCode has been changed as per https://bugs.openjdk.java.net/browse/JDK-8255675

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1089/head:pull/1089`
`$ git checkout pull/1089`
