### PR TITLE
6422025: ThemeReader.cpp can be updated for VC7

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/XPStyle.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/XPStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -593,8 +593,7 @@ class XPStyle {
             if (XPStyle.getXP() == null) {
                 return;
             }
-            if (ThemeReader.isGetThemeTransitionDurationDefined()
-                  && component instanceof JComponent
+            if (component instanceof JComponent
                   && SwingUtilities.getAncestorOfClass(CellRendererPane.class,
                                                        component) == null) {
                 AnimationController.paintSkin((JComponent) component, this,

--- a/src/java.desktop/windows/classes/sun/awt/windows/ThemeReader.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/ThemeReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,13 +34,6 @@ import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-/* !!!! WARNING !!!!
- * This class has to be in sync with
- * src/solaris/classes/sun/awt/windows/ThemeReader.java
- * while we continue to build WinL&F on solaris
- */
-
 
 /**
  * Implements Theme Support for Windows XP.
@@ -298,8 +291,6 @@ public final class ThemeReader {
             readLock.unlock();
         }
     }
-
-    public static native boolean isGetThemeTransitionDurationDefined();
 
     private static native Insets getThemeBackgroundContentMargins(long theme,
                      int part, int state, int boundingWidth, int boundingHeight);


### PR DESCRIPTION
Some of the type definitions have been imported from `UxTheme.h` to the `ThemeReader.cpp` because at that time we supported the windows OS below XP as well as VC6.

It is time to use `UxTheme.h ` directly, note I did not change how we load this library(JDK_LoadSystemLibrary(), as suggested in the comments of the bug it is not necessary that the application will use the win L&F and it is not necessary to link it directly.

mach5 is green

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-6422025](https://bugs.openjdk.java.net/browse/JDK-6422025): ThemeReader.cpp can be updated for VC7


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1090/head:pull/1090`
`$ git checkout pull/1090`
