### PR TITLE
8255546: Missing coverage for javax.smartcardio.CardPermission and ResponseAPDU

### DIFF
--- a/test/jdk/javax/smartcardio/ResponseAPDUTest.java
+++ b/test/jdk/javax/smartcardio/ResponseAPDUTest.java
@@ -67,5 +67,6 @@ public class ResponseAPDUTest {
         assertEquals(RAPDU.getSW(), expectedSw);
         assertEquals(RAPDU.getSW1(), expectedSw1);
         assertEquals(RAPDU.getSW2(), expectedSw2);
+        assertEquals(RAPDU.toString(), "ResponseAPDU: " + R1.length + " bytes, SW=9000");
     }
 }

--- a/test/jdk/javax/smartcardio/ResponseAPDUTest.java
+++ b/test/jdk/javax/smartcardio/ResponseAPDUTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,8 @@
 
 /*
  * @test
- * @bug 8049021
- * @summary Construct ResponseAPDU from byte array and check NR< SW, SW1 and SW2
+ * @bug 8049021 8255546
+ * @summary Construct ResponseAPDU from byte array and check NR< SW, SW1, SW2 and toString
  * @run testng ResponseAPDUTest
  */
 import javax.smartcardio.ResponseAPDU;
@@ -42,6 +42,7 @@ public class ResponseAPDUTest {
     static final ResponseAPDU RAPDU = new ResponseAPDU(R1);
     static byte[] expectedData;
     static int expectedNr, expectedSw1, expectedSw2, expectedSw;
+    static String expectedToString;
 
     @BeforeClass
     public static void setUpClass() throws Exception {
@@ -57,6 +58,9 @@ public class ResponseAPDUTest {
         expectedSw1 = R1[apduLen - 2] & 0xff;
         expectedSw2 = R1[apduLen - 1] & 0xff;
         expectedSw = (expectedSw1 << 8) | expectedSw2;
+
+        expectedToString = "ResponseAPDU: " + R1.length +
+                " bytes, SW=" + Integer.toHexString(expectedSw);
     }
 
     @Test
@@ -67,6 +71,6 @@ public class ResponseAPDUTest {
         assertEquals(RAPDU.getSW(), expectedSw);
         assertEquals(RAPDU.getSW1(), expectedSw1);
         assertEquals(RAPDU.getSW2(), expectedSw2);
-        assertEquals(RAPDU.toString(), "ResponseAPDU: " + R1.length + " bytes, SW=9000");
+        assertEquals(RAPDU.toString(), expectedToString);
     }
 }


### PR DESCRIPTION
This patch is to add code coverage to the following methods
- javax.smartcardio.CardPermission::**implies** (1)
- javax.smartcardio.ResponseAPDU::**toString** (2)

Tests are added following the expected implementation given in the methods specifications

(1) https://github.com/openjdk/jdk/blob/5dfb42fc68099278cbc98e25fb8a91fd957c12e2/src/java.smartcardio/share/classes/javax/smartcardio/CardPermission.java#L214-L229

(2) https://github.com/openjdk/jdk/blob/5dfb42fc68099278cbc98e25fb8a91fd957c12e2/src/java.smartcardio/share/classes/javax/smartcardio/ResponseAPDU.java#L141-L149

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255546](https://bugs.openjdk.java.net/browse/JDK-8255546): Missing coverage for javax.smartcardio.CardPermission and ResponseAPDU


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1092/head:pull/1092`
`$ git checkout pull/1092`
