### PR TITLE
8256380: JDK-8254162 broke 32bit windows build

### DIFF
--- a/src/hotspot/share/prims/scopedMemoryAccess.hpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.hpp
@@ -29,7 +29,7 @@
 #include "jni.h"
 
 extern "C" {
-  void JNICALL JVM_RegisterJDKInternalMiscScopedMemoryAccessMethods(JNIEnv *env, jobject rec, jobject scope, jthrowable exception);
+  void JNICALL JVM_RegisterJDKInternalMiscScopedMemoryAccessMethods(JNIEnv *env, jclass scopedMemoryAccessClass);
 }
 
 #endif // SHARE_PRIMS_SCOPED_MEMORY_ACCESS_HPP


### PR DESCRIPTION
Fix win-32 linker error due to forward declaration and definition signature mismatch.

FWIW, the altered header is included from nativeLookup.cpp, which uses the function pointer of that function. But, since the signature of the definition [1] is different, and due to name mangling on the particular ABI, the symbols of the declaration in the header and definition are different as well, and things fail to link later.

Testing: Building Windows-x86 locally, and running jdk_foreign tests.

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/prims/scopedMemoryAccess.cpp#L181

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256380](https://bugs.openjdk.java.net/browse/JDK-8256380): JDK-8254162 broke 32bit windows build


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1222/head:pull/1222`
`$ git checkout pull/1222`
