### PR TITLE
8256048: Incomplete gitignore setting for netbeans project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 /dist/
 /.idea/
 /.vscode/
-/nbproject/
+nbproject/private/
+nbproject/configurations.xml
+nbproject/project.xml
 /webrev
 /.src-rev
 /.jib/

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,8 @@
 /dist/
 /.idea/
 /.vscode/
+/nbproject/
 nbproject/private/
-nbproject/configurations.xml
-nbproject/project.xml
 /webrev
 /.src-rev
 /.jib/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /dist/
 /.idea/
 /.vscode/
-nbproject/private/
+/nbproject/
 /webrev
 /.src-rev
 /.jib/


### PR DESCRIPTION
Hi all,

The gitignore setting for netbeans project seems to be incomplete.
Only nbproject/private/ [1] is ignored. 

But there are also other files under nbproject/, which should be ignored too.
----------------------------
$ tree -L 1 nbproject/
nbproject/
├── configurations.xml
├── private
└── project.xml
----------------------------

It would be better to fix it.

Thanks.
Best regards,
Jie


[1] https://github.com/openjdk/jdk/blob/master/.gitignore#L5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ❌ (1/2 failed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (build release)](https://github.com/DamonFool/jdk/runs/1377040200)

### Issue
 * [JDK-8256048](https://bugs.openjdk.java.net/browse/JDK-8256048): Incomplete gitignore setting for netbeans project


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1122/head:pull/1122`
`$ git checkout pull/1122`
