### PR TITLE
8250607: C2: Filter type in PhiNode::Value() for induction variables of trip-counted integer loops

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1105,9 +1105,9 @@ const Type* PhiNode::Value(PhaseGVN* phase) const {
           if (bt != BoolTest::ne) {
             if (stride_t->_hi < 0) {          // Down-counter loop
               swap(lo, hi);
-              return TypeInt::make(MIN2(lo->_lo, hi->_lo) , hi->_hi, 3);
+              return TypeInt::make(MIN2(lo->_lo, hi->_lo) , hi->_hi, 3)->filter_speculative(_type);
             } else if (stride_t->_lo >= 0) {
-              return TypeInt::make(lo->_lo, MAX2(lo->_hi, hi->_hi), 3);
+              return TypeInt::make(lo->_lo, MAX2(lo->_hi, hi->_hi), 3)->filter_speculative(_type);
             }
           }
         }


### PR DESCRIPTION
PhiNode::Value() has special logic to compute the type of an iv phi
based on the counted loop's init value and limit. The type is
recomputed from scratch on every call to PhiNode::Value(). As the loop
is transformed, PhiNode::Value() may return a type for the iv phi that
widens. For instance, for:

for (int i = 0; i < 100; i++) {
}

PhiNode::value() returns accurate bounds for the iv phi. But if the
loop is transformed to pre/main/post loops, the init and limit no
longer have types that no longer allow an accurate computation of the
iv phi bounds.

The fix is to filter with the recorded _type for the Phi on every call
of PhiNode::Value().

This change was considered before (by Christian) but was not proposed
for integration because of a performance regression on a micro
benchmark. I investigated the performance regression and added my
findings to the bug report. While I'm not 100% sure I found the root
cause of the regression, the differences I see in the ideal graph of
the hottest methods of the micro benchmark with the change are fairly
small and I don't think that regression should block this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8250607](https://bugs.openjdk.java.net/browse/JDK-8250607): C2: Filter type in PhiNode::Value() for induction variables of trip-counted integer loops


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1114/head:pull/1114`
`$ git checkout pull/1114`
