### PR TITLE
8256037: [TESTBUG] com/sun/jndi/dns/ConfigTests/PortUnreachable.java fails due to the hard coded threshold is small

### DIFF
--- a/test/jdk/com/sun/jndi/dns/ConfigTests/PortUnreachable.java
+++ b/test/jdk/com/sun/jndi/dns/ConfigTests/PortUnreachable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,9 +44,9 @@ public class PortUnreachable extends DNSTestBase {
 
     // Threshold in ms for elapsed time of request failed. Normally, it should
     // be very quick, but consider to different platform and test machine
-    // performance, here we define 1000 ms as threshold which acceptable for
+    // performance, here we define 3000 ms as threshold which acceptable for
     // this test.
-    private static final int THRESHOLD = 1000;
+    private static final int THRESHOLD = 3000;
 
     private long startTime;
 


### PR DESCRIPTION
Hi all,

May I get reviews for this change?

com/sun/jndi/dns/ConfigTests/PortUnreachable.java fails occasionally on some of our testing platforms.
The reason is that the hard coded Threshold (1000 ms) [1] is a little smaller than that (e.g., 1026 ms) on our platforms.

The fix just increases the threshold from 1000 ms to 3000 ms.
Any comments?

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/test/jdk/com/sun/jndi/dns/ConfigTests/PortUnreachable.java#L49

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x86 (hs/tier1 gc)](https://github.com/DamonFool/jdk/runs/1373380514)

### Issue
 * [JDK-8256037](https://bugs.openjdk.java.net/browse/JDK-8256037): [TESTBUG] com/sun/jndi/dns/ConfigTests/PortUnreachable.java fails due to the hard coded threshold is small


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1116/head:pull/1116`
`$ git checkout pull/1116`
