### PR TITLE
8256277: Github Action build on macOS should define OS and Xcode versions

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -991,7 +991,7 @@ jobs:
 
   macos_x64_build:
     name: macOS x64
-    runs-on: "macos-latest"
+    runs-on: "macos-10.15"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_macos_x64 != 'false'
 
@@ -1061,6 +1061,9 @@ jobs:
       - name: Install dependencies
         run: brew install make
 
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_11.3.1.app/Contents/Developer
+
       - name: Configure
         run: >
           bash configure
@@ -1091,7 +1094,7 @@ jobs:
 
   macos_x64_test:
     name: macOS x64
-    runs-on: "macos-latest"
+    runs-on: "macos-10.15"
     needs:
       - prerequisites
       - macos_x64_build
@@ -1203,6 +1206,9 @@ jobs:
 
       - name: Install dependencies
         run: brew install make
+
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_11.3.1.app/Contents/Developer
 
       - name: Find root of jdk image dir
         run: |


### PR DESCRIPTION
We should be more explicit about OS and compiler versions used in the GitHub Actions builds, to avoid problems caused by unexpected changes to the defaults. This patch changes the OS and Xcode versions used from latest (currently 10.15) / default (currently 12.0) to 10.15 / 11.3.1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256277](https://bugs.openjdk.java.net/browse/JDK-8256277): Github Action build on macOS should define OS and Xcode versions


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1201/head:pull/1201`
`$ git checkout pull/1201`
