### PR TITLE
8255989: Remove explicitly unascribed authorship from Java source files

### DIFF
--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ package java.io;
  * types to an output stream in a portable way. An application can
  * then use a data input stream to read the data back in.
  *
- * @author  unascribed
  * @see     java.io.DataInputStream
  * @since   1.0
  */

--- a/src/java.base/share/classes/java/io/Externalizable.java
+++ b/src/java.base/share/classes/java/io/Externalizable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,6 @@ import java.io.ObjectInput;
  * the writeReplace and readResolve methods documented in the Serializable
  * interface.<br>
  *
- * @author  unascribed
  * @see java.io.ObjectOutputStream
  * @see java.io.ObjectInputStream
  * @see java.io.ObjectOutput

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -142,7 +142,6 @@ import sun.security.action.GetPropertyAction;
  * additional file operations, file attributes, and I/O exceptions to help
  * diagnose errors when an operation on a file fails.
  *
- * @author  unascribed
  * @since   1.0
  */
 

--- a/src/java.base/share/classes/java/io/FileNotFoundException.java
+++ b/src/java.base/share/classes/java/io/FileNotFoundException.java
@@ -36,7 +36,6 @@ package java.io;
  * constructors if the file does exist but for some reason is inaccessible, for
  * example when an attempt is made to open a read-only file for writing.
  *
- * @author  unascribed
  * @since   1.0
  */
 

--- a/src/java.base/share/classes/java/io/IOException.java
+++ b/src/java.base/share/classes/java/io/IOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ package java.io;
  * class is the general class of exceptions produced by failed or
  * interrupted I/O operations.
  *
- * @author  unascribed
  * @see     java.io.InputStream
  * @see     java.io.OutputStream
  * @since   1.0

--- a/src/java.base/share/classes/java/io/InterruptedIOException.java
+++ b/src/java.base/share/classes/java/io/InterruptedIOException.java
@@ -33,7 +33,6 @@ package java.io;
  * indicates how many bytes were successfully transferred before
  * the interruption occurred.
  *
- * @author  unascribed
  * @see     java.io.InputStream
  * @see     java.io.OutputStream
  * @see     java.lang.Thread#interrupt()

--- a/src/java.base/share/classes/java/io/InvalidClassException.java
+++ b/src/java.base/share/classes/java/io/InvalidClassException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,6 @@ package java.io;
  *      Specification</cite>
  * </UL>
  *
- * @author  unascribed
  * @since   1.1
  */
 public class InvalidClassException extends ObjectStreamException {

--- a/src/java.base/share/classes/java/io/InvalidObjectException.java
+++ b/src/java.base/share/classes/java/io/InvalidObjectException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ package java.io;
  * @see ObjectInputValidation
  * @since 1.1
  *
- * @author  unascribed
  * @since   1.1
  */
 public class InvalidObjectException extends ObjectStreamException {

--- a/src/java.base/share/classes/java/io/NotActiveException.java
+++ b/src/java.base/share/classes/java/io/NotActiveException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package java.io;
 /**
  * Thrown when serialization or deserialization is not active.
  *
- * @author  unascribed
  * @since   1.1
  */
 public class NotActiveException extends ObjectStreamException {

--- a/src/java.base/share/classes/java/io/NotSerializableException.java
+++ b/src/java.base/share/classes/java/io/NotSerializableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ package java.io;
  * The serialization runtime or the class of the instance can throw
  * this exception. The argument should be the name of the class.
  *
- * @author  unascribed
  * @since   1.1
  */
 public class NotSerializableException extends ObjectStreamException {

--- a/src/java.base/share/classes/java/io/ObjectInput.java
+++ b/src/java.base/share/classes/java/io/ObjectInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ package java.io;
  * objects. DataInput includes methods for the input of primitive types,
  * ObjectInput extends that interface to include objects, arrays, and Strings.
  *
- * @author  unascribed
  * @see java.io.InputStream
  * @see java.io.ObjectOutputStream
  * @see java.io.ObjectInputStream

--- a/src/java.base/share/classes/java/io/ObjectInputValidation.java
+++ b/src/java.base/share/classes/java/io/ObjectInputValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ package java.io;
  * Allows an object to be called when a complete graph of objects has
  * been deserialized.
  *
- * @author  unascribed
  * @see     ObjectInputStream
  * @see     ObjectInputStream#registerValidation(java.io.ObjectInputValidation, int)
  * @since   1.1

--- a/src/java.base/share/classes/java/io/ObjectOutput.java
+++ b/src/java.base/share/classes/java/io/ObjectOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ package java.io;
  * DataOutput includes methods for output of primitive types, ObjectOutput
  * extends that interface to include objects, arrays, and Strings.
  *
- * @author  unascribed
  * @see java.io.InputStream
  * @see java.io.ObjectOutputStream
  * @see java.io.ObjectInputStream

--- a/src/java.base/share/classes/java/io/ObjectStreamConstants.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package java.io;
 /**
  * Constants written into the Object Serialization Stream.
  *
- * @author  unascribed
  * @since 1.1
  */
 public interface ObjectStreamConstants {

--- a/src/java.base/share/classes/java/io/ObjectStreamException.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package java.io;
 /**
  * Superclass of all exceptions specific to Object Stream classes.
  *
- * @author  unascribed
  * @since   1.1
  */
 public abstract class ObjectStreamException extends IOException {

--- a/src/java.base/share/classes/java/io/OptionalDataException.java
+++ b/src/java.base/share/classes/java/io/OptionalDataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,6 @@ package java.io;
  *       is set to 0.
  * </ul>
  *
- * @author  unascribed
  * @since   1.1
  */
 public class OptionalDataException extends ObjectStreamException {

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -55,7 +55,6 @@ import sun.nio.ch.FileChannelImpl;
  * than {@code EOFException} is thrown. In particular, an
  * {@code IOException} may be thrown if the stream has been closed.
  *
- * @author  unascribed
  * @since   1.0
  */
 

--- a/src/java.base/share/classes/java/io/Serializable.java
+++ b/src/java.base/share/classes/java/io/Serializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,7 +174,6 @@ package java.io;
  * the default computed value, but the requirement for matching
  * serialVersionUID values is waived for array classes.
  *
- * @author  unascribed
  * @see java.io.ObjectOutputStream
  * @see java.io.ObjectInputStream
  * @see java.io.ObjectOutput

--- a/src/java.base/share/classes/java/io/StreamCorruptedException.java
+++ b/src/java.base/share/classes/java/io/StreamCorruptedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ package java.io;
  * Thrown when control information that was read from an object stream
  * violates internal consistency checks.
  *
- * @author  unascribed
  * @since   1.1
  */
 public class StreamCorruptedException extends ObjectStreamException {

--- a/src/java.base/share/classes/java/io/WriteAbortedException.java
+++ b/src/java.base/share/classes/java/io/WriteAbortedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@ package java.io;
  * <i>cause</i>, and may be accessed via the {@link Throwable#getCause()}
  * method, as well as the aforementioned "legacy field."
  *
- * @author  unascribed
  * @since   1.1
  */
 public class WriteAbortedException extends ObjectStreamException {

--- a/src/java.base/share/classes/java/lang/AbstractMethodError.java
+++ b/src/java.base/share/classes/java/lang/AbstractMethodError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ package java.lang;
  * incompatibly changed since the currently executing method was last
  * compiled.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class AbstractMethodError extends IncompatibleClassChangeError {

--- a/src/java.base/share/classes/java/lang/ArithmeticException.java
+++ b/src/java.base/share/classes/java/lang/ArithmeticException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@ package java.lang;
  * Throwable, boolean, boolean) suppression were disabled and/or the
  * stack trace was not writable}.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class ArithmeticException extends RuntimeException {

--- a/src/java.base/share/classes/java/lang/ArrayStoreException.java
+++ b/src/java.base/share/classes/java/lang/ArrayStoreException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ package java.lang;
  *     x[0] = new Integer(0);
  * </pre></blockquote>
  *
- * @author  unascribed
  * @since   1.0
  */
 public class ArrayStoreException extends RuntimeException {

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -186,7 +186,6 @@ import sun.reflect.misc.ReflectUtil;
  * Class<String>}.  Use {@code Class<?>} if the class being modeled is
  * unknown.
  *
- * @author  unascribed
  * @see     java.lang.ClassLoader#defineClass(byte[], int, int)
  * @since   1.0
  * @jls 15.8.2 Class Literals

--- a/src/java.base/share/classes/java/lang/ClassCastException.java
+++ b/src/java.base/share/classes/java/lang/ClassCastException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ package java.lang;
  *     System.out.println((String)x);
  * </pre></blockquote>
  *
- * @author  unascribed
  * @since   1.0
  */
 public class ClassCastException extends RuntimeException {

--- a/src/java.base/share/classes/java/lang/ClassCircularityError.java
+++ b/src/java.base/share/classes/java/lang/ClassCircularityError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ package java.lang;
  * Thrown when the Java Virtual Machine detects a circularity in the
  * superclass hierarchy of a class being loaded.
  *
- * @author     unascribed
  * @since      1.0
  */
 public class ClassCircularityError extends LinkageError {

--- a/src/java.base/share/classes/java/lang/ClassFormatError.java
+++ b/src/java.base/share/classes/java/lang/ClassFormatError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ package java.lang;
  * file and determines that the file is malformed or otherwise cannot
  * be interpreted as a class file.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class ClassFormatError extends LinkageError {

--- a/src/java.base/share/classes/java/lang/ClassNotFoundException.java
+++ b/src/java.base/share/classes/java/lang/ClassNotFoundException.java
@@ -49,7 +49,6 @@ import java.io.ObjectStreamField;
  * now known as the <i>cause</i>, and may be accessed via the {@link
  * Throwable#getCause()} method, as well as the aforementioned "legacy method."
  *
- * @author  unascribed
  * @see     java.lang.Class#forName(java.lang.String)
  * @see     java.lang.ClassLoader#findSystemClass(java.lang.String)
  * @see     java.lang.ClassLoader#loadClass(java.lang.String, boolean)

--- a/src/java.base/share/classes/java/lang/CloneNotSupportedException.java
+++ b/src/java.base/share/classes/java/lang/CloneNotSupportedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@ package java.lang;
  * throw this exception to indicate that an object could not or
  * should not be cloned.
  *
- * @author  unascribed
  * @see     java.lang.Cloneable
  * @see     java.lang.Object#clone()
  * @since   1.0

--- a/src/java.base/share/classes/java/lang/Cloneable.java
+++ b/src/java.base/share/classes/java/lang/Cloneable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,6 @@ package java.lang;
  * fact that it implements this interface.  Even if the clone method is invoked
  * reflectively, there is no guarantee that it will succeed.
  *
- * @author  unascribed
  * @see     java.lang.CloneNotSupportedException
  * @see     java.lang.Object#clone()
  * @since   1.0

--- a/src/java.base/share/classes/java/lang/IllegalAccessError.java
+++ b/src/java.base/share/classes/java/lang/IllegalAccessError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ package java.lang;
  * only occur at run time if the definition of a class has
  * incompatibly changed.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class IllegalAccessError extends IncompatibleClassChangeError {

--- a/src/java.base/share/classes/java/lang/IllegalAccessException.java
+++ b/src/java.base/share/classes/java/lang/IllegalAccessException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ package java.lang;
  * executing method does not have access to the definition of
  * the specified class, field, method or constructor.
  *
- * @author  unascribed
  * @see     Class#newInstance()
  * @see     java.lang.reflect.Field#set(Object, Object)
  * @see     java.lang.reflect.Field#setBoolean(Object, boolean)

--- a/src/java.base/share/classes/java/lang/IllegalArgumentException.java
+++ b/src/java.base/share/classes/java/lang/IllegalArgumentException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ package java.lang;
  * Thrown to indicate that a method has been passed an illegal or
  * inappropriate argument.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class IllegalArgumentException extends RuntimeException {

--- a/src/java.base/share/classes/java/lang/IllegalMonitorStateException.java
+++ b/src/java.base/share/classes/java/lang/IllegalMonitorStateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ package java.lang;
  * object's monitor or to notify other threads waiting on an object's
  * monitor without owning the specified monitor.
  *
- * @author  unascribed
  * @see     java.lang.Object#notify()
  * @see     java.lang.Object#notifyAll()
  * @see     java.lang.Object#wait()

--- a/src/java.base/share/classes/java/lang/IllegalThreadStateException.java
+++ b/src/java.base/share/classes/java/lang/IllegalThreadStateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ package java.lang;
  * {@code suspend} and {@code resume} methods in class
  * {@code Thread}.
  *
- * @author  unascribed
  * @see     java.lang.Thread#resume()
  * @see     java.lang.Thread#suspend()
  * @since   1.0

--- a/src/java.base/share/classes/java/lang/IncompatibleClassChangeError.java
+++ b/src/java.base/share/classes/java/lang/IncompatibleClassChangeError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ package java.lang;
  * definition. The definition of some class, on which the currently
  * executing method depends, has since changed.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class IncompatibleClassChangeError extends LinkageError {

--- a/src/java.base/share/classes/java/lang/InstantiationError.java
+++ b/src/java.base/share/classes/java/lang/InstantiationError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ package java.lang;
  * only occur at run time if the definition of a class has
  * incompatibly changed.
  *
- * @author  unascribed
  * @since   1.0
  */
 

--- a/src/java.base/share/classes/java/lang/InstantiationException.java
+++ b/src/java.base/share/classes/java/lang/InstantiationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ package java.lang;
  * <li> the class has no nullary constructor
  *</ul>
  *
- * @author  unascribed
  * @see     java.lang.Class#newInstance()
  * @since   1.0
  */

--- a/src/java.base/share/classes/java/lang/InternalError.java
+++ b/src/java.base/share/classes/java/lang/InternalError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ package java.lang;
  * Thrown to indicate some unexpected internal error has occurred in
  * the Java Virtual Machine.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class InternalError extends VirtualMachineError {

--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -99,7 +99,6 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * occurs only with a specific minimum or maximum value and
  * should be checked against the minimum or maximum as appropriate.
  *
- * @author  unascribed
  * @author  Joseph D. Darcy
  * @since   1.0
  */

--- a/src/java.base/share/classes/java/lang/NegativeArraySizeException.java
+++ b/src/java.base/share/classes/java/lang/NegativeArraySizeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package java.lang;
 /**
  * Thrown if an application tries to create an array with negative size.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class NegativeArraySizeException extends RuntimeException {

--- a/src/java.base/share/classes/java/lang/NoClassDefFoundError.java
+++ b/src/java.base/share/classes/java/lang/NoClassDefFoundError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@ package java.lang;
  * executing class was compiled, but the definition can no longer be
  * found.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class NoClassDefFoundError extends LinkageError {

--- a/src/java.base/share/classes/java/lang/NoSuchFieldError.java
+++ b/src/java.base/share/classes/java/lang/NoSuchFieldError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ package java.lang;
  * only occur at run time if the definition of a class has
  * incompatibly changed.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class NoSuchFieldError extends IncompatibleClassChangeError {

--- a/src/java.base/share/classes/java/lang/NoSuchFieldException.java
+++ b/src/java.base/share/classes/java/lang/NoSuchFieldException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package java.lang;
 /**
  * Signals that the class doesn't have a field of a specified name.
  *
- * @author  unascribed
  * @since   1.1
  */
 public class NoSuchFieldException extends ReflectiveOperationException {

--- a/src/java.base/share/classes/java/lang/NoSuchMethodError.java
+++ b/src/java.base/share/classes/java/lang/NoSuchMethodError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ package java.lang;
  * only occur at run time if the definition of a class has
  * incompatibly changed.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class NoSuchMethodError extends IncompatibleClassChangeError {

--- a/src/java.base/share/classes/java/lang/NoSuchMethodException.java
+++ b/src/java.base/share/classes/java/lang/NoSuchMethodException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package java.lang;
 /**
  * Thrown when a particular method cannot be found.
  *
- * @author     unascribed
  * @since      1.0
  */
 public class NoSuchMethodException extends ReflectiveOperationException {

--- a/src/java.base/share/classes/java/lang/NullPointerException.java
+++ b/src/java.base/share/classes/java/lang/NullPointerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,6 @@ package java.lang;
  * Throwable, boolean, boolean) suppression were disabled and/or the
  * stack trace was not writable}.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class NullPointerException extends RuntimeException {

--- a/src/java.base/share/classes/java/lang/NumberFormatException.java
+++ b/src/java.base/share/classes/java/lang/NumberFormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ package java.lang;
  * a string to one of the numeric types, but that the string does not
  * have the appropriate format.
  *
- * @author  unascribed
  * @see     java.lang.Integer#parseInt(String)
  * @since   1.0
  */

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -32,7 +32,6 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * Every class has {@code Object} as a superclass. All objects,
  * including arrays, implement the methods of this class.
  *
- * @author  unascribed
  * @see     java.lang.Class
  * @since   1.0
  */

--- a/src/java.base/share/classes/java/lang/OutOfMemoryError.java
+++ b/src/java.base/share/classes/java/lang/OutOfMemoryError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@ package java.lang;
  * boolean, boolean) suppression were disabled and/or the stack trace was not
  * writable}.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class OutOfMemoryError extends VirtualMachineError {

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -48,7 +48,6 @@ import jdk.internal.reflect.Reflection;
  * <p>
  * An application cannot create its own instance of this class.
  *
- * @author  unascribed
  * @see     java.lang.Runtime#getRuntime()
  * @since   1.0
  */

--- a/src/java.base/share/classes/java/lang/SecurityException.java
+++ b/src/java.base/share/classes/java/lang/SecurityException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package java.lang;
 /**
  * Thrown by the security manager to indicate a security violation.
  *
- * @author  unascribed
  * @see     java.lang.SecurityManager
  * @since   1.0
  */

--- a/src/java.base/share/classes/java/lang/StackOverflowError.java
+++ b/src/java.base/share/classes/java/lang/StackOverflowError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ package java.lang;
  * Thrown when a stack overflow occurs because an application
  * recurses too deeply.
  *
- * @author unascribed
  * @since   1.0
  */
 public class StackOverflowError extends VirtualMachineError {

--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -74,7 +74,6 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * occurs only with a specific minimum or maximum value and
  * should be checked against the minimum or maximum as appropriate.
  *
- * @author  unascribed
  * @author  Joseph D. Darcy
  * @since   1.3
  */

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -133,7 +133,6 @@ import sun.security.util.SecurityConstants;
  * or method in this class will cause a {@link NullPointerException} to be
  * thrown.
  *
- * @author  unascribed
  * @see     Runnable
  * @see     Runtime#exit(int)
  * @see     #run()

--- a/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ import java.util.Arrays;
  * group, but not to access information about its thread group's
  * parent thread group or any other thread groups.
  *
- * @author  unascribed
  * @since   1.0
  */
 /* The locking strategy for this code is to try to lock only one level of the

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -106,7 +106,6 @@ import java.util.*;
  * {@code String} (the detail message) and a {@code Throwable} (the
  * cause).
  *
- * @author  unascribed
  * @author  Josh Bloch (Added exception chaining and programmatic access to
  *          stack trace in 1.4.)
  * @jls 11.2 Compile-Time Checking of Exceptions

--- a/src/java.base/share/classes/java/lang/UnknownError.java
+++ b/src/java.base/share/classes/java/lang/UnknownError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ package java.lang;
  * Thrown when an unknown but serious exception has occurred in the
  * Java Virtual Machine.
  *
- * @author unascribed
  * @since   1.0
  */
 public class UnknownError extends VirtualMachineError {

--- a/src/java.base/share/classes/java/lang/UnsatisfiedLinkError.java
+++ b/src/java.base/share/classes/java/lang/UnsatisfiedLinkError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ package java.lang;
  * Thrown if the Java Virtual Machine cannot find an appropriate
  * native-language definition of a method declared {@code native}.
  *
- * @author unascribed
  * @see     java.lang.Runtime
  * @since   1.0
  */

--- a/src/java.base/share/classes/java/lang/VerifyError.java
+++ b/src/java.base/share/classes/java/lang/VerifyError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ package java.lang;
  * though well formed, contains some sort of internal inconsistency
  * or security problem.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class VerifyError extends LinkageError {

--- a/src/java.base/share/classes/java/lang/Void.java
+++ b/src/java.base/share/classes/java/lang/Void.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ package java.lang;
  * reference to the {@code Class} object representing the Java keyword
  * void.
  *
- * @author  unascribed
  * @since   1.1
  */
 public final

--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -354,7 +354,6 @@ public class ModuleDescriptor
         }
     }
 
-
 
     /**
      * <p> A package exported by a module, may be qualified or unqualified. </p>
@@ -892,7 +891,6 @@ public class ModuleDescriptor
 
     }
 
-
 
     /**
      * A module's version string.

--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -75,7 +75,6 @@ import sun.net.PlatformSocketImpl;
  * </blockquote>
  * Additional (implementation specific) options may also be supported.
  *
- * @author  unascribed
  * @see     java.net.SocketImpl
  * @see     java.net.ServerSocket#setSocketFactory(java.net.SocketImplFactory)
  * @see     java.nio.channels.ServerSocketChannel

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -96,7 +96,6 @@ import java.util.Collections;
  * </blockquote>
  * Additional (implementation specific) options may also be supported.
  *
- * @author  unascribed
  * @see     java.net.Socket#setSocketImplFactory(java.net.SocketImplFactory)
  * @see     java.net.SocketImpl
  * @see     java.nio.channels.SocketChannel

--- a/src/java.base/share/classes/java/net/SocketImpl.java
+++ b/src/java.base/share/classes/java/net/SocketImpl.java
@@ -60,7 +60,6 @@ import sun.nio.ch.NioSocketImpl;
  * to use the old implementation. The property and old implementation will be
  * removed in a future version.
  *
- * @author  unascribed
  * @since   1.0
  */
 public abstract class SocketImpl implements SocketOptions {

--- a/src/java.base/share/classes/java/net/UnknownServiceException.java
+++ b/src/java.base/share/classes/java/net/UnknownServiceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import java.io.IOException;
  * not make sense, or the application is attempting to write to a
  * read-only URL connection.
  *
- * @author  unascribed
  * @since   1.0
  */
 public class UnknownServiceException extends IOException {

--- a/src/java.base/share/classes/java/util/Dictionary.java
+++ b/src/java.base/share/classes/java/util/Dictionary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,6 @@ package java.util;
  * <strong>NOTE: This class is obsolete.  New implementations should
  * implement the Map interface, rather than extending this class.</strong>
  *
- * @author  unascribed
  * @see     java.util.Map
  * @see     java.lang.Object#equals(java.lang.Object)
  * @see     java.lang.Object#hashCode()

--- a/src/java.base/share/classes/java/util/InputMismatchException.java
+++ b/src/java.base/share/classes/java/util/InputMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ package java.util;
  * retrieved does not match the pattern for the expected type, or
  * that the token is out of range for the expected type.
  *
- * @author  unascribed
  * @see     java.util.Scanner
  * @since   1.5
  */

--- a/src/java.base/share/classes/java/util/NoSuchElementException.java
+++ b/src/java.base/share/classes/java/util/NoSuchElementException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ package java.util;
  * Thrown by various accessor methods to indicate that the element being requested
  * does not exist.
  *
- * @author  unascribed
  * @see     java.util.Enumeration#nextElement()
  * @see     java.util.Iterator#next()
  * @since   1.0

--- a/src/java.base/share/classes/java/util/StringTokenizer.java
+++ b/src/java.base/share/classes/java/util/StringTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,7 +95,6 @@ import java.lang.*;
  *     test
  * </pre></blockquote>
  *
- * @author  unascribed
  * @see     java.io.StreamTokenizer
  * @since   1.0
  */

--- a/src/java.base/share/classes/java/util/regex/PatternSyntaxException.java
+++ b/src/java.base/share/classes/java/util/regex/PatternSyntaxException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ package java.util.regex;
  * Unchecked exception thrown to indicate a syntax error in a
  * regular-expression pattern.
  *
- * @author  unascribed
  * @since 1.4
  */
 

--- a/src/java.base/share/classes/java/util/zip/ZipException.java
+++ b/src/java.base/share/classes/java/util/zip/ZipException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import java.io.IOException;
 /**
  * Signals that a Zip exception of some sort has occurred.
  *
- * @author  unascribed
  * @see     java.io.IOException
  * @since   1.1
  */

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/motif/MotifLookAndFeel.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/motif/MotifLookAndFeel.java
@@ -59,7 +59,6 @@ import sun.awt.OSInfo;
  * version of Swing.  A future release of Swing will provide support for
  * long term persistence.
  *
- * @author unattributed
  * @deprecated The Motif Look and Feel is deprecated with the intent to remove
  *             it in some future release. It is recommended to use
  *             {@link javax.swing.plaf.metal.MetalLookAndFeel} instead.

--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,6 @@ import sun.awt.AWTAccessor.MouseEventAccessor;
 /**
  * A collection of utility methods for Swing.
  *
- * @author unknown
  * @since 1.2
  */
 public class SwingUtilities implements SwingConstants

--- a/src/java.desktop/share/classes/javax/swing/UnsupportedLookAndFeelException.java
+++ b/src/java.desktop/share/classes/javax/swing/UnsupportedLookAndFeelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,6 @@ package javax.swing;
  * has been added to the <code>java.beans</code> package.
  * Please see {@link java.beans.XMLEncoder}.
  *
- * @author unattributed
  * @since 1.2
  */
 @SuppressWarnings("serial") // Same-version serialization only

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,8 +100,6 @@ import java.beans.PropertyChangeEvent;
  * of all JavaBeans
  * has been added to the <code>java.beans</code> package.
  * Please see {@link java.beans.XMLEncoder}.
- *
- * @author unattributed
  */
 @SuppressWarnings("serial") // Same-version serialization only
 public abstract class BasicLookAndFeel extends LookAndFeel implements Serializable

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsLookAndFeel.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,8 +90,6 @@ import com.sun.java.swing.plaf.windows.WindowsIconFactory.VistaMenuItemCheckIcon
  * for short term storage or RMI between applications running the same
  * version of Swing.  A future release of Swing will provide support for
  * long term persistence.
- *
- * @author unattributed
  */
 @SuppressWarnings("serial") // Superclass is not serializable across versions
 public class WindowsLookAndFeel extends BasicLookAndFeel


### PR DESCRIPTION
This PR proposes to remove
1. JavaDoc `@author` tags with unclear semantics: `@author unascribed|unattributed|unknown`
2. A couple of astray Form Feed (a.k.a. FF, `\f`,  `0xC`, or `^L`) characters

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255989](https://bugs.openjdk.java.net/browse/JDK-8255989): Remove explicitly unascribed authorship from Java source files


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to 9f9b0a85e4e0419ee83f8d3c675fb6897b78eb34
 * [Mark Reinhold](https://openjdk.java.net/census#mr) (@mbreinhold - **Reviewer**) ⚠️ Review applies to 9f9b0a85e4e0419ee83f8d3c675fb6897b78eb34
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to 9f9b0a85e4e0419ee83f8d3c675fb6897b78eb34
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to 9f9b0a85e4e0419ee83f8d3c675fb6897b78eb34
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to 9f9b0a85e4e0419ee83f8d3c675fb6897b78eb34


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1100/head:pull/1100`
`$ git checkout pull/1100`
