### PR TITLE
8237495: Java MIDI fails with a dereferenced memory error when asked to send a raw 0xF7

### DIFF
--- a/src/java.desktop/share/native/libjsound/MidiOutDevice.c
+++ b/src/java.desktop/share/native/libjsound/MidiOutDevice.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/native/libjsound/MidiOutDevice.c
+++ b/src/java.desktop/share/native/libjsound/MidiOutDevice.c
@@ -133,7 +133,7 @@ Java_com_sun_media_sound_MidiOutDevice_nSendLongMessage(JNIEnv* e, jobject thisO
     }
     /* "continuation" sysex messages start with F7 (instead of F0), but
        are sent without the F7. */
-    if (data[0] == 0xF7) {
+    if (data[0] == 0xF7 && size > 1) {
         data++;
         size--;
     }

--- a/test/jdk/javax/sound/midi/SysexMessage/SendRawSysexMessage.java
+++ b/test/jdk/javax/sound/midi/SysexMessage/SendRawSysexMessage.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.sound.midi.MidiDevice;
+import javax.sound.midi.MidiMessage;
+import javax.sound.midi.MidiSystem;
+import javax.sound.midi.MidiUnavailableException;
+import javax.sound.midi.Receiver;
+import javax.sound.midi.ShortMessage;
+import javax.sound.midi.SysexMessage;
+
+import static javax.sound.midi.SysexMessage.SPECIAL_SYSTEM_EXCLUSIVE;
+import static javax.sound.midi.SysexMessage.SYSTEM_EXCLUSIVE;
+
+/**
+ * @test
+ * @bug 8237495
+ * @summary fail with a dereferenced memory error when asked to send a raw 0xF7
+ */
+public final class SendRawSysexMessage {
+
+    private static final class RawMidiMessage extends MidiMessage {
+        @Override
+        public RawMidiMessage clone() {
+            return new RawMidiMessage(getMessage());
+        }
+        @Override
+        public int getStatus() {
+            return SYSTEM_EXCLUSIVE; // not that this really matters
+        }
+
+        RawMidiMessage(byte[] data) {
+            super(data.clone());
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        MidiDevice.Info[] infos = MidiSystem.getMidiDeviceInfo();
+        System.err.println("List of devices to test:");
+        for (int i = 0; i < infos.length; i++) {
+            System.err.printf("\t%d.\t%s%n", i, infos[i]);
+        }
+        for (int i = 0; i < infos.length; i++) {
+            System.err.printf("%d.\t%s%n", i, infos[i]);
+            try {
+                test(infos[i]);
+            } catch (MidiUnavailableException ignored){
+                // try next
+            }
+        }
+    }
+
+    private static void test(MidiDevice.Info info) throws Exception {
+        try (MidiDevice device = MidiSystem.getMidiDevice(info)) {
+            System.err.println("Sending to " + device + " (" + info + ")");
+            if (!device.isOpen())
+                device.open();
+            try (Receiver r = device.getReceiver()) {
+                System.err.println("note on");
+                r.send(new ShortMessage(ShortMessage.NOTE_ON, 5, 5), -1);
+                System.err.println("sysex");
+                r.send(new SysexMessage(new byte[]{
+                        (byte) SYSTEM_EXCLUSIVE, 0x0, 0x03, 0x04,
+                        (byte) SPECIAL_SYSTEM_EXCLUSIVE}, 5), -1);
+                System.err.println("raw 1");
+                r.send(new RawMidiMessage(new byte[]{
+                        (byte) 0x02, 0x02, 0x03, 0x04}), -1);
+                System.err.println("raw 2");
+                r.send(new RawMidiMessage(new byte[]{
+                        (byte) 0x09, 0x02, 0x03, 0x04}), -1);
+                System.err.println("raw 3");
+                r.send(new RawMidiMessage(new byte[]{
+                        (byte) SYSTEM_EXCLUSIVE, 0x02, 0x03, 0x04}), -1);
+                System.err.println("raw 4");
+                r.send(new RawMidiMessage(new byte[]{
+                        (byte) 0x02, 0x02, 0x03, 0x04}), -1);
+                System.err.println("raw 5");
+                r.send(new RawMidiMessage(new byte[]{
+                        (byte) 0x02, 0x02, 0x03,
+                        (byte) SPECIAL_SYSTEM_EXCLUSIVE}), -1);
+                System.err.println("raw 6");
+                r.send(new RawMidiMessage(new byte[]{
+                        (byte) SYSTEM_EXCLUSIVE, 0x02, 0x03, 0x04}), -1);
+                System.err.println("sleep");
+                Thread.sleep(1000);
+                System.err.println("raw 7");
+                r.send(new RawMidiMessage(new byte[]{
+                        (byte) 0x02, 0x02, 0x03, 0x04}), -1);
+                System.err.println("sleep");
+                Thread.sleep(1000);
+                System.err.println("raw 8");
+                r.send(new RawMidiMessage(new byte[]{
+                        (byte) SPECIAL_SYSTEM_EXCLUSIVE}), -1);
+                System.err.println("note off");
+                r.send(new ShortMessage(ShortMessage.NOTE_OFF, 5, 5), -1);
+                System.err.println("done, should quit");
+                System.err.println();
+            }
+        }
+    }
+}


### PR DESCRIPTION
The JavaSound supports the special system exclusive message(SysexMessage). 

An important part of the spec:

> Data of a system exclusive message should be stored in the data array of a {@code SysexMessage} as follows: the system exclusive message status byte (0xF0 or 0xF7), all message data bytes, and finally the end-of-exclusive flag (0xF7):
> 
> The first {@code SysexMessage} object containing data for a particular system
> exclusive message should have the status value 0xF0. If this message contains
> all the system exclusive data for the message, it should end with the status
> byte 0xF7 (EOX). Otherwise, additional system exclusive data should be sent
> in one or more {@code SysexMessages} with a status value of 0xF7. The
> {@code SysexMessage} containing the last of the data for the system exclusive
> message should end with the value 0xF7 (EOX) to mark the end of the system
>  exclusive message.

In short, the text above can be represented by these examples:
1. SImple case: `SysexMessage{0xF0, some_data, 0xF7}`
2. "Continuation" sysex messages: `SysexMessage{0xF0,some_data}, SysexMessage{0xF7,some_data}, SysexMessage{0xF7,some_data}, SysexMessage{0xF7,some_data, 0xF7}.`


Note that the second case above the "SysexMessage{0xF7,some_data}" is named as a "continuation" sysex messages.
Usually, when a create a sysex message we carefully calculate the size of the message before sending it to the native code, but the "continuation" sysex messages were implemented in 2003 directly in native after all checks are done, and it just skips the status byte and tries to push nonexistent data to the native device.

So the culprit is in the message like this:
`SysexMessage{0xF0,some_data}, SysexMessage{0xF7}.`

The code assumes that the second message is "continuation", but it does not, it just ends the previous message.

After the fix, we will not consider the 0xF7 as a continuation if there are no data after.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x86 (hs/tier1 gc)](https://github.com/mrserb/jdk/runs/1376532477)

### Issue
 * [JDK-8237495](https://bugs.openjdk.java.net/browse/JDK-8237495): Java MIDI fails with a dereferenced memory error when asked to send a raw 0xF7


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1135/head:pull/1135`
`$ git checkout pull/1135`
