### PR TITLE
8255990: Bitmap region of dynamic CDS archive is not unmapped

### DIFF
--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -1747,6 +1747,7 @@ void MetaspaceShared::initialize_shared_spaces() {
     SymbolTable::serialize_shared_table_header(&rc, false);
     SystemDictionaryShared::serialize_dictionary_headers(&rc, false);
     dynamic_mapinfo->close();
+    dynamic_mapinfo->unmap_region(MetaspaceShared::bm);
   }
 
   if (PrintSharedArchiveAndExit) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
@@ -91,6 +91,8 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
         String topArchiveName  = getNewArchiveName("top");
 
         String runtimeMsg = "Try to map archive(s) at an alternative address";
+        String unmapPrefix = ".*Unmapping region #3 at base 0x.*";
+        String unmapPattern = unmapPrefix + "(Bitmap)";
         String unlockArg = "-XX:+UnlockDiagnosticVMOptions";
 
         // (1) Dump base archive (static)
@@ -121,7 +123,12 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
             "-cp", appJar, mainClass)
             .assertNormalExit(output -> {
                     if (run_reloc) {
-                        output.shouldContain(runtimeMsg);
+                        output.shouldContain(runtimeMsg)
+                              // Check that there are two of the following lines in
+                              // the output. One for static archive and one for
+                              // dynamic archive:
+                              // Unmapping region #3 at base 0x<hex digits> (Bitmap)
+                              .shouldMatchByLine(unmapPrefix, "Hello World", unmapPattern);
                     }
                 });
     }


### PR DESCRIPTION
Add the missing call to `unmap_region` to unmap the bitmap region of a dynamic CDS archive.

Also modify the `DynamicArchiveRelocationTest` to check for the "Unmapping region" message.

Testing:

- [x] tier1
- tiers 2,3,4 (in progress)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255990](https://bugs.openjdk.java.net/browse/JDK-8255990): Bitmap region of dynamic CDS archive is not unmapped


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1151/head:pull/1151`
`$ git checkout pull/1151`
