### PR TITLE
8256178: Add RAII object for file lock

### DIFF
--- a/src/hotspot/share/logging/logFileStreamOutput.cpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.cpp
@@ -97,7 +97,6 @@ int LogFileStreamOutput::write(const LogDecorations& decorations, const char* ms
   }
   written += jio_fprintf(_stream, "%s\n", msg);
   fflush(_stream);
-  os::funlockfile(_stream);
 
   return written;
 }
@@ -115,7 +114,6 @@ int LogFileStreamOutput::write(LogMessageBuffer::Iterator msg_iterator) {
     written += jio_fprintf(_stream, "%s\n", msg_iterator.message());
   }
   fflush(_stream);
-  os::funlockfile(_stream);
 
   return written;
 }

--- a/src/hotspot/share/logging/logFileStreamOutput.cpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,11 +72,25 @@ int LogFileStreamOutput::write_decorations(const LogDecorations& decorations) {
   return total_written;
 }
 
+class FileLocker : public StackObj {
+private:
+  FILE *_file;
+
+public:
+  FileLocker(FILE *file) : _file(file) {
+    os::flockfile(_file);
+  }
+
+  ~FileLocker() {
+    os::funlockfile(_file);
+  }
+};
+
 int LogFileStreamOutput::write(const LogDecorations& decorations, const char* msg) {
   const bool use_decorations = !_decorators.is_empty();
 
   int written = 0;
-  os::flockfile(_stream);
+  FileLocker flocker(_stream);
   if (use_decorations) {
     written += write_decorations(decorations);
     written += jio_fprintf(_stream, " ");
@@ -92,7 +106,7 @@ int LogFileStreamOutput::write(LogMessageBuffer::Iterator msg_iterator) {
   const bool use_decorations = !_decorators.is_empty();
 
   int written = 0;
-  os::flockfile(_stream);
+  FileLocker flocker(_stream);
   for (; !msg_iterator.is_at_end(); msg_iterator++) {
     if (use_decorations) {
       written += write_decorations(msg_iterator.decorations());


### PR DESCRIPTION
This PR is subtask of [JDK-8256008](https://bugs.openjdk.java.net/browse/JDK-8256008) (#1106)

`LogFileStreamOutput::write()` uses `os::flockfile()` and `os::funlockfile()` to serialize write ops. It is better to use RAII because we can ensure `os::funlockfile()` call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256178](https://bugs.openjdk.java.net/browse/JDK-8256178): Add RAII object for file lock


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1156/head:pull/1156`
`$ git checkout pull/1156`
