### PR TITLE
8256203: Simplify RegMask::Empty

### DIFF
--- a/src/hotspot/share/opto/regmask.cpp
+++ b/src/hotspot/share/opto/regmask.cpp
@@ -49,12 +49,7 @@ void OptoReg::dump(int r, outputStream *st) {
 
 
 //=============================================================================
-const RegMask RegMask::Empty(
-# define BODY(I) 0,
-  FORALL_BODY
-# undef BODY
-  0
-);
+const RegMask RegMask::Empty;
 
 //=============================================================================
 bool RegMask::is_vector(uint ireg) {

--- a/src/hotspot/share/opto/regmask.hpp
+++ b/src/hotspot/share/opto/regmask.hpp
@@ -131,7 +131,9 @@ class RegMask {
   }
 
   // Construct an empty mask
-  RegMask() : _RM_UP(), _lwm(_RM_SIZE - 1), _hwm(0) {}
+  RegMask() : _RM_UP(), _lwm(_RM_SIZE - 1), _hwm(0) {
+    assert(valid_watermarks(), "post-condition");
+  }
 
   // Construct a mask with a single bit
   RegMask(OptoReg::Name reg) : RegMask() {


### PR DESCRIPTION
- Simplify RegMask::Empty to use default constructor.
- Add missing validation in the empty constructor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256203](https://bugs.openjdk.java.net/browse/JDK-8256203): Simplify RegMask::Empty


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1167/head:pull/1167`
`$ git checkout pull/1167`
