### PR TITLE
8256036: Shenandoah: MethodHandles adapters section overflows after JDK-8255762

### DIFF
--- a/src/hotspot/cpu/x86/methodHandles_x86.hpp
+++ b/src/hotspot/cpu/x86/methodHandles_x86.hpp
@@ -27,7 +27,7 @@
 
 // Adapters
 enum /* platform_dependent_constants */ {
-  adapter_code_size = 3000 DEBUG_ONLY(+ 6000)
+  adapter_code_size = 4000 DEBUG_ONLY(+ 6000)
 };
 
 // Additional helper methods for MethodHandles code generation:


### PR DESCRIPTION
This seems to happen only under release bits, and only with Shenandoah. This shows up in tier1 after JDK-8255762, but only in release builds. The section in question is "MethodHandles adapters".

```
$ CONF=linux-x86_64-server-release make run-test TEST=java/lang/invoke/6987555/Test6987555.java TEST_VM_OPTS="-XX:+UseShenandoahGC"

STDOUT:
#
# A fatal error has been detected by the Java Runtime Environment:
#
# Internal Error (codeBuffer.cpp:971), pid=907468, tid=907470
# guarantee(sect->end() <= tend) failed: sanity: MethodHandles adapters, 0x00007f76902a9da9, 0x00007f76902a9d38
#
# JRE version: (16.0) (build )
# Java VM: OpenJDK 64-Bit Server VM (16-internal+0-adhoc.shade.jdk, interpreted mode, sharing, compressed oops, shenandoah gc, linux-amd64)
# Problematic frame:
# V [libjvm.so+0x58f47f] CodeBuffer::verify_section_allocation()+0x1ff
```

Additional testing:
  - [x] `java/lang/invoke` tests on Linux x86_64 {fastdebug,release} with Shenandoah
  - [x] `java/lang/invoke` tests on Linux x86_32 {fastdebug,release} with Shenandoah
  - [x] `java/lang/invoke` tests on Linux AArch64 {fastdebug,release} with Shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256036](https://bugs.openjdk.java.net/browse/JDK-8256036): Shenandoah: MethodHandles adapters section overflows after JDK-8255762


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1121/head:pull/1121`
`$ git checkout pull/1121`
