### PR TITLE
8225116: Test OwnedWindowsLeak.java intermittently fails

### DIFF
--- a/test/jdk/java/awt/Window/OwnedWindowsLeak/OwnedWindowsLeak.java
+++ b/test/jdk/java/awt/Window/OwnedWindowsLeak/OwnedWindowsLeak.java
@@ -49,6 +49,7 @@ public class OwnedWindowsLeak
         for (int i = 0; i < 1000; i++)
         {
             Window child = new Window(owner);
+            child.setName("window_" +  i);
             children.add(new WeakReference<Window>(child));
         }
 
@@ -73,24 +74,19 @@ public class OwnedWindowsLeak
             while (ref.get() != null) {
                 System.out.println("ref.get() = " + ref.get());
                 System.gc();
-                Thread.sleep(100);
+                Thread.sleep(1000);
             }
         }
 
         // Fourth, make sure owner's children list contains no elements
-        try
+        Field f = Window.class.getDeclaredField("ownedWindowList");
+        f.setAccessible(true);
+        Vector ownersChildren = (Vector)f.get(owner);
+        while (ownersChildren.size() > 0)
         {
-            Field f = Window.class.getDeclaredField("ownedWindowList");
-            f.setAccessible(true);
-            Vector ownersChildren = (Vector)f.get(owner);
-            if (ownersChildren.size() > 0)
-            {
-                throw new RuntimeException("Test FAILED: some of the child windows are not removed from owner's children list");
-            }
-        }
-        catch (Exception z)
-        {
-            throw new RuntimeException("Test FAILED: unexpected exception", z);
+            System.out.println("ownersChildren = " + ownersChildren);
+            System.gc();
+            Thread.sleep(1000);
         }
 
         // Test passed

--- a/test/jdk/java/awt/Window/OwnedWindowsLeak/OwnedWindowsLeak.java
+++ b/test/jdk/java/awt/Window/OwnedWindowsLeak/OwnedWindowsLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import java.util.Vector;
 
 public class OwnedWindowsLeak
 {
-    public static void main(String[] args)
+    public static void main(String[] args) throws Exception
     {
         Frame owner = new Frame("F");
 
@@ -70,9 +70,10 @@ public class OwnedWindowsLeak
         // Third, make sure all the weak references are null
         for (WeakReference<Window> ref : children)
         {
-            if (ref.get() != null)
-            {
-                throw new RuntimeException("Test FAILED: some of child windows are not GCed");
+            while (ref.get() != null) {
+                System.out.println("ref.get() = " + ref.get());
+                System.gc();
+                Thread.sleep(100);
             }
         }
 
@@ -86,11 +87,6 @@ public class OwnedWindowsLeak
             {
                 throw new RuntimeException("Test FAILED: some of the child windows are not removed from owner's children list");
             }
-        }
-        catch (NoSuchFieldException z)
-        {
-            System.out.println("Test PASSED: no 'ownedWindowList' field in Window class");
-            return;
         }
         catch (Exception z)
         {


### PR DESCRIPTION
This test rarely fails in the past on some configurations but was never a problem listed, and according to the history of CI, it fails 2 times on its own this year.

There are two possible reasons for the failure:
1. At that time we had a memory leak, which was fixed.
2. The test works too fast and it was not enough time for GC to eliminate 1000 windows.

To make the future evaluation simpler I enhanced the test and make it stricter, see some comments inline.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8225116](https://bugs.openjdk.java.net/browse/JDK-8225116): Test OwnedWindowsLeak.java intermittently fails


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1105/head:pull/1105`
`$ git checkout pull/1105`
