### PR TITLE
8251854: [macosx] Java forces the use of discrete GPU

### DIFF
--- a/make/data/bundle/JDK-Info.plist
+++ b/make/data/bundle/JDK-Info.plist
@@ -24,6 +24,8 @@
         <string>@@BUILD_VERSION@@</string>
         <key>NSMicrophoneUsageDescription</key>
         <string>The application is requesting access to the microphone.</string>
+        <key>NSSupportsAutomaticGraphicsSwitching</key>
+        <true/>
         <key>JavaVM</key>
         <dict>
                 <key>JVMCapabilities</key>

--- a/make/data/bundle/JRE-Info.plist
+++ b/make/data/bundle/JRE-Info.plist
@@ -24,6 +24,8 @@
         <string>@@BUILD_VERSION@@</string>
         <key>NSMicrophoneUsageDescription</key>
         <string>The application is requesting access to the microphone.</string>
+        <key>NSSupportsAutomaticGraphicsSwitching</key>
+        <true/>
         <key>JavaVM</key>
         <dict>
                 <key>JVMMinimumFrameworkVersion</key>

--- a/make/data/bundle/cmdline-Info.plist
+++ b/make/data/bundle/cmdline-Info.plist
@@ -12,6 +12,8 @@
         <string>@@BUILD_VERSION@@</string>
         <key>NSMicrophoneUsageDescription</key>
         <string>The application is requesting access to the microphone.</string>
+        <key>NSSupportsAutomaticGraphicsSwitching</key>
+        <true/>
         @@EXTRA@@
 </dict>
 </plist>


### PR DESCRIPTION
This is a review request for the bug particularly fixed some time ago:
https://mail.openjdk.java.net/pipermail/2d-dev/2015-May/005425.html

In that review request it was found that the old fix does not work well in all cases, see:
https://mail.openjdk.java.net/pipermail/2d-dev/2015-August/005611.html

The current fix updates an embedded plist.info, so the java will not require
discrete graphics by default, same as for any other applications. 

The discrete card will be used:
 1. If macOS decided to enable it for some reason
 2. If the java app sets/uses a full-screen window
 3. If the user disable "automatic graphics switching" in the system preferences
 4. If an external monitor is connected to the laptop

In other cases, the integrated graphics will be used, which should be fine in most cases since this graphic is used/tested in the mbp 13/etc. This is not only about rendering performance but also about startup performance, on my current new laptop mbp 16 + Cataline 10.15.7 the switching discrete/integrated causes unexpected delays up to 10 seconds.


Note that the new "metal" pipeline also does not require discrete graphics.

The documentation for NSSupportsAutomaticGraphicsSwitching:
https://developer.apple.com/documentation/bundleresources/information_property_list/nssupportsautomaticgraphicsswitching

I'll create a release note after approval.

Performance numbers:
https://mail.openjdk.java.net/pipermail/2d-dev/2020-August/010979.html
Old review request:
https://mail.openjdk.java.net/pipermail/2d-dev/2020-August/010973.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8251854](https://bugs.openjdk.java.net/browse/JDK-8251854): [macosx] Java forces the use of discrete GPU


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1139/head:pull/1139`
`$ git checkout pull/1139`
