### PR TITLE
8256066: Tests use deprecated TestNG API that is no longer available in new versions

### DIFF
--- a/test/jdk/java/lang/invoke/ConstantIdentityMHTest.java
+++ b/test/jdk/java/lang/invoke/ConstantIdentityMHTest.java
@@ -59,8 +59,7 @@ public class ConstantIdentityMHTest {
         assertEquals(MethodHandles.zero(expectedtype).type().toString(), expected);
     }
 
-    @Test
-    @ExpectedExceptions(NullPointerException.class)
+    @Test(expectedExceptions={ NullPointerException.class })
     public void testZeroNPE() {
         MethodHandle mh = MethodHandles.zero(null);
     }
@@ -73,8 +72,7 @@ public class ConstantIdentityMHTest {
         assertEquals((String)mhEmpty.invoke("x","y"), null);
     }
 
-    @Test
-    @ExpectedExceptions(NullPointerException.class)
+    @Test(expectedExceptions = { NullPointerException.class })
     void testEmptyNPE() {
         MethodHandle lenEmptyMH = MethodHandles.empty(null);
     }

--- a/test/jdk/java/lang/invoke/DropArgumentsTest.java
+++ b/test/jdk/java/lang/invoke/DropArgumentsTest.java
@@ -65,8 +65,7 @@ public class DropArgumentsTest {
         };
     }
 
-    @Test(dataProvider = "dropArgumentsToMatchNPEData")
-    @ExpectedExceptions(NullPointerException.class)
+    @Test(dataProvider = "dropArgumentsToMatchNPEData", expectedExceptions = { NullPointerException.class })
     public void dropArgumentsToMatchNPE(MethodHandle target, int pos, List<Class<?>> valueType, int skip) {
         MethodHandles.dropArgumentsToMatch(target, pos, valueType , skip);
     }
@@ -85,14 +84,12 @@ public class DropArgumentsTest {
         };
     }
 
-    @Test(dataProvider = "dropArgumentsToMatchIAEData")
-    @ExpectedExceptions(IllegalArgumentException.class)
+    @Test(dataProvider = "dropArgumentsToMatchIAEData", expectedExceptions = { IllegalArgumentException.class })
     public void dropArgumentsToMatchIAE(MethodHandle target, int pos, List<Class<?>> valueType, int skip) {
         MethodHandles.dropArgumentsToMatch(target, pos, valueType , skip);
     }
 
-    @Test
-    @ExpectedExceptions(IllegalArgumentException.class)
+    @Test(expectedExceptions = { IllegalArgumentException.class })
     public void dropArgumentsToMatchTestWithVoid() throws Throwable {
         MethodHandle cat = lookup().findVirtual(String.class, "concat",
                                    MethodType.methodType(String.class, String.class));

--- a/test/jdk/java/lang/invoke/VarArgsTest.java
+++ b/test/jdk/java/lang/invoke/VarArgsTest.java
@@ -69,8 +69,7 @@ public class VarArgsTest {
         assertEquals("[two, too]", asListWithVarargs.invoke("two", "too").toString());
     }
 
-    @Test
-    @ExpectedExceptions(IllegalArgumentException.class)
+    @Test(expectedExceptions = { IllegalArgumentException.class })
     public void testWithVarargsIAE() throws Throwable {
         MethodHandle lenMH = publicLookup()
             .findVirtual(String.class, "length", methodType(int.class));


### PR DESCRIPTION
@ExpectedExceptions is no longer available in TestNG 7.*.  Update the tests
to use @Test(expectedExceptions = "...") instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (5/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8256066](https://bugs.openjdk.java.net/browse/JDK-8256066): Tests use deprecated TestNG API that is no longer available in new versions


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1145/head:pull/1145`
`$ git checkout pull/1145`
