### PR TITLE
8256063: Module::getPackages on an unnamed module may return packages that are in a named module 

### DIFF
--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -1077,9 +1077,9 @@ public final class Module implements AnnotatedElement {
      * <p> For named modules, the returned set contains an element for each
      * package in the module. </p>
      *
-     * <p> For unnamed modules, this method is the equivalent to invoking the
-     * {@link ClassLoader#getDefinedPackages() getDefinedPackages} method of
-     * this module's class loader and returning the set of package names. </p>
+     * <p> For unnamed modules, the returned set contains an element for
+     * each package that {@link ClassLoader#getDefinedPackages() has been defined}
+     * in the unnamed module.</p>
      *
      * @return the set of the package names of the packages in this module
      */
@@ -1094,10 +1094,10 @@ public final class Module implements AnnotatedElement {
             } else {
                 packages = loader.packages();
             }
-            return packages.map(Package::getName).collect(Collectors.toSet());
+            return packages.filter(p -> p.module() == this)
+                           .map(Package::getName).collect(Collectors.toSet());
         }
     }
-
 
     // -- creating Module objects --
 

--- a/test/jdk/java/lang/module/Packages/GetPackagesTest.java
+++ b/test/jdk/java/lang/module/Packages/GetPackagesTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @library /test/lib
+ * @build m/*
+ * @run main/othervm --add-modules m test.GetPackagesTest
+ * @summary test the packages returned by Module::getPackages for an unnamed
+ *          module does not include the packages for named modules
+ */
+
+package test;
+
+import java.util.Set;
+import static jdk.test.lib.Asserts.*;
+
+public class GetPackagesTest {
+    public static void main(String... args) throws Exception {
+        // module m contains the package "p"
+        Class<?> c = Class.forName("p.Main");
+        Module m = c.getModule();
+        Module test = GetPackagesTest.class.getModule();
+
+        // module m and unnamed module are defined by the same class loader
+        assertTrue(m.isNamed());
+        assertFalse(test.isNamed());
+        assertTrue(m.getClassLoader() == test.getClassLoader());
+
+        // verify Module::getPackages on an unnamed module only contains
+        // the packages defined to the unnamed module
+        assertEquals(m.getPackages(), Set.of("p"));
+
+        Set<String> pkgs = test.getPackages();
+        assertTrue(pkgs.contains("test"));
+        assertFalse(pkgs.contains("p"));
+    }
+}

--- a/test/jdk/java/lang/module/Packages/m/module-info.java
+++ b/test/jdk/java/lang/module/Packages/m/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+module m {
+    exports p;
+}

--- a/test/jdk/java/lang/module/Packages/m/p/Main.java
+++ b/test/jdk/java/lang/module/Packages/m/p/Main.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package p;
+
+/**
+ * Main class for dummy module.
+ */
+
+public class Main {
+    public static void main(String[] args) {
+    }
+}


### PR DESCRIPTION
If `Module::getPackages` is invoked on the unnamed module of a class loader
then the set of packages returned will include the packages of any named modules
that are defined to that class loader.  This is a spec and implementation bug.

`Module::getPackages` is changed to return the packages that are defined in
the unnamed module. 

CSR: https://bugs.openjdk.java.net/browse/JDK-8256242

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256063](https://bugs.openjdk.java.net/browse/JDK-8256063): Module::getPackages on an unnamed module may return packages that are in a named module 


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1178/head:pull/1178`
`$ git checkout pull/1178`
