### PR TITLE
8254872: Optimize Rotate on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -12786,160 +12786,96 @@ instruct extrAddI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI lshift, 
 
 // This pattern is automatically generated from aarch64_ad.m4
 // DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
-
-// rol expander
-instruct rolL_rReg(iRegLNoSp dst, iRegL src, iRegI shift, rFlagsReg cr)
+instruct rorI_imm(iRegINoSp dst, iRegI src, immI shift)
 %{
-  effect(DEF dst, USE src, USE shift);
+  match(Set dst (RotateRight src shift));
 
-  format %{ "rol    $dst, $src, $shift" %}
-  ins_cost(INSN_COST * 3);
-  ins_encode %{
-    __ subw(rscratch1, zr, as_Register($shift$$reg));
-    __ rorv(as_Register($dst$$reg), as_Register($src$$reg),
-            rscratch1);
-    %}
-  ins_pipe(ialu_reg_reg_vshift);
-%}
-
-// This pattern is automatically generated from aarch64_ad.m4
-// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
-
-// rol expander
-instruct rolI_rReg(iRegINoSp dst, iRegI src, iRegI shift, rFlagsReg cr)
-%{
-  effect(DEF dst, USE src, USE shift);
-
-  format %{ "rol    $dst, $src, $shift" %}
-  ins_cost(INSN_COST * 3);
-  ins_encode %{
-    __ subw(rscratch1, zr, as_Register($shift$$reg));
-    __ rorvw(as_Register($dst$$reg), as_Register($src$$reg),
-            rscratch1);
-    %}
-  ins_pipe(ialu_reg_reg_vshift);
-%}
-
-// This pattern is automatically generated from aarch64_ad.m4
-// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
-instruct rolL_rReg_Var_C_64(iRegLNoSp dst, iRegL src, iRegI shift, immI_64 c_64, rFlagsReg cr)
-%{
-  match(Set dst (OrL (LShiftL src shift) (URShiftL src (SubI c_64 shift))));
-
-  expand %{
-    rolL_rReg(dst, src, shift, cr);
-  %}
-%}
-
-// This pattern is automatically generated from aarch64_ad.m4
-// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
-instruct rolL_rReg_Var_C0(iRegLNoSp dst, iRegL src, iRegI shift, immI0 c0, rFlagsReg cr)
-%{
-  match(Set dst (OrL (LShiftL src shift) (URShiftL src (SubI c0 shift))));
-
-  expand %{
-    rolL_rReg(dst, src, shift, cr);
-  %}
-%}
-
-// This pattern is automatically generated from aarch64_ad.m4
-// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
-instruct rolI_rReg_Var_C_32(iRegINoSp dst, iRegI src, iRegI shift, immI_32 c_32, rFlagsReg cr)
-%{
-  match(Set dst (OrI (LShiftI src shift) (URShiftI src (SubI c_32 shift))));
-
-  expand %{
-    rolI_rReg(dst, src, shift, cr);
-  %}
-%}
-
-// This pattern is automatically generated from aarch64_ad.m4
-// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
-instruct rolI_rReg_Var_C0(iRegINoSp dst, iRegI src, iRegI shift, immI0 c0, rFlagsReg cr)
-%{
-  match(Set dst (OrI (LShiftI src shift) (URShiftI src (SubI c0 shift))));
-
-  expand %{
-    rolI_rReg(dst, src, shift, cr);
-  %}
-%}
-
-// This pattern is automatically generated from aarch64_ad.m4
-// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
-
-// ror expander
-instruct rorL_rReg(iRegLNoSp dst, iRegL src, iRegI shift, rFlagsReg cr)
-%{
-  effect(DEF dst, USE src, USE shift);
-
-  format %{ "ror    $dst, $src, $shift" %}
   ins_cost(INSN_COST);
-  ins_encode %{
-    __ rorv(as_Register($dst$$reg), as_Register($src$$reg),
-            as_Register($shift$$reg));
-    %}
-  ins_pipe(ialu_reg_reg_vshift);
-%}
-
-// This pattern is automatically generated from aarch64_ad.m4
-// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
-
-// ror expander
-instruct rorI_rReg(iRegINoSp dst, iRegI src, iRegI shift, rFlagsReg cr)
-%{
-  effect(DEF dst, USE src, USE shift);
-
   format %{ "ror    $dst, $src, $shift" %}
-  ins_cost(INSN_COST);
+
   ins_encode %{
-    __ rorvw(as_Register($dst$$reg), as_Register($src$$reg),
-            as_Register($shift$$reg));
-    %}
+     __ extrw(as_Register($dst$$reg), as_Register($src$$reg), as_Register($src$$reg),
+               $shift$$constant & 0x1f);
+  %}
   ins_pipe(ialu_reg_reg_vshift);
 %}
 
 // This pattern is automatically generated from aarch64_ad.m4
 // DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
-instruct rorL_rReg_Var_C_64(iRegLNoSp dst, iRegL src, iRegI shift, immI_64 c_64, rFlagsReg cr)
+instruct rorL_imm(iRegLNoSp dst, iRegL src, immI shift)
 %{
-  match(Set dst (OrL (URShiftL src shift) (LShiftL src (SubI c_64 shift))));
+  match(Set dst (RotateRight src shift));
 
-  expand %{
-    rorL_rReg(dst, src, shift, cr);
+  ins_cost(INSN_COST);
+  format %{ "ror    $dst, $src, $shift" %}
+
+  ins_encode %{
+     __ extr(as_Register($dst$$reg), as_Register($src$$reg), as_Register($src$$reg),
+               $shift$$constant & 0x3f);
   %}
+  ins_pipe(ialu_reg_reg_vshift);
 %}
 
 // This pattern is automatically generated from aarch64_ad.m4
 // DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
-instruct rorL_rReg_Var_C0(iRegLNoSp dst, iRegL src, iRegI shift, immI0 c0, rFlagsReg cr)
+instruct rorI_reg(iRegINoSp dst, iRegI src, iRegI shift)
 %{
-  match(Set dst (OrL (URShiftL src shift) (LShiftL src (SubI c0 shift))));
+  match(Set dst (RotateRight src shift));
 
-  expand %{
-    rorL_rReg(dst, src, shift, cr);
+  ins_cost(INSN_COST);
+  format %{ "ror    $dst, $src, $shift" %}
+
+  ins_encode %{
+     __ rorvw(as_Register($dst$$reg), as_Register($src$$reg), as_Register($shift$$reg));
   %}
+  ins_pipe(ialu_reg_reg_vshift);
 %}
 
 // This pattern is automatically generated from aarch64_ad.m4
 // DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
-instruct rorI_rReg_Var_C_32(iRegINoSp dst, iRegI src, iRegI shift, immI_32 c_32, rFlagsReg cr)
+instruct rorL_reg(iRegLNoSp dst, iRegL src, iRegI shift)
 %{
-  match(Set dst (OrI (URShiftI src shift) (LShiftI src (SubI c_32 shift))));
+  match(Set dst (RotateRight src shift));
 
-  expand %{
-    rorI_rReg(dst, src, shift, cr);
+  ins_cost(INSN_COST);
+  format %{ "ror    $dst, $src, $shift" %}
+
+  ins_encode %{
+     __ rorv(as_Register($dst$$reg), as_Register($src$$reg), as_Register($shift$$reg));
   %}
+  ins_pipe(ialu_reg_reg_vshift);
 %}
 
 // This pattern is automatically generated from aarch64_ad.m4
 // DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
-instruct rorI_rReg_Var_C0(iRegINoSp dst, iRegI src, iRegI shift, immI0 c0, rFlagsReg cr)
+instruct rolI_reg(iRegINoSp dst, iRegI src, iRegI shift)
 %{
-  match(Set dst (OrI (URShiftI src shift) (LShiftI src (SubI c0 shift))));
+  match(Set dst (RotateLeft src shift));
 
-  expand %{
-    rorI_rReg(dst, src, shift, cr);
+  ins_cost(INSN_COST);
+  format %{ "rol    $dst, $src, $shift" %}
+
+  ins_encode %{
+     __ subw(rscratch1, zr, as_Register($shift$$reg));
+     __ rorvw(as_Register($dst$$reg), as_Register($src$$reg), rscratch1);
   %}
+  ins_pipe(ialu_reg_reg_vshift);
+%}
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
+instruct rolL_reg(iRegLNoSp dst, iRegL src, iRegI shift)
+%{
+  match(Set dst (RotateLeft src shift));
+
+  ins_cost(INSN_COST);
+  format %{ "rol    $dst, $src, $shift" %}
+
+  ins_encode %{
+     __ subw(rscratch1, zr, as_Register($shift$$reg));
+     __ rorv(as_Register($dst$$reg), as_Register($src$$reg), rscratch1);
+  %}
+  ins_pipe(ialu_reg_reg_vshift);
 %}
 
 

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -1489,6 +1489,22 @@ const Type* RotateLeftNode::Value(PhaseGVN* phase) const {
   }
 }
 
+Node* RotateLeftNode::Ideal(PhaseGVN *phase, bool can_reshape) {
+  const Type *t1 = phase->type(in(1));
+  const Type *t2 = phase->type(in(2));
+  if (t2->isa_int() && t2->is_int()->is_con()) {
+    if (t1->isa_int()) {
+      int lshift = t2->is_int()->get_con() & 31;
+      return new RotateRightNode(in(1), phase->intcon(32 - (lshift & 31)), TypeInt::INT);
+    } else {
+      assert(t1->isa_long(), "Type must be a long");
+      int lshift = t2->is_int()->get_con() & 63;
+      return new RotateRightNode(in(1), phase->intcon(64 - (lshift & 63)), TypeLong::LONG);
+    }
+  }
+  return NULL;
+}
+
 const Type* RotateRightNode::Value(PhaseGVN* phase) const {
   const Type* t1 = phase->type(in(1));
   const Type* t2 = phase->type(in(2));

--- a/src/hotspot/share/opto/mulnode.hpp
+++ b/src/hotspot/share/opto/mulnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -221,6 +221,7 @@ class RotateLeftNode : public TypeNode {
   }
   virtual int Opcode() const;
   virtual const Type* Value(PhaseGVN* phase) const;
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 };
 
 //----------------------- RotateRightNode ----------------------------------


### PR DESCRIPTION
This patch is a supplement for
https://bugs.openjdk.java.net/browse/JDK-8248830.

With the implementation of rotate node in IR, this patch:

1. canonicalizes RotateLeft into RotateRight when shift is a constant,
   so that GVN could identify the pre-existing node better.
2. implements scalar rotate match rules and removes the original
   combinations of Or and Shifts on AArch64.

This patch doesn't implement vector rotate due to the lack of
corresponding vector instructions on AArch64.

Test case below is an explanation for this patch.

        public static int test(int i) {
            int a =  (i >>> 29) | (i << -29);
            int b = i << 3;
            int c = i >>> -3;
            int d = b | c;
            return a ^ d;
        }

Before:

        lsl     w12, w1, #3
        lsr     w10, w1, #29
        add     w11, w10, w12
        orr     w12, w12, w10
        eor     w0, w11, w12

After:

        ror     w10, w1, #29
        eor     w0, w10, w10

Tested jtreg TestRotate.java, hotspot::hotspot_all_no_apps,
jdk::jdk_core, langtools::tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254872](https://bugs.openjdk.java.net/browse/JDK-8254872): Optimize Rotate on AArch64


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1199/head:pull/1199`
`$ git checkout pull/1199`
