### PR TITLE
8256038: G1: Improve comment about mark word handling of displaced mark words 

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -490,12 +490,11 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
         age++;
       }
       if (old_mark.has_displaced_mark_helper()) {
-        // In this case, we have to install the mark word first,
-        // otherwise obj looks to be forwarded (the old mark word,
-        // which contains the forward pointer, was copied)
-        obj->set_mark(old_mark);
+        // In this case, we have to install the old mark word containing the
+        // displacement tag, and update the age in the displaced mark word.
         markWord new_mark = old_mark.displaced_mark_helper().set_age(age);
         old_mark.set_displaced_mark_helper(new_mark);
+        obj->set_mark(old_mark);
       } else {
         obj->set_mark(old_mark.set_age(age));
       }


### PR DESCRIPTION
Hi all,

  can I have reviews for this small comment change that fixes an imho completely misleading comment into something more understandable. Reasons outlined below:

I.e. in the code:

       if (old_mark.has_displaced_mark_helper()) {
        // In this case, we have to install the mark word first,
        // otherwise obj looks to be forwarded (the old mark word,
        // which contains the forward pointer, was copied)
        obj->set_mark(old_mark);
        markWord new_mark = old_mark.displaced_mark_helper().set_age(age);
        old_mark.set_displaced_mark_helper(new_mark);

"in this case ... the obj looks to be forwarded" - it is not true that only in this case the mark word looks to be forwarded because of the copy. G1 always copies the mark word containing the forwarded pointer, i.e. after the copy, the mark word in obj is always the forwarding pointer.
That's why we need to set it to the (eventually updated) old mark word value in all cases....

"we have to install the mark word first" - the order of installing the mark word and updating the displaced mark word is completely irrelevant here - the point is that we need to update the age in the displaced mark word and must not change the old mark word in this branch. The obj->set_mark() call can be at any position actually. 

I went with fixing the comment and setting the mark word last in that code block to be similar to other cases. I refrained from other refactorings like refactoring this into (inlined) methods.

Testing: compilation, some quick tests like gcbasher (but errors here typically make building the image fail).

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256038](https://bugs.openjdk.java.net/browse/JDK-8256038): G1: Improve comment about mark word handling of displaced mark words


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1118/head:pull/1118`
`$ git checkout pull/1118`
