### PR TITLE
8254661: arm32: additional cleanup after fixing SIGSEGV

### DIFF
--- a/src/hotspot/cpu/arm/interp_masm_arm.cpp
+++ b/src/hotspot/cpu/arm/interp_masm_arm.cpp
@@ -983,7 +983,7 @@ void InterpreterMacroAssembler::lock_object(Register Rlock) {
 
 // Unlocks an object. Used in monitorexit bytecode and remove_activation.
 //
-// Argument: R1: Points to BasicObjectLock structure for lock
+// Argument: R0: Points to BasicObjectLock structure for lock
 // Throw an IllegalMonitorException if object is not locked by current thread
 // Blows volatile registers R0-R3, Rtemp, LR. Calls VM.
 void InterpreterMacroAssembler::unlock_object(Register Rlock) {
@@ -996,8 +996,7 @@ void InterpreterMacroAssembler::unlock_object(Register Rlock) {
 
     const Register Robj = R2;
     const Register Rmark = R3;
-    const Register Rresult = R0;
-    assert_different_registers(Robj, Rmark, Rlock, R0, Rtemp);
+    assert_different_registers(Robj, Rmark, Rlock, Rtemp);
 
     const int obj_offset = BasicObjectLock::obj_offset_in_bytes();
     const int lock_offset = BasicObjectLock::lock_offset_in_bytes ();


### PR DESCRIPTION
This change fixes the fastdebug build assertion. This is actually a missing change for [8253901: ARM32: SIGSEGV during monitorexit](https://github.com/openjdk/jdk/pull/503)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254661](https://bugs.openjdk.java.net/browse/JDK-8254661): arm32: additional cleanup after fixing SIGSEGV


### Reviewers
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - Committer)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1157/head:pull/1157`
`$ git checkout pull/1157`
