### PR TITLE
8255980: G1 Service thread register_task can be used after shutdown

### DIFF
--- a/src/hotspot/share/gc/g1/g1ServiceThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ServiceThread.hpp
@@ -28,6 +28,8 @@
 #include "gc/shared/concurrentGCThread.hpp"
 #include "runtime/mutex.hpp"
 
+class G1PeriodicGCTask;
+class G1RemSetSamplingTask;
 class G1ServiceTaskQueue;
 class G1ServiceThread;
 
@@ -103,6 +105,9 @@ class G1ServiceThread: public ConcurrentGCThread {
   Monitor _monitor;
   G1ServiceTaskQueue _task_queue;
 
+  G1RemSetSamplingTask* _remset_task;
+  G1PeriodicGCTask* _periodic_gc_task;
+
   double _vtime_accum;  // Accumulated virtual time.
 
   void run_service();
@@ -122,6 +127,8 @@ class G1ServiceThread: public ConcurrentGCThread {
 
 public:
   G1ServiceThread();
+  ~G1ServiceThread();
+
   double vtime_accum() { return _vtime_accum; }
   // Register a task with the service thread and schedule it. If
   // no delay is specified the task is scheduled to run directly.


### PR DESCRIPTION
Please review this change to improve the service thread task handling during shutdown.

This problem isn't currently visible, but with upcoming changes there is a race where tasks might be added to the service thread after it has been shut down. This becomes problematic because the task queue at that point consists of invalid objects. They are invalid because the tasks are currently stack-allocated on the service thread. This change both allocates the tasks handled by the service thread dynamically and add a check to avoid adding tasks when the service thread has been shut down. Just doing the dynamic allocation would be enough, but there is no reason to add tasks after the thread is shut down.

I've tested this fix together with my concurrent uncommit changes which highlight the problem, and also run tier1 and tier2 for sanity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255980](https://bugs.openjdk.java.net/browse/JDK-8255980): G1 Service thread register_task can be used after shutdown


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1093/head:pull/1093`
`$ git checkout pull/1093`
