### PR TITLE
JDK-8256188: Adjust output of make/autoconf/configure

### DIFF
--- a/make/autoconf/configure
+++ b/make/autoconf/configure
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ export LC_ALL=C
 if test "x$CUSTOM_CONFIG_DIR" != x; then
   custom_hook=$CUSTOM_CONFIG_DIR/custom-hook.m4
   if test ! -e $custom_hook; then
-    echo "CUSTOM_CONFIG_DIR not pointing to a proper custom config dir."
+    echo "CUSTOM_CONFIG_DIR ($CUSTOM_CONFIG_DIR) not pointing to a proper custom config dir."
     echo "Error: Cannot continue" 1>&2
     exit 1
   fi
@@ -83,6 +83,7 @@ autoconf_missing_help() {
   BREW="`type -p brew 2> /dev/null`"
   ZYPPER="`type -p zypper 2> /dev/null`"
   CYGWIN="`type -p cygpath 2> /dev/null`"
+  UNAMEOUT="`uname 2> /dev/null`"
 
   if test "x$ZYPPER" != x; then
     PKGHANDLER_COMMAND="sudo zypper install autoconf"
@@ -92,6 +93,8 @@ autoconf_missing_help() {
     PKGHANDLER_COMMAND="sudo yum install autoconf"
   elif test "x$BREW" != x; then
     PKGHANDLER_COMMAND="brew install autoconf"
+  elif test "x$UNAMEOUT" == xAIX; then
+    echo "You might be able to fix this by installing autoconf from the 'AIX Toolbox for Linux Applications' (or compile it from the sources)."
   elif test "x$CYGWIN" != x; then
     PKGHANDLER_COMMAND="( cd <location of cygwin setup.exe> && cmd /c setup -q -P autoconf )"
   fi
@@ -114,7 +117,7 @@ generate_configure_script() {
     AUTOCONF="`type -p autoconf 2> /dev/null`"
     if test "x$AUTOCONF" = x; then
       echo
-      echo "Autoconf is not found on the PATH, and AUTOCONF is not set."
+      echo "Autoconf is not found on the PATH ($PATH), and AUTOCONF is not set."
       echo "You need autoconf to be able to generate a runnable configure script."
       autoconf_missing_help
       echo "Error: Cannot find autoconf" 1>&2


### PR DESCRIPTION
The script make/autoconf/configure should give a bit more output in case various errors occur (e.g. missing autoconf).
The new output in case of missing autoconf adds the PATH; additionally we show on AIX some info on how to install autoconf.

bash /jdk_6/jdk/jdk/configure
Runnable configure script is not present
...
Autoconf is not found on the PATH (/opt/freeware/bin:/usr/bin:/etc:/usr/sbin), and AUTOCONF is not set.
You need autoconf to be able to generate a runnable configure script.
You might be able to fix this by installing autoconf from the 'AIX Toolbox for Linux Applications' (or compile it from the sources).
Error: Cannot find autoconf

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x86 (hs/tier1 compiler)](https://github.com/MBaesken/jdk/runs/1385235429)

### Issue
 * [JDK-8256188](https://bugs.openjdk.java.net/browse/JDK-8256188): Adjust output of make/autoconf/configure


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1164/head:pull/1164`
`$ git checkout pull/1164`
