### PR TITLE
 8256025: AArch64: MachCallRuntimeNode::ret_addr_offset() is incorrect for stub calls

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1753,7 +1753,9 @@ int MachCallDynamicJavaNode::ret_addr_offset()
 
 int MachCallRuntimeNode::ret_addr_offset() {
   // for generated stubs the call will be
-  //   far_call(addr)
+  //   blr(addr)
+  // or with far branches
+  //   blr(trampoline_stub)
   // for real runtime callouts it will be six instructions
   // see aarch64_enc_java_to_runtime
   //   adr(rscratch2, retaddr)
@@ -1762,7 +1764,7 @@ int MachCallRuntimeNode::ret_addr_offset() {
   //   blr(rscratch1)
   CodeBlob *cb = CodeCache::find_blob(_entry_point);
   if (cb) {
-    return MacroAssembler::far_branch_size();
+    return 1 * NativeInstruction::instruction_size;
   } else {
     return 6 * NativeInstruction::instruction_size;
   }

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1753,9 +1753,9 @@ int MachCallDynamicJavaNode::ret_addr_offset()
 
 int MachCallRuntimeNode::ret_addr_offset() {
   // for generated stubs the call will be
-  //   blr(addr)
+  //   bl(addr)
   // or with far branches
-  //   blr(trampoline_stub)
+  //   bl(trampoline_stub)
   // for real runtime callouts it will be six instructions
   // see aarch64_enc_java_to_runtime
   //   adr(rscratch2, retaddr)


### PR DESCRIPTION
The PR for JDK-8254231 introduces a new assertion in opto/output.cpp to
check the current instruction offset against the offset of the call
return address reported by ret_addr_offset(). This fails on AArch64
because MachCallRuntimeNode::ret_addr_offset() claims four instructions
are generated for a stub call (far branch) but actually it's just
one (blr to stub or trampoline).

Tested tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256025](https://bugs.openjdk.java.net/browse/JDK-8256025): AArch64: MachCallRuntimeNode::ret_addr_offset() is incorrect for stub calls


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to 1570be1e27898168736eb479c85153d9d1dfec4e


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1138/head:pull/1138`
`$ git checkout pull/1138`
