### PR TITLE
8256202: Some tweaks for jarsigner tests PosixPermissionsTest and SymLinkTest

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/SymLinkTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/SymLinkTest.java
@@ -31,28 +31,35 @@
  * @run main/othervm SymLinkTest
  */
 
-import java.io.*;
-import java.net.URI;
-import java.nio.file.*;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Formatter;
 
 import jdk.test.lib.SecurityTools;
 
 public class SymLinkTest {
+    private final static int BYTES_PER_ROW = 8;
     private final static String ZIPFILENAME = "8250968-test.zip";
     private static final String WARNING_MSG = "POSIX file permission and/or symlink " +
             "attributes detected. These attributes are ignored when signing and are not " +
             "protected by the signature.";
 
     public static void main(String[] args) throws Exception {
-        Files.deleteIfExists(Paths.get(ZIPFILENAME));
-        try (FileOutputStream fos = new FileOutputStream(ZIPFILENAME)) {
-            fos.write(ZIPBYTES);
+        // call main with an argument to print the prepared zipfile as byte array declaration
+        if (args.length > 0) {
+            System.out.println("Bytes of " + ZIPFILENAME + ":");
+            System.out.println(createByteArray(Files.readAllBytes(Path.of(ZIPFILENAME)), "ZIPBYTES"));
+            System.exit(0);
         }
 
-        // check permissions before signing
+        Files.write(Path.of(ZIPFILENAME), ZIPBYTES);
+
+        // check attributes before signing
         verifyExtraAttrs(ZIPFILENAME);
 
+        // generate key for signing
         SecurityTools.keytool(
                 "-genkey",
                 "-keyalg", "RSA",
@@ -64,6 +71,7 @@ public class SymLinkTest {
                 "-validity", "365")
                 .shouldHaveExitValue(0);
 
+        // sign zip file - expect warning
         SecurityTools.jarsigner(
                 "-keystore", "examplekeystore",
                 "-verbose", ZIPFILENAME,
@@ -73,10 +81,12 @@ public class SymLinkTest {
                 .shouldHaveExitValue(0)
                 .shouldContain(WARNING_MSG);
 
-        // zip file now signed. Recheck attributes
+        // recheck attributes after signing
         verifyExtraAttrs(ZIPFILENAME);
 
-        SecurityTools.jarsigner("-keystore", "examplekeystore",
+        // verify zip file - expect warning
+        SecurityTools.jarsigner(
+                "-keystore", "examplekeystore",
                 "-storepass", "password",
                 "-keypass", "password",
                 "-verbose",
@@ -114,48 +124,57 @@ public class SymLinkTest {
      * @param name Name to be used in the byte array declaration
      * @return The formatted byte array declaration
      */
-    public static String createByteArray(byte[] bytes, String name) {
-        StringBuilder sb = new StringBuilder(bytes.length * 5);
-        Formatter fmt = new Formatter(sb);
-        fmt.format("    public static byte[] %s = {", name);
-        final int linelen = 8;
-        for (int i = 0; i < bytes.length; i++) {
-            if (i % linelen == 0) {
-                fmt.format("%n        ");
+    private static String createByteArray(byte[] bytes, String name) {
+        StringBuilder sb = new StringBuilder();
+        try (Formatter fmt = new Formatter(sb)) {
+            fmt.format("    public final static byte[] %s = {", name);
+            for (int i = 0; i < bytes.length; i++) {
+                int mod = i % BYTES_PER_ROW;
+                if (mod == 0) {
+                    fmt.format("%n        ");
+                } else {
+                    fmt.format(" ");
+                }
+                fmt.format("(byte)0x%02x", bytes[i]);
+                if (i != bytes.length - 1) {
+                    fmt.format(",");
+                }
             }
-            fmt.format(" (byte) 0x%x,", bytes[i] & 0xff);
+            fmt.format("%n    };%n");
         }
-        fmt.format("%n    };%n");
         return sb.toString();
     }
 
     /*
-     * Created using the createByteArray utility method.
-     * The zipfile itself was created via this example:
+     * The zipfile itself was created like this:
+     * $ ln -s ../z z
      * $ ls -l z
      * lrwxrwxrwx 1 test test 4 Aug 27 18:33 z -> ../z
-     * $ zip -ry test.zip z
+     * $ zip -ry 8250968-test.zip z
+     *
+     * The byte array representation was generated using the createByteArray utility method:
+     * $ java SymLinkTest generate
      */
     public final static byte[] ZIPBYTES = {
-            (byte) 0x50, (byte) 0x4b, (byte) 0x3, (byte) 0x4, (byte) 0xa, (byte) 0x0, (byte) 0x0, (byte) 0x0,
-            (byte) 0x0, (byte) 0x0, (byte) 0x2e, (byte) 0x94, (byte) 0x1b, (byte) 0x51, (byte) 0xb4, (byte) 0xcc,
-            (byte) 0xb6, (byte) 0xf1, (byte) 0x4, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x4, (byte) 0x0,
-            (byte) 0x0, (byte) 0x0, (byte) 0x1, (byte) 0x0, (byte) 0x1c, (byte) 0x0, (byte) 0x7a, (byte) 0x55,
-            (byte) 0x54, (byte) 0x9, (byte) 0x0, (byte) 0x3, (byte) 0x77, (byte) 0xfc, (byte) 0x47, (byte) 0x5f,
-            (byte) 0x78, (byte) 0xfc, (byte) 0x47, (byte) 0x5f, (byte) 0x75, (byte) 0x78, (byte) 0xb, (byte) 0x0,
-            (byte) 0x1, (byte) 0x4, (byte) 0xec, (byte) 0x3, (byte) 0x0, (byte) 0x0, (byte) 0x4, (byte) 0xec,
-            (byte) 0x3, (byte) 0x0, (byte) 0x0, (byte) 0x2e, (byte) 0x2e, (byte) 0x2f, (byte) 0x7a, (byte) 0x50,
-            (byte) 0x4b, (byte) 0x1, (byte) 0x2, (byte) 0x1e, (byte) 0x3, (byte) 0xa, (byte) 0x0, (byte) 0x0,
-            (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x2e, (byte) 0x94, (byte) 0x1b, (byte) 0x51, (byte) 0xb4,
-            (byte) 0xcc, (byte) 0xb6, (byte) 0xf1, (byte) 0x4, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x4,
-            (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x1, (byte) 0x0, (byte) 0x18, (byte) 0x0, (byte) 0x0,
-            (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0xff,
-            (byte) 0xa1, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x7a, (byte) 0x55, (byte) 0x54,
-            (byte) 0x5, (byte) 0x0, (byte) 0x3, (byte) 0x77, (byte) 0xfc, (byte) 0x47, (byte) 0x5f, (byte) 0x75,
-            (byte) 0x78, (byte) 0xb, (byte) 0x0, (byte) 0x1, (byte) 0x4, (byte) 0xec, (byte) 0x3, (byte) 0x0,
-            (byte) 0x0, (byte) 0x4, (byte) 0xec, (byte) 0x3, (byte) 0x0, (byte) 0x0, (byte) 0x50, (byte) 0x4b,
-            (byte) 0x5, (byte) 0x6, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x1, (byte) 0x0,
-            (byte) 0x1, (byte) 0x0, (byte) 0x47, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x3f, (byte) 0x0,
-            (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0,
+        (byte)0x50, (byte)0x4b, (byte)0x03, (byte)0x04, (byte)0x0a, (byte)0x00, (byte)0x00, (byte)0x00,
+        (byte)0x00, (byte)0x00, (byte)0x2e, (byte)0x94, (byte)0x1b, (byte)0x51, (byte)0xb4, (byte)0xcc,
+        (byte)0xb6, (byte)0xf1, (byte)0x04, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x04, (byte)0x00,
+        (byte)0x00, (byte)0x00, (byte)0x01, (byte)0x00, (byte)0x1c, (byte)0x00, (byte)0x7a, (byte)0x55,
+        (byte)0x54, (byte)0x09, (byte)0x00, (byte)0x03, (byte)0x77, (byte)0xfc, (byte)0x47, (byte)0x5f,
+        (byte)0x78, (byte)0xfc, (byte)0x47, (byte)0x5f, (byte)0x75, (byte)0x78, (byte)0x0b, (byte)0x00,
+        (byte)0x01, (byte)0x04, (byte)0xec, (byte)0x03, (byte)0x00, (byte)0x00, (byte)0x04, (byte)0xec,
+        (byte)0x03, (byte)0x00, (byte)0x00, (byte)0x2e, (byte)0x2e, (byte)0x2f, (byte)0x7a, (byte)0x50,
+        (byte)0x4b, (byte)0x01, (byte)0x02, (byte)0x1e, (byte)0x03, (byte)0x0a, (byte)0x00, (byte)0x00,
+        (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x2e, (byte)0x94, (byte)0x1b, (byte)0x51, (byte)0xb4,
+        (byte)0xcc, (byte)0xb6, (byte)0xf1, (byte)0x04, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x04,
+        (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x01, (byte)0x00, (byte)0x18, (byte)0x00, (byte)0x00,
+        (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0xff,
+        (byte)0xa1, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x7a, (byte)0x55, (byte)0x54,
+        (byte)0x05, (byte)0x00, (byte)0x03, (byte)0x77, (byte)0xfc, (byte)0x47, (byte)0x5f, (byte)0x75,
+        (byte)0x78, (byte)0x0b, (byte)0x00, (byte)0x01, (byte)0x04, (byte)0xec, (byte)0x03, (byte)0x00,
+        (byte)0x00, (byte)0x04, (byte)0xec, (byte)0x03, (byte)0x00, (byte)0x00, (byte)0x50, (byte)0x4b,
+        (byte)0x05, (byte)0x06, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x01, (byte)0x00,
+        (byte)0x01, (byte)0x00, (byte)0x47, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x3f, (byte)0x00,
+        (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00
     };
 }


### PR DESCRIPTION
Working on 11u backports of JDK-8218021 and JDK-8250968, I found some minor points for improvement in tests
test/jdk/sun/security/tools/jarsigner/PosixPermissionsTest.java and
test/jdk/sun/security/tools/jarsigner/SymLinkTest.java

The details

PosixPermissionsTest:
- it can run on any system, no matter if the default filesystem supports Posix or not since Posix support is only required for the zipfs which is always true.
- improve some comments for the test flow

SymLinkTest:
- make output of createByteArray prettier
- improve inline comments to ease understanding
- add an option to main for generating ZIPBYTES
- use "Files.write(Path.of(ZIPFILENAME), ZIPBYTES)" for creating the test zipfile

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256202](https://bugs.openjdk.java.net/browse/JDK-8256202): Some tweaks for jarsigner tests PosixPermissionsTest and SymLinkTest


### Reviewers
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1166/head:pull/1166`
`$ git checkout pull/1166`
