### PR TITLE
8066622 8066637: remove deprecated using java.io.File.toURL() in internal classes

### DIFF
--- a/src/java.desktop/share/classes/java/awt/SplashScreen.java
+++ b/src/java.desktop/share/classes/java/awt/SplashScreen.java
@@ -223,9 +223,9 @@ public final class SplashScreen {
                     String jarName = _getImageJarName(splashPtr);
                     if (fileName != null) {
                         if (jarName != null) {
-                            imageURL = new URL("jar:"+(new File(jarName).toURL().toString())+"!/"+fileName);
+                            imageURL = new URL("jar:"+(new File(jarName).toURI().toURL().toString())+"!/"+fileName);
                         } else {
-                            imageURL = new File(fileName).toURL();
+                            imageURL = new File(fileName).toURI().toURL();
                         }
                     }
                 }

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/PerfDataBufferImpl.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/PerfDataBufferImpl.java
@@ -168,7 +168,7 @@ public abstract class PerfDataBufferImpl {
         if (filename != null) {
             File f = new File(filename);
             try {
-                aliasURL = f.toURL();
+                aliasURL = f.toURI().toURL();
 
             } catch (MalformedURLException e) {
                 throw new IllegalArgumentException(e);


### PR DESCRIPTION
In result of Javadoc to do not use java.io.File.toURL()
Change use  java.io.File.toURL().toURI() instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8066622](https://bugs.openjdk.java.net/browse/JDK-8066622)

### Issue
 * [JDK-8066622](https://bugs.openjdk.java.net/browse/JDK-8066622): Fix deprecation warnings in java.desktop module ⚠️ Title mismatch between PR and JBS.


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1108/head:pull/1108`
`$ git checkout pull/1108`
