### PR TITLE
8256050: JVM crashes with -XX:+PrintDeoptimizationDetails

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3607,9 +3607,19 @@ void InstanceKlass::oop_print_value_on(oop obj, outputStream* st) {
       st->print(" = ");
       vmtarget->print_value_on(st);
     } else {
-      java_lang_invoke_MemberName::clazz(obj)->print_value_on(st);
+      oop clazz = java_lang_invoke_MemberName::clazz(obj);
+      oop name  = java_lang_invoke_MemberName::name(obj);
+      if (clazz != NULL) {
+        clazz->print_value_on(st);
+      } else {
+        st->print("NULL");
+      }
       st->print(".");
-      java_lang_invoke_MemberName::name(obj)->print_value_on(st);
+      if (name != NULL) {
+        name->print_value_on(st);
+      } else {
+        st->print("NULL");
+      }
     }
   }
 }

--- a/src/hotspot/share/oops/markWord.cpp
+++ b/src/hotspot/share/oops/markWord.cpp
@@ -28,17 +28,19 @@
 #include "runtime/objectMonitor.hpp"
 #include "utilities/ostream.hpp"
 
-void markWord::print_on(outputStream* st) const {
+void markWord::print_on(outputStream* st, bool print_monitor_info) const {
   if (is_marked()) {  // last bits = 11
     st->print(" marked(" INTPTR_FORMAT ")", value());
   } else if (has_monitor()) {  // last bits = 10
     // have to check has_monitor() before is_locked()
     st->print(" monitor(" INTPTR_FORMAT ")=", value());
-    ObjectMonitor* mon = monitor();
-    if (mon == NULL) {
-      st->print("NULL (this should never be seen!)");
-    } else {
-      mon->print_on(st);
+    if (print_monitor_info) {
+      ObjectMonitor* mon = monitor();
+      if (mon == NULL) {
+        st->print("NULL (this should never be seen!)");
+      } else {
+        mon->print_on(st);
+      }
     }
   } else if (is_locked()) {  // last bits != 01 => 00
     // thin locked

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -355,7 +355,7 @@ class markWord {
   static inline markWord prototype_for_klass(const Klass* klass);
 
   // Debugging
-  void print_on(outputStream* st) const;
+  void print_on(outputStream* st, bool print_monitor_info = true) const;
 
   // Prepare address of oop for placement into mark
   inline static markWord encode_pointer_as_mark(void* p) { return from_pointer(p).set_marked(); }

--- a/src/hotspot/share/runtime/basicLock.cpp
+++ b/src/hotspot/share/runtime/basicLock.cpp
@@ -23,14 +23,17 @@
  */
 
 #include "precompiled.hpp"
+#include "oops/oop.inline.hpp"
 #include "runtime/basicLock.hpp"
 #include "runtime/synchronizer.hpp"
 
-void BasicLock::print_on(outputStream* st) const {
+void BasicLock::print_on(outputStream* st, oop owner) const {
   st->print("monitor");
   markWord mark_word = displaced_header();
-  if (mark_word.value() != 0)
-    mark_word.print_on(st);
+  if (mark_word.value() != 0) {
+    bool print_monitor_info = (owner != NULL) && (owner->mark() == markWord::from_pointer((void*)this));
+    mark_word.print_on(st, print_monitor_info);
+  }
 }
 
 void BasicLock::move_to(oop obj, BasicLock* dest) {

--- a/src/hotspot/share/runtime/basicLock.cpp
+++ b/src/hotspot/share/runtime/basicLock.cpp
@@ -31,6 +31,7 @@ void BasicLock::print_on(outputStream* st, oop owner) const {
   st->print("monitor");
   markWord mark_word = displaced_header();
   if (mark_word.value() != 0) {
+    // Print monitor info if there's an owning oop and it refers to this BasicLock.
     bool print_monitor_info = (owner != NULL) && (owner->mark() == markWord::from_pointer((void*)this));
     mark_word.print_on(st, print_monitor_info);
   }

--- a/src/hotspot/share/runtime/basicLock.hpp
+++ b/src/hotspot/share/runtime/basicLock.hpp
@@ -43,7 +43,7 @@ class BasicLock {
     Atomic::store(&_displaced_header, header);
   }
 
-  void print_on(outputStream* st) const;
+  void print_on(outputStream* st, oop owner) const;
 
   // move a basic lock (used during deoptimization
   void move_to(oop obj, BasicLock* dest);

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -509,7 +509,7 @@ void frame::interpreter_frame_print_on(outputStream* st) const {
     current->obj()->print_value_on(st);
     st->print_cr("]");
     st->print(" - lock   [");
-    current->lock()->print_on(st);
+    current->lock()->print_on(st, current->obj());
     st->print_cr("]");
   }
   // monitor

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -669,7 +669,7 @@ void javaVFrame::print() {
     }
     tty->cr();
     tty->print("\t  ");
-    monitor->lock()->print_on(tty);
+    monitor->lock()->print_on(tty, monitor->owner());
     tty->cr();
   }
 }


### PR DESCRIPTION
-XX:+PrintDeoptimizationDetails triggers intermittent crashes. I spotted 2 independent problems which the patch addresses:
  * `markWord::print_on` doesn't handle displaced header case well (the pointer stored in the header may be stale);
  * `InstanceKlass::oop_print_value_on` dumps some specific details about `MemberName`, but the code assumes the instance is fully initialized. It's not necessarily the case: for example, deoptimization can happen when `MemberName` constructor is being executed.  

Testing:
- [x] manually verified that the crashes go away -XX:+PrintDeoptimizationDetails
- [x] hs-precheckin-comp,hs-tier1,hs-tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (5/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8256050](https://bugs.openjdk.java.net/browse/JDK-8256050): JVM crashes with -XX:+PrintDeoptimizationDetails


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to a41c82cda9d46bc8c2e57e0ecd31c72c51cc424f
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to a41c82cda9d46bc8c2e57e0ecd31c72c51cc424f


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1124/head:pull/1124`
`$ git checkout pull/1124`
