### PR TITLE
8256290: javac/lambda/T8031967.java fails with StackOverflowError on x86_32

### DIFF
--- a/test/langtools/tools/javac/lambda/T8031967.java
+++ b/test/langtools/tools/javac/lambda/T8031967.java
@@ -27,7 +27,7 @@
  * @summary Ensure javac can handle very deeply nested chain of method invocations occurring as
  *          a parameter to other method invocations.
  * @modules jdk.compiler
- * @run main T8031967
+ * @run main/othervm -Xss1m T8031967
  */
 
 import java.io.IOException;


### PR DESCRIPTION
Observe:

```
$ CONF=linux-x86-server-fastdebug make images run-test TEST=tools/javac/lambda/T8031967.java

STDOUT:
STDERR:
/Test.java:3: error: cannot find symbol
        GroupLayout l = new GroupLayout();
        ^
  symbol: class GroupLayout
  location: class Test
/Test.java:3: error: cannot find symbol
        GroupLayout l = new GroupLayout();
                            ^
  symbol: class GroupLayout
  location: class Test
java.lang.IllegalStateException: java.lang.StackOverflowError
at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.analyze(JavacTaskImpl.java:383)
at T8031967.runTestCase(T8031967.java:108)
at T8031967.run(T8031967.java:55)
at T8031967.main(T8031967.java:49)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:564)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
at java.base/java.lang.Thread.run(Thread.java:831)
Caused by: java.lang.StackOverflowError
at jdk.compiler/com.sun.tools.javac.comp.Resolve.resolveIdent(Resolve.java:2651)
at jdk.compiler/com.sun.tools.javac.comp.Attr.visitIdent(Attr.java:4020)
at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCIdent.accept(JCTree.java:2407)
```

x86_32 defaults to 320K stack size, x86_64 (and pretty much every other platform) defaults to 1M stack size. Setting -Xss1M explicitly makes the test pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256290](https://bugs.openjdk.java.net/browse/JDK-8256290): javac/lambda/T8031967.java fails with StackOverflowError on x86_32


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1193/head:pull/1193`
`$ git checkout pull/1193`
