### PR TITLE
8256308: Send arguments to javac server in a config file

### DIFF
--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -215,18 +215,30 @@ define SetupJavaCompilationBody
     ifeq ($$(ENABLE_JAVAC_SERVER)+$$($1_CLASSPATH), true+)
       $1_JAVAC := $$(INTERIM_LANGTOOLS_ARGS) -m jdk.compiler.interim/com.sun.tools.sjavac.Main
 
-      # How to launch the server. This must use JAVA_DETACH, which is the "big" java
-      # with an ability to detach from fixpath (on Windows)
-      # This will be executed by the client, if needed.
-      $1_JAVAC_SERVER_CMD := $$(JAVA_DETACH) $$($1_JAVA_FLAGS) $$($1_JAVAC)
-      $1_ESCAPED_CMD := $$(subst $$(SPACE),%20,$$(subst $$(COMMA),%2C,$$(strip $$($1_JAVAC_SERVER_CMD))))
+      # Create a configuration file with the needed information for the javac
+      # server to function properly.
+      $1_JAVAC_SERVER_CONFIG := $$(JAVAC_SERVER_DIR)/server.conf
 
-      # The port file contains the tcp/ip on which the server listens
+      # The portfile contains the tcp/ip on which the server listens
       # and the cookie necessary to talk to the server.
-      $1_JAVA_SERVER_FLAGS := --server:portfile=$$(JAVAC_SERVER_DIR)/server.port,sjavac=$$($1_ESCAPED_CMD)
+      $1_JAVAC_PORT_FILE := $$(JAVAC_SERVER_DIR)/server.port
 
-      # Always use small to launch client
-      $1_JAVAC_CMD := $$(JAVA_SMALL) $$($1_JAVA_FLAGS) $$($1_JAVAC) $$($1_JAVA_SERVER_FLAGS)
+      # The servercmd specified how to launch the server. This must use
+      # JAVA_DETACH, which is the "big" java with an ability to detach from
+      # fixpath (on Windows) This will be executed by the client, if needed.
+      $1_JAVAC_SERVER_CMD := $$(JAVA_DETACH) $$($1_JAVA_FLAGS) $$($1_JAVAC)
+
+      $1_CONFIG_VARDEPS :=$$($1_JAVAC_PORT_FILE) $$($1_JAVAC_SERVER_CMD)
+      $1_CONFIG_VARDEPS_FILE := $$(call DependOnVariable, $1_CONFIG_VARDEPS, \
+        $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1.config_vardeps)
+
+      $$($1_JAVAC_SERVER_CONFIG): $$($1_CONFIG_VARDEPS_FILE)
+	$(ECHO) portfile=$$($1_JAVAC_PORT_FILE) > $$@
+	$(ECHO) servercmd=$$($1_JAVAC_SERVER_CMD) >> $$@
+
+      # Always use small java to launch client
+      $1_JAVAC_CMD := $$(JAVA_SMALL) $$($1_JAVA_FLAGS) $$($1_JAVAC) \
+          --server:conf=$$($1_JAVAC_SERVER_CONFIG)
     else
       # No javac server
       $1_JAVAC := $$(INTERIM_LANGTOOLS_ARGS) -m jdk.compiler.interim/com.sun.tools.javac.Main
@@ -442,7 +454,7 @@ define SetupJavaCompilationBody
 
     # Do the actual compilation
     $$($1_COMPILE_TARGET): $$($1_SRCS) $$($1_FILELIST) $$($1_DEPENDS) \
-        $$($1_VARDEPS_FILE) $$($1_EXTRA_DEPS)
+        $$($1_VARDEPS_FILE) $$($1_EXTRA_DEPS) $$($1_JAVAC_SERVER_CONFIG)
 		$$(call MakeDir, $$(@D))
 		$$(call ExecuteWithLog, $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$$($1_SAFE_NAME)_batch, \
 		    $$($1_JAVAC_CMD) $$($1_FLAGS) \

--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -177,6 +177,8 @@ define SetupJavaCompilationBody
     $$(error Must specify BIN (in $1))
   endif
 
+  $1_SAFE_NAME := $$(strip $$(subst /,_, $1))
+
   ifeq ($$($1_SMALL_JAVA), )
     # If unspecified, default to true
     $1_SMALL_JAVA := true
@@ -217,7 +219,7 @@ define SetupJavaCompilationBody
 
       # Create a configuration file with the needed information for the javac
       # server to function properly.
-      $1_JAVAC_SERVER_CONFIG := $$(JAVAC_SERVER_DIR)/server.conf
+      $1_JAVAC_SERVER_CONFIG := $$(JAVAC_SERVER_DIR)/$$($1_SAFE_NAME)-server.conf
 
       # The portfile contains the tcp/ip on which the server listens
       # and the cookie necessary to talk to the server.
@@ -343,9 +345,6 @@ define SetupJavaCompilationBody
       $$(error No source files found for $1)
     endif
   else
-
-    $1_SAFE_NAME := $$(strip $$(subst /,_, $1))
-
     # All files below META-INF are always copied.
     $1_ALL_COPIES := $$(filter $$(addsuffix /META-INF%,$$($1_SRC)),$$($1_ALL_SRCS))
     # Find all files to be copied from source to bin.

--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -219,7 +219,7 @@ define SetupJavaCompilationBody
 
       # Create a configuration file with the needed information for the javac
       # server to function properly.
-      $1_JAVAC_SERVER_CONFIG := $$(JAVAC_SERVER_DIR)/$$($1_SAFE_NAME)-server.conf
+      $1_JAVAC_SERVER_CONFIG := $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$$($1_SAFE_NAME)-server.conf
 
       # The portfile contains the tcp/ip on which the server listens
       # and the cookie necessary to talk to the server.

--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -234,16 +234,16 @@ define SetupJavaCompilationBody
       # fixpath (on Windows) This will be executed by the client, if needed.
       $1_JAVAC_SERVER_CMD := $$(JAVA_DETACH) $$($1_JAVA_FLAGS) $$($1_JAVAC)
 
-      $1_CONFIG_VARDEPS :=$$($1_JAVAC_PORT_FILE) $$($1_JAVAC_SERVER_CMD)
+      $1_CONFIG_VARDEPS := $$($1_JAVAC_PORT_FILE) $$($1_JAVAC_SERVER_CMD)
       $1_CONFIG_VARDEPS_FILE := $$(call DependOnVariable, $1_CONFIG_VARDEPS, \
-        $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1.config_vardeps)
+          $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1.config_vardeps)
 
       ifeq ($(call isBuildOs, windows), true)
         $1_ECHO_COMMAND := $(FIXPATH) cmd /c echo
       else
         $1_ECHO_COMMAND := $(ECHO)
       endif
-              $$($1_JAVAC_SERVER_CONFIG): $$($1_CONFIG_VARDEPS_FILE)
+      $$($1_JAVAC_SERVER_CONFIG): $$($1_CONFIG_VARDEPS_FILE)
 	$$($1_ECHO_COMMAND) portfile=$$($1_JAVAC_PORT_FILE) > $$@
 	$$($1_ECHO_COMMAND) servercmd=$$($1_JAVAC_SERVER_CMD) >> $$@
 

--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -177,6 +177,10 @@ define SetupJavaCompilationBody
     $$(error Must specify BIN (in $1))
   endif
 
+  ifneq ($$($1_MODULE), )
+    $1_MODULE_SUBDIR := /$$($1_MODULE)
+  endif
+
   $1_SAFE_NAME := $$(strip $$(subst /,_, $1))
 
   ifeq ($$($1_SMALL_JAVA), )
@@ -280,10 +284,6 @@ define SetupJavaCompilationBody
 
   ifneq ($$($1_CLASSPATH), )
     $1_FLAGS += -cp $$(call PathList, $$($1_CLASSPATH))
-  endif
-
-  ifneq ($$($1_MODULE), )
-    $1_MODULE_SUBDIR := /$$($1_MODULE)
   endif
 
   # Make sure the dirs exist, or that one of the EXTRA_FILES, that may not

--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -234,9 +234,14 @@ define SetupJavaCompilationBody
       $1_CONFIG_VARDEPS_FILE := $$(call DependOnVariable, $1_CONFIG_VARDEPS, \
         $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1.config_vardeps)
 
-      $$($1_JAVAC_SERVER_CONFIG): $$($1_CONFIG_VARDEPS_FILE)
-	$(ECHO) portfile=$$($1_JAVAC_PORT_FILE) > $$@
-	$(ECHO) servercmd=$$($1_JAVAC_SERVER_CMD) >> $$@
+      ifeq ($(call isBuildOs, windows), true)
+        $1_ECHO_COMMAND := $(FIXPATH) cmd /c echo
+      else
+        $1_ECHO_COMMAND := $(ECHO)
+      endif
+              $$($1_JAVAC_SERVER_CONFIG): $$($1_CONFIG_VARDEPS_FILE)
+	$$($1_ECHO_COMMAND) portfile=$$($1_JAVAC_PORT_FILE) > $$@
+	$$($1_ECHO_COMMAND) servercmd=$$($1_JAVAC_SERVER_CMD) >> $$@
 
       # Always use small java to launch client
       $1_JAVAC_CMD := $$(JAVA_SMALL) $$($1_JAVA_FLAGS) $$($1_JAVAC) \

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Util.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,13 +79,21 @@ public class Util {
         return extractStringOption(opName, s, null);
     }
 
-    public static String extractStringOption(String opName, String s, String deflt) {
+    private static String extractStringOptionWithDelimiter(String opName, String s, String deflt, char delimiter) {
         int p = s.indexOf(opName+"=");
         if (p == -1) return deflt;
         p+=opName.length()+1;
-        int pe = s.indexOf(',', p);
+        int pe = s.indexOf(delimiter, p);
         if (pe == -1) pe = s.length();
         return s.substring(p, pe);
+    }
+
+    public static String extractStringOption(String opName, String s, String deflt) {
+        return extractStringOptionWithDelimiter(opName, s, deflt, ',');
+    }
+
+    public static String extractStringOptionLine(String opName, String s, String deflt) {
+        return extractStringOptionWithDelimiter(opName, s, deflt, '\n').strip();
     }
 
     public static boolean extractBooleanOption(String opName, String s, boolean deflt) {


### PR DESCRIPTION
Currently, to use the javac server, a horrendously long command line option is created, looking like this: `--server:portfile=<path to portfile>:sjavac=<command to launch server>`, where the sjavac command has had all spaces replaced by %20. Since Project Jigsaw, the set of module arguments needed is huge to begin with, making this command line incomprehensible after mangling.

Apart from making java command lines hard to read (and copy/paste!) by developers, it also makes it hard for scripts to parse. The upcoming winenv rewrite is dependent on being able to differentiate between path names and other arguments, which is not possible in this mess.

So, instead, let's write it to a file, without any escaping, and just pass the configuration file name to the server.

Note that this will change the behavior of the javac server, but as the source code states this is not a documented or externally supported API no CSR is needed. 

I also cleaned up some code in SjavacClient, in particular code relating to the passing of arguments. (We never change poolsize or keepalive when we call it.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256308](https://bugs.openjdk.java.net/browse/JDK-8256308): Send arguments to javac server in a config file


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Joel Borggrén-Franck](https://openjdk.java.net/census#jfranck) (@jbf - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1195/head:pull/1195`
`$ git checkout pull/1195`
