### PR TITLE
8256201: java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java failed

### DIFF
--- a/test/jdk/java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java
+++ b/test/jdk/java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java
@@ -55,6 +55,7 @@ public final class FullscreenWindowProps {
             }
         };
         try {
+            frame.setUndecorated(true); // workaround JDK-8256257
             frame.setBackground(Color.MAGENTA);
             frame.setVisible(true);
             gd.setFullScreenWindow(frame);


### PR DESCRIPTION
The new test added in JDK-8211999 hits a bug on Linux (in mach5 it is passed on ubuntu 18.04 and failed on 20.04). The problem is that the bounds of the fullscreen frame include insets of the frame additionally to the screen size.

The behavior of the decorated full-screen window is not specified:
https://docs.oracle.com/en/java/javase/11/docs/api/java.desktop/java/awt/GraphicsDevice.html#setFullScreenWindow(java.awt.Window)

But it will be good to have the same cross-platform behavior. So I filed a separate bug to investigate the behavior of decorated frame in the fullscreen mode:
https://bugs.openjdk.java.net/browse/JDK-8256257

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x86 (hs/tier1 compiler)](https://github.com/mrserb/jdk/runs/1389172954)

### Issue
 * [JDK-8256201](https://bugs.openjdk.java.net/browse/JDK-8256201): java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java failed


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1180/head:pull/1180`
`$ git checkout pull/1180`
