### PR TITLE
8138588: VerifyMergedCPBytecodes option cleanup needed

### DIFF
--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -1452,7 +1452,8 @@ jvmtiError VM_RedefineClasses::load_new_class_versions(TRAPS) {
       }
     }
 
-    if (VerifyMergedCPBytecodes) {
+#ifdef ASSERT
+    {
       // verify what we have done during constant pool merging
       {
         RedefineVerifyMark rvm(the_class, scratch_class, state);
@@ -1472,6 +1473,7 @@ jvmtiError VM_RedefineClasses::load_new_class_versions(TRAPS) {
         }
       }
     }
+#endif // ASSERT
 
     Rewriter::rewrite(scratch_class, THREAD);
     if (!HAS_PENDING_EXCEPTION) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -556,6 +556,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "InsertMemBarAfterArraycopy",    JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "Debugging",                     JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "UseRDPCForConstantTableBase",   JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
+  { "VerifyMergedCPBytecodes",       JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
 
 #ifdef TEST_VERIFY_SPECIAL_JVM_FLAGS
   // These entries will generate build errors.  Their purpose is to test the macros.

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -872,10 +872,6 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, StressLdcRewrite, false,                                    \
           "Force ldc -> ldc_w rewrite during RedefineClasses")              \
                                                                             \
-  /* change to false by default sometime after Mustang */                   \
-  product(bool, VerifyMergedCPBytecodes, true,                              \
-          "Verify bytecodes after RedefineClasses constant pool merging")   \
-                                                                            \
   product(bool, AllowRedefinitionToAddDeleteMethods, false,                 \
           "(Deprecated) Allow redefinition to add and delete private "      \
           "static or final methods for compatibility with old releases")    \

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFlags.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFlags.java
@@ -65,7 +65,6 @@ public class ClhsdbFlags {
                     "UnlockDiagnosticVMOptions = true",
                     "MaxFDLimit = false",
                     "MaxJavaStackTraceDepth = 1024",
-                    "VerifyMergedCPBytecodes",
                     "ConcGCThreads", "UseThreadPriorities",
                     "ShowHiddenFrames"));
             expStrMap.put("flags -nd", List.of(


### PR DESCRIPTION
This option has been removed in favor of always verifying the bytecodes in debug mode.  Tested with tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8138588](https://bugs.openjdk.java.net/browse/JDK-8138588): VerifyMergedCPBytecodes option cleanup needed


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1137/head:pull/1137`
`$ git checkout pull/1137`
