### PR TITLE
8244679: JVM/TI GetCurrentContendedMonitor/contmon001 failed due to "(IsSameObject#3) unexpected monitor object: 0x000000562336DBA8"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon001.java
@@ -64,7 +64,7 @@ public class contmon001 {
 
     public static int run(String argv[], PrintStream ref) {
         out = ref;
-        doSleep(); // If it would do any class loading, do it now.
+        doSleep(); // If we need to load any classes to execute doSleep(), do it now.
         for (int i = 0; i < argv.length; i++) {
             if (argv[i].equals("-v")) // verbose mode
                 DEBUG_MODE = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon001.java
@@ -64,7 +64,6 @@ public class contmon001 {
 
     public static int run(String argv[], PrintStream ref) {
         out = ref;
-        doSleep(); // If we need to load any classes to execute doSleep(), do it now.
         for (int i = 0; i < argv.length; i++) {
             if (argv[i].equals("-v")) // verbose mode
                 DEBUG_MODE = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon001.java
@@ -23,7 +23,6 @@
 
 package nsk.jvmti.GetCurrentContendedMonitor;
 
-import nsk.share.Wicket;
 import java.io.PrintStream;
 
 public class contmon001 {
@@ -42,8 +41,8 @@ public class contmon001 {
         }
     }
 
-    public static Wicket startingBarrier;
-    public static Wicket waitingBarrier;
+    public static volatile boolean startingBarrier = true;
+    public static volatile boolean waitingBarrier = true;
     static Object lockFld = new Object();
 
     static boolean DEBUG_MODE = false;
@@ -55,8 +54,17 @@ public class contmon001 {
         System.exit(run(args, System.out) + 95/*STATUS_TEMP*/);
     }
 
+    public static void doSleep() {
+        try {
+            Thread.sleep(10);
+        } catch (Exception e) {
+            throw new Error("Unexpected " + e);
+        }
+    }
+
     public static int run(String argv[], PrintStream ref) {
         out = ref;
+        doSleep(); // If it would do any class loading, do it now.
         for (int i = 0; i < argv.length; i++) {
             if (argv[i].equals("-v")) // verbose mode
                 DEBUG_MODE = true;
@@ -75,13 +83,13 @@ public class contmon001 {
             out.println("Check #1 done");
 
         contmon001a thr = new contmon001a();
-        startingBarrier = new Wicket();
-        waitingBarrier = new Wicket();
 
         thr.start();
         if (DEBUG_MODE)
             out.println("\nWaiting for auxiliary thread ...");
-        startingBarrier.waitFor();
+        while (startingBarrier) {
+            doSleep();
+        }
         if (DEBUG_MODE)
             out.println("Auxiliary thread is ready");
 
@@ -93,7 +101,9 @@ public class contmon001 {
 
         thr.letItGo();
 
-        waitingBarrier.waitFor();
+        while (waitingBarrier) {
+            doSleep();
+        }
         synchronized (lockFld) {
             if (DEBUG_MODE)
                 out.println("\nMain thread entered lockFld's monitor"
@@ -138,7 +148,7 @@ class contmon001a extends Thread {
 
         if (contmon001.DEBUG_MODE)
             contmon001.out.println("notifying main thread");
-        contmon001.startingBarrier.unlock();
+        contmon001.startingBarrier = false;
 
         if (contmon001.DEBUG_MODE)
             contmon001.out.println("thread is going to loop while <flag> is true ...");
@@ -158,7 +168,7 @@ class contmon001a extends Thread {
             contmon001.out.println("looping is done: <flag> is false");
 
         synchronized (contmon001.lockFld) {
-            contmon001.waitingBarrier.unlock();
+            contmon001.waitingBarrier = false;
             if (contmon001.DEBUG_MODE)
                 contmon001.out.println("\nthread entered lockFld's monitor"
                     + "\n\tand releasing it through the lockFld.wait() call");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon002.java
@@ -23,7 +23,6 @@
 
 package nsk.jvmti.GetCurrentContendedMonitor;
 
-import nsk.share.Wicket;
 import java.io.PrintStream;
 
 public class contmon002 {
@@ -42,7 +41,7 @@ public class contmon002 {
         }
     }
 
-    public static Wicket startingBarrier;
+    public static boolean startingBarrier = true;
 
     public static void main(String[] args) {
         args = nsk.share.jvmti.JVMTITest.commonInit(args);
@@ -50,13 +49,24 @@ public class contmon002 {
         System.exit(run(args, System.out) + 95/*STATUS_TEMP*/);
     }
 
+    public static void doSleep() {
+        try {
+            Thread.sleep(10);
+        } catch (Exception e) {
+            throw new Error("Unexpected " + e);
+        }
+    }
+
     public static int run(String argv[], PrintStream ref) {
+        doSleep(); // If it would do any class loading, do it now.
+
         checkMon(1, Thread.currentThread());
 
         contmon002a thr = new contmon002a();
-        startingBarrier = new Wicket();
         thr.start();
-        startingBarrier.waitFor();
+        while (startingBarrier) {
+            doSleep();
+        }
         checkMon(2, thr);
         thr.letItGo();
         try {
@@ -73,7 +83,7 @@ class contmon002a extends Thread {
     private volatile boolean flag = true;
 
     private synchronized void meth() {
-        contmon002.startingBarrier.unlock();
+        contmon002.startingBarrier = false;
         int i = 0;
         int n = 1000;
         while (flag) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon002.java
@@ -58,7 +58,7 @@ public class contmon002 {
     }
 
     public static int run(String argv[], PrintStream ref) {
-        doSleep(); // If it would do any class loading, do it now.
+        doSleep(); // If we need to load any classes to execute doSleep(), do it now.
 
         checkMon(1, Thread.currentThread());
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon002.java
@@ -58,8 +58,6 @@ public class contmon002 {
     }
 
     public static int run(String argv[], PrintStream ref) {
-        doSleep(); // If we need to load any classes to execute doSleep(), do it now.
-
         checkMon(1, Thread.currentThread());
 
         contmon002a thr = new contmon002a();


### PR DESCRIPTION
As the stack trace in the bug shows, we cannot load classes, since we may take a monitor.
Resulting in an unexpected result to GetCurrentContendedMonitor().
Trying to use some decent primitive, e.g. Wicket/Semaphore/.., without being implementation dependent means we must warm up every possible scenario, since it may use a new class.
Instead I here just use sleep + volatile for the barriers.

I cannot reproduce with these changes.

Chewing through T6 as most issues have been seen there - passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8244679](https://bugs.openjdk.java.net/browse/JDK-8244679): JVM/TI GetCurrentContendedMonitor/contmon001 failed due to "(IsSameObject#3) unexpected monitor object: 0x000000562336DBA8"


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer) ⚠️ Review applies to 8103a64166c552a3ba75a44fb79295ec93795509
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to 32879e2d4961e3f579ecd1227a9f3b9c9f598b0a
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 32879e2d4961e3f579ecd1227a9f3b9c9f598b0a
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to 32879e2d4961e3f579ecd1227a9f3b9c9f598b0a


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1177/head:pull/1177`
`$ git checkout pull/1177`
