### PR TITLE
8256278: Shenandoah: Avoid num of dead callback from weak processor in Shenandoah root verifier	

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -36,7 +36,6 @@
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "gc/shared/oopStorage.inline.hpp"
 #include "gc/shared/oopStorageSet.hpp"
-#include "gc/shared/weakProcessor.inline.hpp"
 #include "runtime/thread.hpp"
 #include "utilities/debug.hpp"
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -100,8 +100,8 @@ void ShenandoahRootVerifier::oops_do(OopClosure* oops) {
 
   if (verify(WeakRoots)) {
     shenandoah_assert_safepoint();
-    AlwaysTrueClosure always_true;
-    WeakProcessor::weak_oops_do(&always_true, oops);
+    serial_weak_roots_do(oops);
+    concurrent_weak_roots_do(oops);
   } else if (verify(SerialWeakRoots)) {
     shenandoah_assert_safepoint();
     serial_weak_roots_do(oops);


### PR DESCRIPTION
Shenandoah root verifier currently uses WeakProcessor to verify weak oops, but it always generates report_num_dead callback if registered. This callback fails runtime/stringtable/StringTableCleaningTest.java test with -XX:+ShenandoahVerify.

Test:

- [x] hotspot_gc_shenandoah
- [x] Passed failed test
       TEST_VM_OPTS="-XX:+UseShenandoahGC -XX:+UnlockDiagnosticVMOptions -XX:-ShenandoahVerify" make 
       CONF=linux-x86_64-server-release run-test TEST=runtime/stringtable/StringTableCleaningTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256278](https://bugs.openjdk.java.net/browse/JDK-8256278): Shenandoah: Avoid num of dead callback from weak processor in Shenandoah root verifier


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1189/head:pull/1189`
`$ git checkout pull/1189`
