### PR TITLE
8256318: AArch64: Add support for floating-point absolute difference

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -13973,6 +13973,34 @@ instruct absD_reg(vRegD dst, vRegD src) %{
   ins_pipe(fp_uop_d);
 %}
 
+instruct absdF_reg(vRegF dst, vRegF src1, vRegF src2) %{
+  match(Set dst (AbsF (SubF src1 src2)));
+
+  ins_cost(INSN_COST * 3);
+  format %{ "fabds   $dst, $src1, $src2" %}
+  ins_encode %{
+    __ fabds(as_FloatRegister($dst$$reg),
+             as_FloatRegister($src1$$reg),
+             as_FloatRegister($src2$$reg));
+  %}
+
+  ins_pipe(fp_uop_s);
+%}
+
+instruct absdD_reg(vRegD dst, vRegD src1, vRegD src2) %{
+  match(Set dst (AbsD (SubD src1 src2)));
+
+  ins_cost(INSN_COST * 3);
+  format %{ "fabdd   $dst, $src1, $src2" %}
+  ins_encode %{
+    __ fabdd(as_FloatRegister($dst$$reg),
+             as_FloatRegister($src1$$reg),
+             as_FloatRegister($src2$$reg));
+  %}
+
+  ins_pipe(fp_uop_d);
+%}
+
 instruct sqrtD_reg(vRegD dst, vRegD src) %{
   match(Set dst (SqrtD src));
 
@@ -18070,6 +18098,47 @@ instruct vabs2D(vecX dst, vecX src)
   format %{ "fabs  $dst,$src\t# vector (2D)" %}
   ins_encode %{
     __ fabs(as_FloatRegister($dst$$reg), __ T2D, as_FloatRegister($src$$reg));
+  %}
+  ins_pipe(vunop_fp128);
+%}
+
+// --------------------------------- FABS DIFF --------------------------------
+
+instruct vabsd2F(vecD dst, vecD src1, vecD src2)
+%{
+  predicate(n->as_Vector()->length() == 2);
+  match(Set dst (AbsVF (SubVF src1 src2)));
+  ins_cost(INSN_COST * 3);
+  format %{ "fabd  $dst,$src1,$src2\t# vector (2S)" %}
+  ins_encode %{
+    __ fabd(as_FloatRegister($dst$$reg), __ T2S,
+            as_FloatRegister($src1$$reg), as_FloatRegister($src2$$reg));
+  %}
+  ins_pipe(vunop_fp64);
+%}
+
+instruct vabsd4F(vecX dst, vecX src1, vecX src2)
+%{
+  predicate(n->as_Vector()->length() == 4);
+  match(Set dst (AbsVF (SubVF src1 src2)));
+  ins_cost(INSN_COST * 3);
+  format %{ "fabd  $dst,$src1,$src2\t# vector (4S)" %}
+  ins_encode %{
+    __ fabd(as_FloatRegister($dst$$reg), __ T4S,
+            as_FloatRegister($src1$$reg), as_FloatRegister($src2$$reg));
+  %}
+  ins_pipe(vunop_fp128);
+%}
+
+instruct vabsd2D(vecX dst, vecX src1, vecX src2)
+%{
+  predicate(n->as_Vector()->length() == 2);
+  match(Set dst (AbsVD (SubVD src1 src2)));
+  ins_cost(INSN_COST * 3);
+  format %{ "fabd  $dst,$src1,$src2\t# vector (2D)" %}
+  ins_encode %{
+    __ fabd(as_FloatRegister($dst$$reg), __ T2D,
+            as_FloatRegister($src1$$reg), as_FloatRegister($src2$$reg));
   %}
   ins_pipe(vunop_fp128);
 %}

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -1949,7 +1949,7 @@ public:
     starti;
     f(op31, 31, 29);
     f(0b11110, 28, 24);
-    f(type, 23, 22), f(1, 21), f(opcode, 15, 12), f(0b10, 11, 10);
+    f(type, 23, 22), f(1, 21), f(opcode, 15, 10);
     rf(Vm, 16), rf(Vn, 5), rf(Vd, 0);
   }
 
@@ -1958,21 +1958,23 @@ public:
     data_processing(op31, type, opcode, Vd, Vn, Vm);    \
   }
 
-  INSN(fmuls, 0b000, 0b00, 0b0000);
-  INSN(fdivs, 0b000, 0b00, 0b0001);
-  INSN(fadds, 0b000, 0b00, 0b0010);
-  INSN(fsubs, 0b000, 0b00, 0b0011);
-  INSN(fmaxs, 0b000, 0b00, 0b0100);
-  INSN(fmins, 0b000, 0b00, 0b0101);
-  INSN(fnmuls, 0b000, 0b00, 0b1000);
+  INSN(fabds,  0b011, 0b10, 0b110101);
+  INSN(fmuls,  0b000, 0b00, 0b000010);
+  INSN(fdivs,  0b000, 0b00, 0b000110);
+  INSN(fadds,  0b000, 0b00, 0b001010);
+  INSN(fsubs,  0b000, 0b00, 0b001110);
+  INSN(fmaxs,  0b000, 0b00, 0b010010);
+  INSN(fmins,  0b000, 0b00, 0b010110);
+  INSN(fnmuls, 0b000, 0b00, 0b100010);
 
-  INSN(fmuld, 0b000, 0b01, 0b0000);
-  INSN(fdivd, 0b000, 0b01, 0b0001);
-  INSN(faddd, 0b000, 0b01, 0b0010);
-  INSN(fsubd, 0b000, 0b01, 0b0011);
-  INSN(fmaxd, 0b000, 0b01, 0b0100);
-  INSN(fmind, 0b000, 0b01, 0b0101);
-  INSN(fnmuld, 0b000, 0b01, 0b1000);
+  INSN(fabdd,  0b011, 0b11, 0b110101);
+  INSN(fmuld,  0b000, 0b01, 0b000010);
+  INSN(fdivd,  0b000, 0b01, 0b000110);
+  INSN(faddd,  0b000, 0b01, 0b001010);
+  INSN(fsubd,  0b000, 0b01, 0b001110);
+  INSN(fmaxd,  0b000, 0b01, 0b010010);
+  INSN(fmind,  0b000, 0b01, 0b010110);
+  INSN(fnmuld, 0b000, 0b01, 0b100010);
 
 #undef INSN
 
@@ -2482,6 +2484,7 @@ public:
     f(T==T2D ? 1:0, 22); f(1, 21), rf(Vm, 16), f(op3, 15, 10), rf(Vn, 5), rf(Vd, 0);    \
   }
 
+  INSN(fabd, 1, 1, 0b110101);
   INSN(fadd, 0, 0, 0b110101);
   INSN(fdiv, 1, 0, 0b111111);
   INSN(fmul, 1, 0, 0b110111);
@@ -2689,7 +2692,7 @@ public:
   INSN(sshr, 0, 0b000001, /* isSHR = */ true);
   INSN(ushr, 1, 0b000001, /* isSHR = */ true);
   INSN(usra, 1, 0b000101, /* isSHR = */ true);
-  INSN(ssra, 0, 0b000101, /* isSHAR =*/ true);
+  INSN(ssra, 0, 0b000101, /* isSHR = */ true);
 
 #undef INSN
 

--- a/test/hotspot/jtreg/compiler/c2/Test8217359.java
+++ b/test/hotspot/jtreg/compiler/c2/Test8217359.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2019, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/TestFoldCompares.java
+++ b/test/hotspot/jtreg/compiler/c2/TestFoldCompares.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/TestReplaceEquivPhis.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReplaceEquivPhis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestVectorShiftShorts.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestVectorShiftShorts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnUnsupportedCPU.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA3Intrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA3Intrinsics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA3MultiBlockIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA3MultiBlockIntrinsics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/loopopts/TestBeautifyLoops.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestBeautifyLoops.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/loopopts/TestBeautifyLoops_2.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestBeautifyLoops_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2019, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestSearchAlignment.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestSearchAlignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/invokedynamic/DynamicConstantHelper.jasm
+++ b/test/hotspot/jtreg/runtime/invokedynamic/DynamicConstantHelper.jasm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/invokedynamic/TestDynamicConstant.java
+++ b/test/hotspot/jtreg/runtime/invokedynamic/TestDynamicConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/provider/MessageDigest/SHA3.java
+++ b/test/jdk/sun/security/provider/MessageDigest/SHA3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/Base64Encode.java
+++ b/test/micro/org/openjdk/bench/java/util/Base64Encode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/vm/compiler/FloatingScalarVectorAbsDiff.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/FloatingScalarVectorAbsDiff.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.Random;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class FloatingScalarVectorAbsDiff {
+    @Param({"1024"})
+    public int count;
+
+    private float[]  floatsA,  floatsB,  floatsD;
+    private double[] doublesA, doublesB, doublesD;
+
+    @Param("316731")
+    private int seed;
+    private Random r = new Random(seed);
+
+    @Setup
+    public void init() {
+        floatsA  = new float[count];
+        doublesA = new double[count];
+
+        floatsB  = new float[count];
+        doublesB = new double[count];
+
+        floatsD  = new float[count];
+        doublesD = new double[count];
+
+        for (int i = 0; i < count; i++) {
+            floatsA[i]  = r.nextFloat();
+            doublesB[i] = r.nextDouble();
+
+            floatsB[i]  = r.nextFloat();
+            doublesB[i] = r.nextDouble();
+        }
+    }
+
+    @Benchmark
+    public void testVectorAbsDiffFloat() {
+        for (int i = 0; i < count; i++) {
+            floatsD[i] = Math.abs(floatsA[i] - floatsB[i]);
+        }
+    }
+
+    @Benchmark
+    public void testVectorAbsDiffDouble() {
+        for (int i = 0; i < count; i++) {
+            doublesD[i] = Math.abs(doublesA[i] - doublesB[i]);
+        }
+    }
+
+    @Benchmark
+    public void testScalarAbsDiffFloat(Blackhole bh) {
+        float a = r.nextFloat();
+        float b = r.nextFloat();
+
+        for (int i = 0; i < count; i++) {
+            a = Math.abs(a - b);
+            b = Math.abs(b - a);
+        }
+
+        bh.consume(a + b);
+    }
+
+    @Benchmark
+    public void testScalarAbsDiffDouble(Blackhole bh) {
+        double a = r.nextDouble();
+        double b = r.nextDouble();
+
+        for (int i = 0; i < count; i++) {
+            a = Math.abs(a - b);
+            b = Math.abs(b - a);
+        }
+
+        bh.consume(a + b);
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorShiftAccumulate.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorShiftAccumulate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This supports for floating-point absolute difference instructions, i.e. FABD scalar/vector.

Verified with linux-aarch64-server-release, tier1-3.

Added a JMH micro `test/micro/org/openjdk/bench/vm/compiler/FloatingScalarVectorAbsDiff.java` for performance test.

The FABD (scalar), the performance tests handle registers directly, the average latency reduces to almost half of (~57%) the original.
For FABD (vector), we restrict the data size (~24KB) to be less than L1 data cache size (32KB),
so that the memory access can hit in L1, and witness 14.2% (float) and 21.2% (double) improvements.

The JMH results on Kunpeng916:

```
Benchmark                                            (count)  (seed)  Mode  Cnt     Score    Error  Units

# before, fsub+fabs
FloatingScalarVectorAbsDiff.testScalarAbsDiffDouble     1024  316731  avgt   10  6038.333 ± 3.889  ns/op
FloatingScalarVectorAbsDiff.testScalarAbsDiffFloat      1024  316731  avgt   10  6005.125 ± 3.025  ns/op
FloatingScalarVectorAbsDiff.testVectorAbsDiffDouble     1024  316731  avgt   10   950.340 ± 9.398  ns/op
FloatingScalarVectorAbsDiff.testVectorAbsDiffFloat      1024  316731  avgt   10   454.350 ± 1.798  ns/op

# after, fabd
FloatingScalarVectorAbsDiff.testScalarAbsDiffDouble     1024  316731  avgt   10  3483.801 ± 1.763  ns/op
FloatingScalarVectorAbsDiff.testScalarAbsDiffFloat      1024  316731  avgt   10  3442.412 ± 1.866  ns/op
FloatingScalarVectorAbsDiff.testVectorAbsDiffDouble     1024  316731  avgt   10   816.301 ± 4.454  ns/op
FloatingScalarVectorAbsDiff.testVectorAbsDiffFloat      1024  316731  avgt   10   354.710 ± 1.001  ns/op
```