### PR TITLE
8256393: Github Actions build on Linux should define OS and GCC versions

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   prerequisites:
     name: Prerequisites
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     outputs:
       should_run: ${{ steps.check_submit.outputs.should_run }}
       bundle_id: ${{ steps.check_bundle_id.outputs.bundle_id }}
@@ -88,7 +88,7 @@ jobs:
         if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
 
       - name: Build jtreg
-        run: sh make/build-all.sh ${JAVA_HOME}
+        run: sh make/build-all.sh ${JAVA_HOME_8_X64}
         working-directory: jtreg
         if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
 
@@ -106,7 +106,7 @@ jobs:
 
   linux_x64_build:
     name: Linux x64
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_x64 != 'false'
 
@@ -185,7 +185,9 @@ jobs:
           path: gtest
 
       - name: Install dependencies
-        run: sudo apt-get install libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
+        run: |
+          sudo apt-get install libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
       - name: Configure
         run: >
@@ -217,7 +219,7 @@ jobs:
 
   linux_x64_test:
     name: Linux x64
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     needs:
       - prerequisites
       - linux_x64_build
@@ -396,7 +398,7 @@ jobs:
 
   linux_aarch64_build:
     name: Linux aarch64
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     needs:
       - prerequisites
       - linux_x64_build
@@ -532,7 +534,7 @@ jobs:
 
   linux_arm_build:
     name: Linux arm
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     needs:
       - prerequisites
       - linux_x64_build
@@ -668,7 +670,7 @@ jobs:
 
   linux_s390x_build:
     name: Linux s390x
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     needs:
       - prerequisites
       - linux_x64_build
@@ -804,7 +806,7 @@ jobs:
 
   linux_ppc64le_build:
     name: Linux ppc64le
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     needs:
       - prerequisites
       - linux_x64_build
@@ -940,7 +942,7 @@ jobs:
 
   linux_x86_build:
     name: Linux x86
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_x86 != 'false'
 
@@ -1014,7 +1016,8 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get install gcc-multilib g++-multilib libfreetype6-dev:i386 libxrandr-dev:i386 libxtst-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libcups2-dev:i386 libasound2-dev:i386
+          sudo apt-get install gcc-10-multilib g++-10-multilib libfreetype6-dev:i386 libxrandr-dev:i386 libxtst-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libcups2-dev:i386 libasound2-dev:i386
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
       - name: Configure
         run: >
@@ -1047,7 +1050,7 @@ jobs:
 
   linux_x86_test:
     name: Linux x86
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     needs:
       - prerequisites
       - linux_x86_build
@@ -1838,7 +1841,7 @@ jobs:
 
   artifacts:
     name: Post-process artifacts
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     if: always()
     continue-on-error: true
     needs:

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
+          sudo apt-get install gcc-10=10.2.0-5ubuntu1~20 g++-10=10.2.0-5ubuntu1~20 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
       - name: Configure

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install gcc-10=10.2.0-5ubuntu1~20 g++-10=10.2.0-5ubuntu1~20 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
+          sudo apt-get install gcc-10=10.2.0-5ubuntu1~20.04 g++-10=10.2.0-5ubuntu1~20.04 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
       - name: Configure


### PR DESCRIPTION
We should be more explicit about OS and compiler versions used in the GitHub Actions builds, to avoid problems caused by unexpected changes to the defaults. This patch changes the OS and GCC versions used from ubuntu-latest (currently 18.04, but will change to 20.04 sometime soon) / default (currently 9.3.0) to 20.04 / 10.2.0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256393](https://bugs.openjdk.java.net/browse/JDK-8256393): Github Actions build on Linux should define OS and GCC versions


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 87ab0729245d5904e326729a700b35eb29a4ecc3
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 87ab0729245d5904e326729a700b35eb29a4ecc3
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1225/head:pull/1225`
`$ git checkout pull/1225`
