### PR TITLE
[RFC] Introduce BreakAtCompileId

### DIFF
--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1562,7 +1562,7 @@ void MachUEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
   /* WARNING these NOPs are critical so that verified entry point is properly
      4 bytes aligned for patching by NativeJump::patch_verified_entry() */
   int nops_cnt = 4 - ((cbuf.insts_size() - insts_size) & 0x3);
-  if (OptoBreakpoint) {
+  if (OptoBreakpoint || BreakAtCompileId) {
     // Leave space for int3
     nops_cnt -= 1;
   }

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -137,6 +137,9 @@
   notproduct(intx, BreakAtNode, 0,                                          \
           "Break at construction of this Node (either _idx or _debug_idx)") \
                                                                             \
+  notproduct(intx, BreakAtCompileId, 0,                                     \
+          "Break at compile id")                                            \
+                                                                            \
   notproduct(bool, OptoBreakpointC2R, false,                                \
           "insert breakpoint at runtime stub entry")                        \
                                                                             \

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -374,9 +374,10 @@ void PhaseOutput::Output() {
 
   // Break before main entry point
   if ((C->method() && C->directive()->BreakAtExecuteOption) ||
-      (OptoBreakpoint && C->is_method_compilation())       ||
-      (OptoBreakpointOSR && C->is_osr_compilation())       ||
-      (OptoBreakpointC2R && !C->method())                   ) {
+      (OptoBreakpoint && C->is_method_compilation())        ||
+      (OptoBreakpointOSR && C->is_osr_compilation())        ||
+      (OptoBreakpointC2R && !C->method())                   ||
+      (BreakAtCompileId  == C->compile_id())                 ) {
     // checking for C->method() means that OptoBreakpoint does not apply to
     // runtime stubs or frame converters
     C->cfg()->insert( entry, 1, new MachBreakpointNode() );


### PR DESCRIPTION
Hi,

`OptoBreakpoint` is useful for debugging C2 compiler when porting some cpu for jdk8u.  It is able to `b breakpoint` for breaking at the prolog about for example Compile_id = 2.  But when fixed several bugs for C2,  it needs to press `c` times and times again for reaching the proper Compile_id.  So here comes `BreakAtCompileId`.  It is able to break at the precise Compile_id which you want to debug.

```
gdb -ex=r --args $JAVA -Xcomp -XX:+PrintCompilation -XX:BreakAtCompileId=430  -version


(gdb) b breakpoint                                                                   
Breakpoint 1 at 0x7ffff633b0d0: breakpoint. (133 locations)

   6333  433       3       java.util.ImmutableCollections$List12::get (35 bytes)   made not entrant

Thread 2 "java" hit Breakpoint 1, 0x00007ffff711f410 in os::breakpoint() () at /home/zhaixiang/projects
452         if (pslash != NULL) {
(gdb) si
0x00007fffe01b46d1 in ?? ()
(gdb) x/22i $pc-44
   0x7fffe01b46a5:      shl    $0x3,%edx
   0x7fffe01b46a8:      movabs $0x800000000,%r11
   0x7fffe01b46b2:      add    %r11,%r10
   0x7fffe01b46b5:      cmp    %r10,%rax
   0x7fffe01b46b8:      jne    0x7fffd87cf920
   0x7fffe01b46be:      nop
   0x7fffe01b46bf:      nop
   0x7fffe01b46c0:      mov    %eax,-0x16000(%rsp)
   0x7fffe01b46c7:      push   %rbp
   0x7fffe01b46c8:      sub    $0x10,%rsp
   0x7fffe01b46cc:      callq  0x7ffff711f410 <_ZN2os10breakpointEv>
=> 0x7fffe01b46d1:      mov    0xc(%rsi),%r11d
   0x7fffe01b46d5:      mov    0x10(%rsi),%r10d
   0x7fffe01b46d9:      cmp    %r11d,%r10d
   0x7fffe01b46dc:      je     0x7fffe01b46f6
   0x7fffe01b46de:      mov    $0x1,%eax
   0x7fffe01b46e3:      add    $0x10,%rsp
   0x7fffe01b46e7:      pop    %rbp
   0x7fffe01b46e8:      cmp    0x128(%r15),%rsp
   0x7fffe01b46ef:      ja     0x7fffe01b46fa
   0x7fffe01b46f5:      retq   
   0x7fffe01b46f6:      xor    %eax,%eax
(gdb) i r
rax            0x7fffe01b46c0      140736953272000
rbx            0x8004699e8         34364365288
rcx            0x1                 1
rdx            0x7fffc5068980      140736498928000
rsi            0x62a020b40         26474580800
rdi            0x1                 1
rbp            0x7ffff5a668d0      0x7ffff5a668d0
rsp            0x7ffff5a66290      0x7ffff5a66290
r8             0x80008eeb0         34360323760
r9             0x7ffb4cf60         34354810720
r10            0x800012488         34359813256
r11            0x800000000         34359738368
r12            0x0                 0
r13            0x7292dae5          1922226917
r14            0x62a020818         26474579992
r15            0x7ffff00271e0      140737220080096
rip            0x7fffe01b46d1      0x7fffe01b46d1
eflags         0x206               [ PF IF ]
cs             0x33                51
ss             0x2b                43
ds             0x0                 0
es             0x0                 0
fs             0x0                 0
gs             0x0                 0
```

Thanks,
[Leslie Zhai](https://openjdk.java.net/census#lzhai)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1129/head:pull/1129`
`$ git checkout pull/1129`
