### PR TITLE
8256040: Shenandoah: Allow NULL referent in ShenandoahReferenceProcessor::should_discover()

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -265,7 +265,7 @@ template <typename T>
 bool ShenandoahReferenceProcessor::should_discover(oop reference, ReferenceType type) const {
   T* referent_addr = (T*) java_lang_ref_Reference::referent_addr_raw(reference);
   T heap_oop = RawAccess<>::oop_load(referent_addr);
-  oop referent = CompressedOops::decode_not_null(heap_oop);
+  oop referent = CompressedOops::decode(heap_oop);
 
   if (is_inactive<T>(reference, referent, type)) {
     log_trace(gc,ref)("Reference inactive: " PTR_FORMAT, p2i(reference));


### PR DESCRIPTION
Testing showed the following assert:

```
# Internal Error (/home/rkennke/src/openjdk/jdk/src/hotspot/share/oops/compressedOops.inline.hpp:54), pid=711923, tid=712264
# assert(!is_null(v)) failed: narrow oop value can never be zero

V [libjvm.so+0x1629c84] bool ShenandoahReferenceProcessor::should_discover<narrowOop>(oop, ReferenceType) const+0x404
V [libjvm.so+0x162a01b] bool ShenandoahReferenceProcessor::discover<narrowOop>(oop, ReferenceType, unsigned int)+0x4b
V [libjvm.so+0x16239e8] ShenandoahReferenceProcessor::discover_reference(oop, ReferenceType)+0x138
V [libjvm.so+0x15b7a26] bool InstanceRefKlass::try_discover<narrowOop, ShenandoahMarkRefsMetadataClosure>(oop, ReferenceType, ShenandoahMarkRefsMetadataClosure*)+0x96
V [libjvm.so+0x15b7b3d] void InstanceRefKlass::oop_oop_iterate_discovery<narrowOop, ShenandoahMarkRefsMetadataClosure, AlwaysContains>(oop, ReferenceType, ShenandoahMarkRefsMetadataClosure*, AlwaysContains&) [clone .constprop.696]+0x3d
V [libjvm.so+0x15b7ce1] void InstanceRefKlass::oop_oop_iterate_ref_processing<narrowOop, ShenandoahMarkRefsMetadataClosure, AlwaysContains>(oop, ShenandoahMarkRefsMetadataClosure*, AlwaysContains&)+0x81
V [libjvm.so+0x15b835e] void OopOopIterateDispatch<ShenandoahMarkRefsMetadataClosure>::Table::oop_oop_iterate<InstanceRefKlass, narrowOop>(ShenandoahMarkRefsMetadataClosure*, oop, Klass*)+0x1ee
V [libjvm.so+0x15a905e] void ShenandoahConcurrentMark::do_task<ShenandoahMarkRefsMetadataClosure>(Padded<BufferedOverflowTaskQueue<ShenandoahMarkTask, (MEMFLAGS)5, 131072u>, 128ul>*, ShenandoahMarkRefsMetadataClosure*, unsigned short*, ShenandoahMarkTask*)+0x7be
V [libjvm.so+0x15ab81e] void ShenandoahConcurrentMark::mark_loop_work<ShenandoahMarkRefsMetadataClosure, true>(ShenandoahMarkRefsMetadataClosure*, unsigned short*, unsigned int, TaskTerminator*)+0x3ce
```

We have this code in ShRefProc::should_discover():
  oop referent = CompressedOops::decode_not_null(heap_oop);

However, the referent can legally be NULL. We even treat NULL specially in is_inactive(). 

Testing:
- [x] hotspot_gc_shenandoah
- [x] tier1+UseShenandoahGC+ShenandoahVerify (which originally showed the problem)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256040](https://bugs.openjdk.java.net/browse/JDK-8256040): Shenandoah: Allow NULL referent in ShenandoahReferenceProcessor::should_discover()


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1117/head:pull/1117`
`$ git checkout pull/1117`
