### PR TITLE
8255992: JFR EventWriter does not use first string from StringPool with id 0

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
@@ -129,7 +129,7 @@ public final class EventWriter {
         }
         if (length > StringPool.MIN_LIMIT && length < StringPool.MAX_LIMIT) {
             long l = StringPool.addString(s);
-            if (l > -1) {
+            if (l >= 0) {
                 putByte(StringParser.Encoding.CONSTANT_POOL.byteValue());
                 putLong(l);
                 return;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
@@ -129,7 +129,7 @@ public final class EventWriter {
         }
         if (length > StringPool.MIN_LIMIT && length < StringPool.MAX_LIMIT) {
             long l = StringPool.addString(s);
-            if (l > 0) {
+            if (l > -1) {
                 putByte(StringParser.Encoding.CONSTANT_POOL.byteValue());
                 putLong(l);
                 return;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
@@ -129,7 +129,7 @@ public final class EventWriter {
         }
         if (length > StringPool.MIN_LIMIT && length < StringPool.MAX_LIMIT) {
             long l = StringPool.addString(s);
-            if (l >= 0) {
+            if (l > 0) {
                 putByte(StringParser.Encoding.CONSTANT_POOL.byteValue());
                 putLong(l);
                 return;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/StringPool.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/StringPool.java
@@ -49,7 +49,7 @@ public final class StringPool {
     }
     private static class SimpleStringIdPool {
         /* string id index */
-        private final AtomicLong sidIdx = new AtomicLong();
+        private final AtomicLong sidIdx = new AtomicLong(1);
         /* epoch of cached strings */
         private boolean poolEpoch;
         /* the cache */


### PR DESCRIPTION
This allows string pool entry with id 0 to be written in short form for the event data.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255992](https://bugs.openjdk.java.net/browse/JDK-8255992): JFR EventWriter does not use first string from StringPool with id 0


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1097/head:pull/1097`
`$ git checkout pull/1097`
