### PR TITLE
8256018: Adler32/CRC32/CRC32C missing reachabilityFence

### DIFF
--- a/src/java.base/share/classes/java/util/zip/Adler32.java
+++ b/src/java.base/share/classes/java/util/zip/Adler32.java
@@ -100,7 +100,6 @@ public class Adler32 implements Checksum {
         if (buffer.isDirect()) {
             try {
                 adler = updateByteBuffer(adler, ((DirectBuffer)buffer).address(), pos, rem);
-
             } finally {
                 Reference.reachabilityFence(buffer);
             }

--- a/src/java.base/share/classes/java/util/zip/Adler32.java
+++ b/src/java.base/share/classes/java/util/zip/Adler32.java
@@ -25,6 +25,7 @@
 
 package java.util.zip;
 
+import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import sun.nio.ch.DirectBuffer;
 
@@ -96,8 +97,13 @@ public class Adler32 implements Checksum {
         int rem = limit - pos;
         if (rem <= 0)
             return;
-        if (buffer instanceof DirectBuffer) {
-            adler = updateByteBuffer(adler, ((DirectBuffer)buffer).address(), pos, rem);
+        if (buffer.isDirect()) {
+            try {
+                adler = updateByteBuffer(adler, ((DirectBuffer)buffer).address(), pos, rem);
+
+            } finally {
+                Reference.reachabilityFence(buffer);
+            }
         } else if (buffer.hasArray()) {
             adler = updateBytes(adler, buffer.array(), pos + buffer.arrayOffset(), rem);
         } else {

--- a/src/java.base/share/classes/java/util/zip/CRC32.java
+++ b/src/java.base/share/classes/java/util/zip/CRC32.java
@@ -25,6 +25,7 @@
 
 package java.util.zip;
 
+import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
@@ -95,8 +96,12 @@ public class CRC32 implements Checksum {
         int rem = limit - pos;
         if (rem <= 0)
             return;
-        if (buffer instanceof DirectBuffer) {
-            crc = updateByteBuffer(crc, ((DirectBuffer)buffer).address(), pos, rem);
+        if (buffer.isDirect()) {
+            try {
+                crc = updateByteBuffer(crc, ((DirectBuffer)buffer).address(), pos, rem);
+            } finally {
+                Reference.reachabilityFence(buffer);
+            }
         } else if (buffer.hasArray()) {
             crc = updateBytes(crc, buffer.array(), pos + buffer.arrayOffset(), rem);
         } else {

--- a/src/java.base/share/classes/java/util/zip/CRC32C.java
+++ b/src/java.base/share/classes/java/util/zip/CRC32C.java
@@ -24,6 +24,7 @@
  */
 package java.util.zip;
 
+import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -170,9 +171,13 @@ public final class CRC32C implements Checksum {
             return;
         }
 
-        if (buffer instanceof DirectBuffer) {
-            crc = updateDirectByteBuffer(crc, ((DirectBuffer) buffer).address(),
-                                         pos, limit);
+        if (buffer.isDirect()) {
+            try {
+                crc = updateDirectByteBuffer(crc, ((DirectBuffer) buffer).address(),
+                        pos, limit);
+            } finally {
+                Reference.reachabilityFence(buffer);
+            }
         } else if (buffer.hasArray()) {
             crc = updateBytes(crc, buffer.array(), pos + buffer.arrayOffset(),
                               limit + buffer.arrayOffset());


### PR DESCRIPTION
Hi, 

Please review the fix for JDK-8256018 which addresses the issue that  the update(ByteBuffer)  methods of Adler32, CRC32, and CRC32C should use Reference.reachabilityFence to ensure that direct byte buffer are kept kept alive when they are accessed directly.

The Mach5 jdk-tier1, jdk-tier2, jdk-tier3 as well as the  jck:api/java_util/zip,jck:api/java_util/jar continue to run clean.

Best
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256018](https://bugs.openjdk.java.net/browse/JDK-8256018): Adler32/CRC32/CRC32C missing reachabilityFence


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 267f2375a76d318b9abd2541bc2e9c5b4e3e70c9


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1149/head:pull/1149`
`$ git checkout pull/1149`
