### PR TITLE
8255058: C1: assert(is_virtual()) failed: type check

### DIFF
--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -1942,15 +1942,14 @@ void LinearScan::resolve_exception_edge(XHandler* handler, int throwing_op_id, i
     move_resolver.set_multiple_reads_allowed();
 
     Constant* con = from_value->as_Constant();
-    if (con != NULL && !con->is_pinned()) {
-      // unpinned constants may have no register, so add mapping from constant to interval
+    if (con != NULL && (!con->is_pinned() || con->operand()->is_constant())) {
+      // Need a mapping from constant to interval if unpinned (may have no register) or if the operand is a constant (no register).
       move_resolver.add_mapping(LIR_OprFact::value_type(con->type()), to_interval);
     } else {
       // search split child at the throwing op_id
       Interval* from_interval = interval_at_op_id(from_value->operand()->vreg_number(), throwing_op_id);
       move_resolver.add_mapping(from_interval, to_interval);
     }
-
   } else {
     // no phi function, so use reg_num also for from_interval
     // search split child at the throwing op_id

--- a/test/hotspot/jtreg/compiler/c1/TestPinnedConstantExceptionEdge.java
+++ b/test/hotspot/jtreg/compiler/c1/TestPinnedConstantExceptionEdge.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8255058
+ * @summary Add check in LinearScan::resolve_exception_edge for pinned constant that is not virtual which cannot be used to find an interval which
+            resulted in an assertion error.
+ * @run main/othervm -Xcomp -XX:TieredStopAtLevel=1 -XX:CompileCommand=dontinline,compiler.c1.TestPinnedConstantExceptionEdge::dontInline
+ *                   -XX:CompileCommand=compileonly,compiler.c1.TestPinnedConstantExceptionEdge::* compiler.c1.TestPinnedConstantExceptionEdge
+ */
+package compiler.c1;
+
+public class TestPinnedConstantExceptionEdge {
+
+    public static long iFld = 0;
+    public static boolean b1;
+    public static boolean b2;
+
+    public static void test() {
+        int x = 5;
+        int y = 11;
+        for (int i = 1; i < 8; i++) {
+            for (int j = 1; j < 2; ++j) {
+                if (b1) {
+                    try {
+                        y = (x / x);
+                        y = (500 / i);
+                        y = (-214 / i);
+                    } catch (ArithmeticException a_e) {}
+                    // Recursion too deep in UseCountComputer::uses_do and therefore constant 1 is pinned.
+                    iFld += (b1 ? 1 : 0) + (b2 ? 1 : 0) + 5 + 7 + 6 + 5 + y
+                            + dontInline(7) + dontInline(5) + 8 + 8 + 9
+                            + dontInline(3) + dontInline(3) + dontInline(4)
+                            + dontInline(dontInline(5)) + dontInline(2);
+                    return;
+                }
+            }
+        }
+    }
+
+    // Not inlined
+    public static int dontInline(int a) {
+        return 0;
+    }
+
+    public static void main(String[] strArr) {
+        test();
+    }
+}
+


### PR DESCRIPTION
The following code for handling phi functions of an exception entry block in the method `LinearScan::resolve_exception_edge` assumes that pinned `Constant` instructions (executing the else case) have a virtual operand and therefore an interval assigned:
https://github.com/openjdk/jdk/blob/05b824567c346a7d136c01d23f56a908e7efc6d7/src/hotspot/share/c1/c1_LinearScan.cpp#L1944-L1952
In the testcase, however, this is not the case: A `Constant` instruction with a constant operand that is part of the long addition chain in the assignment for `iFld` (starting on L52) is pinned in `UseCountComputer::block_do`because it recursed too deeply:
https://github.com/openjdk/jdk/blob/05b824567c346a7d136c01d23f56a908e7efc6d7/src/hotspot/share/c1/c1_IR.cpp#L388-L392
https://github.com/openjdk/jdk/blob/05b824567c346a7d136c01d23f56a908e7efc6d7/src/hotspot/share/c1/c1_IR.cpp#L414-L423
As a result, the else case is executed in `LinearScan::resolve_exception_edge` which results in this assertion failure because `vreg_num()` only works on virtual operands that belong to an interval.

The fix is straight forward to also do a mapping to an interval for pinned `Constant` instructions with constant operands as we already do for non-pinned `Constant` instructions.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255058](https://bugs.openjdk.java.net/browse/JDK-8255058): C1: assert(is_virtual()) failed: type check


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1202/head:pull/1202`
`$ git checkout pull/1202`
