### PR TITLE
8256216: Enable reproducible builds in jib-profiles

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -249,6 +249,7 @@ var getJibProfilesCommon = function (input, data) {
         dependencies: ["boot_jdk", "gnumake", "jtreg", "jib", "autoconf", "jmh", "jcov"],
         default_make_targets: ["product-bundles", "test-bundles", "static-libs-bundles"],
         configure_args: concat("--enable-jtreg-failure-handler",
+            "--with-source-date=current",
             "--with-exclude-translations=de,es,fr,it,ko,pt_BR,sv,ca,tr,cs,sk,ja_JP_A,ja_JP_HA,ja_JP_HI,ja_JP_I,zh_TW,zh_HK",
             "--disable-manpages",
             "--disable-jvm-feature-aot",

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -249,13 +249,17 @@ var getJibProfilesCommon = function (input, data) {
         dependencies: ["boot_jdk", "gnumake", "jtreg", "jib", "autoconf", "jmh", "jcov"],
         default_make_targets: ["product-bundles", "test-bundles", "static-libs-bundles"],
         configure_args: concat("--enable-jtreg-failure-handler",
-            "--with-source-date=current",
             "--with-exclude-translations=de,es,fr,it,ko,pt_BR,sv,ca,tr,cs,sk,ja_JP_A,ja_JP_HA,ja_JP_HI,ja_JP_I,zh_TW,zh_HK",
             "--disable-manpages",
             "--disable-jvm-feature-aot",
             "--disable-jvm-feature-graal",
             "--disable-jvm-feature-shenandoahgc",
             versionArgs(input, common))
+    };
+    // Extra settings for release profiles
+    common.release_profile_base = {
+        configure_args: ["--enable-reproducible-build",
+        "--with-source-date=current"]
     };
     // Extra settings for debug profiles
     common.debug_suffix = "-debug";
@@ -796,6 +800,13 @@ var getJibProfilesProfiles = function (input, common, data) {
             // Do not inherit artifact definitions from base profile
             delete profiles[cmpBaselineName].artifacts;
         });
+    });
+
+    // After creating all derived profiles, we can add the release profile base
+    // to the main profiles
+    common.main_profile_names.forEach(function (name) {
+        profiles[name] = concatObjects(profiles[name],
+            common.release_profile_base);
     });
 
     // Artifacts of JCov profiles

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -258,8 +258,10 @@ var getJibProfilesCommon = function (input, data) {
     };
     // Extra settings for release profiles
     common.release_profile_base = {
-        configure_args: ["--enable-reproducible-build",
-        "--with-source-date=current"]
+        configure_args: [
+            "--enable-reproducible-build",
+            "--with-source-date=current",
+        ],
     };
     // Extra settings for debug profiles
     common.debug_suffix = "-debug";


### PR DESCRIPTION
The time has come to actually turn on the support for reproducible builds by default in the jib profiles.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ⏳ (9/9 running) | ⏳ (9/9 running) |    |  ⏳ (9/9 running) |

### Issue
 * [JDK-8256216](https://bugs.openjdk.java.net/browse/JDK-8256216): Enable reproducible builds in jib-profiles


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1176/head:pull/1176`
`$ git checkout pull/1176`
