### PR TITLE
8256264: Printed GlyphVector outline with low DPI has bad quality on Windows

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
@@ -1760,8 +1760,8 @@ final class WPathGraphics extends PathGraphics {
             /* Convert the quad path to a bezier.
              */
              case PathIterator.SEG_QUADTO:
-                int lastX = wPrinterJob.getPenX();
-                int lastY = wPrinterJob.getPenY();
+                float lastX = wPrinterJob.getPenX();
+                float lastY = wPrinterJob.getPenY();
                 float c1x = lastX + (segment[0] - lastX) * 2 / 3;
                 float c1y = lastY + (segment[1] - lastY) * 2 / 3;
                 float c2x = segment[2] - (segment[2] - segment[0]) * 2/ 3;

--- a/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
@@ -362,6 +362,11 @@ public final class WPrinterJob extends RasterPrinterJob
 
     private java.awt.peer.ComponentPeer dialogOwnerPeer = null;
 
+    private static final boolean enablePrecisionScale;
+    private static final float precisionScale = 1000.0f;
+    private int graphicsMode;
+    private double[] worldTransform = new double[6];
+
  /* Static Initializations */
 
     static {
@@ -371,6 +376,11 @@ public final class WPrinterJob extends RasterPrinterJob
         initIDs();
 
         Win32FontManager.registerJREFontsForPrinting();
+
+        enablePrecisionScale =
+                java.security.AccessController.doPrivileged(
+                        new sun.security.action.GetBooleanAction(
+                                "sun.java2d.print.enablePathPrecisionScale"));
     }
 
     /* Constructors */
@@ -953,11 +963,37 @@ public final class WPrinterJob extends RasterPrinterJob
     }
 
     protected void beginPath() {
+        precisionScaleBegin();
         beginPath(getPrintDC());
     }
 
     protected void endPath() {
         endPath(getPrintDC());
+        precisionScaleEnd();
+    }
+
+    protected float precisionScaleUp(float value) {
+        return enablePrecisionScale ? value * precisionScale : value;
+    }
+
+    protected float precisionScaleDown(float value) {
+        return enablePrecisionScale ? value / precisionScale : value;
+    }
+
+    protected void precisionScaleBegin() {
+        if (enablePrecisionScale) {
+            graphicsMode = setAdvancedGraphicsMode();
+            getWorldTransform(worldTransform);
+            float invPrecisionScale = 1.0f / precisionScale;
+            scale(invPrecisionScale, invPrecisionScale);
+        }
+    }
+
+    protected void precisionScaleEnd() {
+        if (enablePrecisionScale) {
+            setWorldTransform(worldTransform);
+            setGraphicsMode(graphicsMode);
+        }
     }
 
     protected void closeFigure() {
@@ -969,20 +1005,23 @@ public final class WPrinterJob extends RasterPrinterJob
     }
 
     protected void moveTo(float x, float y) {
-        moveTo(getPrintDC(), x, y);
+        moveTo(getPrintDC(),
+               precisionScaleUp(x), precisionScaleUp(y));
     }
 
     protected void lineTo(float x, float y) {
-        lineTo(getPrintDC(), x, y);
+        lineTo(getPrintDC(),
+               precisionScaleUp(x), precisionScaleUp(y));
     }
 
     protected void polyBezierTo(float control1x, float control1y,
                                 float control2x, float control2y,
                                 float endX, float endY) {
 
-        polyBezierTo(getPrintDC(), control1x, control1y,
-                               control2x, control2y,
-                               endX, endY);
+        polyBezierTo(getPrintDC(),
+                     precisionScaleUp(control1x), precisionScaleUp(control1y),
+                     precisionScaleUp(control2x), precisionScaleUp(control2y),
+                     precisionScaleUp(endX), precisionScaleUp(endY));
     }
 
     /**
@@ -993,6 +1032,44 @@ public final class WPrinterJob extends RasterPrinterJob
      */
     protected void setPolyFillMode(int fillRule) {
         setPolyFillMode(getPrintDC(), fillRule);
+    }
+
+    /**
+     * Set the GDI graphics mode to {@code GM_ADVANCED}.
+     */
+    private int setAdvancedGraphicsMode() {
+        return setAdvancedGraphicsMode(getPrintDC());
+    }
+
+    /**
+     * Set the GDI graphics mode.
+     * The {@code mode} should
+     * be one of the following Windows constants:
+     * {@code GM_COMPATIBLE} or {@code GM_ADVANCED}.
+     */
+    private int setGraphicsMode(int mode) {
+        return setGraphicsMode(getPrintDC(), mode);
+    }
+
+    /**
+     * Scale the GDI World Transform.
+     */
+    private void scale(double scaleX, double scaleY) {
+        scale(getPrintDC(), scaleX, scaleY);
+    }
+
+    /**
+     * Get the GDI World Transform.
+     */
+    private void getWorldTransform(double[] transform) {
+        getWorldTransform(getPrintDC(), transform);
+    }
+
+    /**
+     * Set the GDI World Transform.
+     */
+    private void setWorldTransform(double[] transform) {
+        setWorldTransform(getPrintDC(), transform);
     }
 
     /*
@@ -1020,9 +1097,9 @@ public final class WPrinterJob extends RasterPrinterJob
      * Return the x coordinate of the current pen
      * position in the print device context.
      */
-    protected int getPenX() {
+    protected float getPenX() {
 
-        return getPenX(getPrintDC());
+        return precisionScaleDown(getPenX(getPrintDC()));
     }
 
 
@@ -1030,9 +1107,9 @@ public final class WPrinterJob extends RasterPrinterJob
      * Return the y coordinate of the current pen
      * position in the print device context.
      */
-    protected int getPenY() {
+    protected float getPenY() {
 
-        return getPenY(getPrintDC());
+        return precisionScaleDown(getPenY(getPrintDC()));
     }
 
     /**
@@ -1469,6 +1546,39 @@ public final class WPrinterJob extends RasterPrinterJob
      * {@code ALTERNATE} or {@code WINDING}.
      */
     protected native void setPolyFillMode(long printDC, int fillRule);
+
+    /**
+     * Set the GDI graphics mode to {@code GM_ADVANCED}
+     * into the device context {@code printDC}.
+     */
+    protected native int setAdvancedGraphicsMode(long printDC);
+
+    /**
+     * Set the GDI graphics mode to {@code GM_ADVANCED}
+     * into the device context {@code printDC}.
+     * The {@code mode} should
+     * be one of the following Windows constants:
+     * {@code GM_COMPATIBLE} or {@code GM_ADVANCED}.
+     */
+    protected native int setGraphicsMode(long printDC, int mode);
+
+    /**
+     * Scale the GDI World Transform
+     * of the device context {@code printDC}.
+     */
+    protected native void scale(long printDC, double scaleX, double scaleY);
+
+    /**
+     * Get the GDI World Transform
+     * from the device context {@code printDC}.
+     */
+    protected native void getWorldTransform(long printDC, double[] transform);
+
+    /**
+     * Set the GDI World Transform
+     * into the device context {@code printDC}.
+     */
+    protected native void setWorldTransform(long printDC, double[] transform);
 
     /**
      * Create a Window's solid brush for the color specified

--- a/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
@@ -362,7 +362,6 @@ public final class WPrinterJob extends RasterPrinterJob
 
     private java.awt.peer.ComponentPeer dialogOwnerPeer = null;
 
-    private static final boolean enablePrecisionScale;
     private static final float precisionScale = 1000.0f;
     private int graphicsMode;
     private double[] worldTransform = new double[6];
@@ -376,11 +375,6 @@ public final class WPrinterJob extends RasterPrinterJob
         initIDs();
 
         Win32FontManager.registerJREFontsForPrinting();
-
-        enablePrecisionScale =
-                java.security.AccessController.doPrivileged(
-                        new sun.security.action.GetBooleanAction(
-                                "sun.java2d.print.enablePathPrecisionScale"));
     }
 
     /* Constructors */
@@ -973,27 +967,23 @@ public final class WPrinterJob extends RasterPrinterJob
     }
 
     protected float precisionScaleUp(float value) {
-        return enablePrecisionScale ? value * precisionScale : value;
+        return value * precisionScale;
     }
 
     protected float precisionScaleDown(float value) {
-        return enablePrecisionScale ? value / precisionScale : value;
+        return value / precisionScale;
     }
 
     protected void precisionScaleBegin() {
-        if (enablePrecisionScale) {
-            graphicsMode = setAdvancedGraphicsMode();
-            getWorldTransform(worldTransform);
-            float invPrecisionScale = 1.0f / precisionScale;
-            scale(invPrecisionScale, invPrecisionScale);
-        }
+        graphicsMode = setAdvancedGraphicsMode();
+        getWorldTransform(worldTransform);
+        float invPrecisionScale = 1.0f / precisionScale;
+        scale(invPrecisionScale, invPrecisionScale);
     }
 
     protected void precisionScaleEnd() {
-        if (enablePrecisionScale) {
-            setWorldTransform(worldTransform);
-            setGraphicsMode(graphicsMode);
-        }
+        setWorldTransform(worldTransform);
+        setGraphicsMode(graphicsMode);
     }
 
     protected void closeFigure() {

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -1934,6 +1934,111 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_WPrinterJob_setPolyFillMode
 
 /*
  * Class:     sun_awt_windows_WPrinterJob
+ * Method:    setAdvancedGraphicsMode
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_sun_awt_windows_WPrinterJob_setAdvancedGraphicsMode
+(JNIEnv *env, jobject self, jlong printDC) {
+    TRY;
+
+    return (jint) ::SetGraphicsMode((HDC)printDC, GM_ADVANCED);
+
+    CATCH_BAD_ALLOC_RET(0);
+}
+
+/*
+ * Class:     sun_awt_windows_WPrinterJob
+ * Method:    setGraphicsMode
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_sun_awt_windows_WPrinterJob_setGraphicsMode
+(JNIEnv *env, jobject self, jlong printDC, jint mode) {
+    TRY;
+
+    return (jint) ::SetGraphicsMode((HDC)printDC, mode);
+
+    CATCH_BAD_ALLOC_RET(0);
+}
+
+/*
+ * Class:     sun_awt_windows_WPrinterJob
+ * Method:    scale
+ * Signature: (JDD)V
+ */
+JNIEXPORT void JNICALL Java_sun_awt_windows_WPrinterJob_scale
+(JNIEnv *env, jobject self, jlong printDC, jdouble scaleX, jdouble scaleY) {
+    TRY;
+
+    XFORM xForm;
+
+    xForm.eM11 = (FLOAT) scaleX;
+    xForm.eM12 = (FLOAT) 0;
+    xForm.eM21 = (FLOAT) 0;
+    xForm.eM22 = (FLOAT) scaleY;
+    xForm.eDx  = (FLOAT) 0;
+    xForm.eDy  = (FLOAT) 0;
+
+    ::ModifyWorldTransform((HDC)printDC, &xForm, MWT_RIGHTMULTIPLY);
+
+    CATCH_BAD_ALLOC;
+}
+
+/*
+ * Class:     sun_awt_windows_WPrinterJob
+ * Method:    getWorldTransform
+ * Signature: (J[D)V
+ */
+JNIEXPORT void JNICALL Java_sun_awt_windows_WPrinterJob_getWorldTransform
+(JNIEnv* env, jobject self, jlong printDC, jdoubleArray transform) {
+    TRY;
+
+    double elems[6];
+    XFORM xForm;
+
+    ::GetWorldTransform((HDC)printDC, &xForm);
+
+    elems[0] = (double) xForm.eM11;
+    elems[1] = (double) xForm.eM12;
+    elems[2] = (double) xForm.eM21;
+    elems[3] = (double) xForm.eM22;
+    elems[4] = (double) xForm.eDx;
+    elems[5] = (double) xForm.eDy;
+
+    env->SetDoubleArrayRegion(transform, 0, 6, elems);
+
+    CATCH_BAD_ALLOC;
+}
+
+/*
+ * Class:     sun_awt_windows_WPrinterJob
+ * Method:    setWorldTransform
+ * Signature: (J[D)V
+ */
+JNIEXPORT void JNICALL Java_sun_awt_windows_WPrinterJob_setWorldTransform
+(JNIEnv* env, jobject self, jlong printDC, jdoubleArray transform) {
+    TRY;
+
+    double *elems;
+    XFORM xForm;
+
+    elems = env->GetDoubleArrayElements(transform, 0);
+
+    xForm.eM11 = (FLOAT) elems[0];
+    xForm.eM12 = (FLOAT) elems[1];
+    xForm.eM21 = (FLOAT) elems[2];
+    xForm.eM22 = (FLOAT) elems[3];
+    xForm.eDx  = (FLOAT) elems[4];
+    xForm.eDy  = (FLOAT) elems[5];
+
+    ::SetWorldTransform((HDC)printDC, &xForm);
+
+    env->ReleaseDoubleArrayElements(transform, elems, 0);
+
+    CATCH_BAD_ALLOC;
+}
+
+/*
+ * Class:     sun_awt_windows_WPrinterJob
  * Method:    selectSolidBrush
  * Signature: (JIII)V
  */

--- a/test/jdk/java/awt/print/PathPrecisionScaleFactor/PathPrecisionScaleFactorTest.java
+++ b/test/jdk/java/awt/print/PathPrecisionScaleFactor/PathPrecisionScaleFactorTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8256264
+ * @requires (os.family == "windows")
+ * @summary Check that a GlyphVector outline is printed with good quility on low dpi printers
+ * @run main/othervm/manual -Dsun.java2d.print.enablePathPrecisionScale=true PathPrecisionScaleFactorTest
+ */
+
+import javax.print.PrintServiceLookup;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.font.FontRenderContext;
+import java.awt.font.GlyphVector;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class PathPrecisionScaleFactorTest {
+
+    private static final String DESCRIPTION =
+            " 1. Setup 'Microsoft Print to PDF' printer on Windows.\n" +
+                    " 2. Press Print button to print the text to PDF.\n" +
+                    " 3. Choose 'Microsoft Print to PDF' on the print dialog and press OK\n" +
+                    "    Two strings should be printed." +
+                    "    The first line is printed using drawString() method" +
+                    "    and the second line is printed using filling glyph vector outline.\n" +
+                    " 3. Open the PDF file, zoom in the text and check that chars on the second line " +
+                    "    (especially 'a' and 's') are not distorted and have the similar quality" +
+                    "     as on the first line.\n" +
+                    " 4. If so, press PASS button, otherwise press FAIL button.\n";
+
+    private static final CountDownLatch testEndedSignal = new CountDownLatch(1);
+    private static final int testTimeout = 300000;
+    private static volatile String testFailureMsg;
+    private static volatile boolean testPassed;
+    private static volatile boolean testFinished;
+
+    public static void main(String[] args) throws Exception {
+
+        SwingUtilities.invokeLater(() -> createAndShowTestDialog());
+
+        try {
+            if (!testEndedSignal.await(testTimeout, TimeUnit.MILLISECONDS)) {
+                throw new RuntimeException(String.format(
+                        "Test timeout '%d ms' elapsed.", testTimeout));
+            }
+            if (!testPassed) {
+                String failureMsg = testFailureMsg;
+                if ((failureMsg != null) && (!failureMsg.trim().isEmpty())) {
+                    throw new RuntimeException(failureMsg);
+                } else {
+                    throw new RuntimeException("Test failed.");
+                }
+            }
+        } catch (InterruptedException ie) {
+            throw new RuntimeException(ie);
+        } finally {
+            testFinished = true;
+        }
+    }
+
+    private static void pass() {
+        testPassed = true;
+        testEndedSignal.countDown();
+    }
+
+    private static void fail(String failureMsg) {
+        testFailureMsg = failureMsg;
+        testPassed = false;
+        testEndedSignal.countDown();
+    }
+
+    private static String convertMillisToTimeStr(int millis) {
+        if (millis < 0) {
+            return "00:00:00";
+        }
+        int hours = millis / 3600000;
+        int minutes = (millis - hours * 3600000) / 60000;
+        int seconds = (millis - hours * 3600000 - minutes * 60000) / 1000;
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+
+    private static void createAndShowTestDialog() {
+
+        final JDialog dialog = new JDialog();
+        dialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        dialog.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                dialog.dispose();
+                fail("Main dialog was closed.");
+            }
+        });
+
+        final JLabel testTimeoutLabel = new JLabel(String.format(
+                "Test timeout: %s", convertMillisToTimeStr(testTimeout)));
+        final long startTime = System.currentTimeMillis();
+        final Timer timer = new Timer(0, null);
+        timer.setDelay(1000);
+        timer.addActionListener((e) -> {
+            int leftTime = testTimeout - (int) (System.currentTimeMillis() - startTime);
+            if ((leftTime < 0) || testFinished) {
+                timer.stop();
+                dialog.dispose();
+            }
+            testTimeoutLabel.setText(String.format(
+                    "Test timeout: %s", convertMillisToTimeStr(leftTime)));
+        });
+        timer.start();
+
+        JTextArea textArea = new JTextArea(DESCRIPTION);
+        textArea.setEditable(false);
+
+        final JButton testButton = new JButton("Print");
+        final JButton passButton = new JButton("PASS");
+        final JButton failButton = new JButton("FAIL");
+        testButton.addActionListener((e) -> {
+            testButton.setEnabled(false);
+            new Thread(() -> {
+                try {
+                    doTest();
+
+                    SwingUtilities.invokeLater(() -> {
+                        passButton.setEnabled(true);
+                        failButton.setEnabled(true);
+                    });
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                    dialog.dispose();
+                    fail("Exception occurred in a thread executing the test.");
+                }
+            }).start();
+        });
+        passButton.setEnabled(false);
+        passButton.addActionListener((e) -> {
+            dialog.dispose();
+            pass();
+        });
+        failButton.setEnabled(false);
+        failButton.addActionListener((e) -> {
+            dialog.dispose();
+            fail("TitledBorder label is cut off");
+        });
+
+        JPanel mainPanel = new JPanel(new BorderLayout());
+        JPanel labelPanel = new JPanel(new FlowLayout());
+        labelPanel.add(testTimeoutLabel);
+        mainPanel.add(labelPanel, BorderLayout.NORTH);
+        mainPanel.add(textArea, BorderLayout.CENTER);
+        JPanel buttonPanel = new JPanel(new FlowLayout());
+        buttonPanel.add(testButton);
+        buttonPanel.add(passButton);
+        buttonPanel.add(failButton);
+        mainPanel.add(buttonPanel, BorderLayout.SOUTH);
+        dialog.add(mainPanel);
+
+        dialog.pack();
+        dialog.setVisible(true);
+    }
+
+    private static void doTest() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                new PathPrecisionScaleFactorPrintable();
+            } catch (PrinterException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private static class PathPrecisionScaleFactorPrintable implements Printable {
+
+        PathPrecisionScaleFactorPrintable() throws PrinterException {
+            PrinterJob job = PrinterJob.getPrinterJob();
+            job.setPrintService(PrintServiceLookup.lookupDefaultPrintService());
+            job.setPrintable(this);
+
+            if (job.printDialog()) {
+                job.print();
+            } else {
+                throw new RuntimeException("Printing was canceled!");
+            }
+        }
+
+        void paint(Graphics2D g) {
+
+            String text = "abcdefghijklmnopqrstuvwxyz";
+            Font font = new Font("Times New Roman", Font.PLAIN, 8);
+            drawText(g, font, text);
+        }
+
+        private static void drawText(Graphics2D g, Font font, String text) {
+
+            g.setFont(font);
+            FontRenderContext frc = new FontRenderContext(new AffineTransform(), false, true);
+
+            Rectangle clip = g.getClipBounds();
+            int cx = (int) clip.getCenterX();
+            int cy = (int) clip.getCenterY();
+
+            FontMetrics metrics = g.getFontMetrics();
+            int w = metrics.stringWidth(text);
+            int h = metrics.getHeight();
+
+            int x = cx - w / 2;
+            int y = cy - h / 2;
+
+            g.drawString(text + " [draw string]", x, y);
+            GlyphVector gv = font.createGlyphVector(frc, text + " [glyph vector]");
+            g.fill(gv.getOutline(x, y + h));
+        }
+
+        @Override
+        public int print(Graphics graphics, PageFormat pageFormat, int index) {
+            if (index == 0) {
+                paint((Graphics2D) graphics);
+                return PAGE_EXISTS;
+            } else {
+                return NO_SUCH_PAGE;
+            }
+        }
+    }
+}

--- a/test/jdk/java/awt/print/PathPrecisionScaleFactor/PathPrecisionScaleFactorTest.java
+++ b/test/jdk/java/awt/print/PathPrecisionScaleFactor/PathPrecisionScaleFactorTest.java
@@ -27,7 +27,7 @@
  * @bug 8256264
  * @requires (os.family == "windows")
  * @summary Check that a GlyphVector outline is printed with good quility on low dpi printers
- * @run main/othervm/manual -Dsun.java2d.print.enablePathPrecisionScale=true PathPrecisionScaleFactorTest
+ * @run main/othervm/manual PathPrecisionScaleFactorTest
  */
 
 import javax.print.PrintServiceLookup;


### PR DESCRIPTION
Printing text using GlyphVector outline has bad quality on printers with low DPI on Windows.
The GDI system used for text printing on Windows accepts only integer path coordinates.
Rounding GlyphVector outline coordinates leads to distorted printed text.

To reproduce the issue run the [PrintGlyphVectorOutlineSample](https://bugs.openjdk.java.net/secure/attachment/91398/PrintGlyphVectorOutlineSample.java)  file on Windows and select a low DPI
printer in the printer dialog. The sample prints two lines, one using Graphics drawString() method and another by
filling GlyphVector outline. Chars on the second line are distorted.

It is also possible to reproduce the issue running the sample and printing the text to PDF: [fill-glyph-vector-outline.png](https://bugs.openjdk.java.net/secure/attachment/91397/fill-glyph-vector-outline.png)

The proposed fix introduce "sun.java2d.print.enablePathPrecisionScale" property which being enabled
scales the GDI WorldTransform down and GlyphVector outline coordinates up.
This allows to keep some digits after a dot from being rounded.
The value for scaling is chosen to be 1000 in the same way how it is used  by `String trunc(float f)` method from PSPrinterJob class on Linux:
https://github.com/openjdk/jdk/blob/ed615e3ca0d681e8e67cdbf1d5d964979ccd7888/src/java.desktop/share/classes/sun/print/PSPrinterJob.java#L1489

See the  [fill-glyph-vector-outline-enable-path-scale-factor.png](https://bugs.openjdk.java.net/secure/attachment/91399/fill-glyph-vector-outline-enable-path-scale-factor.png) screenshot which shows how the GlyphVector outline is filled after the fix with the enabled "sun.java2d.print.enablePathPrecisionScale" option.

[fill-glyph-vector-outline-diff.png](https://bugs.openjdk.java.net/secure/attachment/91400/fill-glyph-vector-outline-diff.png) shows difference of GlyphVector outline printing before and after the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256264](https://bugs.openjdk.java.net/browse/JDK-8256264): Printed GlyphVector outline with low DPI has bad quality on Windows


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1183/head:pull/1183`
`$ git checkout pull/1183`
