### PR TITLE
8256267: Relax compiler/floatingpoint/NaNTest.java for x86_32 and lower -XX:+UseSSE

### DIFF
--- a/test/hotspot/jtreg/compiler/floatingpoint/NaNTest.java
+++ b/test/hotspot/jtreg/compiler/floatingpoint/NaNTest.java
@@ -49,8 +49,8 @@ public class NaNTest {
                               readBackValue);
         } else {
             String message = String.format("Original and read back float values mismatch\n0x%X 0x%X\n",
-                                                originalValue,
-                                                readBackValue);
+                                           originalValue,
+                                           readBackValue);
             if (expectStable) {
                 throw new RuntimeException(message);
             } else {
@@ -68,8 +68,8 @@ public class NaNTest {
                               readBackValue);
         } else {
             String message = String.format("Original and read back double values mismatch\n0x%X 0x%X\n",
-                                                originalValue,
-                                                readBackValue);
+                                           originalValue,
+                                           readBackValue);
             if (expectStable) {
                 throw new RuntimeException(message);
             } else {
@@ -81,14 +81,14 @@ public class NaNTest {
     public static void main(String args[]) {
         System.out.println("### NanTest started");
 
-        // Some platforms are known not to treat signalling NaNs properly.
+        // Some platforms are known to strip signaling NaNs.
         // The block below can be used to except them.
         boolean expectStableFloats = true;
         boolean expectStableDoubles = true;
 
         // On x86_32 without relevant SSE-enabled stubs, we are entering
         // native methods that use FPU instructions, and those strip the
-        // signalling NaNs.
+        // signaling NaNs.
         if (Platform.isX86()) {
             int sse = WHITE_BOX.getIntxVMFlag("UseSSE").intValue();
             expectStableFloats = (sse >= 1);

--- a/test/hotspot/jtreg/compiler/floatingpoint/NaNTest.java
+++ b/test/hotspot/jtreg/compiler/floatingpoint/NaNTest.java
@@ -35,6 +35,7 @@
 package compiler.floatingpoint;
 
 import jdk.test.lib.Platform;
+import jtreg.SkippedException;
 import sun.hotspot.WhiteBox;
 
 public class NaNTest {
@@ -72,8 +73,6 @@ public class NaNTest {
     }
 
     public static void main(String args[]) {
-        System.out.println("### NanTest started");
-
         // Some platforms are known to strip signaling NaNs.
         // The block below can be used to except them.
         boolean expectStableFloats = true;
@@ -90,11 +89,18 @@ public class NaNTest {
 
         if (expectStableFloats) {
            testFloat();
-        }
-        if (expectStableDoubles) {
-           testDouble();
+        } else {
+           System.out.println("Stable floats cannot be expected, skipping");
         }
 
-        System.out.println("### NanTest ended");
+        if (expectStableDoubles) {
+           testDouble();
+        } else {
+           System.out.println("Stable doubles cannot be expected, skipping");
+        }
+
+        if (!expectStableFloats && !expectStableDoubles) {
+           throw new SkippedException("No tests were run.");
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/floatingpoint/NaNTest.java
+++ b/test/hotspot/jtreg/compiler/floatingpoint/NaNTest.java
@@ -40,42 +40,35 @@ import sun.hotspot.WhiteBox;
 public class NaNTest {
     static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
 
-    static void testFloat(boolean expectStable) {
+    static void testFloat() {
         int originalValue = 0x7f800001;
         int readBackValue = Float.floatToRawIntBits(Float.intBitsToFloat(originalValue));
-        if (originalValue == readBackValue) {
+        if (originalValue != readBackValue) {
+            String errorMessage = String.format("Original and read back float values mismatch\n0x%X 0x%X\n",
+                                                originalValue,
+                                                readBackValue);
+            throw new RuntimeException(errorMessage);
+        } else {
             System.out.printf("Written and read back float values match\n0x%X 0x%X\n",
                               originalValue,
                               readBackValue);
-        } else {
-            String message = String.format("Original and read back float values mismatch\n0x%X 0x%X\n",
-                                           originalValue,
-                                           readBackValue);
-            if (expectStable) {
-                throw new RuntimeException(message);
-            } else {
-                System.out.println(message);
-            }
         }
     }
 
-    static void testDouble(boolean expectStable) {
+    static void testDouble() {
         long originalValue = 0xFFF0000000000001L;
         long readBackValue = Double.doubleToRawLongBits(Double.longBitsToDouble(originalValue));
-        if (originalValue == readBackValue) {
+        if (originalValue != readBackValue) {
+            String errorMessage = String.format("Original and read back double values mismatch\n0x%X 0x%X\n",
+                                                originalValue,
+                                                readBackValue);
+            throw new RuntimeException(errorMessage);
+        } else {
             System.out.printf("Written and read back double values match\n0x%X 0x%X\n",
                               originalValue,
                               readBackValue);
-        } else {
-            String message = String.format("Original and read back double values mismatch\n0x%X 0x%X\n",
-                                           originalValue,
-                                           readBackValue);
-            if (expectStable) {
-                throw new RuntimeException(message);
-            } else {
-                System.out.println(message);
-            }
         }
+
     }
 
     public static void main(String args[]) {
@@ -95,8 +88,12 @@ public class NaNTest {
             expectStableDoubles = (sse >= 2);
         }
 
-        testFloat(expectStableFloats);
-        testDouble(expectStableDoubles);
+        if (expectStableFloats) {
+           testFloat();
+        }
+        if (expectStableDoubles) {
+           testDouble();
+        }
 
         System.out.println("### NanTest ended");
     }


### PR DESCRIPTION
Reproduces like this:

```
$ CONF=linux-x86-server-fastdebug make images run-test TEST=compiler/floatingpoint/NaNTest.java TEST_VM_OPTS="-XX:UseSSE=1"

STDOUT:
### NanTest started
Written and read back float values match
0x7F800001 0x7F800001
STDERR:
java.lang.RuntimeException: Original and read back double values mismatch
0xFFF0000000000001 0xFFF8000000000001

at compiler.floatingpoint.NaNTest.testDouble(NaNTest.java:56)
at compiler.floatingpoint.NaNTest.main(NaNTest.java:69)
```

After reading through [JDK-8076373](https://bugs.openjdk.java.net/browse/JDK-8076373), I think the test cannot be expected to pass without SSE >= 2 for doubles, and SSE >= 1 for floats on x86_32. This change adds the platform and UseSSE sensing to test.

Additional testing:
 - [x] Affected test on Linux x86_32 with `-XX:UseSSE={0,1,2}`
 - [x] Affected test on Linux x86_64 with `-XX:UseSSE={0,1,2}`
 - [x] Affected test on Linux AArch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256267](https://bugs.openjdk.java.net/browse/JDK-8256267): Relax compiler/floatingpoint/NaNTest.java for x86_32 and lower -XX:+UseSSE


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1187/head:pull/1187`
`$ git checkout pull/1187`
