### PR TITLE
8256323: Remove HeapRegionManager::update_committed_space() 

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.hpp
@@ -107,9 +107,6 @@ class HeapRegionManager: public CHeapObj<mtGC> {
   // Pass down commit calls to the VirtualSpace.
   void commit_regions(uint index, size_t num_regions = 1, WorkGang* pretouch_gang = NULL);
 
-  // Notify other data structures about change in the heap layout.
-  void update_committed_space(HeapWord* old_end, HeapWord* new_end);
-
   // Find a contiguous set of empty or uncommitted regions of length num_regions and return
   // the index of the first region or G1_NO_HRM_INDEX if the search was unsuccessful.
   // Start and end defines the range to seek in, policy is first-fit.


### PR DESCRIPTION
Hi all,

  can I have reviews for this trivial removal of the unimplemented function declaration of HeapRegionManager::update_committed_space()?

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256323](https://bugs.openjdk.java.net/browse/JDK-8256323): Remove HeapRegionManager::update_committed_space()


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1219/head:pull/1219`
`$ git checkout pull/1219`
