### PR TITLE
8256015: Shenandoah: Add missing Shenandoah implementation in WB_isObjectInOldGen

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -385,6 +385,11 @@ WB_ENTRY(jboolean, WB_isObjectInOldGen(JNIEnv* env, jobject o, jobject obj))
     return Universe::heap()->is_in(p);
   }
 #endif
+#if INCLUDE_SHENANDOAHGC
+  if (UseShenandoahGC) {
+    return Universe::heap()->is_in(p);
+  }
+#endif
   GenCollectedHeap* gch = GenCollectedHeap::heap();
   return !gch->is_in_young(p);
 WB_END


### PR DESCRIPTION
The test gc/TestReferenceRefersTo.java fails with Shenandoah because of a missing implementation in WB_isObjectInOldGen:

Internal Error (/home/rkennke/src/openjdk/jdk/src/hotspot/share/gc/shared/collectedHeap.hpp:207), pid=511307, tid=511422
assert(kind == heap->kind()) failed: Heap kind 6 should be 1

This is introduced by JDK-8188055. 

Testing: hotspot_gc_shenandoah, tier1+Shenandoah, TestReferenceRefersTo.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ❌ (1/2 failed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (build debug)](https://github.com/rkennke/jdk/runs/1370381574)

### Issue
 * [JDK-8256015](https://bugs.openjdk.java.net/browse/JDK-8256015): Shenandoah: Add missing Shenandoah implementation in WB_isObjectInOldGen


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1111/head:pull/1111`
`$ git checkout pull/1111`
