### PR TITLE
8245215 Obsolete InitialBootClassLoaderMetaspaceSize and UseLargePagesInMetaspace

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -529,8 +529,6 @@ static SpecialFlag const special_jvm_flags[] = {
   { "BiasedLockingDecayTime",              JDK_Version::jdk(15), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "UseOptoBiasInlining",                 JDK_Version::jdk(15), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "PrintPreciseBiasedLockingStatistics", JDK_Version::jdk(15), JDK_Version::jdk(16), JDK_Version::jdk(17) },
-  { "InitialBootClassLoaderMetaspaceSize", JDK_Version::jdk(15), JDK_Version::jdk(16), JDK_Version::jdk(17) },
-  { "UseLargePagesInMetaspace",            JDK_Version::jdk(15), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "CriticalJNINatives",                  JDK_Version::jdk(16), JDK_Version::jdk(17), JDK_Version::jdk(18) },
 
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
@@ -553,6 +551,8 @@ static SpecialFlag const special_jvm_flags[] = {
   { "UseNewFieldLayout",             JDK_Version::jdk(15), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "UseSemaphoreGCThreadsSynchronization", JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "ForceNUMA",                     JDK_Version::jdk(15), JDK_Version::jdk(16), JDK_Version::jdk(17) },
+  { "InitialBootClassLoaderMetaspaceSize", JDK_Version::jdk(15), JDK_Version::jdk(16), JDK_Version::jdk(17) },
+  { "UseLargePagesInMetaspace",            JDK_Version::jdk(15), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "InsertMemBarAfterArraycopy",    JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "Debugging",                     JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },
   { "UseRDPCForConstantTableBase",   JDK_Version::undefined(), JDK_Version::jdk(16), JDK_Version::jdk(17) },

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -197,10 +197,6 @@ const intx ObjectAlignmentInBytes = 8;
   develop(bool, LargePagesIndividualAllocationInjectError, false,           \
           "Fail large pages individual allocation")                         \
                                                                             \
-  product(bool, UseLargePagesInMetaspace, false,                            \
-          "(Deprecated) Use large page memory in metaspace. "               \
-          "Only used if UseLargePages is enabled.")                         \
-                                                                            \
   product(bool, UseNUMA, false,                                             \
           "Use NUMA if available")                                          \
                                                                             \
@@ -945,11 +941,6 @@ const intx ObjectAlignmentInBytes = 8;
                                                                             \
   product(bool, IgnoreEmptyClassPaths, false,                               \
           "Ignore empty path elements in -classpath")                       \
-                                                                            \
-  product(size_t, InitialBootClassLoaderMetaspaceSize,                      \
-          NOT_LP64(2200*K) LP64_ONLY(4*M),                                  \
-          "(Deprecated) Initial size of the boot class loader data metaspace") \
-          range(30*K, max_uintx/BytesPerWord)                               \
                                                                             \
   product(bool, PrintHeapAtSIGBREAK, true,                                  \
           "Print heap layout in response to SIGBREAK")                      \

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -120,23 +120,6 @@ public class CompressedClassPointers {
         output.shouldHaveExitValue(0);
     }
 
-    // Using large pages for heap and metaspace.
-    // Note that this is still unexciting since the compressed class space always uses small pages;
-    // UseLargePagesInMetaspace only affects non-class metaspace.
-    public static void largePagesForHeapAndMetaspaceTest() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            "-XX:+UnlockDiagnosticVMOptions",
-            "-Xmx128m",
-            "-XX:+UseLargePages", "-XX:+UseLargePagesInMetaspace",
-            logging_option,
-            "-XX:+VerifyBeforeGC", "-version");
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        if (testNarrowKlassBase()) {
-            output.shouldContain("Narrow klass base:");
-        }
-        output.shouldHaveExitValue(0);
-    }
-
     public static void heapBaseMinAddressTest() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-XX:HeapBaseMinAddress=1m",
@@ -311,7 +294,6 @@ public class CompressedClassPointers {
         smallHeapTestWith1G();
         largeHeapTest();
         largePagesForHeapTest();
-        largePagesForHeapAndMetaspaceTest();
         heapBaseMinAddressTest();
         sharingTest();
 


### PR DESCRIPTION
Please review this change to obsolete options "InitialBootClassLoaderMetaspaceSize and UseLargePagesInMetaspace in JDK-16.  The change was tested with tiers 1-2 on Linux, Windows, and MacOS, and tiers 3-5 on Linux x64.  Additionally, the options were tested locally:

> $JAVA_TEST/bin/java -XX:+UseLargePagesInMetaspace -version
Java HotSpot(TM) 64-Bit Server VM warning: Ignoring option UseLargePagesInMetaspace; support was removed in 16.0
java version "16-internal" 2021-03-16
        ...
> $JAVA_TEST/bin/java -XX:InitialBootClassLoaderMetaspaceSize=4 -version
Java HotSpot(TM) 64-Bit Server VM warning: Ignoring option InitialBootClassLoaderMetaspaceSize; support was removed in 16.0
java version "16-internal" 2021-03-16
      ...

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8245215](https://bugs.openjdk.java.net/browse/JDK-8245215): Obsolete InitialBootClassLoaderMetaspaceSize and UseLargePagesInMetaspace


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1194/head:pull/1194`
`$ git checkout pull/1194`
