### PR TITLE
JDK-8256287: [windows] add loop fuse to map_or_reserve_memory_aligned

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3172,7 +3172,7 @@ static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fi
     // Which may fail, hence the loop.
     aligned_base = file_desc != -1 ? os::attempt_map_memory_to_file_at(aligned_base, size, file_desc) :
                                      os::attempt_reserve_memory_at(aligned_base, size);
-    attempts ++;
+    attempts++;
 
   } while (aligned_base == NULL && attempts < max_attempts);
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3150,9 +3150,8 @@ static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fi
 
   char* aligned_base = NULL;
   static const int max_attempts = 20;
-  int attempts = 0;
 
-  do {
+  for (int attempt = 0; attempt < max_attempts && aligned_base == NULL; attempt ++) {
     char* extra_base = file_desc != -1 ? os::map_memory_to_file(extra_size, file_desc) :
                                          os::reserve_memory(extra_size);
     if (extra_base == NULL) {
@@ -3172,11 +3171,9 @@ static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fi
     // Which may fail, hence the loop.
     aligned_base = file_desc != -1 ? os::attempt_map_memory_to_file_at(aligned_base, size, file_desc) :
                                      os::attempt_reserve_memory_at(aligned_base, size);
-    attempts++;
+  }
 
-  } while (aligned_base == NULL && attempts < max_attempts);
-
-  assert(aligned_base != NULL, "Did not manage to re-map after %d attempts?", attempts);
+  assert(aligned_base != NULL, "Did not manage to re-map after %d attempts?", max_attempts);
 
   return aligned_base;
 }


### PR DESCRIPTION
Hi,

may I please have reviews for this little fix:

On windows, `map_or_reserve_memory_aligned()` attempts to allocate aligned memory by:
1) reserving larger area
2) releasing it
3) attempting to re-reserve into the vacated address space a smaller area at the aligned start address

Since this may fail (between (2) and (3) someone may have grabbed part of that address space concurrently), we do this in a loop. However, when failing to release it we will loop-reserve endlessly.

This is one of the reasons for JDK-8255954 whose root cause will be fixed with JDK-8255978. But we should guard against endless loops independently from that.

This patch:
- limits the number we try this to 20. If in 20 cases someone else grabs address space concurrently, something is off...
- now correctly handles the return code of the release operation (1): in debug we assert, since if release_memory() fails something is wrong and we should take a look. In the release case, we now return an error.


Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256287](https://bugs.openjdk.java.net/browse/JDK-8256287): [windows] add loop fuse to map_or_reserve_memory_aligned


### Reviewers
 * [Ludovic Henry](https://openjdk.java.net/census#luhenry) (@luhenry - Author) ⚠️ Review applies to e716a994372b4e9d2c460acbf117677851144984
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1191/head:pull/1191`
`$ git checkout pull/1191`
