### PR TITLE
8255273: jshell crashes with UnsupportedOperationException: Should not get here.

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
@@ -364,11 +364,49 @@ class ConsoleIOContext extends IOContext {
                                              .distinct()
                                              .count() == 2;
                 boolean tooManyItems = suggestions.size() > /*in.getAutoprintThreshold()*/AUTOPRINT_THRESHOLD;
-                CompletionTask ordinaryCompletion =
-                        new OrdinaryCompletionTask(suggestions,
-                                                   anchor[0],
-                                                   !command && !doc.isEmpty(),
-                                                   hasBoth);
+                CompletionTask ordinaryCompletion;
+                List<CharSequence> ordinaryCompletionToShow;
+
+                if (hasBoth) {
+                    ordinaryCompletionToShow =
+                        suggestions.stream()
+                                   .filter(Suggestion::matchesType)
+                                   .map(Suggestion::continuation)
+                                   .distinct()
+                                   .collect(Collectors.toList());
+                } else {
+                    ordinaryCompletionToShow =
+                        suggestions.stream()
+                                   .map(Suggestion::continuation)
+                                   .distinct()
+                                   .collect(Collectors.toList());
+                }
+
+                if (ordinaryCompletionToShow.isEmpty()) {
+                    ordinaryCompletion = new ContinueCompletionTask();
+                } else {
+                    Optional<String> prefixOpt =
+                            suggestions.stream()
+                                       .map(Suggestion::continuation)
+                                       .reduce(ConsoleIOContext::commonPrefix);
+
+                    String prefix =
+                            prefixOpt.orElse("").substring(cursor - anchor[0]);
+
+                    if (!prefix.isEmpty() && !command) {
+                        //the completion will fill in the prefix, which will invalidate
+                        //the documentation, avoid adding documentation tasks into the
+                        //todo list:
+                        doc = List.of();
+                    }
+
+                    ordinaryCompletion =
+                            new OrdinaryCompletionTask(ordinaryCompletionToShow,
+                                                       prefix,
+                                                       !command && !doc.isEmpty(),
+                                                       hasBoth);
+                }
+
                 CompletionTask allCompletion = new AllSuggestionsCompletionTask(suggestions, anchor[0]);
 
                 todo = new ArrayList<>();
@@ -567,17 +605,17 @@ class ConsoleIOContext extends IOContext {
     }
 
     private final class OrdinaryCompletionTask implements CompletionTask {
-        private final List<Suggestion> suggestions;
-        private final int anchor;
+        private final List<CharSequence> toShow;
+        private final String prefix;
         private final boolean cont;
         private final boolean showSmart;
 
-        public OrdinaryCompletionTask(List<Suggestion> suggestions,
-                                      int anchor,
+        public OrdinaryCompletionTask(List<CharSequence> toShow,
+                                      String prefix,
                                       boolean cont,
                                       boolean showSmart) {
-            this.suggestions = suggestions;
-            this.anchor = anchor;
+            this.toShow = toShow;
+            this.prefix = prefix;
             this.cont = cont;
             this.showSmart = showSmart;
         }
@@ -589,34 +627,7 @@ class ConsoleIOContext extends IOContext {
 
         @Override
         public Result perform(String text, int cursor) throws IOException {
-            List<CharSequence> toShow;
-
-            if (showSmart) {
-                toShow =
-                    suggestions.stream()
-                               .filter(Suggestion::matchesType)
-                               .map(Suggestion::continuation)
-                               .distinct()
-                               .collect(Collectors.toList());
-            } else {
-                toShow =
-                    suggestions.stream()
-                               .map(Suggestion::continuation)
-                               .distinct()
-                               .collect(Collectors.toList());
-            }
-
-            if (toShow.isEmpty()) {
-                return Result.CONTINUE;
-            }
-
-            Optional<String> prefix =
-                    suggestions.stream()
-                               .map(Suggestion::continuation)
-                               .reduce(ConsoleIOContext::commonPrefix);
-
-            String prefixStr = prefix.orElse("").substring(cursor - anchor);
-            in.putString(prefixStr);
+            in.putString(prefix);
 
             boolean showItems = toShow.size() > 1 || showSmart;
 
@@ -625,7 +636,7 @@ class ConsoleIOContext extends IOContext {
                 printColumns(toShow);
             }
 
-            if (!prefixStr.isEmpty())
+            if (!prefix.isEmpty())
                 return showItems ? Result.FINISH : Result.SKIP_NOREPAINT;
 
             return cont ? Result.CONTINUE : Result.FINISH;
@@ -796,6 +807,19 @@ class ConsoleIOContext extends IOContext {
             return doPrintFullDocumentation(todo, doc, false);
         }
 
+    }
+
+    private static class ContinueCompletionTask implements ConsoleIOContext.CompletionTask {
+
+        @Override
+        public String description() {
+            throw new UnsupportedOperationException("Should not get here.");
+        }
+
+        @Override
+        public CompletionTask.Result perform(String text, int cursor) throws IOException {
+            return CompletionTask.Result.CONTINUE;
+        }
     }
 
     @Override

--- a/test/langtools/jdk/jshell/ToolTabSnippetTest.java
+++ b/test/langtools/jdk/jshell/ToolTabSnippetTest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8177076 8185426 8189595 8188072 8221759
+ * @bug 8177076 8185426 8189595 8188072 8221759 8255273
  * @modules
  *     jdk.compiler/com.sun.tools.javac.api
  *     jdk.compiler/com.sun.tools.javac.main
@@ -331,4 +331,13 @@ public class ToolTabSnippetTest extends UITesting {
     //where:
         private final Compiler compiler = new Compiler();
 
+    public void testDocumentationAfterInsert() throws Exception {
+        doRunTest((inputSink, out) -> {
+            inputSink.write("import java.time.*\n");
+            waitOutput(out, PROMPT);
+
+            inputSink.write("new Instant" + TAB);
+            waitOutput(out, PROMPT + "new InstantiationE");
+        });
+    }
 }


### PR DESCRIPTION
Consider JShell interaction like:

```
jshell> import java.time.*;

jshell> new Instant<tab>
```

This will crash the JShell with an `UnsupportedOperationException`. The ultimately reason is that:
-completions are computed, and are `InstantiationError(` and `InstantiationException(`, with a common prefix `InstantiationE`
-documentation is computed, and is for java.time.Instant

The completion machine then gets into a state where it fills in the common prefix, and that it would like say something along the lines of "Press tab once more to see signature/documentation.", but that does not make much sense (as the documentation is computed for a wrong input - the new input is `new InstantiationE`, not `Instant`, so the documentation is already invalid for that.

(The `UnsupportedOperationException` is in place where the "Press tab once more to see signature/documentation." should happen, because the code should not get into a state like this.)

The proposed solution is to cancel the documentation if a prefix is (to be) filled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255273](https://bugs.openjdk.java.net/browse/JDK-8255273): jshell crashes with UnsupportedOperationException: Should not get here.


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1125/head:pull/1125`
`$ git checkout pull/1125`
