### PR TITLE
8255973: Add more logging to debug JDK-8255917

### DIFF
--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -118,6 +118,7 @@
   LOG_TAG(monitormismatch) \
   LOG_TAG(nestmates) \
   LOG_TAG(nmethod) \
+  LOG_TAG(nmt) \
   LOG_TAG(normalize) \
   LOG_TAG(numa) \
   LOG_TAG(objecttagging) \

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1669,7 +1669,7 @@ char* os::attempt_reserve_memory_at(char* addr, size_t bytes) {
   if (result != NULL) {
     MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
   } else {
-    log_info(metaspace)("Attempt to reserve memory at " INTPTR_FORMAT 	" for "
+    log_info(metaspace)("Attempt to reserve memory at " INTPTR_FORMAT " for "
                          SIZE_FORMAT " bytes failed", p2i(addr), bytes);
   }
   return result;

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1669,8 +1669,11 @@ char* os::attempt_reserve_memory_at(char* addr, size_t bytes) {
   if (result != NULL) {
     MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
   } else {
-    log_info(metaspace)("Attempt to reserve memory at " INTPTR_FORMAT " for "
-                         SIZE_FORMAT " bytes failed", p2i(addr), bytes);
+    LogTarget(Debug, os, metaspace) lt;
+    if (lt.is_enabled()) {
+      lt.print("Attempt to reserve memory at " INTPTR_FORMAT " for "
+                         SIZE_FORMAT " bytes failed\n", p2i(addr), bytes);
+    }
   }
   return result;
 }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1669,11 +1669,8 @@ char* os::attempt_reserve_memory_at(char* addr, size_t bytes) {
   if (result != NULL) {
     MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
   } else {
-    LogTarget(Debug, os, metaspace) lt;
-    if (lt.is_enabled()) {
-      lt.print("Attempt to reserve memory at " INTPTR_FORMAT " for "
-                         SIZE_FORMAT " bytes failed\n", p2i(addr), bytes);
-    }
+    log_debug(os)("Attempt to reserve memory at " INTPTR_FORMAT " for "
+                 SIZE_FORMAT " bytes failed, errno %d", p2i(addr), bytes, get_last_error());
   }
   return result;
 }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1668,6 +1668,9 @@ char* os::attempt_reserve_memory_at(char* addr, size_t bytes) {
   char* result = pd_attempt_reserve_memory_at(addr, bytes);
   if (result != NULL) {
     MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
+  } else {
+    log_info(metaspace)("Attempt to reserve memory at " INTPTR_FORMAT 	" for "
+                         SIZE_FORMAT " bytes failed", p2i(addr), bytes);
   }
   return result;
 }

--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -383,7 +383,7 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
       // CDS reserves the whole region for mapping CDS archive, then maps each section into the region.
       // NMT reports CDS as a whole.
       if (reserved_rgn->flag() == mtClassShared) {
-        log_info(nmt)("CDS reserved region \'%s\' as a whole type class (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
+        log_info(nmt)("CDS reserved region \'%s\' as a whole (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
                       reserved_rgn->flag_name(), p2i(reserved_rgn->base()), reserved_rgn->size());
         assert(reserved_rgn->contain_region(base_addr, size), "Reserved CDS region should contain this mapping region");
         return true;
@@ -392,7 +392,7 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
       // Mapped CDS string region.
       // The string region(s) is part of the java heap.
       if (reserved_rgn->flag() == mtJavaHeap) {
-        log_info(nmt)("CDS reserved region \'%s\' as a whole type heap " INTPTR_FORMAT ": " SIZE_FORMAT,
+        log_info(nmt)("CDS reserved region \'%s\' as a whole (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
                       reserved_rgn->flag_name(), p2i(reserved_rgn->base()), reserved_rgn->size());
         assert(reserved_rgn->contain_region(base_addr, size), "Reserved heap region should contain this mapping region");
         return true;

--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -290,7 +290,7 @@ size_t ReservedMemoryRegion::committed_size() const {
 
 void ReservedMemoryRegion::set_flag(MEMFLAGS f) {
   assert((flag() == mtNone || flag() == f),
-         "Overwrite memory type for region [" PTR_FORMAT "-" PTR_FORMAT "), %u->%u.",
+         "Overwrite memory type for region [" INTPTR_FORMAT "-" INTPTR_FORMAT "), %u->%u.",
          p2i(base()), p2i(end()), (unsigned)flag(), (unsigned)f);
   if (flag() != f) {
     VirtualMemorySummary::move_reserved_memory(flag(), f, size());
@@ -343,6 +343,8 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
   ReservedMemoryRegion  rgn(base_addr, size, stack, flag);
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
 
+  log_info(nmt)("Add reserved region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
+                rgn.flag_name(), p2i(rgn.base()), rgn.size());
   if (reserved_rgn == NULL) {
     VirtualMemorySummary::record_reserved_memory(size, flag);
     return _reserved_regions->add(rgn) != NULL;
@@ -381,6 +383,8 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
       // CDS reserves the whole region for mapping CDS archive, then maps each section into the region.
       // NMT reports CDS as a whole.
       if (reserved_rgn->flag() == mtClassShared) {
+        log_info(nmt)("CDS reserved region \'%s\' as a whole type class (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
+                      reserved_rgn->flag_name(), p2i(reserved_rgn->base()), reserved_rgn->size());
         assert(reserved_rgn->contain_region(base_addr, size), "Reserved CDS region should contain this mapping region");
         return true;
       }
@@ -388,14 +392,16 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
       // Mapped CDS string region.
       // The string region(s) is part of the java heap.
       if (reserved_rgn->flag() == mtJavaHeap) {
+        log_info(nmt)("CDS reserved region \'%s\' as a whole type heap " INTPTR_FORMAT ": " SIZE_FORMAT,
+                      reserved_rgn->flag_name(), p2i(reserved_rgn->base()), reserved_rgn->size());
         assert(reserved_rgn->contain_region(base_addr, size), "Reserved heap region should contain this mapping region");
         return true;
       }
 
       // Print some more details. Don't use UL here to avoid circularities.
 #ifdef ASSERT
-      tty->print_cr("Error: existing region: [" PTR_FORMAT "-" PTR_FORMAT "), flag %u.\n"
-                    "       new region: [" PTR_FORMAT "-" PTR_FORMAT "), flag %u.",
+      tty->print_cr("Error: existing region: [" INTPTR_FORMAT "-" INTPTR_FORMAT "), flag %u.\n"
+                    "       new region: [" INTPTR_FORMAT "-" INTPTR_FORMAT "), flag %u.",
                     p2i(reserved_rgn->base()), p2i(reserved_rgn->end()), (unsigned)reserved_rgn->flag(),
                     p2i(base_addr), p2i(base_addr + size), (unsigned)flag);
 #endif
@@ -430,9 +436,15 @@ bool VirtualMemoryTracker::add_committed_region(address addr, size_t size,
   ReservedMemoryRegion  rgn(addr, size);
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
 
-  assert(reserved_rgn != NULL, "No reserved region");
+  if (reserved_rgn == NULL) {
+    log_info(nmt)("Add committed region \'%s\', No reserved region found for  (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
+                  rgn.flag_name(),  p2i(rgn.base()), rgn.size());
+  }
+  assert(reserved_rgn != NULL, "Add committed region, No reserved region found");
   assert(reserved_rgn->contain_region(addr, size), "Not completely contained");
   bool result = reserved_rgn->add_committed_region(addr, size, stack);
+  log_info(nmt)("Add committed region \'%s\'(" INTPTR_FORMAT ", " SIZE_FORMAT ") %s",
+                rgn.flag_name(),  p2i(rgn.base()), rgn.size(), (result ? "Succeeded" : "Failed"));
   return result;
 }
 
@@ -443,9 +455,12 @@ bool VirtualMemoryTracker::remove_uncommitted_region(address addr, size_t size) 
 
   ReservedMemoryRegion  rgn(addr, size);
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
-  assert(reserved_rgn != NULL, "No reserved region");
+  assert(reserved_rgn != NULL, "No reserved region (" INTPTR_FORMAT ", " SIZE_FORMAT ")", p2i(addr), size);
   assert(reserved_rgn->contain_region(addr, size), "Not completely contained");
+  const char* flag_name = reserved_rgn->flag_name();  // after remove, info is not complete
   bool result = reserved_rgn->remove_uncommitted_region(addr, size);
+  log_info(nmt)("Removed uncommitted region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ") %s",
+                flag_name,  p2i(addr), size, (result ? " Succeeded" : "Failed"));
   return result;
 }
 
@@ -454,12 +469,19 @@ bool VirtualMemoryTracker::remove_released_region(ReservedMemoryRegion* rgn) {
   assert(_reserved_regions != NULL, "Sanity check");
 
   // uncommit regions within the released region
-  if (!rgn->remove_uncommitted_region(rgn->base(), rgn->size())) {
+  ReservedMemoryRegion backup(*rgn);
+  bool result = rgn->remove_uncommitted_region(rgn->base(), rgn->size());
+  log_info(nmt)("Remove uncommitted region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ") %s",
+                backup.flag_name(), p2i(backup.base()), backup.size(), (result ? "Succeeded" : "Failed"));
+  if (!result) {
     return false;
   }
 
   VirtualMemorySummary::record_released_memory(rgn->size(), rgn->flag());
-  return _reserved_regions->remove(*rgn);
+  result =  _reserved_regions->remove(*rgn);
+  log_info(nmt)("Removed region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ") from _resvered_regions %s" ,
+                backup.flag_name(), p2i(backup.base()), backup.size(), (result ? "Succeeded" : "Failed"));
+  return result;
 }
 
 bool VirtualMemoryTracker::remove_released_region(address addr, size_t size) {
@@ -470,6 +492,10 @@ bool VirtualMemoryTracker::remove_released_region(address addr, size_t size) {
   ReservedMemoryRegion  rgn(addr, size);
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
 
+  if (reserved_rgn == NULL) {
+    log_info(nmt)("No reserved region found for (" INTPTR_FORMAT ", " SIZE_FORMAT ")!",
+                  p2i(rgn.base()), rgn.size());
+  }
   assert(reserved_rgn != NULL, "No reserved region");
   if (reserved_rgn->same_region(addr, size)) {
     return remove_released_region(reserved_rgn);
@@ -527,8 +553,10 @@ bool VirtualMemoryTracker::split_reserved_region(address addr, size_t size, size
   NativeCallStack original_stack = *reserved_rgn->call_stack();
   MEMFLAGS original_flags = reserved_rgn->flag();
 
+  const char* name = reserved_rgn->flag_name();
   remove_released_region(reserved_rgn);
-
+  log_info(nmt)("Split region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ")  with size " SIZE_FORMAT,
+                name, p2i(rgn.base()), rgn.size(), split);
   // Now, create two new regions.
   add_reserved_region(addr, split, original_stack, original_flags);
   add_reserved_region(addr + split, size - split, original_stack, original_flags);

--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -343,7 +343,7 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
   ReservedMemoryRegion  rgn(base_addr, size, stack, flag);
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
 
-  log_info(nmt)("Add reserved region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
+  log_debug(nmt)("Add reserved region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
                 rgn.flag_name(), p2i(rgn.base()), rgn.size());
   if (reserved_rgn == NULL) {
     VirtualMemorySummary::record_reserved_memory(size, flag);
@@ -383,7 +383,7 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
       // CDS reserves the whole region for mapping CDS archive, then maps each section into the region.
       // NMT reports CDS as a whole.
       if (reserved_rgn->flag() == mtClassShared) {
-        log_info(nmt)("CDS reserved region \'%s\' as a whole (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
+        log_debug(nmt)("CDS reserved region \'%s\' as a whole (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
                       reserved_rgn->flag_name(), p2i(reserved_rgn->base()), reserved_rgn->size());
         assert(reserved_rgn->contain_region(base_addr, size), "Reserved CDS region should contain this mapping region");
         return true;
@@ -392,7 +392,7 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
       // Mapped CDS string region.
       // The string region(s) is part of the java heap.
       if (reserved_rgn->flag() == mtJavaHeap) {
-        log_info(nmt)("CDS reserved region \'%s\' as a whole (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
+        log_debug(nmt)("CDS reserved region \'%s\' as a whole (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
                       reserved_rgn->flag_name(), p2i(reserved_rgn->base()), reserved_rgn->size());
         assert(reserved_rgn->contain_region(base_addr, size), "Reserved heap region should contain this mapping region");
         return true;
@@ -437,13 +437,13 @@ bool VirtualMemoryTracker::add_committed_region(address addr, size_t size,
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
 
   if (reserved_rgn == NULL) {
-    log_info(nmt)("Add committed region \'%s\', No reserved region found for  (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
+    log_debug(nmt)("Add committed region \'%s\', No reserved region found for  (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
                   rgn.flag_name(),  p2i(rgn.base()), rgn.size());
   }
   assert(reserved_rgn != NULL, "Add committed region, No reserved region found");
   assert(reserved_rgn->contain_region(addr, size), "Not completely contained");
   bool result = reserved_rgn->add_committed_region(addr, size, stack);
-  log_info(nmt)("Add committed region \'%s\'(" INTPTR_FORMAT ", " SIZE_FORMAT ") %s",
+  log_debug(nmt)("Add committed region \'%s\'(" INTPTR_FORMAT ", " SIZE_FORMAT ") %s",
                 rgn.flag_name(),  p2i(rgn.base()), rgn.size(), (result ? "Succeeded" : "Failed"));
   return result;
 }
@@ -459,7 +459,7 @@ bool VirtualMemoryTracker::remove_uncommitted_region(address addr, size_t size) 
   assert(reserved_rgn->contain_region(addr, size), "Not completely contained");
   const char* flag_name = reserved_rgn->flag_name();  // after remove, info is not complete
   bool result = reserved_rgn->remove_uncommitted_region(addr, size);
-  log_info(nmt)("Removed uncommitted region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ") %s",
+  log_debug(nmt)("Removed uncommitted region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ") %s",
                 flag_name,  p2i(addr), size, (result ? " Succeeded" : "Failed"));
   return result;
 }
@@ -471,7 +471,7 @@ bool VirtualMemoryTracker::remove_released_region(ReservedMemoryRegion* rgn) {
   // uncommit regions within the released region
   ReservedMemoryRegion backup(*rgn);
   bool result = rgn->remove_uncommitted_region(rgn->base(), rgn->size());
-  log_info(nmt)("Remove uncommitted region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ") %s",
+  log_debug(nmt)("Remove uncommitted region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ") %s",
                 backup.flag_name(), p2i(backup.base()), backup.size(), (result ? "Succeeded" : "Failed"));
   if (!result) {
     return false;
@@ -479,7 +479,7 @@ bool VirtualMemoryTracker::remove_released_region(ReservedMemoryRegion* rgn) {
 
   VirtualMemorySummary::record_released_memory(rgn->size(), rgn->flag());
   result =  _reserved_regions->remove(*rgn);
-  log_info(nmt)("Removed region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ") from _resvered_regions %s" ,
+  log_debug(nmt)("Removed region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ") from _resvered_regions %s" ,
                 backup.flag_name(), p2i(backup.base()), backup.size(), (result ? "Succeeded" : "Failed"));
   return result;
 }
@@ -493,7 +493,7 @@ bool VirtualMemoryTracker::remove_released_region(address addr, size_t size) {
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
 
   if (reserved_rgn == NULL) {
-    log_info(nmt)("No reserved region found for (" INTPTR_FORMAT ", " SIZE_FORMAT ")!",
+    log_debug(nmt)("No reserved region found for (" INTPTR_FORMAT ", " SIZE_FORMAT ")!",
                   p2i(rgn.base()), rgn.size());
   }
   assert(reserved_rgn != NULL, "No reserved region");
@@ -555,7 +555,7 @@ bool VirtualMemoryTracker::split_reserved_region(address addr, size_t size, size
 
   const char* name = reserved_rgn->flag_name();
   remove_released_region(reserved_rgn);
-  log_info(nmt)("Split region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ")  with size " SIZE_FORMAT,
+  log_debug(nmt)("Split region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ")  with size " SIZE_FORMAT,
                 name, p2i(rgn.base()), rgn.size(), split);
   // Now, create two new regions.
   add_reserved_region(addr, split, original_stack, original_flags);

--- a/src/hotspot/share/services/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.hpp
@@ -306,7 +306,6 @@ class ReservedMemoryRegion : public VirtualMemoryRegion {
 
   void  set_flag(MEMFLAGS flag);
   inline MEMFLAGS flag() const            { return _flag;  }
-
   // uncommitted thread stack bottom, above guard pages if there is any.
   address thread_stack_uncommitted_bottom() const;
 
@@ -339,6 +338,8 @@ class ReservedMemoryRegion : public VirtualMemoryRegion {
 
     return *this;
   }
+
+  const char* flag_name() { return NMTUtil::flag_to_name(_flag); }
 
  private:
   // The committed region contains the uncommitted region, subtract the uncommitted

--- a/src/hotspot/share/services/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.hpp
@@ -306,6 +306,7 @@ class ReservedMemoryRegion : public VirtualMemoryRegion {
 
   void  set_flag(MEMFLAGS flag);
   inline MEMFLAGS flag() const            { return _flag;  }
+
   // uncommitted thread stack bottom, above guard pages if there is any.
   address thread_stack_uncommitted_bottom() const;
 

--- a/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
@@ -60,6 +60,8 @@ public class SharedBaseAddress {
                 .addPrefix("-XX:SharedBaseAddress=" + testEntry)
                 .addPrefix("-Xlog:cds=debug")
                 .addPrefix("-Xlog:cds+reloc=debug")
+                .addPrefix("-Xlog:nmt")
+                .addPrefix("-Xlog:metaspace")
                 .addPrefix("-XX:NativeMemoryTracking=detail");
 
             CDSTestUtils.createArchiveAndCheck(opts);

--- a/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
@@ -60,8 +60,8 @@ public class SharedBaseAddress {
                 .addPrefix("-XX:SharedBaseAddress=" + testEntry)
                 .addPrefix("-Xlog:cds=debug")
                 .addPrefix("-Xlog:cds+reloc=debug")
-                .addPrefix("-Xlog:nmt")
-                .addPrefix("-Xlog:metaspace")
+                .addPrefix("-Xlog:nmt=debug")
+                .addPrefix("-Xlog:os+metaspace=debug")
                 .addPrefix("-XX:NativeMemoryTracking=detail");
 
             CDSTestUtils.createArchiveAndCheck(opts);

--- a/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
@@ -61,7 +61,7 @@ public class SharedBaseAddress {
                 .addPrefix("-Xlog:cds=debug")
                 .addPrefix("-Xlog:cds+reloc=debug")
                 .addPrefix("-Xlog:nmt=debug")
-                .addPrefix("-Xlog:os+metaspace=debug")
+                .addPrefix("-Xlog:os=debug")
                 .addPrefix("-XX:NativeMemoryTracking=detail");
 
             CDSTestUtils.createArchiveAndCheck(opts);


### PR DESCRIPTION
Hi, Please review

  JDK-8255917 failed on not finding the committed region from the _reserved_regions list when try to add the region to the committed list. It looks like possible the region was released without logged. 
  Added a log tag for tracing Native Memory Tracking (NMT) add/remove recorded info. This could help us to identify the problem for NMT or the code behind NMT. Function pd_attempt_reserve_memory_at could fail, but no message logged, so added a logging for its failure. 

Tests: tier1-4, local jtreg.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255973](https://bugs.openjdk.java.net/browse/JDK-8255973): Add more logging to debug JDK-8255917


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to 51aef42262d0d9ca34d7eb378c750d55de5bce8d
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1150/head:pull/1150`
`$ git checkout pull/1150`
