### PR TITLE
8256054: C2: Floating-point min/max operations on vectors intermittently produce wrong results for NaN values

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -878,6 +878,7 @@ void C2_MacroAssembler::vabsnegf(int opcode, XMMRegister dst, XMMRegister src, i
 
 void C2_MacroAssembler::pminmax(int opcode, BasicType elem_bt, XMMRegister dst, XMMRegister src, XMMRegister tmp) {
   assert(opcode == Op_MinV || opcode == Op_MaxV, "sanity");
+  assert(tmp == xnoreg || elem_bt == T_LONG, "unused");
 
   if (opcode == Op_MinV) {
     if (elem_bt == T_BYTE) {
@@ -889,6 +890,7 @@ void C2_MacroAssembler::pminmax(int opcode, BasicType elem_bt, XMMRegister dst, 
     } else {
       assert(elem_bt == T_LONG, "required");
       assert(tmp == xmm0, "required");
+      assert_different_registers(dst, src, tmp);
       movdqu(xmm0, dst);
       pcmpgtq(xmm0, src);
       blendvpd(dst, src);  // xmm0 as mask
@@ -903,6 +905,7 @@ void C2_MacroAssembler::pminmax(int opcode, BasicType elem_bt, XMMRegister dst, 
     } else {
       assert(elem_bt == T_LONG, "required");
       assert(tmp == xmm0, "required");
+      assert_different_registers(dst, src, tmp);
       movdqu(xmm0, src);
       pcmpgtq(xmm0, dst);
       blendvpd(dst, src);  // xmm0 as mask
@@ -927,6 +930,7 @@ void C2_MacroAssembler::vpminmax(int opcode, BasicType elem_bt,
       if (UseAVX > 2 && (vlen_enc == Assembler::AVX_512bit || VM_Version::supports_avx512vl())) {
         vpminsq(dst, src1, src2, vlen_enc);
       } else {
+        assert_different_registers(dst, src1, src2);
         vpcmpgtq(dst, src1, src2, vlen_enc);
         vblendvpd(dst, src1, src2, dst, vlen_enc);
       }
@@ -943,6 +947,7 @@ void C2_MacroAssembler::vpminmax(int opcode, BasicType elem_bt,
       if (UseAVX > 2 && (vlen_enc == Assembler::AVX_512bit || VM_Version::supports_avx512vl())) {
         vpmaxsq(dst, src1, src2, vlen_enc);
       } else {
+        assert_different_registers(dst, src1, src2);
         vpcmpgtq(dst, src1, src2, vlen_enc);
         vblendvpd(dst, src2, src1, dst, vlen_enc);
       }
@@ -960,6 +965,7 @@ void C2_MacroAssembler::vminmax_fp(int opcode, BasicType elem_bt,
   assert(opcode == Op_MinV || opcode == Op_MinReductionV ||
          opcode == Op_MaxV || opcode == Op_MaxReductionV, "sanity");
   assert(elem_bt == T_FLOAT || elem_bt == T_DOUBLE, "sanity");
+  assert_different_registers(a, b, tmp, atmp, btmp);
 
   bool is_min = (opcode == Op_MinV || opcode == Op_MinReductionV);
   bool is_double_word = is_double_word_type(elem_bt);
@@ -1000,6 +1006,7 @@ void C2_MacroAssembler::evminmax_fp(int opcode, BasicType elem_bt,
   assert(opcode == Op_MinV || opcode == Op_MinReductionV ||
          opcode == Op_MaxV || opcode == Op_MaxReductionV, "sanity");
   assert(elem_bt == T_FLOAT || elem_bt == T_DOUBLE, "sanity");
+  assert_different_registers(dst, a, b, atmp, btmp);
 
   bool is_min = (opcode == Op_MinV || opcode == Op_MinReductionV);
   bool is_double_word = is_double_word_type(elem_bt);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -5787,7 +5787,7 @@ instruct evminmaxFP_reg_eavx(vec dst, vec a, vec b, vec atmp, vec btmp) %{
             is_floating_point_type(vector_element_basic_type(n))); // T_FLOAT, T_DOUBLE
   match(Set dst (MinV a b));
   match(Set dst (MaxV a b));
-  effect(USE a, USE b, TEMP atmp, TEMP btmp);
+  effect(TEMP dst, USE a, USE b, TEMP atmp, TEMP btmp);
   format %{ "vector_minmaxFP  $dst,$a,$b\t!using $atmp, $btmp as TEMP" %}
   ins_encode %{
     assert(UseAVX > 2, "required");


### PR DESCRIPTION
Floating-point min/max operations on vectors intermittently produce wrong results for NaN values.

The problem boils down to a missing "TEMP dst" declaration on AVX512-related AD instruction. Without it`dst` vector register may match one of the input registers and it breaks the computation since it assumes all the used registers are different.

The fix adds missing effect and also introduces additional asserts to catch similar problems in the future.  

Testing:
- [x] jdk/incubator/vector w/ -XX:+DeoptimizeALot on AVX512-capable hardware
- [x] hs-precheckin-comp, hs-tier1, hs-tier2

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256054](https://bugs.openjdk.java.net/browse/JDK-8256054): C2: Floating-point min/max operations on vectors intermittently produce wrong results for NaN values 


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1128/head:pull/1128`
`$ git checkout pull/1128`
