### PR TITLE
8255916:  [macos] javax/swing/JInternalFrame/6647340/bug6647340.java timed out

### DIFF
--- a/test/jdk/javax/swing/JInternalFrame/6647340/bug6647340.java
+++ b/test/jdk/javax/swing/JInternalFrame/6647340/bug6647340.java
@@ -26,9 +26,6 @@
  * @bug 6647340
  * @summary Checks that iconified internal frame follows
  *          the main frame borders properly.
- * @author Mikhail Lapshin
- * @library /lib/client/
- * @build ExtendedRobot
  * @run main bug6647340
  */
 
@@ -39,21 +36,21 @@ import java.beans.PropertyVetoException;
 public class bug6647340 {
     private JFrame frame;
     private Point location;
+    private Point iconloc;
     private JInternalFrame jif;
-    private static ExtendedRobot robot = createRobot();
+    private static Robot robot;
 
     public static void main(String[] args) throws Exception {
+        robot = new Robot();
         final bug6647340 test = new bug6647340();
         try {
-            SwingUtilities.invokeAndWait(new Runnable() {
-                public void run() {
-                    test.setupUI();
-                }
-            });
+            SwingUtilities.invokeAndWait(() -> test.setupUI());
+            robot.waitForIdle();
+            robot.delay(1000);
             test.test();
         } finally {
             if (test.frame != null) {
-                test.frame.dispose();
+                SwingUtilities.invokeAndWait(() -> test.frame.dispose());
             }
         }
     }
@@ -77,75 +74,67 @@ public class bug6647340 {
     }
 
     private void test() throws Exception {
-        sync();
         test1();
-        sync();
+
+        robot.waitForIdle();
+        robot.delay(500);
         check1();
-        sync();
+        robot.waitForIdle();
+
         test2();
-        sync();
+        robot.waitForIdle();
+        robot.delay(500);
         check2();
     }
 
     private void test1() throws Exception {
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                setIcon(true);
-                location = jif.getDesktopIcon().getLocation();
-                Dimension size = frame.getSize();
-                frame.setSize(size.width + 100, size.height + 100);
-            }
+        SwingUtilities.invokeAndWait(() -> {
+            setIcon(true);
+            location = jif.getDesktopIcon().getLocation();
+            Dimension size = frame.getSize();
+            frame.setSize(size.width + 100, size.height + 100);
         });
     }
 
     private void test2() throws Exception {
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                setIcon(false);
-            }
+        SwingUtilities.invokeAndWait(() -> {
+            setIcon(false);
         });
-        sync();
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                Dimension size = frame.getSize();
-                frame.setSize(size.width - 100, size.height - 100);
-            }
+        robot.waitForIdle();
+        robot.delay(500);
+
+        SwingUtilities.invokeAndWait(() -> {
+            Dimension size = frame.getSize();
+            frame.setSize(size.width - 100, size.height - 100);
         });
-        sync();
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                setIcon(true);
-            }
+        robot.waitForIdle();
+        robot.delay(500);
+
+        SwingUtilities.invokeAndWait(() -> {
+            setIcon(true);
         });
     }
 
-    private void check1() {
-        if (!jif.getDesktopIcon().getLocation().equals(location)) {
+    private void check1() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            iconloc = jif.getDesktopIcon().getLocation();
+        });
+        if (!iconloc.equals(location)) {
             System.out.println("First test passed");
         } else {
             throw new RuntimeException("Icon isn't shifted with the frame bounds");
         }
     }
 
-    private void check2() {
-        if (jif.getDesktopIcon().getLocation().equals(location)) {
+    private void check2() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            iconloc = jif.getDesktopIcon().getLocation();
+        });
+        if (iconloc.equals(location)) {
             System.out.println("Second test passed");
         } else {
             throw new RuntimeException("Icon isn't located near the frame bottom");
         }
-    }
-
-    private static void sync() {
-        robot.waitForIdle();
-    }
-    private static ExtendedRobot createRobot() {
-        try {
-             ExtendedRobot robot = new ExtendedRobot();
-             return robot;
-         }catch(Exception ex) {
-             ex.printStackTrace();
-             throw new Error("Unexpected Failure");
-         }
     }
 
     private void setIcon(boolean b) {

--- a/test/jdk/javax/swing/JInternalFrame/6647340/bug6647340.java
+++ b/test/jdk/javax/swing/JInternalFrame/6647340/bug6647340.java
@@ -35,8 +35,8 @@ import java.beans.PropertyVetoException;
 
 public class bug6647340 {
     private JFrame frame;
-    private Point location;
-    private Point iconloc;
+    private volatile Point location;
+    private volatile Point iconloc;
     private JInternalFrame jif;
     private static Robot robot;
 


### PR DESCRIPTION
This test has failed in one of jdk nightly testing although it always passed locally. Made the test use robot delays, waitForIdle() to make it more stable and appropriate to run in slower mach5 systems and also remove the dependancy on ExtendedRobot.
Mach5 job has been run for several iterations in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (2/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Windows x64 (hs/tier1 gc)](https://github.com/prsadhuk/jdk/runs/1378057734)
- [Windows x64 (hs/tier1 serviceability)](https://github.com/prsadhuk/jdk/runs/1378057747)
- [macOS x64 (hs/tier1 gc)](https://github.com/prsadhuk/jdk/runs/1377972883)

### Issue
 * [JDK-8255916](https://bugs.openjdk.java.net/browse/JDK-8255916): [macos] javax/swing/JInternalFrame/6647340/bug6647340.java timed out


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1115/head:pull/1115`
`$ git checkout pull/1115`
