### PR TITLE
JDK-8254162 broke 32bit windows build

### DIFF
--- a/src/hotspot/share/prims/scopedMemoryAccess.hpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.hpp
@@ -29,7 +29,7 @@
 #include "jni.h"
 
 extern "C" {
-  void JNICALL JVM_RegisterJDKInternalMiscScopedMemoryAccessMethods(JNIEnv *env, jobject rec, jobject scope, jthrowable exception);
+  void JNICALL JVM_RegisterJDKInternalMiscScopedMemoryAccessMethods(JNIEnv *env, jclass scopedMemoryAccessClass);
 }
 
 #endif // SHARE_PRIMS_SCOPED_MEMORY_ACCESS_HPP


### PR DESCRIPTION
This simple patch fixes a build issue on Windows x86 introduced by the new scoped memory access changes. The culprit is a signature mismatch between hpp and cpp function definition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (4/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8254162](https://bugs.openjdk.java.net/browse/JDK-8254162)

### Issue
 * [JDK-8254162](https://bugs.openjdk.java.net/browse/JDK-8254162): Implementation of Foreign-Memory Access API (Third Incubator) ⚠️ Title mismatch between PR and JBS.


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1224/head:pull/1224`
`$ git checkout pull/1224`
