### PR TITLE
8256238: Remove Matcher::pass_original_key_for_aes

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2516,11 +2516,6 @@ const uint Matcher::vector_ideal_reg(int len) {
   return 0;
 }
 
-// AES support not yet implemented
-const bool Matcher::pass_original_key_for_aes() {
-  return false;
-}
-
 // aarch64 supports misaligned vectors store/load.
 const bool Matcher::misaligned_vectors_ok() {
   return true;

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -1041,11 +1041,6 @@ const bool Matcher::misaligned_vectors_ok() {
   return false;
 }
 
-// ARM doesn't support AES intrinsics
-const bool Matcher::pass_original_key_for_aes() {
-  return false;
-}
-
 const bool Matcher::convL2FSupported(void) {
   return false;
 }

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2200,11 +2200,6 @@ const bool Matcher::misaligned_vectors_ok() {
   return false;
 }
 
-// PPC AES support not yet implemented
-const bool Matcher::pass_original_key_for_aes() {
-  return false;
-}
-
 // RETURNS: whether this branch offset is short enough that a short
 // branch can be used.
 //

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1588,11 +1588,6 @@ const bool Matcher::misaligned_vectors_ok() {
   return true;
 }
 
-// Not yet ported to z/Architecture.
-const bool Matcher::pass_original_key_for_aes() {
-  return false;
-}
-
 // RETURNS: whether this branch offset is short enough that a short
 // branch can be used.
 //

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1899,12 +1899,6 @@ const bool Matcher::misaligned_vectors_ok() {
   return true;
 }
 
-// x86 AES instructions are compatible with SunJCE expanded
-// keys, hence we do not need to pass the original key to stubs
-const bool Matcher::pass_original_key_for_aes() {
-  return false;
-}
-
 
 const bool Matcher::convi2l_type_required = true;
 

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5700,9 +5700,9 @@ bool LibraryCallKit::inline_cipherBlockChaining_AESCrypt(vmIntrinsics::ID id) {
 
   // Call the stub, passing src_start, dest_start, k_start, r_start and src_len
   Node* cbcCrypt = make_runtime_call(RC_LEAF|RC_NO_FP,
-                                OptoRuntime::cipherBlockChaining_aescrypt_Type(),
-                                stubAddr, stubName, TypePtr::BOTTOM,
-                                src_start, dest_start, k_start, r_start, len);
+                                     OptoRuntime::cipherBlockChaining_aescrypt_Type(),
+                                     stubAddr, stubName, TypePtr::BOTTOM,
+                                     src_start, dest_start, k_start, r_start, len);
 
   // return cipher length (int)
   Node* retvalue = _gvn.transform(new ProjNode(cbcCrypt, TypeFunc::Parms));
@@ -5783,9 +5783,9 @@ bool LibraryCallKit::inline_electronicCodeBook_AESCrypt(vmIntrinsics::ID id) {
 
   // Call the stub, passing src_start, dest_start, k_start, r_start and src_len
   Node* ecbCrypt = make_runtime_call(RC_LEAF | RC_NO_FP,
-                               OptoRuntime::electronicCodeBook_aescrypt_Type(),
-                               stubAddr, stubName, TypePtr::BOTTOM,
-                               src_start, dest_start, k_start, len);
+                                     OptoRuntime::electronicCodeBook_aescrypt_Type(),
+                                     stubAddr, stubName, TypePtr::BOTTOM,
+                                     src_start, dest_start, k_start, len);
 
   // return cipher length (int)
   Node* retvalue = _gvn.transform(new ProjNode(ecbCrypt, TypeFunc::Parms));
@@ -5862,9 +5862,9 @@ bool LibraryCallKit::inline_counterMode_AESCrypt(vmIntrinsics::ID id) {
 
   // Call the stub, passing src_start, dest_start, k_start, r_start and src_len
   Node* ctrCrypt = make_runtime_call(RC_LEAF|RC_NO_FP,
-                               OptoRuntime::counterMode_aescrypt_Type(),
-                               stubAddr, stubName, TypePtr::BOTTOM,
-                               src_start, dest_start, k_start, cnt_start, len, saved_encCounter_start, used);
+                                     OptoRuntime::counterMode_aescrypt_Type(),
+                                     stubAddr, stubName, TypePtr::BOTTOM,
+                                     src_start, dest_start, k_start, cnt_start, len, saved_encCounter_start, used);
 
   // return cipher length (int)
   Node* retvalue = _gvn.transform(new ProjNode(ctrCrypt, TypeFunc::Parms));

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5612,22 +5612,10 @@ bool LibraryCallKit::inline_aescrypt_Block(vmIntrinsics::ID id) {
   Node* k_start = get_key_start_from_aescrypt_object(aescrypt_object);
   if (k_start == NULL) return false;
 
-  if (Matcher::pass_original_key_for_aes()) {
-    // on SPARC we need to pass the original key since key expansion needs to happen in intrinsics due to
-    // compatibility issues between Java key expansion and SPARC crypto instructions
-    Node* original_k_start = get_original_key_start_from_aescrypt_object(aescrypt_object);
-    if (original_k_start == NULL) return false;
-
-    // Call the stub.
-    make_runtime_call(RC_LEAF|RC_NO_FP, OptoRuntime::aescrypt_block_Type(),
-                      stubAddr, stubName, TypePtr::BOTTOM,
-                      src_start, dest_start, k_start, original_k_start);
-  } else {
-    // Call the stub.
-    make_runtime_call(RC_LEAF|RC_NO_FP, OptoRuntime::aescrypt_block_Type(),
-                      stubAddr, stubName, TypePtr::BOTTOM,
-                      src_start, dest_start, k_start);
-  }
+  // Call the stub.
+  make_runtime_call(RC_LEAF|RC_NO_FP, OptoRuntime::aescrypt_block_Type(),
+                    stubAddr, stubName, TypePtr::BOTTOM,
+                    src_start, dest_start, k_start);
 
   return true;
 }
@@ -5710,25 +5698,11 @@ bool LibraryCallKit::inline_cipherBlockChaining_AESCrypt(vmIntrinsics::ID id) {
   if (objRvec == NULL) return false;
   Node* r_start = array_element_address(objRvec, intcon(0), T_BYTE);
 
-  Node* cbcCrypt;
-  if (Matcher::pass_original_key_for_aes()) {
-    // on SPARC we need to pass the original key since key expansion needs to happen in intrinsics due to
-    // compatibility issues between Java key expansion and SPARC crypto instructions
-    Node* original_k_start = get_original_key_start_from_aescrypt_object(aescrypt_object);
-    if (original_k_start == NULL) return false;
-
-    // Call the stub, passing src_start, dest_start, k_start, r_start, src_len and original_k_start
-    cbcCrypt = make_runtime_call(RC_LEAF|RC_NO_FP,
-                                 OptoRuntime::cipherBlockChaining_aescrypt_Type(),
-                                 stubAddr, stubName, TypePtr::BOTTOM,
-                                 src_start, dest_start, k_start, r_start, len, original_k_start);
-  } else {
-    // Call the stub, passing src_start, dest_start, k_start, r_start and src_len
-    cbcCrypt = make_runtime_call(RC_LEAF|RC_NO_FP,
-                                 OptoRuntime::cipherBlockChaining_aescrypt_Type(),
-                                 stubAddr, stubName, TypePtr::BOTTOM,
-                                 src_start, dest_start, k_start, r_start, len);
-  }
+  // Call the stub, passing src_start, dest_start, k_start, r_start and src_len
+  Node* cbcCrypt = make_runtime_call(RC_LEAF|RC_NO_FP,
+                                OptoRuntime::cipherBlockChaining_aescrypt_Type(),
+                                stubAddr, stubName, TypePtr::BOTTOM,
+                                src_start, dest_start, k_start, r_start, len);
 
   // return cipher length (int)
   Node* retvalue = _gvn.transform(new ProjNode(cbcCrypt, TypeFunc::Parms));
@@ -5807,13 +5781,8 @@ bool LibraryCallKit::inline_electronicCodeBook_AESCrypt(vmIntrinsics::ID id) {
   Node* k_start = get_key_start_from_aescrypt_object(aescrypt_object);
   if (k_start == NULL) return false;
 
-  Node* ecbCrypt;
-  if (Matcher::pass_original_key_for_aes()) {
-    // no SPARC version for AES/ECB intrinsics now.
-    return false;
-  }
   // Call the stub, passing src_start, dest_start, k_start, r_start and src_len
-  ecbCrypt = make_runtime_call(RC_LEAF | RC_NO_FP,
+  Node* ecbCrypt = make_runtime_call(RC_LEAF | RC_NO_FP,
                                OptoRuntime::electronicCodeBook_aescrypt_Type(),
                                stubAddr, stubName, TypePtr::BOTTOM,
                                src_start, dest_start, k_start, len);
@@ -5891,13 +5860,8 @@ bool LibraryCallKit::inline_counterMode_AESCrypt(vmIntrinsics::ID id) {
   Node* saved_encCounter_start = array_element_address(saved_encCounter, intcon(0), T_BYTE);
   Node* used = field_address_from_object(counterMode_object, "used", "I", /*is_exact*/ false);
 
-  Node* ctrCrypt;
-  if (Matcher::pass_original_key_for_aes()) {
-    // no SPARC version for AES/CTR intrinsics now.
-    return false;
-  }
   // Call the stub, passing src_start, dest_start, k_start, r_start and src_len
-  ctrCrypt = make_runtime_call(RC_LEAF|RC_NO_FP,
+  Node* ctrCrypt = make_runtime_call(RC_LEAF|RC_NO_FP,
                                OptoRuntime::counterMode_aescrypt_Type(),
                                stubAddr, stubName, TypePtr::BOTTOM,
                                src_start, dest_start, k_start, cnt_start, len, saved_encCounter_start, used);
@@ -5930,17 +5894,6 @@ Node * LibraryCallKit::get_key_start_from_aescrypt_object(Node *aescrypt_object)
   // now have the array, need to get the start address of the K array
   Node* k_start = array_element_address(objAESCryptKey, intcon(0), T_INT);
   return k_start;
-}
-
-//------------------------------get_original_key_start_from_aescrypt_object-----------------------
-Node * LibraryCallKit::get_original_key_start_from_aescrypt_object(Node *aescrypt_object) {
-  Node* objAESCryptKey = load_field_from_object(aescrypt_object, "lastKey", "[B", /*is_exact*/ false);
-  assert (objAESCryptKey != NULL, "wrong version of com.sun.crypto.provider.AESCrypt");
-  if (objAESCryptKey == NULL) return (Node *) NULL;
-
-  // now have the array, need to get the start address of the lastKey array
-  Node* original_k_start = array_element_address(objAESCryptKey, intcon(0), T_BYTE);
-  return original_k_start;
 }
 
 //----------------------------inline_cipherBlockChaining_AESCrypt_predicate----------------------------

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -273,7 +273,6 @@ class LibraryCallKit : public GraphKit {
   Node* inline_electronicCodeBook_AESCrypt_predicate(bool decrypting);
   Node* inline_counterMode_AESCrypt_predicate();
   Node* get_key_start_from_aescrypt_object(Node* aescrypt_object);
-  Node* get_original_key_start_from_aescrypt_object(Node* aescrypt_object);
   bool inline_ghash_processBlocks();
   bool inline_base64_encodeBlock();
   bool inline_digestBase_implCompress(vmIntrinsics::ID id);

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -351,9 +351,6 @@ public:
   // CPU supports misaligned vectors store/load.
   static const bool misaligned_vectors_ok();
 
-  // Should original key array reference be passed to AES stubs
-  static const bool pass_original_key_for_aes();
-
   // Used to determine a "low complexity" 64-bit constant.  (Zero is simple.)
   // The standard of comparison is one (StoreL ConL) vs. two (StoreI ConI).
   // Depends on the details of 64-bit constant generation on the CPU.

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -785,18 +785,12 @@ const TypeFunc* OptoRuntime::array_fill_Type() {
 const TypeFunc* OptoRuntime::aescrypt_block_Type() {
   // create input type (domain)
   int num_args      = 3;
-  if (Matcher::pass_original_key_for_aes()) {
-    num_args = 4;
-  }
   int argcnt = num_args;
   const Type** fields = TypeTuple::fields(argcnt);
   int argp = TypeFunc::Parms;
   fields[argp++] = TypePtr::NOTNULL;    // src
   fields[argp++] = TypePtr::NOTNULL;    // dest
   fields[argp++] = TypePtr::NOTNULL;    // k array
-  if (Matcher::pass_original_key_for_aes()) {
-    fields[argp++] = TypePtr::NOTNULL;    // original k array
-  }
   assert(argp == TypeFunc::Parms+argcnt, "correct decoding");
   const TypeTuple* domain = TypeTuple::make(TypeFunc::Parms+argcnt, fields);
 
@@ -878,9 +872,6 @@ const TypeFunc* OptoRuntime::updateBytesAdler32_Type() {
 const TypeFunc* OptoRuntime::cipherBlockChaining_aescrypt_Type() {
   // create input type (domain)
   int num_args      = 5;
-  if (Matcher::pass_original_key_for_aes()) {
-    num_args = 6;
-  }
   int argcnt = num_args;
   const Type** fields = TypeTuple::fields(argcnt);
   int argp = TypeFunc::Parms;
@@ -889,9 +880,6 @@ const TypeFunc* OptoRuntime::cipherBlockChaining_aescrypt_Type() {
   fields[argp++] = TypePtr::NOTNULL;    // k array
   fields[argp++] = TypePtr::NOTNULL;    // r array
   fields[argp++] = TypeInt::INT;        // src len
-  if (Matcher::pass_original_key_for_aes()) {
-    fields[argp++] = TypePtr::NOTNULL;    // original k array
-  }
   assert(argp == TypeFunc::Parms+argcnt, "correct decoding");
   const TypeTuple* domain = TypeTuple::make(TypeFunc::Parms+argcnt, fields);
 
@@ -906,9 +894,6 @@ const TypeFunc* OptoRuntime::cipherBlockChaining_aescrypt_Type() {
 const TypeFunc* OptoRuntime::electronicCodeBook_aescrypt_Type() {
   // create input type (domain)
   int num_args = 4;
-  if (Matcher::pass_original_key_for_aes()) {
-     num_args = 5;
-  }
   int argcnt = num_args;
   const Type** fields = TypeTuple::fields(argcnt);
   int argp = TypeFunc::Parms;
@@ -916,9 +901,6 @@ const TypeFunc* OptoRuntime::electronicCodeBook_aescrypt_Type() {
   fields[argp++] = TypePtr::NOTNULL;    // dest
   fields[argp++] = TypePtr::NOTNULL;    // k array
   fields[argp++] = TypeInt::INT;        // src len
-  if (Matcher::pass_original_key_for_aes()) {
-     fields[argp++] = TypePtr::NOTNULL;    // original k array
-  }
   assert(argp == TypeFunc::Parms + argcnt, "correct decoding");
   const TypeTuple* domain = TypeTuple::make(TypeFunc::Parms + argcnt, fields);
 
@@ -933,9 +915,6 @@ const TypeFunc* OptoRuntime::electronicCodeBook_aescrypt_Type() {
 const TypeFunc* OptoRuntime::counterMode_aescrypt_Type() {
   // create input type (domain)
   int num_args = 7;
-  if (Matcher::pass_original_key_for_aes()) {
-    num_args = 8;
-  }
   int argcnt = num_args;
   const Type** fields = TypeTuple::fields(argcnt);
   int argp = TypeFunc::Parms;
@@ -946,9 +925,6 @@ const TypeFunc* OptoRuntime::counterMode_aescrypt_Type() {
   fields[argp++] = TypeInt::INT; // src len
   fields[argp++] = TypePtr::NOTNULL; // saved_encCounter
   fields[argp++] = TypePtr::NOTNULL; // saved used addr
-  if (Matcher::pass_original_key_for_aes()) {
-    fields[argp++] = TypePtr::NOTNULL; // original k array
-  }
   assert(argp == TypeFunc::Parms + argcnt, "correct decoding");
   const TypeTuple* domain = TypeTuple::make(TypeFunc::Parms + argcnt, fields);
   // returning cipher len (int)


### PR DESCRIPTION
This removes Matcher::pass_original_key_for_aes() and related code. This was added to workaround some limitations with the AES provider on SPARC and is now effectively dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256238](https://bugs.openjdk.java.net/browse/JDK-8256238): Remove Matcher::pass_original_key_for_aes


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1175/head:pull/1175`
`$ git checkout pull/1175`
