### PR TITLE
8256220: C1: x86_32 fails with -XX:UseSSE=1 after JDK-8210764 due to mishandled lir_neg

### DIFF
--- a/src/hotspot/cpu/x86/c1_LinearScan_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LinearScan_x86.cpp
@@ -550,21 +550,6 @@ void FpuStackAllocator::handle_op1(LIR_Op1* op1) {
       break;
     }
 
-    case lir_neg: {
-      if (in->is_fpu_register() && !in->is_xmm_register()) {
-        assert(res->is_fpu_register() && !res->is_xmm_register(), "must be");
-        assert(in->is_last_use(), "old value gets destroyed");
-
-        insert_free_if_dead(res, in);
-        insert_exchange(in);
-        new_in = to_fpu_stack_top(in);
-
-        do_rename(in, res);
-        new_res = to_fpu_stack_top(res);
-      }
-      break;
-    }
-
     case lir_convert: {
       Bytecodes::Code bc = op1->as_OpConvert()->bytecode();
       switch (bc) {
@@ -772,7 +757,8 @@ void FpuStackAllocator::handle_op2(LIR_Op2* op2) {
     }
 
     case lir_abs:
-    case lir_sqrt: {
+    case lir_sqrt:
+    case lir_neg: {
       // Right argument appears to be unused
       assert(right->is_illegal(), "must be");
       assert(left->is_fpu_register(), "must be");


### PR DESCRIPTION
This failure manifests on many tests in `tier1`:

```
$ CONF=linux-x86-server-fastdebug make images run-test TEST=tier1 TEST_VM_OPTS="-XX:UseSSE=1"

# Internal Error (/home/shade/trunks/jdk/src/hotspot/cpu/x86/c1_LinearScan_x86.cpp:794), pid=1484789, tid=1484820
# assert(false) failed: missed a fpu-operation
#
# JRE version: OpenJDK Runtime Environment (16.0) (fastdebug build 16-internal+0-adhoc.shade.jdk)
# Java VM: OpenJDK Server VM (fastdebug 16-internal+0-adhoc.shade.jdk, mixed mode, tiered, g1 gc, linux-x86)
# Problematic frame:
# V [libjvm.so+0x6d6300] FpuStackAllocator::handle_op2(LIR_Op2*)+0xf0
```

Amending that assert implies we miss "neg". I believe it was missed when [JDK-8210764](https://bugs.openjdk.java.net/browse/JDK-8210764) changed `lir_neg` from `LIR_Op1` to `LIR_Op2`. At first I just moved the block to appropriate switch that handles `op2`, but then I realized `lir_neg` code is basically the same as for `lir_abs` in the same switch.

Testing:
 - [x] Linux x86_32 fastdebug tier1 with `-XX:UseSSE=0` (some leftover failures)
 - [x] Linux x86_32 fastdebug tier1 with `-XX:UseSSE=1` (some leftover failures)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256220](https://bugs.openjdk.java.net/browse/JDK-8256220): C1: x86_32 fails with -XX:UseSSE=1 after JDK-8210764 due to mishandled lir_neg


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1173/head:pull/1173`
`$ git checkout pull/1173`
