### PR TITLE
8256051: nmethod_entry_barrier stub miscalculates xmm spill size on x86_32

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -3669,7 +3669,7 @@ class StubGenerator: public StubCodeGenerator {
     __ pusha();
 
     // xmm0 and xmm1 may be used for passing float/double arguments
-    const int xmm_size = wordSize * 2;
+    const int xmm_size = wordSize * 4;
     const int xmm_spill_size = xmm_size * 2;
     __ subptr(rsp, xmm_spill_size);
     __ movdqu(Address(rsp, xmm_size * 1), xmm1);


### PR DESCRIPTION
nmethod_entry_barrier stub miscalculates xmm spill size on x86_32, instead of 4 * wordSize, it uses 2 * wordSize.

This bug only affects Shenandoah, as it is the only GC that supports concurrent class unloading on x86_32.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256051](https://bugs.openjdk.java.net/browse/JDK-8256051): nmethod_entry_barrier stub miscalculates xmm spill size on x86_32


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1170/head:pull/1170`
`$ git checkout pull/1170`
