### PR TITLE
8256237: Zero: non-PCH build fails after JDK-8253064

### DIFF
--- a/src/hotspot/share/runtime/monitorDeflationThread.cpp
+++ b/src/hotspot/share/runtime/monitorDeflationThread.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/javaClasses.hpp"
+#include "memory/universe.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/java.hpp"
 #include "runtime/javaCalls.hpp"


### PR DESCRIPTION
This shows up in GH actions, and reproduces locally:

```
/home/shade/trunks/jdk/src/hotspot/share/runtime/monitorDeflationThread.cpp: In static member function 'static void MonitorDeflationThread::initialize()':
/home/shade/trunks/jdk/src/hotspot/share/runtime/monitorDeflationThread.cpp:42:32: error: 'Universe' has not been declared
   42 | Handle thread_group (THREAD, Universe::system_thread_group());
      | ^~~~~~~~
```
Attention @dcubed-ojdk ;)

Testing:
 - [x] Local Linux x86_64 Zero fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (5/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8256237](https://bugs.openjdk.java.net/browse/JDK-8256237): Zero: non-PCH build fails after JDK-8253064


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1174/head:pull/1174`
`$ git checkout pull/1174`
