### PR TITLE
8256244: java/lang/ProcessHandle/PermissionTest.java fails with TestNG 7.1

### DIFF
--- a/test/jdk/java/lang/ProcessHandle/PermissionTest.java
+++ b/test/jdk/java/lang/ProcessHandle/PermissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@ import java.util.PropertyPermission;
 
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeGroups;
 import org.testng.annotations.Test;
 
 /*
@@ -118,45 +117,54 @@ public class PermissionTest {
         }
     }
 
-    @BeforeGroups (groups = {"NoManageProcessPermission"})
+    /**
+     * Setup a policy that would reject ProcessHandle requests without Permissions ManageProcess.
+     */
     public void noPermissionsSetup(){
         Policy.setPolicy(new TestPolicy());
         SecurityManager sm = new SecurityManager();
         System.setSecurityManager(sm);
     }
 
-    @Test(groups = { "NoManageProcessPermission" }, expectedExceptions = SecurityException.class)
+    @Test(expectedExceptions = SecurityException.class)
     public void noPermissionAllChildren() {
+        noPermissionsSetup();
         currentHndl.descendants();
     }
 
-    @Test(groups = { "NoManageProcessPermission" }, expectedExceptions = SecurityException.class)
+    @Test(expectedExceptions = SecurityException.class)
     public void noPermissionAllProcesses() {
+        noPermissionsSetup();
         ProcessHandle.allProcesses();
     }
 
-    @Test(groups = { "NoManageProcessPermission" }, expectedExceptions = SecurityException.class)
+    @Test(expectedExceptions = SecurityException.class)
     public void noPermissionChildren() {
+        noPermissionsSetup();
         currentHndl.children();
     }
 
-    @Test(groups = { "NoManageProcessPermission" }, expectedExceptions = SecurityException.class)
+    @Test(expectedExceptions = SecurityException.class)
     public void noPermissionCurrent() {
+        noPermissionsSetup();
         ProcessHandle.current();
     }
 
-    @Test(groups = { "NoManageProcessPermission" }, expectedExceptions = SecurityException.class)
+    @Test(expectedExceptions = SecurityException.class)
     public void noPermissionOf() {
+        noPermissionsSetup();
         ProcessHandle.of(0);
     }
 
-    @Test(groups = { "NoManageProcessPermission" }, expectedExceptions = SecurityException.class)
+    @Test(expectedExceptions = SecurityException.class)
     public void noPermissionParent() {
+        noPermissionsSetup();
         currentHndl.parent();
     }
 
-    @Test(groups = { "NoManageProcessPermission" }, expectedExceptions = SecurityException.class)
+    @Test(expectedExceptions = SecurityException.class)
     public void noPermissionProcessToHandle() throws IOException {
+        noPermissionsSetup();
         Process p = null;
         try {
             ProcessBuilder pb = new ProcessBuilder("sleep", "30");


### PR DESCRIPTION
TestNG 7.1 changed/corrected the way that @BeforeGroups are selected at runtime.
The test was depending on @BeforeGroups to initialize common security policy for a number of tests.
The tests are modified to individually setup the needed security manager and policy.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (2/9 running) | ⏳ (3/9 running) | ⏳ (8/9 running) | ⏳ (5/9 running) |

### Issue
 * [JDK-8256244](https://bugs.openjdk.java.net/browse/JDK-8256244): java/lang/ProcessHandle/PermissionTest.java fails with TestNG 7.1


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1190/head:pull/1190`
`$ git checkout pull/1190`
