### PR TITLE
8256039: Shenandoah: runtime/stringtable/StringTableCleaningTest.java fails

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.inline.hpp
@@ -53,7 +53,9 @@ ShenandoahParallelWeakRootsCleaningTask<IsAlive, KeepAlive>::~ShenandoahParallel
   if (StringDedup::is_enabled()) {
     StringDedup::gc_epilogue();
   }
-  _weak_processing_task.report_num_dead();
+  if (_include_concurrent_roots) {
+    _weak_processing_task.report_num_dead();
+  }
 }
 
 template<typename IsAlive, typename KeepAlive>


### PR DESCRIPTION
If parallel cleaning does not process concurrent weak roots, it should not notify GC on dead entries (which always 0).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256039](https://bugs.openjdk.java.net/browse/JDK-8256039): Shenandoah: runtime/stringtable/StringTableCleaningTest.java fails


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1133/head:pull/1133`
`$ git checkout pull/1133`
