### PR TITLE
8251377: [macos11] JTabbedPane selected tab text is barely legible

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
@@ -496,4 +496,8 @@ public class AquaImageFactory {
     public static Color getSelectionInactiveForegroundColorUIResource() {
         return new SystemColorProxy(LWCToolkit.getAppleColor(LWCToolkit.INACTIVE_SELECTION_FOREGROUND_COLOR));
     }
+
+    public static Color getControlTextColorUIResource() {
+        return new SystemColorProxy(LWCToolkit.getAppleColor(LWCToolkit.CONTROL_TEXT_COLOR));
+    }
 }

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
@@ -497,7 +497,7 @@ public class AquaImageFactory {
         return new SystemColorProxy(LWCToolkit.getAppleColor(LWCToolkit.INACTIVE_SELECTION_FOREGROUND_COLOR));
     }
 
-    public static Color getControlTextColorUIResource() {
+    public static Color getSelectedControlColorUIResource() {
         return new SystemColorProxy(LWCToolkit.getAppleColor(LWCToolkit.SELECTED_CONTROL_TEXT_COLOR));
     }
 }

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
@@ -498,6 +498,6 @@ public class AquaImageFactory {
     }
 
     public static Color getControlTextColorUIResource() {
-        return new SystemColorProxy(LWCToolkit.getAppleColor(LWCToolkit.CONTROL_TEXT_COLOR));
+        return new SystemColorProxy(LWCToolkit.getAppleColor(LWCToolkit.SELECTED_CONTROL_TEXT_COLOR));
     }
 }

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
@@ -327,7 +327,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
 
         final ColorUIResource selectedTabTitlePressedColor = new ColorUIResource(240, 240, 240);
         final ColorUIResource selectedTabTitleDisabledColor = new ColorUIResource(new Color(1, 1, 1, 0.55f));
-        final Color selectedTabTitleNormalColor = AquaImageFactory.getControlTextColorUIResource();
+        final Color selectedTabTitleNormalColor = AquaImageFactory.getSelectedControlColorUIResource();
         final ColorUIResource selectedTabTitleShadowDisabledColor = new ColorUIResource(new Color(0, 0, 0, 0.25f));
         final ColorUIResource selectedTabTitleShadowNormalColor = mediumTranslucentBlack;
         final ColorUIResource nonSelectedTabTitleNormalColor = black;

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
@@ -327,7 +327,9 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
 
         final ColorUIResource selectedTabTitlePressedColor = new ColorUIResource(240, 240, 240);
         final ColorUIResource selectedTabTitleDisabledColor = new ColorUIResource(new Color(1, 1, 1, 0.55f));
-        final ColorUIResource selectedTabTitleNormalColor = white;
+        final ColorUIResource selectedTabTitleNormalColor =
+                        System.getProperty("os.version").contains("10.16") ?
+                                    new ColorUIResource(Color.lightGray) : white;
         final ColorUIResource selectedTabTitleShadowDisabledColor = new ColorUIResource(new Color(0, 0, 0, 0.25f));
         final ColorUIResource selectedTabTitleShadowNormalColor = mediumTranslucentBlack;
         final ColorUIResource nonSelectedTabTitleNormalColor = black;

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
@@ -327,9 +327,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
 
         final ColorUIResource selectedTabTitlePressedColor = new ColorUIResource(240, 240, 240);
         final ColorUIResource selectedTabTitleDisabledColor = new ColorUIResource(new Color(1, 1, 1, 0.55f));
-        final ColorUIResource selectedTabTitleNormalColor =
-                        System.getProperty("os.version").contains("10.16") ?
-                                    new ColorUIResource(Color.lightGray) : white;
+        final Color selectedTabTitleNormalColor = AquaImageFactory.getControlTextColorUIResource();
         final ColorUIResource selectedTabTitleShadowDisabledColor = new ColorUIResource(new Color(0, 0, 0, 0.25f));
         final ColorUIResource selectedTabTitleShadowNormalColor = mediumTranslucentBlack;
         final ColorUIResource nonSelectedTabTitleNormalColor = black;

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
@@ -208,12 +208,12 @@ public final class LWCToolkit extends LWToolkit {
     public static final int KEYBOARD_FOCUS_COLOR = 0;
     public static final int INACTIVE_SELECTION_BACKGROUND_COLOR = 1;
     public static final int INACTIVE_SELECTION_FOREGROUND_COLOR = 2;
-    public static final int CONTROL_TEXT_COLOR = 3;
+    public static final int SELECTED_CONTROL_TEXT_COLOR = 3;
     private static int[] appleColors = {
         0xFF808080, // keyboardFocusColor = Color.gray;
         0xFFC0C0C0, // secondarySelectedControlColor
         0xFF303030, // controlDarkShadowColor
-        0xFFFFFFFF, // controlTextColor
+        0xFFFFFFFF, // selectedControlColor
     };
 
     private native void loadNativeColors(final int[] systemColors, final int[] appleColors);

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
@@ -204,14 +204,16 @@ public final class LWCToolkit extends LWToolkit {
     /*
      * System colors with default initial values, overwritten by toolkit if system values differ and are available.
      */
-    private static final int NUM_APPLE_COLORS = 3;
+    private static final int NUM_APPLE_COLORS = 4;
     public static final int KEYBOARD_FOCUS_COLOR = 0;
     public static final int INACTIVE_SELECTION_BACKGROUND_COLOR = 1;
     public static final int INACTIVE_SELECTION_FOREGROUND_COLOR = 2;
+    public static final int CONTROL_TEXT_COLOR = 3;
     private static int[] appleColors = {
         0xFF808080, // keyboardFocusColor = Color.gray;
         0xFFC0C0C0, // secondarySelectedControlColor
         0xFF303030, // controlDarkShadowColor
+        0xFFFFFFFF, // controlTextColor
     };
 
     private native void loadNativeColors(final int[] systemColors, final int[] appleColors);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
@@ -117,7 +117,7 @@ static JNF_STATIC_MEMBER_CACHE(jm_systemColorsChanged, jc_LWCToolkit, "systemCol
     appleColors[sun_lwawt_macosx_LWCToolkit_KEYBOARD_FOCUS_COLOR] =                    [NSColor keyboardFocusIndicatorColor];
     appleColors[sun_lwawt_macosx_LWCToolkit_INACTIVE_SELECTION_BACKGROUND_COLOR] =    [NSColor secondarySelectedControlColor];
     appleColors[sun_lwawt_macosx_LWCToolkit_INACTIVE_SELECTION_FOREGROUND_COLOR] =    [NSColor controlDarkShadowColor];
-    appleColors[sun_lwawt_macosx_LWCToolkit_CONTROL_TEXT_COLOR] =                     [NSColor alternateSelectedControlTextColor];
+    appleColors[sun_lwawt_macosx_LWCToolkit_SELECTED_CONTROL_TEXT_COLOR] =                     [NSColor selectedControlColor];
 
     for (i = 0; i < sun_lwawt_macosx_LWCToolkit_NUM_APPLE_COLORS; i++) {
         [appleColors[i] retain];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
@@ -117,6 +117,7 @@ static JNF_STATIC_MEMBER_CACHE(jm_systemColorsChanged, jc_LWCToolkit, "systemCol
     appleColors[sun_lwawt_macosx_LWCToolkit_KEYBOARD_FOCUS_COLOR] =                    [NSColor keyboardFocusIndicatorColor];
     appleColors[sun_lwawt_macosx_LWCToolkit_INACTIVE_SELECTION_BACKGROUND_COLOR] =    [NSColor secondarySelectedControlColor];
     appleColors[sun_lwawt_macosx_LWCToolkit_INACTIVE_SELECTION_FOREGROUND_COLOR] =    [NSColor controlDarkShadowColor];
+    appleColors[sun_lwawt_macosx_LWCToolkit_CONTROL_TEXT_COLOR] =                     [NSColor alternateSelectedControlTextColor];
 
     for (i = 0; i < sun_lwawt_macosx_LWCToolkit_NUM_APPLE_COLORS; i++) {
         [appleColors[i] retain];


### PR DESCRIPTION
On macOS 11 (bigsur) beta, using the Swing Aqua Look and Feel, the text of the selected JTabbedPane tab title text is just a light gray outline of white text on a white background. The macOS 11 design inverted from dark background / light text to light background / dark text, 
Proposed fix is to use dark color in light background so I used lightGray instead of "white" which is being used now, if we are on BigSur.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251377](https://bugs.openjdk.java.net/browse/JDK-8251377): [macos11] JTabbedPane selected tab text is barely legible


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1182/head:pull/1182`
`$ git checkout pull/1182`
