### PR TITLE
8255387: Japanese characters were printed upside down on AIX

### DIFF
--- a/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
+++ b/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -529,7 +529,8 @@ Java_sun_font_FreetypeFontScaler_createScalerContextNative(
      */
     if ((aa != TEXT_AA_ON) && (fm != TEXT_FM_ON) &&
         !context->doBold && !context->doItalize &&
-        (context->transform.yx == 0) && (context->transform.xy == 0))
+        (context->transform.yx == 0) && (context->transform.xy == 0) &&
+        (context->transform.yy > 0))
     {
         context->useSbits = 1;
     }

--- a/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
+++ b/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
@@ -530,7 +530,7 @@ Java_sun_font_FreetypeFontScaler_createScalerContextNative(
     if ((aa != TEXT_AA_ON) && (fm != TEXT_FM_ON) &&
         !context->doBold && !context->doItalize &&
         (context->transform.yx == 0) && (context->transform.xy == 0) &&
-        (context->transform.yy > 0))
+        (context->transform.xx > 0) && (context->transform.yy > 0))
     {
         context->useSbits = 1;
     }

--- a/test/jdk/java/awt/font/Rotate/MirrorTest.java
+++ b/test/jdk/java/awt/font/Rotate/MirrorTest.java
@@ -22,10 +22,10 @@
  */
 
 /*
- * @test PrintTranslateTest
+ * @test MirrorTest
  * @bug 8255387
  * @summary Vertial mirrored characters should be drawn correctly
- * @run main PrintTranslateTest
+ * @run main MirrorTest
  */
 
 import java.awt.Color;
@@ -37,7 +37,7 @@ import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 
-public class PrintTranslateTest{
+public class MirrorTest{
     static String target = "\u3042";
     static final int SIZE = 50;
     static final int LIMIT = 40;

--- a/test/jdk/java/awt/font/Rotate/MirrorTest.java
+++ b/test/jdk/java/awt/font/Rotate/MirrorTest.java
@@ -37,7 +37,7 @@ import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 
-public class MirrorTest{
+public class MirrorTest {
     static String target = "\u3042";
     static final int SIZE = 50;
     static final int LIMIT = 40;

--- a/test/jdk/java/awt/font/Rotate/MirrorTest.java
+++ b/test/jdk/java/awt/font/Rotate/MirrorTest.java
@@ -24,7 +24,7 @@
 /*
  * @test MirrorTest
  * @bug 8255387
- * @summary Vertial mirrored characters should be drawn correctly
+ * @summary Mirrored characters should be drawn correctly
  * @run main MirrorTest
  */
 
@@ -60,7 +60,7 @@ public class MirrorTest {
         return image;
     }
 
-    static BufferedImage drawMirror(Font font) {
+    static BufferedImage drawVerticalMirror(Font font) {
         BufferedImage image = new BufferedImage(SIZE, SIZE,
                                       BufferedImage.TYPE_BYTE_BINARY);
         Graphics2D g2d = image.createGraphics();
@@ -83,6 +83,30 @@ public class MirrorTest {
         return image;
     }
 
+    static BufferedImage drawHorizontalMirror(Font font) {
+        BufferedImage image = new BufferedImage(SIZE, SIZE,
+                                      BufferedImage.TYPE_BYTE_BINARY);
+        Graphics2D g2d = image.createGraphics();
+        g2d.setColor(Color.white);
+        g2d.fillRect(0, 0, image.getWidth(), image.getHeight());
+        g2d.setColor(Color.black);
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                             RenderingHints.VALUE_ANTIALIAS_OFF);
+
+        AffineTransform base = g2d.getTransform();
+        AffineTransform trans = new AffineTransform(-1.0, 0, 0, 1.0, 0, 0);
+        trans.concatenate(base);
+        g2d.setTransform(trans);
+
+        g2d.setFont(font);
+
+        FontMetrics fm = g2d.getFontMetrics();
+        g2d.drawString(target, 5-image.getWidth(), fm.getAscent());
+        g2d.dispose();
+        return image;
+    }
+
+
     public static void main(String[] args) {
         GraphicsEnvironment ge =
             GraphicsEnvironment.getLocalGraphicsEnvironment();
@@ -94,20 +118,32 @@ public class MirrorTest {
             }
             font = font.deriveFont(12.0f);
             BufferedImage img1 = drawNormal(font);
-            BufferedImage img2 = drawMirror(font);
-            int errorCount = 0;
+            BufferedImage img2 = drawVerticalMirror(font);
+            int errorCount1 = 0;
             for (int j = 0; j < SIZE; j++) {
                 for (int i = 0; i < SIZE; i++) {
                     int c1 = img1.getRGB(i, j) & 0xFFFFFF;
                     int c2 = img2.getRGB(i, SIZE-j-1) & 0xFFFFFF;
                     if (c1 != c2) {
-                        errorCount++;
+                        errorCount1++;
                     }
                 }
             }
-            if (errorCount > LIMIT) {
-                System.out.println("ErrorCount="+errorCount);
-                System.out.println("Font="+font);
+
+            img2 = drawHorizontalMirror(font);
+            int errorCount2 = 0;
+            for (int j = 0; j < SIZE; j++) {
+                for (int i = 0; i < SIZE; i++) {
+                    int c1 = img1.getRGB(i, j) & 0xFFFFFF;
+                    int c2 = img2.getRGB(SIZE-i-1, j) & 0xFFFFFF;
+                    if (c1 != c2) {
+                        errorCount2++;
+                    }
+                }
+            }
+
+            if (errorCount1 > LIMIT || errorCount2 > LIMIT) {
+                System.out.println("ErrorCount:"+errorCount1+","+errorCount2);
                 throw new RuntimeException(
                     "Incorrect mirrored character with " + font);
             }

--- a/test/jdk/java/awt/print/PrinterJob/PrintTranslateTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintTranslateTest.java
@@ -24,7 +24,7 @@
 /*
  * @test PrintTranslateTest
  * @bug 8255387
- * @summary Virtial mirrored characters should be drawn correctly
+ * @summary Vertial mirrored characters should be drawn correctly
  * @run main PrintTranslateTest
  */
 
@@ -104,7 +104,6 @@ public class PrintTranslateTest{
                         errorCount++;
                     }
                 }
-                sb.append("\n");
             }
             if (errorCount > LIMIT) {
                 System.out.println("ErrorCount="+errorCount);

--- a/test/jdk/java/awt/print/PrinterJob/PrintTranslateTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintTranslateTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test PrintTranslateTest
+ * @bug 8255387
+ * @summary Virtial mirrored characters should be drawn correctly
+ * @run main PrintTranslateTest
+ */
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsEnvironment;
+import java.awt.RenderingHints;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+
+public class PrintTranslateTest{
+    static String target = "\u3042";
+    static final int SIZE = 50;
+    static final int LIMIT = 40;
+
+    static BufferedImage drawNormal(Font font) {
+        BufferedImage image = new BufferedImage(SIZE, SIZE,
+                                      BufferedImage.TYPE_BYTE_BINARY);
+        Graphics2D g2d = image.createGraphics();
+        g2d.setColor(Color.white);
+        g2d.fillRect(0, 0, image.getWidth(), image.getHeight());
+        g2d.setColor(Color.black);
+        //Set antialias on not to use embedded bitmap for reference
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                             RenderingHints.VALUE_ANTIALIAS_ON);
+
+        g2d.setFont(font);
+        FontMetrics fm = g2d.getFontMetrics();
+        g2d.drawString(target, 5, fm.getAscent());
+        g2d.dispose();
+        return image;
+    }
+
+    static BufferedImage drawMirror(Font font) {
+        BufferedImage image = new BufferedImage(SIZE, SIZE,
+                                      BufferedImage.TYPE_BYTE_BINARY);
+        Graphics2D g2d = image.createGraphics();
+        g2d.setColor(Color.white);
+        g2d.fillRect(0, 0, image.getWidth(), image.getHeight());
+        g2d.setColor(Color.black);
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                             RenderingHints.VALUE_ANTIALIAS_OFF);
+
+        AffineTransform base = g2d.getTransform();
+        AffineTransform trans = new AffineTransform(1.0, 0, 0, -1.0, 0, 0);
+        trans.concatenate(base);
+        g2d.setTransform(trans);
+
+        g2d.setFont(font);
+
+        FontMetrics fm = g2d.getFontMetrics();
+        g2d.drawString(target, 5, -image.getHeight()+fm.getAscent());
+        g2d.dispose();
+        return image;
+    }
+
+    public static void main(String[] args) {
+        GraphicsEnvironment ge =
+            GraphicsEnvironment.getLocalGraphicsEnvironment();
+        Font fonts[] = ge.getAllFonts();
+
+        for (Font font: fonts) {
+            if (!font.canDisplay(target.charAt(0))) {
+                continue;
+            }
+            font = font.deriveFont(12.0f);
+            BufferedImage img1 = drawNormal(font);
+            BufferedImage img2 = drawMirror(font);
+            int errorCount = 0;
+            for (int j = 0; j < SIZE; j++) {
+                for (int i = 0; i < SIZE; i++) {
+                    int c1 = img1.getRGB(i, j) & 0xFFFFFF;
+                    int c2 = img2.getRGB(i, SIZE-j-1) & 0xFFFFFF;
+                    if (c1 != c2) {
+                        errorCount++;
+                    }
+                }
+                sb.append("\n");
+            }
+            if (errorCount > LIMIT) {
+                System.out.println("ErrorCount="+errorCount);
+                System.out.println("Font="+font);
+                throw new RuntimeException(
+                    "Incorrect mirrored character with " + font);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Hi,

Could you review this fix? Under some special conditions, non-English characters were printed upside down.

At printing with raster image, the image was generated from bottom to top. So, each characters should also be drawn as vertical mirrored. However, freetype doesn't support to transform it if the font is using embedded bitmap and non-English. As the result, these Japanese characters were printed as upside down.

In this case, freetype should be prevented to use embedded bitmap.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255387](https://bugs.openjdk.java.net/browse/JDK-8255387): Japanese characters were printed upside down on AIX


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to 5bd7d84bbd0d57503e728f59ba9e6cae2dbc554b
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1218/head:pull/1218`
`$ git checkout pull/1218`
