### PR TITLE
8227106: InitiatingHeapOccupancyPercent is G1-specific but defined in shared

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -51,6 +51,18 @@
           "of the optimal occupancy to start marking.")                     \
           range(1, max_intx)                                                \
                                                                             \
+    product(uintx, InitiatingHeapOccupancyPercent, 45,                      \
+          "The percent occupancy (IHOP) of the current old generation "     \
+          "capacity above which a concurrent mark cycle will be initiated " \
+          "Its value may change over time if adaptive IHOP is enabled, "    \
+          "otherwise the value remains constant. "                          \
+          "In the latter case a value of 0 will result as frequent as "     \
+          "possible concurrent marking cycles. A value of 100 disables "    \
+          "concurrent marking. "                                            \
+          "Fragmentation waste in the old generation is not considered "    \
+          "free space in this calculation. (G1 collector only)")            \
+          range(0, 100)                                                     \
+                                                                            \
   product(uintx, G1ConfidencePercent, 50,                                   \
           "Confidence level for MMU/pause predictions")                     \
           range(0, 100)                                                     \

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -232,18 +232,6 @@
                "ParallelRefProcEnabled is true. Specify 0 to disable and "  \
                "use all threads.")                                          \
                                                                             \
-  product(uintx, InitiatingHeapOccupancyPercent, 45,                        \
-          "The percent occupancy (IHOP) of the current old generation "     \
-          "capacity above which a concurrent mark cycle will be initiated " \
-          "Its value may change over time if adaptive IHOP is enabled, "    \
-          "otherwise the value remains constant. "                          \
-          "In the latter case a value of 0 will result as frequent as "     \
-          "possible concurrent marking cycles. A value of 100 disables "    \
-          "concurrent marking. "                                            \
-          "Fragmentation waste in the old generation is not considered "    \
-          "free space in this calculation. (G1 collector only)")            \
-          range(0, 100)                                                     \
-                                                                            \
   notproduct(bool, ScavengeALot, false,                                     \
           "Force scavenge at every Nth exit from the runtime system "       \
           "(N=ScavengeALotInterval)")                                       \


### PR DESCRIPTION
Hi all,

Please review this little fix of G1.
The command line option InitiatingHeapOccupancyPercent is G1-specific. But it is defined in shared/gc_globals.hpp rather than g1/g1_globals.hpp. This patch moves it to the proper location.
Thank you for taking the time to review.

Best Regards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8227106](https://bugs.openjdk.java.net/browse/JDK-8227106): InitiatingHeapOccupancyPercent is G1-specific but defined in shared


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1217/head:pull/1217`
`$ git checkout pull/1217`
