### PR TITLE
8256182: Update qemu-debootstrap cross-compilation recipe

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -635,15 +635,30 @@ cp: cannot stat `arm-linux-gnueabihf/libXt.so&#39;: No such file or directory</c
 <ul>
 <li>Create chroot on the <em>build</em> system, configuring it for <em>target</em> system:</li>
 </ul>
-<pre><code>sudo qemu-debootstrap --arch=arm64 --verbose \
-       --include=fakeroot,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng12-dev \
-       --resolve-deps jessie /chroots/arm64 http://httpredir.debian.org/debian/</code></pre>
+<pre><code>sudo qemu-debootstrap \
+  --arch=arm64 \
+  --verbose \
+  --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev \
+  --resolve-deps \
+  buster \
+  ~/sysroot-arm64 \
+  http://httpredir.debian.org/debian/</code></pre>
+<ul>
+<li>Make sure the symlinks inside the newly created chroot point to proper locations:</li>
+</ul>
+<pre><code>sudo chroot ~/sysroot-arm64 symlinks -cr .</code></pre>
 <ul>
 <li>Configure and build with newly created chroot as sysroot/toolchain-path:</li>
 </ul>
-<pre><code>CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ sh ./configure --openjdk-target=aarch64-linux-gnu --with-sysroot=/chroots/arm64/ --with-toolchain-path=/chroots/arm64/
+<pre><code>CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ sh ./configure \
+ --openjdk-target=aarch64-linux-gnu \
+ --with-sysroot=~/sysroot-arm64 \
+ --with-toolchain-path=~/sysroot-arm64 \
+ --with-freetype-lib=~/sysroot-arm64/usr/lib/aarch64-linux-gnu/ \
+ --with-freetype-include=~/sysroot-arm64/usr/include/freetype2/ \
+ --x-libraries=~/sysroot-arm64/usr/lib/aarch64-linux-gnu/
 make images
-ls build/linux-aarch64-normal-server-release/</code></pre>
+ls build/linux-aarch64-server-release/</code></pre>
 <p>The build does not create new files in that chroot, so it can be reused for multiple builds without additional cleanup.</p>
 <p>Architectures that are known to successfully cross-compile like this are:</p>
 <table>

--- a/doc/building.html
+++ b/doc/building.html
@@ -629,12 +629,9 @@ cp: cannot stat `arm-linux-gnueabihf/libXt.so&#39;: No such file or directory</c
 <p>Fortunately, you can create sysroots for foreign architectures with tools provided by your OS. On Debian/Ubuntu systems, one could use <code>qemu-deboostrap</code> to create the <em>target</em> system chroot, which would have the native libraries and headers specific to that <em>target</em> system. After that, we can use the cross-compiler on the <em>build</em> system, pointing into chroot to get the build dependencies right. This allows building for foreign architectures with native compilation speed.</p>
 <p>For example, cross-compiling to AArch64 from x86_64 could be done like this:</p>
 <ul>
-<li>Install cross-compiler on the <em>build</em> system:</li>
-</ul>
-<pre><code>apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu</code></pre>
-<ul>
-<li>Create chroot on the <em>build</em> system, configuring it for <em>target</em> system:</li>
-</ul>
+<li><p>Install cross-compiler on the <em>build</em> system:</p>
+<pre><code>apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu</code></pre></li>
+<li><p>Create chroot on the <em>build</em> system, configuring it for <em>target</em> system:</p>
 <pre><code>sudo qemu-debootstrap \
   --arch=arm64 \
   --verbose \
@@ -642,14 +639,10 @@ cp: cannot stat `arm-linux-gnueabihf/libXt.so&#39;: No such file or directory</c
   --resolve-deps \
   buster \
   ~/sysroot-arm64 \
-  http://httpredir.debian.org/debian/</code></pre>
-<ul>
-<li>Make sure the symlinks inside the newly created chroot point to proper locations:</li>
-</ul>
-<pre><code>sudo chroot ~/sysroot-arm64 symlinks -cr .</code></pre>
-<ul>
-<li>Configure and build with newly created chroot as sysroot/toolchain-path:</li>
-</ul>
+  http://httpredir.debian.org/debian/</code></pre></li>
+<li><p>Make sure the symlinks inside the newly created chroot point to proper locations:</p>
+<pre><code>sudo chroot ~/sysroot-arm64 symlinks -cr .</code></pre></li>
+<li><p>Configure and build with newly created chroot as sysroot/toolchain-path:</p>
 <pre><code>CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ sh ./configure \
  --openjdk-target=aarch64-linux-gnu \
  --with-sysroot=~/sysroot-arm64 \
@@ -658,7 +651,8 @@ cp: cannot stat `arm-linux-gnueabihf/libXt.so&#39;: No such file or directory</c
  --with-freetype-include=~/sysroot-arm64/usr/include/freetype2/ \
  --x-libraries=~/sysroot-arm64/usr/lib/aarch64-linux-gnu/
 make images
-ls build/linux-aarch64-server-release/</code></pre>
+ls build/linux-aarch64-server-release/</code></pre></li>
+</ul>
 <p>The build does not create new files in that chroot, so it can be reused for multiple builds without additional cleanup.</p>
 <p>Architectures that are known to successfully cross-compile like this are:</p>
 <table>

--- a/doc/building.md
+++ b/doc/building.md
@@ -1092,16 +1092,33 @@ apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
 
   * Create chroot on the *build* system, configuring it for *target* system:
 ```
-sudo qemu-debootstrap --arch=arm64 --verbose \
-       --include=fakeroot,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng12-dev \
-       --resolve-deps jessie /chroots/arm64 http://httpredir.debian.org/debian/
+sudo qemu-debootstrap \
+  --arch=arm64 \
+  --verbose \
+  --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev \
+  --resolve-deps \
+  buster \
+  ~/sysroot-arm64 \
+  http://httpredir.debian.org/debian/
+```
+
+  * Make sure the symlinks inside the newly created chroot point to proper locations:
+
+```
+sudo chroot ~/sysroot-arm64 symlinks -cr .
 ```
 
   * Configure and build with newly created chroot as sysroot/toolchain-path:
 ```
-CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ sh ./configure --openjdk-target=aarch64-linux-gnu --with-sysroot=/chroots/arm64/ --with-toolchain-path=/chroots/arm64/
+CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ sh ./configure \
+ --openjdk-target=aarch64-linux-gnu \
+ --with-sysroot=~/sysroot-arm64 \
+ --with-toolchain-path=~/sysroot-arm64 \
+ --with-freetype-lib=~/sysroot-arm64/usr/lib/aarch64-linux-gnu/ \
+ --with-freetype-include=~/sysroot-arm64/usr/include/freetype2/ \
+ --x-libraries=~/sysroot-arm64/usr/lib/aarch64-linux-gnu/
 make images
-ls build/linux-aarch64-normal-server-release/
+ls build/linux-aarch64-server-release/
 ```
 
 The build does not create new files in that chroot, so it can be reused for multiple builds

--- a/doc/building.md
+++ b/doc/building.md
@@ -1086,39 +1086,39 @@ for foreign architectures with native compilation speed.
 For example, cross-compiling to AArch64 from x86_64 could be done like this:
 
   * Install cross-compiler on the *build* system:
-```
-apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
-```
+    ```
+    apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+    ```
 
   * Create chroot on the *build* system, configuring it for *target* system:
-```
-sudo qemu-debootstrap \
-  --arch=arm64 \
-  --verbose \
-  --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev \
-  --resolve-deps \
-  buster \
-  ~/sysroot-arm64 \
-  http://httpredir.debian.org/debian/
-```
+    ```
+    sudo qemu-debootstrap \
+      --arch=arm64 \
+      --verbose \
+      --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev \
+      --resolve-deps \
+      buster \
+      ~/sysroot-arm64 \
+      http://httpredir.debian.org/debian/
+    ```
 
   * Make sure the symlinks inside the newly created chroot point to proper locations:
-```
-sudo chroot ~/sysroot-arm64 symlinks -cr .
-```
+    ```
+    sudo chroot ~/sysroot-arm64 symlinks -cr .
+    ```
 
   * Configure and build with newly created chroot as sysroot/toolchain-path:
-```
-CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ sh ./configure \
- --openjdk-target=aarch64-linux-gnu \
- --with-sysroot=~/sysroot-arm64 \
- --with-toolchain-path=~/sysroot-arm64 \
- --with-freetype-lib=~/sysroot-arm64/usr/lib/aarch64-linux-gnu/ \
- --with-freetype-include=~/sysroot-arm64/usr/include/freetype2/ \
- --x-libraries=~/sysroot-arm64/usr/lib/aarch64-linux-gnu/
-make images
-ls build/linux-aarch64-server-release/
-```
+    ```
+    CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ sh ./configure \
+     --openjdk-target=aarch64-linux-gnu \
+     --with-sysroot=~/sysroot-arm64 \
+     --with-toolchain-path=~/sysroot-arm64 \
+     --with-freetype-lib=~/sysroot-arm64/usr/lib/aarch64-linux-gnu/ \
+     --with-freetype-include=~/sysroot-arm64/usr/include/freetype2/ \
+     --x-libraries=~/sysroot-arm64/usr/lib/aarch64-linux-gnu/
+    make images
+    ls build/linux-aarch64-server-release/
+    ```
 
 The build does not create new files in that chroot, so it can be reused for multiple builds
 without additional cleanup.

--- a/doc/building.md
+++ b/doc/building.md
@@ -1103,7 +1103,6 @@ sudo qemu-debootstrap \
 ```
 
   * Make sure the symlinks inside the newly created chroot point to proper locations:
-
 ```
 sudo chroot ~/sysroot-arm64 symlinks -cr .
 ```


### PR DESCRIPTION
Update the docs with the (f)actual recipe used in JDK-8256127.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256182](https://bugs.openjdk.java.net/browse/JDK-8256182): Update qemu-debootstrap cross-compilation recipe


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1160/head:pull/1160`
`$ git checkout pull/1160`
