### PR TITLE
8229862: NPE in jdk.compiler/com.sun.tools.javac.jvm.Code.emitop0(Code.java:570)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -1454,11 +1454,11 @@ public class LambdaToMethod extends TreeTranslator {
                     localContext = localContext.prev;
                 }
             }
+            super.visitNewClass(tree);
             if (context() != null && !inReferencedClass && isLocal) {
                 LambdaTranslationContext lambdaContext = (LambdaTranslationContext)context();
                 captureLocalClassDefs(def, lambdaContext);
             }
-            super.visitNewClass(tree);
         }
         //where
             void captureLocalClassDefs(Symbol csym, final LambdaTranslationContext lambdaContext) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -2827,7 +2827,14 @@ public class Lower extends TreeTranslator {
         // If we have an anonymous class, create its flat version, rather
         // than the class or interface following new.
         if (tree.def != null) {
-            translate(tree.def);
+            Map<Symbol, Symbol> prevLambdaTranslationMap = lambdaTranslationMap;
+            try {
+                lambdaTranslationMap = null;
+                translate(tree.def);
+            } finally {
+                lambdaTranslationMap = prevLambdaTranslationMap;
+            }
+
             tree.clazz = access(make_at(tree.clazz.pos()).Ident(tree.def.sym));
             tree.def = null;
         } else {

--- a/test/langtools/tools/javac/lambda/LambdaConv30.java
+++ b/test/langtools/tools/javac/lambda/LambdaConv30.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8229862
+ * @summary Verifying lambdas anonymous classes whose supertype captures works.
+ * @compile LambdaConv30.java
+ * @run main LambdaConv30
+ */
+public class LambdaConv30 {
+
+     public static void main(String[] args) {
+        Integer a = 1;
+        class Inner {
+            int i;
+            Inner(int i) {
+                this.i = i;
+            }
+
+            public int result() {
+                return a * 1000 + i;
+            }
+        }
+        SAM s = v -> new Inner(v) { }.result();
+        if (s.m(2) != 1002) {
+            throw new AssertionError("Unexpected value!");
+        }
+     }
+
+     interface SAM {
+         int m(int v);
+     }
+}

--- a/test/langtools/tools/javac/lambda/LambdaConv30.java
+++ b/test/langtools/tools/javac/lambda/LambdaConv30.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Based on Bernard's code from:
http://mail.openjdk.java.net/pipermail/compiler-dev/2020-October/015225.html

Capturing anonymous classes inside lambdas may fail to compile, because:
-the captured variables are not detected correctly, because `LambdaToMethod...captureLocalClassDefs` needs to find the AST node for the given `ClassSymbol`, but it has not yet been added into the `localClassDefs`. The proposed solution is to re-order the tasks done for JCNewClass, and call the super implementation sooner. This will enter the `ClassSymbol` and corresponding AST node into `localClassDefs` before the capture variables detection.
-inside the anonymous class definition, some references to the captured variables are replaced using a map that maps captured variables for lambdas (`lambdaTranslationMap`) - but inside the anonymous class, there the captured variables should be mapped using the anonymous class' map/proxies (to fields). The proposed solution is to clear `lambdaTranslationMap` before processing the anonymous class body.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8229862](https://bugs.openjdk.java.net/browse/JDK-8229862): NPE in jdk.compiler/com.sun.tools.javac.jvm.Code.emitop0(Code.java:570)


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to 288dac25266f1e05c4c6d34adfedb77072a1d442


### Contributors
 * Bernard Blaser `<bsrbnd@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1221/head:pull/1221`
`$ git checkout pull/1221`
