### PR TITLE
8256363: Define toString() for MGF1ParameterSpec

### DIFF
--- a/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
@@ -25,8 +25,6 @@
 
 package java.security.spec;
 
-import java.security.spec.AlgorithmParameterSpec;
-
 /**
  * This class specifies the set of parameters used with mask generation
  * function MGF1 in OAEP Padding and RSASSA-PSS signature scheme, as
@@ -165,6 +163,6 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
 
     @Override
     public String toString() {
-        return "MGF1:" + mdName;
+        return "MGF1ParameterSpec[hashAlgorithm=" + mdName + "]";
     }
 }

--- a/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
@@ -162,4 +162,9 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
     public String getDigestAlgorithm() {
         return mdName;
     }
+
+    @Override
+    public String toString() {
+        return "MGF1:" + mdName;
+    }
 }

--- a/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
@@ -220,11 +220,12 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("MD: " + mdName + ", ")
-                .append("MGF: " + mgfSpec + ", ")
-                .append("SaltLength: " + saltLen + ", ")
-                .append("TrailerField: " + trailerField);
+        StringBuilder sb = new StringBuilder("PSSParameterSpec[");
+        sb.append("hashAlgorithm=" + mdName + ", ")
+                .append("maskGenAlgorithm=" + mgfSpec + ", ")
+                .append("saltLength=" + saltLen + ", ")
+                .append("trailerField=" + trailerField)
+                .append(']');
         return sb.toString();
     }
 }

--- a/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -221,10 +221,10 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("MD: " + mdName + "\n")
-                .append("MGF: " + mgfSpec + "\n")
-                .append("SaltLength: " + saltLen + "\n")
-                .append("TrailerField: " + trailerField + "\n");
+        sb.append("MD: " + mdName + ", ")
+                .append("MGF: " + mgfSpec + ", ")
+                .append("SaltLength: " + saltLen + ", ")
+                .append("TrailerField: " + trailerField);
         return sb.toString();
     }
 }

--- a/src/java.base/share/classes/sun/security/util/SignatureUtil.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureUtil.java
@@ -510,15 +510,15 @@ public class SignatureUtil {
     private static class PSSParamsHolder {
         final static PSSParameterSpec PSS_256_SPEC = new PSSParameterSpec(
                 "SHA-256", "MGF1",
-                new MGF1ParameterSpec("SHA-256"),
+                MGF1ParameterSpec.SHA256,
                 32, PSSParameterSpec.TRAILER_FIELD_BC);
         final static PSSParameterSpec PSS_384_SPEC = new PSSParameterSpec(
                 "SHA-384", "MGF1",
-                new MGF1ParameterSpec("SHA-384"),
+                MGF1ParameterSpec.SHA384,
                 48, PSSParameterSpec.TRAILER_FIELD_BC);
         final static PSSParameterSpec PSS_512_SPEC = new PSSParameterSpec(
                 "SHA-512", "MGF1",
-                new MGF1ParameterSpec("SHA-512"),
+                MGF1ParameterSpec.SHA512,
                 64, PSSParameterSpec.TRAILER_FIELD_BC);
     }
 


### PR DESCRIPTION
Without this method, `PSSParameterSpec::toString` shows something like:
```
MD: SHA-256
MGF: java.security.spec.MGF1ParameterSpec@77b52d12
SaltLength: 32
TrailerField: 1
```
This is ugly.

Noreg-trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256363](https://bugs.openjdk.java.net/browse/JDK-8256363): Define toString() for MGF1ParameterSpec


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1208/head:pull/1208`
`$ git checkout pull/1208`
