### PR TITLE
8231599: NPE when loading a preview classfile from a future Java version

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -2577,10 +2577,12 @@ public class ClassReader {
         majorVersion = nextChar();
         int maxMajor = Version.MAX().major;
         int maxMinor = Version.MAX().minor;
+        boolean previewClassFile =
+                minorVersion == ClassFile.PREVIEW_MINOR_VERSION;
         if (majorVersion > maxMajor ||
             majorVersion * 1000 + minorVersion <
             Version.MIN().major * 1000 + Version.MIN().minor) {
-            if (majorVersion == (maxMajor + 1))
+            if (majorVersion == (maxMajor + 1) && !previewClassFile)
                 log.warning(Warnings.BigMajorVersion(currentClassFile,
                                                      majorVersion,
                                                      maxMajor));
@@ -2592,7 +2594,7 @@ public class ClassReader {
                                    Integer.toString(maxMinor));
         }
 
-        if (minorVersion == ClassFile.PREVIEW_MINOR_VERSION) {
+        if (previewClassFile) {
             if (!preview.isEnabled()) {
                 log.error(preview.disabledError(currentClassFile, majorVersion));
             } else {

--- a/test/langtools/tools/javac/preview/classReaderTest/TooNewMajorVersionTest.java
+++ b/test/langtools/tools/javac/preview/classReaderTest/TooNewMajorVersionTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8231599
+ * @summary Verify javac does not crash on preview classfiles from the future
+            Java versions.
+ * @library /tools/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.jvm
+ *      jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main TooNewMajorVersionTest
+ */
+
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+import com.sun.tools.javac.jvm.ClassFile.Version;
+
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class TooNewMajorVersionTest extends TestRunner {
+
+    protected ToolBox tb;
+
+    TooNewMajorVersionTest() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String... args) throws Exception {
+        TooNewMajorVersionTest t = new TooNewMajorVersionTest();
+        t.runTests();
+    }
+
+    protected void runTests() throws Exception {
+        runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    @Test
+    public void brokenMajorVersionWithPreview(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                               class C {
+                                   private Object o = null;
+                                   private boolean b = o instanceof String s;
+                               }
+                               """);
+        Path classes = base.resolve("classes");
+
+        Files.createDirectories(classes);
+
+        for (int upgrade = 1; upgrade < 3; upgrade++) {
+            new JavacTask(tb)
+                    .outdir(classes)
+                    .options("-XDforcePreview",
+                             "--enable-preview",
+                             "--release", String.valueOf(Runtime.version().feature()))
+                    .files(tb.findJavaFiles(src))
+                    .run()
+                    .writeAll();
+
+            Path classfile = classes.resolve("C.class");
+            int wrongMajor;
+
+            try (RandomAccessFile f = new RandomAccessFile(classfile.toFile(), "rw")) {
+                f.readInt();
+                short minor = f.readShort();
+                if (minor != (-1)) {
+                    throw new AssertionError("Unexpected minor version: " + minor);
+                }
+                long point = f.getFilePointer();
+                short major = f.readShort();
+                f.seek(point);
+                f.writeShort(wrongMajor = major + upgrade);
+            }
+
+            Path test = base.resolve("test");
+            tb.writeJavaFiles(test, "class Test extends C {}");
+            Path testClasses = base.resolve("classes");
+
+            Files.createDirectories(testClasses);
+
+            for (String extraOption : new String[] {"-XDignored", "--enable-preview"}) {
+                List<String> log = new JavacTask(tb)
+                        .outdir(testClasses)
+                        .options("-XDrawDiagnostics",
+                                 "-classpath", classes.toString(),
+                                 "--release", String.valueOf(Runtime.version().feature()),
+                                 extraOption)
+                        .files(tb.findJavaFiles(test))
+                        .run(Task.Expect.FAIL)
+                        .writeAll()
+                        .getOutputLines(Task.OutputKind.DIRECT);
+                List<String> expected = List.of(
+                        "Test.java:1:20: compiler.err.cant.access: C, (compiler.misc.bad.class.file.header: C.class, (compiler.misc.wrong.version: " + wrongMajor + ", 65535, " + Version.MAX().major + ", 0))",
+                        "1 error"
+                );
+                if (!log.equals(expected))
+                    throw new Exception("expected output not found" + log);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The javac's ClassReader accepts class files with major version that is +1 higher than the current platform's major version. See https://bugs.openjdk.java.net/browse/JDK-6330997 for more information.

A problem is that when this too-new class file is a preview class file, the Preview class will attempt to produce a warning (or error) which includes the user-readable name of the Java platform, and it cannot find the name of the future platform name.

If the major version of the class file is >+1 higher than the current platform's, there is no such problem: ClassReader will reject to analyze the class file right away.

The proposed (middle ground) fix here is that ClassReader will reject all preview class files with major version > current platform's major version. It will keep accepting non-preview class files with major version +1 than the current.

With this patch, the standard error is produced:
```
brokenMajorVersionWithPreview/test/Test.java:1: error: cannot access C
class Test extends C {}
                   ^
  bad class file: brokenMajorVersionWithPreview/classes/C.class
    class file has wrong version 61.65535, should be 60.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
1 error
```

Alternatives include:

 * reject all class files with major version > current
 * accept preview class files with major version +1 than the current, and attempt the generate a sensible (future) platform name

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8231599](https://bugs.openjdk.java.net/browse/JDK-8231599): NPE when loading a preview classfile from a future Java version


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1123/head:pull/1123`
`$ git checkout pull/1123`
