### PR TITLE
8256276: Temporarily disable gtest special_flags

### DIFF
--- a/test/hotspot/gtest/runtime/test_special_flags.cpp
+++ b/test/hotspot/gtest/runtime/test_special_flags.cpp
@@ -30,7 +30,7 @@
 // The test will only fail late in the release cycle as a reminder,
 // in case it has been forgotten.
 #ifdef ASSERT
-TEST_VM(special_flags, verify_special_flags) {
+TEST_VM(DISABLED_special_flags, verify_special_flags) {
   ASSERT_TRUE(Arguments::verify_special_jvm_flags(true)) << "Special flag verification failed";
 }
 #endif


### PR DESCRIPTION
Please review the following small fix. This issue will get resolved in the next days so this is just to reduce noise in the pipeline.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (3/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8256276](https://bugs.openjdk.java.net/browse/JDK-8256276): Temporarily disable gtest special_flags


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1188/head:pull/1188`
`$ git checkout pull/1188`
