### PR TITLE
8255787: Tag container tests that use cGroups with cgroups keyword

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -31,7 +31,8 @@
 # headful:              test can be run only on headful host
 # intermittent:         flaky test, known to fail intermittently
 # randomness:           test uses randomness, test cases differ from run to run
-keys=stress headful intermittent randomness
+# cgroups:              test uses cgroups
+keys=stress headful intermittent randomness cgroups
 
 groups=TEST.groups TEST.quick-groups
 

--- a/test/hotspot/jtreg/containers/cgroup/CgroupSubsystemFactory.java
+++ b/test/hotspot/jtreg/containers/cgroup/CgroupSubsystemFactory.java
@@ -23,6 +23,7 @@
 
 /*
  * @test CgroupSubsystemFactory
+ * @key cgroups
  * @requires os.family == "linux"
  * @library /testlibrary /test/lib
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/containers/cgroup/PlainRead.java
+++ b/test/hotspot/jtreg/containers/cgroup/PlainRead.java
@@ -23,6 +23,7 @@
 
 /*
  * @test PlainRead
+ * @key cgroups
  * @requires os.family == "linux"
  * @library /testlibrary /test/lib
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key cgroups
  * @summary Test JVM's CPU resource awareness when running inside docker container
  * @requires docker.support
  * @library /test/lib

--- a/test/hotspot/jtreg/containers/docker/TestCPUSets.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUSets.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key cgroups
  * @summary Test JVM's awareness of cpu sets (cpus and mems)
  * @requires docker.support
  * @requires (os.arch != "s390x")

--- a/test/hotspot/jtreg/containers/docker/TestJFREvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFREvents.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key cgroups
  * @summary Ensure that certain JFR events return correct results for resource values
  *          when run inside Docker container, such as available CPU and memory.
  *          Also make sure that PIDs are based on value provided by container,

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key cgroups
  * @summary Test JVM's memory resource awareness when running inside docker container
  * @requires docker.support
  * @library /test/lib

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -13,8 +13,9 @@
 # run. Tests that are not headful are "headless".
 # A test flagged with key "printer" requires a printer to succeed, else
 # throws a PrinterException or the like.
+# A test flagged with cgroups uses cgroups.
 
-keys=2d dnd headful i18n intermittent printer randomness jfr
+keys=2d dnd headful i18n intermittent printer randomness jfr cgroups
 
 # Tests that must run in othervm mode
 othervm.dirs=java/awt java/beans javax/accessibility javax/imageio javax/sound javax/swing javax/print \

--- a/test/jdk/jdk/internal/platform/cgroup/TestCgroupMetrics.java
+++ b/test/jdk/jdk/internal/platform/cgroup/TestCgroupMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key cgroups
  * @requires os.family == "linux"
  * @modules java.base/jdk.internal.platform
  * @library /test/lib

--- a/test/jdk/jdk/internal/platform/cgroup/TestCgroupSubsystemController.java
+++ b/test/jdk/jdk/internal/platform/cgroup/TestCgroupSubsystemController.java
@@ -43,6 +43,7 @@ import jdk.test.lib.util.FileUtils;
 
 /*
  * @test
+ * @key cgroups
  * @requires os.family == "linux"
  * @modules java.base/jdk.internal.platform
  * @library /test/lib

--- a/test/jdk/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
+++ b/test/jdk/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
@@ -42,6 +42,7 @@ import jdk.test.lib.util.FileUtils;
 
 /*
  * @test
+ * @key cgroups
  * @requires os.family == "linux"
  * @modules java.base/jdk.internal.platform
  * @library /test/lib

--- a/test/jdk/jdk/internal/platform/docker/TestDockerCpuMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerCpuMetrics.java
@@ -32,6 +32,7 @@ import jdk.test.lib.containers.docker.DockerTestUtils;
 
 /*
  * @test
+ * @key cgroups
  * @summary Test JDK Metrics class when running inside docker container
  * @requires docker.support
  * @library /test/lib

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /*
  * @test
+ * @key cgroups
  * @summary Test JDK Metrics class when running inside docker container
  * @requires docker.support
  * @library /test/lib

--- a/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
+++ b/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key cgroups
  * @bug 8242480
  * @requires docker.support
  * @library /test/lib

--- a/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key cgroups
  * @summary Test JDK Metrics class when running inside docker container
  * @requires docker.support
  * @library /test/lib


### PR DESCRIPTION
Please review this small change to add a cgroups keyword to tests that use cgroups.  The fix was tested by running Mach5 container tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255787](https://bugs.openjdk.java.net/browse/JDK-8255787): Tag container tests that use cGroups with cgroups keyword


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1148/head:pull/1148`
`$ git checkout pull/1148`
