### PR TITLE
8256046: Shenandoah: Mix-in NULL_PTR in non-strong ShLRBNode's type

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -2945,11 +2945,12 @@ const Type* ShenandoahLoadReferenceBarrierNode::bottom_type() const {
   if (t == TypePtr::NULL_PTR) {
     return t;
   }
-  const Type* type = t;
-  if (kind() != ShenandoahBarrierSet::AccessKind::NORMAL) {
-    type = type->meet(TypePtr::NULL_PTR);
+
+  if (kind() == ShenandoahBarrierSet::AccessKind::NORMAL) {
+    return t;
   }
-  return type;
+
+  return t->meet(TypePtr::NULL_PTR);
 }
 
 const Type* ShenandoahLoadReferenceBarrierNode::Value(PhaseGVN* phase) const {
@@ -2961,11 +2962,11 @@ const Type* ShenandoahLoadReferenceBarrierNode::Value(PhaseGVN* phase) const {
     return t2;
   }
 
-  const Type* type = t2;
-  if (kind() != ShenandoahBarrierSet::AccessKind::NORMAL) {
-    type = type->meet(TypePtr::NULL_PTR);
+  if (kind() == ShenandoahBarrierSet::AccessKind::NORMAL) {
+    return t2;
   }
-  return type;
+
+  return t2->meet(TypePtr::NULL_PTR);
 }
 
 Node* ShenandoahLoadReferenceBarrierNode::Identity(PhaseGVN* phase) {

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -2945,7 +2945,7 @@ const Type* ShenandoahLoadReferenceBarrierNode::bottom_type() const {
   if (t == TypePtr::NULL_PTR) {
     return t;
   }
-  const Type* type = t->is_oopptr();
+  const Type* type = t;
   if (kind() != ShenandoahBarrierSet::AccessKind::NORMAL) {
     type = type->meet(TypePtr::NULL_PTR);
   }
@@ -2961,7 +2961,7 @@ const Type* ShenandoahLoadReferenceBarrierNode::Value(PhaseGVN* phase) const {
     return t2;
   }
 
-  const Type* type = t2->is_oopptr();
+  const Type* type = t2;
   if (kind() != ShenandoahBarrierSet::AccessKind::NORMAL) {
     type = type->meet(TypePtr::NULL_PTR);
   }

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -2945,7 +2945,11 @@ const Type* ShenandoahLoadReferenceBarrierNode::bottom_type() const {
   if (t == TypePtr::NULL_PTR) {
     return t;
   }
-  return t->is_oopptr();
+  const Type* type = t->is_oopptr();
+  if (kind() != ShenandoahBarrierSet::AccessKind::NORMAL) {
+    type = type->meet(TypePtr::NULL_PTR);
+  }
+  return type;
 }
 
 const Type* ShenandoahLoadReferenceBarrierNode::Value(PhaseGVN* phase) const {
@@ -2958,6 +2962,9 @@ const Type* ShenandoahLoadReferenceBarrierNode::Value(PhaseGVN* phase) const {
   }
 
   const Type* type = t2->is_oopptr();
+  if (kind() != ShenandoahBarrierSet::AccessKind::NORMAL) {
+    type = type->meet(TypePtr::NULL_PTR);
+  }
   return type;
 }
 


### PR DESCRIPTION
Testing found this problem (very rare/hard to reproduce):

```
# Internal Error (d:/a/jdk/jdk/jdk/src/hotspot/cpu/x86/macroAssembler_x86.cpp:880), pid=6160, tid=5828
# fatal error: DEBUG MESSAGE: unexpected null in intrinsic
```

I believe this may be caused by non-strong LRB reporting a non-NULL type by passing-through its input's type, even though it may actually return NULL on non-NULL inputs. If this serves as input to an intrinsic, it may lead to elimination of surrounding null-check, and thus end up passing a NULL to the intrinsic even thought it should not. 

Testing:
 - [x] hotspot_gc_shenandoah
 - [ ] tier1+Shenandoah
 - [ ] tier2+Shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ⏳ (3/9 running) | ❌ (1/9 failed) |

**Failed test task**
- [macOS x64 (hs/tier1 common)](https://github.com/rkennke/jdk/runs/1380054352)

### Issue
 * [JDK-8256046](https://bugs.openjdk.java.net/browse/JDK-8256046): Shenandoah: Mix-in NULL_PTR in non-strong ShLRBNode's type


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to 6fbeabb3e5357d8893c33f01eec5c0f1d660e41f
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1120/head:pull/1120`
`$ git checkout pull/1120`
