### PR TITLE
8256052: Remove unused allocation type from fieldInfo

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1557,14 +1557,13 @@ class ClassFileParser::FieldAllocationCount : public ResourceObj {
     }
   }
 
-  FieldAllocationType update(bool is_static, BasicType type) {
+  void update(bool is_static, BasicType type) {
     FieldAllocationType atype = basic_type_to_atype(is_static, type);
     if (atype != BAD_ALLOCATION_TYPE) {
       // Make sure there is no overflow with injected fields.
       assert(count[atype] < 0xFFFF, "More than 65535 fields");
       count[atype]++;
     }
-    return atype;
   }
 };
 
@@ -1704,8 +1703,8 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
                       constantvalue_index);
     const BasicType type = cp->basic_type_for_signature_at(signature_index);
 
-    // Remember how many oops we encountered and compute allocation type
-    const FieldAllocationType atype = fac->update(is_static, type);
+    // Update FieldAllocationCount for this kind of field
+    fac->update(is_static, type);
 
     // After field is initialized with type, we can augment it with aux info
     if (parsed_annotations.has_any_annotations()) {
@@ -1748,8 +1747,8 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
 
       const BasicType type = Signature::basic_type(injected[n].signature());
 
-      // Remember how many oops we encountered and compute allocation type
-      const FieldAllocationType atype = fac->update(false, type);
+      // Update FieldAllocationCount for this kind of field
+      fac->update(false, type);
       index++;
     }
   }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1706,7 +1706,6 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
 
     // Remember how many oops we encountered and compute allocation type
     const FieldAllocationType atype = fac->update(is_static, type);
-    field->set_allocation_type(atype);
 
     // After field is initialized with type, we can augment it with aux info
     if (parsed_annotations.has_any_annotations()) {
@@ -1751,7 +1750,6 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
 
       // Remember how many oops we encountered and compute allocation type
       const FieldAllocationType atype = fac->update(false, type);
-      field->set_allocation_type(atype);
       index++;
     }
   }

--- a/src/hotspot/share/oops/fieldInfo.hpp
+++ b/src/hotspot/share/oops/fieldInfo.hpp
@@ -58,8 +58,8 @@ class FieldInfo {
   //    [--contention_group--]....................10  - contended field with contention group
   //    [------------------offset----------------]01  - real field offset
 
-  // Bit O indicates if the packed field contains an offset (O=1) or not (O=1)
-  // Bit C indicates if the field is contended (C=1) or not (C=1)
+  // Bit O indicates if the packed field contains an offset (O=1) or not (O=0)
+  // Bit C indicates if the field is contended (C=1) or not (C=0)
   //       (if it is contended, the high packed field contains the contention group)
 
   enum FieldOffset {

--- a/src/hotspot/share/oops/fieldInfo.hpp
+++ b/src/hotspot/share/oops/fieldInfo.hpp
@@ -47,19 +47,21 @@ class FieldInfo {
   // as an array of 6 shorts.
 
 #define FIELDINFO_TAG_SIZE             2
-#define FIELDINFO_TAG_BLANK            0
-#define FIELDINFO_TAG_OFFSET           1
-#define FIELDINFO_TAG_TYPE_PLAIN       2
-#define FIELDINFO_TAG_TYPE_CONTENDED   3
-#define FIELDINFO_TAG_MASK             3
+#define FIELDINFO_TAG_OFFSET           1 << 0
+#define FIELDINFO_TAG_CONTENDED        1 << 1
 
   // Packed field has the tag, and can be either of:
   //    hi bits <--------------------------- lo bits
   //   |---------high---------|---------low---------|
-  //    ..........................................00  - blank
+  //    ..........................................CO
+  //    ..........................................00  - non-contended field
+  //    [--contention_group--]....................10  - contended field with contention group
   //    [------------------offset----------------]01  - real field offset
-  //    ......................[-------type-------]10  - plain field with type
-  //    [--contention_group--][-------type-------]11  - contended field with type and contention group
+
+  // Bit O indicates if the packed field contains an offset (O=1) or not (O=1)
+  // Bit C indicates if the field is contended (C=1) or not (C=1)
+  //       (if it is contended, the high packed field contains the contention group)
+
   enum FieldOffset {
     access_flags_offset      = 0,
     name_index_offset        = 1,
@@ -103,78 +105,22 @@ class FieldInfo {
 
   u2 access_flags() const                        { return _shorts[access_flags_offset];            }
   u4 offset() const {
-    u2 lo = _shorts[low_packed_offset];
-    switch(lo & FIELDINFO_TAG_MASK) {
-      case FIELDINFO_TAG_OFFSET:
-        return build_int_from_shorts(_shorts[low_packed_offset], _shorts[high_packed_offset]) >> FIELDINFO_TAG_SIZE;
-#ifndef PRODUCT
-      case FIELDINFO_TAG_TYPE_PLAIN:
-        fatal("Asking offset for the plain type field");
-      case FIELDINFO_TAG_TYPE_CONTENDED:
-        fatal("Asking offset for the contended type field");
-      case FIELDINFO_TAG_BLANK:
-        fatal("Asking offset for the blank field");
-#endif
-    }
-    ShouldNotReachHere();
-    return 0;
+    assert((_shorts[low_packed_offset] & FIELDINFO_TAG_OFFSET) != 0, "Offset must have been set");
+    return build_int_from_shorts(_shorts[low_packed_offset], _shorts[high_packed_offset]) >> FIELDINFO_TAG_SIZE;
   }
 
   bool is_contended() const {
-    u2 lo = _shorts[low_packed_offset];
-    switch(lo & FIELDINFO_TAG_MASK) {
-      case FIELDINFO_TAG_TYPE_PLAIN:
-        return false;
-      case FIELDINFO_TAG_TYPE_CONTENDED:
-        return true;
-#ifndef PRODUCT
-      case FIELDINFO_TAG_OFFSET:
-        fatal("Asking contended flag for the field with offset");
-      case FIELDINFO_TAG_BLANK:
-        fatal("Asking contended flag for the blank field");
-#endif
-    }
-    ShouldNotReachHere();
-    return false;
+    return (_shorts[low_packed_offset] & FIELDINFO_TAG_CONTENDED) != 0;
   }
 
   u2 contended_group() const {
-    u2 lo = _shorts[low_packed_offset];
-    switch(lo & FIELDINFO_TAG_MASK) {
-      case FIELDINFO_TAG_TYPE_PLAIN:
-        return 0;
-      case FIELDINFO_TAG_TYPE_CONTENDED:
-        return _shorts[high_packed_offset];
-#ifndef PRODUCT
-      case FIELDINFO_TAG_OFFSET:
-        fatal("Asking the contended group for the field with offset");
-      case FIELDINFO_TAG_BLANK:
-        fatal("Asking the contended group for the blank field");
-#endif
-    }
-    ShouldNotReachHere();
-    return 0;
+    assert((_shorts[low_packed_offset] & FIELDINFO_TAG_OFFSET) == 0, "Offset must not have been set");
+    assert((_shorts[low_packed_offset] & FIELDINFO_TAG_CONTENDED) != 0, "Field must be contended");
+    return _shorts[high_packed_offset];
  }
 
-  u2 allocation_type() const {
-    u2 lo = _shorts[low_packed_offset];
-    switch(lo & FIELDINFO_TAG_MASK) {
-      case FIELDINFO_TAG_TYPE_PLAIN:
-      case FIELDINFO_TAG_TYPE_CONTENDED:
-        return (lo >> FIELDINFO_TAG_SIZE);
-#ifndef PRODUCT
-      case FIELDINFO_TAG_OFFSET:
-        fatal("Asking the field type for field with offset");
-      case FIELDINFO_TAG_BLANK:
-        fatal("Asking the field type for the blank field");
-#endif
-    }
-    ShouldNotReachHere();
-    return 0;
-  }
-
   bool is_offset_set() const {
-    return (_shorts[low_packed_offset] & FIELDINFO_TAG_MASK) == FIELDINFO_TAG_OFFSET;
+    return (_shorts[low_packed_offset] & FIELDINFO_TAG_OFFSET)!= 0;
   }
 
   Symbol* name(ConstantPool* cp) const {
@@ -200,41 +146,11 @@ class FieldInfo {
     _shorts[high_packed_offset] = extract_high_short_from_int(val);
   }
 
-  void set_allocation_type(int type) {
-    u2 lo = _shorts[low_packed_offset];
-    switch(lo & FIELDINFO_TAG_MASK) {
-      case FIELDINFO_TAG_BLANK:
-        _shorts[low_packed_offset] = ((type << FIELDINFO_TAG_SIZE)) & 0xFFFF;
-        _shorts[low_packed_offset] &= ~FIELDINFO_TAG_MASK;
-        _shorts[low_packed_offset] |= FIELDINFO_TAG_TYPE_PLAIN;
-        return;
-#ifndef PRODUCT
-      case FIELDINFO_TAG_TYPE_PLAIN:
-      case FIELDINFO_TAG_TYPE_CONTENDED:
-      case FIELDINFO_TAG_OFFSET:
-        fatal("Setting the field type with overwriting");
-#endif
-    }
-    ShouldNotReachHere();
-  }
-
   void set_contended_group(u2 val) {
-    u2 lo = _shorts[low_packed_offset];
-    switch(lo & FIELDINFO_TAG_MASK) {
-      case FIELDINFO_TAG_TYPE_PLAIN:
-        _shorts[low_packed_offset] |= FIELDINFO_TAG_TYPE_CONTENDED;
-        _shorts[high_packed_offset] = val;
-        return;
-#ifndef PRODUCT
-      case FIELDINFO_TAG_TYPE_CONTENDED:
-        fatal("Overwriting contended group");
-      case FIELDINFO_TAG_BLANK:
-        fatal("Setting contended group for the blank field");
-      case FIELDINFO_TAG_OFFSET:
-        fatal("Setting contended group for field with offset");
-#endif
-    }
-    ShouldNotReachHere();
+    assert((_shorts[low_packed_offset] & FIELDINFO_TAG_OFFSET) == 0, "Offset must not have been set");
+    assert((_shorts[low_packed_offset] & FIELDINFO_TAG_CONTENDED) == 0, "Overwritting contended group");
+    _shorts[low_packed_offset] |= FIELDINFO_TAG_CONTENDED;
+    _shorts[high_packed_offset] = val;
   }
 
   bool is_internal() const {

--- a/src/hotspot/share/oops/fieldStreams.hpp
+++ b/src/hotspot/share/oops/fieldStreams.hpp
@@ -134,10 +134,6 @@ class FieldStreamBase : public StackObj {
     return field()->offset();
   }
 
-  int allocation_type() const {
-    return field()->allocation_type();
-  }
-
   void set_offset(int offset) {
     field()->set_offset(offset);
   }

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -2257,8 +2257,8 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   /*************************************/                                 \
                                                                           \
   declare_preprocessor_constant("FIELDINFO_TAG_SIZE", FIELDINFO_TAG_SIZE) \
-  declare_preprocessor_constant("FIELDINFO_TAG_MASK", FIELDINFO_TAG_MASK) \
   declare_preprocessor_constant("FIELDINFO_TAG_OFFSET", FIELDINFO_TAG_OFFSET) \
+  declare_preprocessor_constant("FIELDINFO_TAG_CONTENDED", FIELDINFO_TAG_CONTENDED) \
                                                                           \
   /************************************************/                      \
   /* InstanceKlass InnerClassAttributeOffset enum */                      \

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -2258,7 +2258,6 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
                                                                           \
   declare_preprocessor_constant("FIELDINFO_TAG_SIZE", FIELDINFO_TAG_SIZE) \
   declare_preprocessor_constant("FIELDINFO_TAG_OFFSET", FIELDINFO_TAG_OFFSET) \
-  declare_preprocessor_constant("FIELDINFO_TAG_CONTENDED", FIELDINFO_TAG_CONTENDED) \
                                                                           \
   /************************************************/                      \
   /* InstanceKlass InnerClassAttributeOffset enum */                      \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
@@ -56,7 +56,6 @@ public class InstanceKlass extends Klass {
   private static int HIGH_OFFSET;
   private static int FIELD_SLOTS;
   private static short FIELDINFO_TAG_SIZE;
-  private static short FIELDINFO_TAG_MASK;
   private static short FIELDINFO_TAG_OFFSET;
 
   // ClassState constants
@@ -117,7 +116,6 @@ public class InstanceKlass extends Klass {
     HIGH_OFFSET                    = db.lookupIntConstant("FieldInfo::high_packed_offset").intValue();
     FIELD_SLOTS                    = db.lookupIntConstant("FieldInfo::field_slots").intValue();
     FIELDINFO_TAG_SIZE             = db.lookupIntConstant("FIELDINFO_TAG_SIZE").shortValue();
-    FIELDINFO_TAG_MASK             = db.lookupIntConstant("FIELDINFO_TAG_MASK").shortValue();
     FIELDINFO_TAG_OFFSET           = db.lookupIntConstant("FIELDINFO_TAG_OFFSET").shortValue();
 
     // read ClassState constants
@@ -397,7 +395,7 @@ public class InstanceKlass extends Klass {
     U2Array fields = getFields();
     short lo = fields.at(index * FIELD_SLOTS + LOW_OFFSET);
     short hi = fields.at(index * FIELD_SLOTS + HIGH_OFFSET);
-    if ((lo & FIELDINFO_TAG_MASK) == FIELDINFO_TAG_OFFSET) {
+    if ((lo & FIELDINFO_TAG_OFFSET) == FIELDINFO_TAG_OFFSET) {
       return VM.getVM().buildIntFromShorts(lo, hi) >> FIELDINFO_TAG_SIZE;
     }
     throw new RuntimeException("should not reach here");


### PR DESCRIPTION
Please review this small cleanup code, removing the now unused allocation type from the fieldInfo structure.

Tested with Mach5, tiers 1 to 3 and locally by running test/hotspot/jtreg/serviceability/sa tests.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256052](https://bugs.openjdk.java.net/browse/JDK-8256052): Remove unused allocation type from fieldInfo


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to c048832e68f3bc7bb22d43c65fa86f584593f57b
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**) ⚠️ Review applies to b4b24792e979420061ad6be9f3cab95ad184bc4f
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1130/head:pull/1130`
`$ git checkout pull/1130`
