### PR TITLE
8256166: [C2] Registers get confused on Big Endian after 8221404

### DIFF
--- a/src/hotspot/share/opto/regmask.hpp
+++ b/src/hotspot/share/opto/regmask.hpp
@@ -110,7 +110,12 @@ class RegMask {
     FORALL_BODY
 #   undef BODY
     int dummy = 0) {
+#if defined(VM_LITTLE_ENDIAN) || !defined(_LP64)
 #   define BODY(I) _RM_I[I] = a##I;
+#else
+    // We need to swap ints.
+#   define BODY(I) _RM_I[I ^ 1] = a##I;
+#endif
     FORALL_BODY
 #   undef BODY
     _lwm = 0;


### PR DESCRIPTION
C2 crashes with broken register encoding on Big Endian platforms after JDK-8221404 was pushed.
Reason is that int values "_RM_I" are pairwise swapped on 64 bit Big Endian platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ⏳ (3/9 running) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256166](https://bugs.openjdk.java.net/browse/JDK-8256166): [C2] Registers get confused on Big Endian after 8221404


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1165/head:pull/1165`
`$ git checkout pull/1165`
