### PR TITLE
8256337: ap01t001.cpp, 67: Received unexpected number of ObjectFree events: 7

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP01/ap01t001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP01/ap01t001.java
@@ -32,6 +32,8 @@ import nsk.share.jvmti.*;
 public class ap01t001 extends DebugeeClass implements Cloneable {
     /* number of interations to provoke garbage collecting */
     final static int GC_TRYS = 4;
+    // Prevent test run instance from being freed too early
+    static ap01t001 keepAlive;
 
     public static void main(String[] argv) {
         argv = nsk.share.jvmti.JVMTITest.commonInit(argv);
@@ -41,7 +43,7 @@ public class ap01t001 extends DebugeeClass implements Cloneable {
     }
 
     public static int run(String argv[], PrintStream out) {
-        return new ap01t001().runThis(argv, out);
+        return (keepAlive = new ap01t001()).runThis(argv, out);
     }
 /*
     private native void setTag();


### PR DESCRIPTION
The ap01t001 test creates six extra instances of the tested class, let them die, and then checks that it gets exactly six ObjectFree callbacks. The problem is that this is verified in the VMDeath callback and at that point the instance has gone out-of-scope and and a seventh ObjectFree event has been triggered.

My proposed fix is to ensure that the test instance is kept alive.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256337](https://bugs.openjdk.java.net/browse/JDK-8256337): ap01t001.cpp, 67: Received unexpected number of ObjectFree events: 7


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1204/head:pull/1204`
`$ git checkout pull/1204`
