### PR TITLE
8256009: Remove src/hotspot/share/adlc/Test/i486.ad

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -3888,7 +3888,7 @@ frame %{
   // The `sig' array is to be updated. sig[j] represents the location
   // of the j-th argument, either a register or a stack slot.
 
-  // Comment taken from i486.ad:
+  // Comment taken from x86_32.ad:
   // Body of function which returns an integer array locating
   // arguments either in registers or in stack slots. Passed an array
   // of ideal registers called "sig" and a "length" count. Stack-slot
@@ -3900,7 +3900,7 @@ frame %{
     SharedRuntime::java_calling_convention(sig_bt, regs, length, false);
   %}
 
-  // Comment taken from i486.ad:
+  // Comment taken from x86_32.ad:
   // Body of function which returns an integer array locating
   // arguments either in registers or in stack slots. Passed an array
   // of ideal registers called "sig" and a "length" count. Stack-slot

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -549,7 +549,7 @@ JVM_handle_bsd_signal(int sig,
         int op = pc[0];
         if (op == 0xDB) {
           // FIST
-          // TODO: The encoding of D2I in i486.ad can cause an exception
+          // TODO: The encoding of D2I in x86_32.ad can cause an exception
           // prior to the fist instruction if there was an invalid operation
           // pending. We want to dismiss that exception. From the win_32
           // side it also seems that if it really was the fist causing

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -340,7 +340,7 @@ JVM_handle_linux_signal(int sig,
         int op = pc[0];
         if (op == 0xDB) {
           // FIST
-          // TODO: The encoding of D2I in i486.ad can cause an exception
+          // TODO: The encoding of D2I in x86_32.ad can cause an exception
           // prior to the fist instruction if there was an invalid operation
           // pending. We want to dismiss that exception. From the win_32
           // side it also seems that if it really was the fist causing

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -3000,7 +3000,7 @@ void ArchDesc::define_oper_interface(FILE *fp, OperandForm &oper, FormDict &glob
       // Provide a non-NULL return for disp_as_type() that will allow adr_type()
       // to correctly compute the access type for alias analysis.
       //
-      // See BugId 4796752, operand indOffset32X in i486.ad
+      // See BugId 4796752, operand indOffset32X in x86_32.ad
       int idx = rep_var_to_constant_index(disp, oper, globals);
       fprintf(fp,"  virtual const TypePtr *disp_as_type() const { return _c%d; }\n", idx);
     }

--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -295,7 +295,7 @@ const Node* MachNode::get_base_and_disp(intptr_t &offset, const TypePtr* &adr_ty
     }
     offset = disp;
 
-    // In i486.ad, indOffset32X uses base==RegI and disp==RegP,
+    // In x86_32.ad, indOffset32X uses base==RegI and disp==RegP,
     // this will prevent alias analysis without the following support:
     // Lookup the TypePtr used by indOffset32X, a compile-time constant oop,
     // Add the offset determined by the "base", or use Type::OffsetBot.

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -151,7 +151,7 @@ public:
   virtual int  index_position() const;  // index edge position, or -1
 
   // Access the TypeKlassPtr of operands with a base==RegI and disp==RegP
-  // Only returns non-null value for i486.ad's indOffset32X
+  // Only returns non-null value for x86_32.ad's indOffset32X
   virtual const TypePtr *disp_as_type() const { return NULL; }
 
   // Return the label

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2337,7 +2337,7 @@ void Parse::do_one_bytecode() {
     if (Matcher::convL2FSupported()) {
       a = pop_pair();
       b = _gvn.transform( new ConvL2FNode(a));
-      // For i486.ad, FILD doesn't restrict precision to 24 or 53 bits.
+      // For x86_32.ad, FILD doesn't restrict precision to 24 or 53 bits.
       // Rather than storing the result into an FP register then pushing
       // out to memory to round, the machine instruction that implements
       // ConvL2D is responsible for rounding.
@@ -2352,7 +2352,7 @@ void Parse::do_one_bytecode() {
   case Bytecodes::_l2d:
     a = pop_pair();
     b = _gvn.transform( new ConvL2DNode(a));
-    // For i486.ad, rounding is always necessary (see _l2f above).
+    // For x86_32.ad, rounding is always necessary (see _l2f above).
     // c = dprecision_rounding(b);
     c = _gvn.transform(b);
     push_pair(c);

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -59,8 +59,8 @@
 
 // The "core" versions of monitor enter and exit reside in this file.
 // The interpreter and compilers contain specialized transliterated
-// variants of the enter-exit fast-path operations.  See i486.ad fast_lock(),
-// for instance.  If you make changes here, make sure to modify the
+// variants of the enter-exit fast-path operations.  See c2_MacroAssembler_x86.cpp
+// fast_lock(...) for instance.  If you make changes here, make sure to modify the
 // interpreter, and both C1 and C2 fast-path inline locking code emission.
 //
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
src/hotspot/share/adlc/Test/i486.ad is empty.
It might be better to remove it.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ❌ (1/2 failed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |    | 

**Failed test task**
- [macOS x64 (build debug)](https://github.com/DamonFool/jdk/runs/1373767215)

### Issue
 * [JDK-8256009](https://bugs.openjdk.java.net/browse/JDK-8256009): Remove src/hotspot/share/adlc/Test/i486.ad


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1107/head:pull/1107`
`$ git checkout pull/1107`
