### PR TITLE
8254016: Test8237524 fails with -XX:-CompactStrings option

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/Test8237524.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/Test8237524.java
@@ -29,7 +29,7 @@
  *
  * @modules java.base/java.lang:open
  *
- * @run main/othervm compiler.intrinsics.Test8237524
+ * @run main/othervm -XX:+CompactStrings compiler.intrinsics.Test8237524
  */
 
 package compiler.intrinsics;


### PR DESCRIPTION
The test compares two strings created from same byte array: Latin vs UTF16. The expected effect (strings are different) is valid only for COMPACT_STRINGS=true case (otherwise both strings are treated as UTF16). Particularly on ARM32 test fails because CompactStrings is off by default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254016](https://bugs.openjdk.java.net/browse/JDK-8254016): Test8237524 fails with -XX:-CompactStrings option


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1226/head:pull/1226`
`$ git checkout pull/1226`
