### PR TITLE
8255947: [macos] Signed macOS jpackage app doesn't filter spurious '-psn' argument

### DIFF
--- a/src/jdk.jpackage/linux/native/common/LinuxSysInfo.cpp
+++ b/src/jdk.jpackage/linux/native/common/LinuxSysInfo.cpp
@@ -25,6 +25,7 @@
 
 #include <limits.h>
 #include <unistd.h>
+#include "UnixSysInfo.h"
 #include "FileUtils.h"
 #include "ErrorHandling.h"
 
@@ -40,6 +41,14 @@ tstring getProcessModulePath() {
     }
 
     return tstring(buffer, len);
+}
+
+tstring_array getCommandArgs(CommandArgProgramNameMode progNameMode) {
+    tstring_array result;
+    for (int i = progNameMode == ExcludeProgramName ? 1 : 0; i < argc; i++) {
+        result.push_back(argv[i]);
+    }
+    return result;
 }
 
 } // end of namespace SysInfo

--- a/src/jdk.jpackage/macosx/native/common/MacSysInfo.cpp
+++ b/src/jdk.jpackage/macosx/native/common/MacSysInfo.cpp
@@ -32,8 +32,6 @@
 
 namespace SysInfo {
 
-#define PSN_ARG "-psn_"
-
 tstring getRealPath(const std::vector<char>& in) {
     std::vector<char> out(PATH_MAX);
 
@@ -82,11 +80,12 @@ tstring getProcessModulePath() {
 
 tstring_array getCommandArgs(CommandArgProgramNameMode progNameMode) {
     tstring_array result;
+    const tstring psnArgPrefix = "-psn_";
     for (int i = progNameMode == ExcludeProgramName ? 1 : 0; i < argc; i++) {
-        if (strncmp(argv[i], PSN_ARG, strlen(PSN_ARG)) == 0) {
-            continue;
+        const tstring arg = argv[i];
+        if (!tstrings::startsWith(arg, psnArgPrefix)) {
+            result.push_back(arg);
         }
-        result.push_back(argv[i]);
     }
     return result;
 }

--- a/src/jdk.jpackage/macosx/native/common/MacSysInfo.cpp
+++ b/src/jdk.jpackage/macosx/native/common/MacSysInfo.cpp
@@ -26,10 +26,13 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <mach-o/dyld.h>
+#include "UnixSysInfo.h"
 #include "FileUtils.h"
 #include "ErrorHandling.h"
 
 namespace SysInfo {
+
+#define PSN_ARG "-psn_"
 
 tstring getRealPath(const std::vector<char>& in) {
     std::vector<char> out(PATH_MAX);
@@ -75,6 +78,17 @@ tstring getProcessModulePath() {
     tstring reply = getRealPath(buffer);
 
     return FileUtils::toAbsolutePath(reply);
+}
+
+tstring_array getCommandArgs(CommandArgProgramNameMode progNameMode) {
+    tstring_array result;
+    for (int i = progNameMode == ExcludeProgramName ? 1 : 0; i < argc; i++) {
+        if (strncmp(argv[i], PSN_ARG, strlen(PSN_ARG)) == 0) {
+            continue;
+        }
+        result.push_back(argv[i]);
+    }
+    return result;
 }
 
 } // end of namespace SysInfo

--- a/src/jdk.jpackage/unix/native/common/UnixSysInfo.cpp
+++ b/src/jdk.jpackage/unix/native/common/UnixSysInfo.cpp
@@ -56,15 +56,6 @@ bool isEnvVariableSet(const tstring& name) {
 }
 
 
-tstring_array getCommandArgs(CommandArgProgramNameMode progNameMode) {
-    tstring_array result;
-    for (int i = progNameMode == ExcludeProgramName ? 1 : 0; i < argc; i++) {
-        result.push_back(argv[i]);
-    }
-    return result;
-}
-
-
 int argc = 0;
 char** argv = 0;
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
@@ -355,9 +355,15 @@ public final class HelloApp {
             executeAndVerifyOutput(false, args);
         }
 
-        public void executeAndVerifyOutput(boolean removePath, String... args) {
-            getExecutor(args).dumpOutput().setRemovePath(removePath).execute();
+        public void executeAndVerifyOutput(boolean removePath,
+                List<String> launcherArgs, List<String> appArgs) {
+            getExecutor(launcherArgs.toArray(new String[0])).dumpOutput()
+                    .setRemovePath(removePath).execute();
+            Path outputFile = TKit.workDir().resolve(OUTPUT_FILENAME);
+            verifyOutputFile(outputFile, appArgs, params);
+        }
 
+        public void executeAndVerifyOutput(boolean removePath, String... args) {
             final List<String> launcherArgs = List.of(args);
             final List<String> appArgs;
             if (launcherArgs.isEmpty()) {
@@ -366,8 +372,7 @@ public final class HelloApp {
                 appArgs = launcherArgs;
             }
 
-            Path outputFile = TKit.workDir().resolve(OUTPUT_FILENAME);
-            verifyOutputFile(outputFile, appArgs, params);
+            executeAndVerifyOutput(removePath, launcherArgs, appArgs);
         }
 
         public Executor.Result executeOnly(boolean removePath, String...args) {

--- a/test/jdk/tools/jpackage/macosx/ArgumentsFilteringTest.java
+++ b/test/jdk/tools/jpackage/macosx/ArgumentsFilteringTest.java
@@ -25,8 +25,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.ArrayList;
 import jdk.jpackage.test.JPackageCommand;
-import jdk.jpackage.test.TKit;
 import jdk.jpackage.test.HelloApp;
+import jdk.jpackage.test.Annotations.Test;
 
 /**
  * Tests generation of app image and then launches app by passing -psn_1_1
@@ -40,32 +40,33 @@ import jdk.jpackage.test.HelloApp;
  * @test
  * @summary jpackage with -psn
  * @library ../helpers
- * @library /test/lib
- * @library base
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
+ * @compile ArgumentsFilteringTest.java
  * @requires (os.family == "mac")
- * @run main/othervm -Xmx512m ArgumentsFilteringTest
+ * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=ArgumentsFilteringTest
  */
 public class ArgumentsFilteringTest {
 
-    public static void main(String[] args) throws Exception {
-        TKit.run(args, () -> {
-            // Case 1
-            JPackageCommand cmd = JPackageCommand.helloAppImage();
-            cmd.executeAndAssertHelloAppImageCreated();
-            Path launcherPath = cmd.appLauncherPath();
-            HelloApp.assertApp(launcherPath)
-                    .executeAndVerifyOutput(false, List.of("-psn_1_1"),
-                            new ArrayList<>());
+    @Test
+    public void test1() {
+        JPackageCommand cmd = JPackageCommand.helloAppImage();
+        cmd.executeAndAssertHelloAppImageCreated();
+        Path launcherPath = cmd.appLauncherPath();
+        HelloApp.assertApp(launcherPath)
+                .executeAndVerifyOutput(false, List.of("-psn_1_1"),
+                        new ArrayList<>());
+    }
 
-            // Case 2
-            cmd.addArguments("--arguments", "-psn_2_2");
-            cmd.executeAndAssertHelloAppImageCreated();
-            launcherPath = cmd.appLauncherPath();
-            HelloApp.assertApp(launcherPath)
-                    .executeAndVerifyOutput(false, List.of("-psn_1_1"),
-                            List.of("-psn_2_2"));
-        });
+    @Test
+    public void test2() {
+        JPackageCommand cmd = JPackageCommand.helloAppImage()
+                .addArguments("--arguments", "-psn_2_2");
+        cmd.executeAndAssertHelloAppImageCreated();
+        Path launcherPath = cmd.appLauncherPath();
+        HelloApp.assertApp(launcherPath)
+                .executeAndVerifyOutput(false, List.of("-psn_1_1"),
+                        List.of("-psn_2_2"));
     }
 }

--- a/test/jdk/tools/jpackage/macosx/ArgumentsFilteringTest.java
+++ b/test/jdk/tools/jpackage/macosx/ArgumentsFilteringTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.ArrayList;
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.HelloApp;
+
+/**
+ * Tests generation of app image and then launches app by passing -psn_1_1
+ * argument via command line and checks that -psn_1_1 is not passed to
+ * application. Second test app image is generated -psn_2_2 and then app is
+ * launched with -psn_1_1 and we should filter -psn_1_1 and keep -psn_2_2.
+ * See JDK-8255947.
+ */
+
+/*
+ * @test
+ * @summary jpackage with -psn
+ * @library ../helpers
+ * @library /test/lib
+ * @library base
+ * @build jdk.jpackage.test.*
+ * @modules jdk.jpackage/jdk.jpackage.internal
+ * @requires (os.family == "mac")
+ * @run main/othervm -Xmx512m ArgumentsFilteringTest
+ */
+public class ArgumentsFilteringTest {
+
+    public static void main(String[] args) throws Exception {
+        TKit.run(args, () -> {
+            // Case 1
+            JPackageCommand cmd = JPackageCommand.helloAppImage();
+            cmd.executeAndAssertHelloAppImageCreated();
+            Path launcherPath = cmd.appLauncherPath();
+            HelloApp.assertApp(launcherPath)
+                    .executeAndVerifyOutput(false, List.of("-psn_1_1"),
+                            new ArrayList<>());
+
+            // Case 2
+            cmd.addArguments("--arguments", "-psn_2_2");
+            cmd.executeAndAssertHelloAppImageCreated();
+            launcherPath = cmd.appLauncherPath();
+            HelloApp.assertApp(launcherPath)
+                    .executeAndVerifyOutput(false, List.of("-psn_1_1"),
+                            List.of("-psn_2_2"));
+        });
+    }
+}


### PR DESCRIPTION
This is regression from JDK-8242302 and for some reason removing -psn argument code was removed during refactoring. Fixed be adding removing -psn argument back. Also, test was added to test this functionality.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (3/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8255947](https://bugs.openjdk.java.net/browse/JDK-8255947): [macos] Signed macOS jpackage app doesn't filter spurious '-psn' argument


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**) ⚠️ Review applies to 7df8d2251c63c7fff66e759812321ab9fc4a95d2
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1154/head:pull/1154`
`$ git checkout pull/1154`
