### PR TITLE
8252588: HotSpot Style Guide should permit uniform initialization

### DIFF
--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -49,6 +49,7 @@
 <li><a href="#thread_local">thread_local</a></li>
 <li><a href="#nullptr">nullptr</a></li>
 <li><a href="#atomic">&lt;atomic&gt;</a></li>
+<li><a href="#uniform-initialization">Uniform Initialization</a></li>
 <li><a href="#additional-permitted-features">Additional Permitted Features</a></li>
 <li><a href="#excluded-features">Excluded Features</a></li>
 <li><a href="#undecided-features">Undecided Features</a></li>
@@ -275,6 +276,17 @@ while ( test_foo(args...) ) { // No, excess spaces around control</code></pre></
 <p>Do not use facilities provided by the <code>&lt;atomic&gt;</code> header (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2427.html">n2427</a>), (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2752.htm">n2752</a>); instead, use the HotSpot <code>Atomic</code> class and related facilities.</p>
 <p>Atomic operations in HotSpot code must have semantics which are consistent with those provided by the JDK's compilers for Java. There are platform-specific implementation choices that a C++ compiler might make or change that are outside the scope of the C++ Standard, and might differ from what the Java compilers implement.</p>
 <p>In addition, HotSpot <code>Atomic</code> has a concept of &quot;conservative&quot; memory ordering, which may differ from (may be stronger than) sequentially consistent. There are algorithms in HotSpot that are believed to rely on that ordering.</p>
+<h3 id="uniform-initialization">Uniform Initialization</h3>
+<p>The use of <em>uniform initialization</em> (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2672.htm">n2672</a>), also known as <em>brace initialization</em>, is permitted.</p>
+<p>Some relevant sections from cppreference.com:</p>
+<ul>
+<li><a href="https://en.cppreference.com/w/cpp/language/initialization">initialization</a></li>
+<li><a href="https://en.cppreference.com/w/cpp/language/value_initialization">value initialization</a></li>
+<li><a href="https://en.cppreference.com/w/cpp/language/direct_initialization">direct initialization</a></li>
+<li><a href="https://en.cppreference.com/w/cpp/language/list_initialization">list initialization</a></li>
+<li><a href="https://en.cppreference.com/w/cpp/language/aggregate_initialization">aggregate initialization</a></li>
+</ul>
+<p>Although related, the use of <code>std::initializer_list</code> remains forbidden, as part of the avoidance of the C++ Standard Library in HotSpot code.</p>
 <h3 id="additional-permitted-features">Additional Permitted Features</h3>
 <ul>
 <li><p><code>constexpr</code> (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2235.pdf">n2235</a>) (<a href="https://isocpp.org/files/papers/N3652.html">n3652</a>)</p></li>

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -681,6 +681,23 @@ ordering, which may differ from (may be stronger than) sequentially
 consistent.  There are algorithms in HotSpot that are believed to rely
 on that ordering.
 
+### Uniform Initialization
+
+The use of _uniform initialization_
+([n2672](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2672.htm)),
+also known as _brace initialization_, is permitted.
+
+Some relevant sections from cppreference.com:
+
+* [initialization](https://en.cppreference.com/w/cpp/language/initialization)
+* [value initialization](https://en.cppreference.com/w/cpp/language/value_initialization)
+* [direct initialization](https://en.cppreference.com/w/cpp/language/direct_initialization)
+* [list initialization](https://en.cppreference.com/w/cpp/language/list_initialization)
+* [aggregate initialization](https://en.cppreference.com/w/cpp/language/aggregate_initialization)
+
+Although related, the use of `std::initializer_list` remains forbidden, as
+part of the avoidance of the C++ Standard Library in HotSpot code.
+
 ### Additional Permitted Features
 
 * `constexpr`


### PR DESCRIPTION
Please review and vote on this change to the HotSpot Style Guide to
permit the use of uniform initialization, aka brace initialization, in
HotSpot code.  Uniform initialization is a feature added in C++11.

This is a modification of the Style Guide, so rough consensus among
the HotSpot Group members is required to make this change.  Only Group
members should vote for approval (via the github PR), though reasoned
objectsions or comments from anyone will be considered.  A decision to
approve will not be made before Monday 16-Nov-2020 at 12h00 UTC.

[Note: This is the first attempt to change the Style Guide since the
revision that added a description for a change process (requires rough
consensus of the Group), and also since the start of using git and
github PRs.  I'm making a guess at how to instantiate that process
within the new mechanisms.]

/label hotspot

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252588](https://bugs.openjdk.java.net/browse/JDK-8252588): HotSpot Style Guide should permit uniform initialization


### Reviewers
 * [John R Rose](https://openjdk.java.net/census#jrose) (@rose00 - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1119/head:pull/1119`
`$ git checkout pull/1119`
