### PR TITLE
8246778: Compiler implementation for Sealed Classes (Second Preview)

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2127,16 +2127,32 @@ JVM_ENTRY(jobjectArray, JVM_GetPermittedSubclasses(JNIEnv* env, jclass current))
     JvmtiVMObjectAllocEventCollector oam;
     Array<u2>* subclasses = ik->permitted_subclasses();
     int length = subclasses == NULL ? 0 : subclasses->length();
-    objArrayOop r = oopFactory::new_objArray(SystemDictionary::String_klass(),
+    objArrayOop r = oopFactory::new_objArray(SystemDictionary::Class_klass(),
                                              length, CHECK_NULL);
     objArrayHandle result(THREAD, r);
+    int count = 0;
     for (int i = 0; i < length; i++) {
       int cp_index = subclasses->at(i);
-      // This returns <package-name>/<class-name>.
-      Symbol* klass_name = ik->constants()->klass_name_at(cp_index);
-      assert(klass_name != NULL, "Unexpected null klass_name");
-      Handle perm_subtype_h = java_lang_String::create_from_symbol(klass_name, CHECK_NULL);
-      result->obj_at_put(i, perm_subtype_h());
+      Klass* k = ik->constants()->klass_at(cp_index, THREAD);
+      if (HAS_PENDING_EXCEPTION) {
+        if (PENDING_EXCEPTION->is_a(SystemDictionary::VirtualMachineError_klass())) {
+          return NULL; // propagate VMEs
+        }
+        CLEAR_PENDING_EXCEPTION;
+        continue;
+      }
+      if (k->is_instance_klass()) {
+        result->obj_at_put(count++, k->java_mirror());
+      }
+    }
+    if (count < length) {
+      objArrayOop r2 = oopFactory::new_objArray(SystemDictionary::Class_klass(),
+                                                count, CHECK_NULL);
+      objArrayHandle result2(THREAD, r2);
+      for (int i = 0; i < count; i++) {
+        result2->obj_at_put(i, result->obj_at(i));
+      }
+      return (jobjectArray)JNIHandles::make_local(THREAD, result2());
     }
     return (jobjectArray)JNIHandles::make_local(THREAD, result());
   }

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -200,8 +200,6 @@ public final class Class<T> implements java.io.Serializable,
     private static final int ENUM      = 0x00004000;
     private static final int SYNTHETIC = 0x00001000;
 
-    private static final ClassDesc[] EMPTY_CLASS_DESC_ARRAY = new ClassDesc[0];
-
     private static native void registerNatives();
     static {
         registerNatives();
@@ -4366,48 +4364,44 @@ public final class Class<T> implements java.io.Serializable,
      *           may be removed in a future release, or upgraded to permanent
      *           features of the Java language.}
      *
-     * Returns an array containing {@code ClassDesc} objects representing all the
+     * Returns an array containing {@code Class} objects representing all the
      * direct subclasses or direct implementation classes permitted to extend or
      * implement this class or interface if it is sealed. The order of such elements
      * is unspecified. If this {@code Class} object represents a primitive type,
      * {@code void}, an array type, or a class or interface that is not sealed,
      * an empty array is returned.
      *
-     * @return an array of class descriptors of all the permitted subclasses of this class or interface
+     * @return an array of class objects of all the permitted subclasses of this class or interface
      *
      * @jls 8.1 Class Declarations
      * @jls 9.1 Interface Declarations
      * @since 15
      */
     @jdk.internal.PreviewFeature(feature=jdk.internal.PreviewFeature.Feature.SEALED_CLASSES, essentialAPI=false)
-    public ClassDesc[] permittedSubclasses() {
-        String[] subclassNames;
-        if (isArray() || isPrimitive() || (subclassNames = getPermittedSubclasses0()).length == 0) {
-            return EMPTY_CLASS_DESC_ARRAY;
+    public Class<?>[] getPermittedSubclasses() {
+        Class<?>[] subClasses;
+        if (isArray() || isPrimitive() || (subClasses = getPermittedSubclasses0()).length == 0) {
+            return EMPTY_CLASS_ARRAY;
         }
-        ClassDesc[] constants = new ClassDesc[subclassNames.length];
-        int i = 0;
-        for (String subclassName : subclassNames) {
-            try {
-                constants[i++] = ClassDesc.of(subclassName.replace('/', '.'));
-            } catch (IllegalArgumentException iae) {
-                throw new InternalError("Invalid type in permitted subclasses information: " + subclassName, iae);
-            }
-        }
-        return constants;
+        return subClasses;
     }
 
     /**
-     * * {@preview Associated with sealed classes, a preview feature of the Java language.
+     * {@preview Associated with sealed classes, a preview feature of the Java language.
      *
      *           This method is associated with <i>sealed classes</i>, a preview
      *           feature of the Java language. Preview features
      *           may be removed in a future release, or upgraded to permanent
      *           features of the Java language.}
      *
-     * Returns {@code true} if and only if this {@code Class} object represents a sealed class or interface.
-     * If this {@code Class} object represents a primitive type, {@code void}, or an array type, this method returns
+     * Returns {@code true} if and only if this {@code Class} object represents
+     * a sealed class or interface. If this {@code Class} object represents a
+     * primitive type, {@code void}, or an array type, this method returns
      * {@code false}.
+     *
+     * @apiNote
+     * This method reports on a distinct concept of sealing from
+     * {@link Package#isSealed() Package::isSealed}.
      *
      * @return {@code true} if and only if this {@code Class} object represents a sealed class or interface.
      *
@@ -4421,8 +4415,8 @@ public final class Class<T> implements java.io.Serializable,
         if (isArray() || isPrimitive()) {
             return false;
         }
-        return permittedSubclasses().length != 0;
+        return getPermittedSubclasses().length != 0;
     }
 
-    private native String[] getPermittedSubclasses0();
+    private native Class<?>[] getPermittedSubclasses0();
 }

--- a/src/java.base/share/classes/java/lang/Package.java
+++ b/src/java.base/share/classes/java/lang/Package.java
@@ -221,6 +221,10 @@ public class Package extends NamedPackage implements java.lang.reflect.Annotated
     /**
      * Returns true if this package is sealed.
      *
+     * @apiNote
+     * This method reports on a distinct concept of sealing from
+     * {@link Class#isSealed() Class::isSealed}.
+     *
      * @return true if the package is sealed, false otherwise
      */
     public boolean isSealed() {

--- a/src/java.base/share/native/libjava/Class.c
+++ b/src/java.base/share/native/libjava/Class.c
@@ -81,7 +81,7 @@ static JNINativeMethod methods[] = {
     {"getNestMembers0",      "()[" CLS,     (void *)&JVM_GetNestMembers},
     {"getRecordComponents0", "()[" RC,      (void *)&JVM_GetRecordComponents},
     {"isRecord0",            "()Z",         (void *)&JVM_IsRecord},
-    {"getPermittedSubclasses0", "()[" STR,  (void *)&JVM_GetPermittedSubclasses},
+    {"getPermittedSubclasses0", "()[" CLS,  (void *)&JVM_GetPermittedSubclasses},
 };
 
 #undef OBJ

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1629,32 +1629,69 @@ public class Types {
     }
 
     /**
-     * Is t is castable to s?<br>
+     * Is t castable to s?<br>
      * s is assumed to be an erased type.<br>
      * (not defined for Method and ForAll types).
      */
     public boolean isCastable(Type t, Type s, Warner warn) {
+        // if same type
         if (t == s)
             return true;
+        // if one of the types is primitive
         if (t.isPrimitive() != s.isPrimitive()) {
             t = skipTypeVars(t, false);
             return (isConvertible(t, s, warn)
                     || (s.isPrimitive() &&
                         isSubtype(boxedClass(s).type, t)));
         }
+        boolean result;
         if (warn != warnStack.head) {
             try {
                 warnStack = warnStack.prepend(warn);
                 checkUnsafeVarargsConversion(t, s, warn);
-                return isCastable.visit(t,s);
+                result = isCastable.visit(t,s);
             } finally {
                 warnStack = warnStack.tail;
             }
         } else {
-            return isCastable.visit(t,s);
+            result = isCastable.visit(t,s);
         }
+        if ((t.tsym.isSealed() || s.tsym.isSealed())) {
+            return (t.isCompound() || s.isCompound()) ?
+                    false :
+                    !areDisjoint((ClassSymbol)t.tsym, (ClassSymbol)s.tsym);
+        }
+        return result;
     }
     // where
+        private boolean areDisjoint(ClassSymbol ts, ClassSymbol ss) {
+            if (isSubtype(ts.type, ss.type)) {
+                return false;
+            }
+            // if both are classes or both are interfaces, shortcut
+            if (ts.isInterface() == ss.isInterface()) {
+                return !(isSubtype(ss.type, ts.type));
+            }
+            if (ts.isInterface() && !ss.isInterface()) {
+                /* so ts is interface but ss is a class
+                 * an interface is disjoint from a class if the class is disjoint form the interface
+                 */
+                return areDisjoint(ss, ts);
+            }
+            // a final class that is not subtype of ss is disjoint
+            if (!ts.isInterface() && ts.isFinal()) {
+                return true;
+            }
+            // if at least one is sealed
+            if (ts.isSealed() || ss.isSealed()) {
+                // permitted subtypes have to be disjoint with the other symbol
+                ClassSymbol sealedOne = ts.isSealed() ? ts : ss;
+                ClassSymbol other = sealedOne == ts ? ss : ts;
+                return sealedOne.permitted.stream().allMatch(sym -> areDisjoint((ClassSymbol)sym, other));
+            }
+            return false;
+        }
+
         private TypeRelation isCastable = new TypeRelation() {
 
             public Boolean visitType(Type t, Type s) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1306,7 +1306,10 @@ public class Check {
                            SEALED | NON_SEALED)
                  && checkDisjoint(pos, flags,
                                 SEALED,
-                           FINAL | NON_SEALED)) {
+                           FINAL | NON_SEALED)
+                 && checkDisjoint(pos, flags,
+                                SEALED,
+                                ANNOTATION)) {
             // skip
         }
         return flags & (mask | ~ExtendedStandardFlags) | implicit;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4264,11 +4264,19 @@ public class JavacParser implements Parser {
     private boolean allowedAfterSealedOrNonSealed(Token next, boolean local, boolean currentIsNonSealed) {
         return local ?
             switch (next.kind) {
-                case MONKEYS_AT, ABSTRACT, FINAL, STRICTFP, CLASS, INTERFACE, ENUM -> true;
+                case MONKEYS_AT -> {
+                    Token afterNext = S.token(2);
+                    yield afterNext.kind != INTERFACE || currentIsNonSealed;
+                }
+                case ABSTRACT, FINAL, STRICTFP, CLASS, INTERFACE, ENUM -> true;
                 default -> false;
             } :
             switch (next.kind) {
-                case MONKEYS_AT, PUBLIC, PROTECTED, PRIVATE, ABSTRACT, STATIC, FINAL, STRICTFP, CLASS, INTERFACE, ENUM -> true;
+                case MONKEYS_AT -> {
+                    Token afterNext = S.token(2);
+                    yield afterNext.kind != INTERFACE || currentIsNonSealed;
+                }
+                case PUBLIC, PROTECTED, PRIVATE, ABSTRACT, STATIC, FINAL, STRICTFP, CLASS, INTERFACE, ENUM -> true;
                 case IDENTIFIER -> isNonSealedIdentifier(next, currentIsNonSealed ? 3 : 1) || next.name() == names.sealed;
                 default -> false;
             };

--- a/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclasses.jcod
+++ b/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclasses.jcod
@@ -21,11 +21,10 @@
  * questions.
  */
 
-// This class has entries in its PermittedSubclasses attribute that do not exist.
-// Test that this does not prevent JVM_GetPermittedSubclasses() from returning
-// their names.
+// This class has an entry in its PermittedSubclasses attribute that does not exist.
+// Test that JVM_GetPermittedSubclasses() only returns the existing class.
 //
-// sealed class NoLoadSubclasses permits iDontExist, I/Dont/Exist/Either { }
+// sealed class NoLoadSubclasses permits OldClassFile, I/Dont/Exist/Either { }
 //
 class NoLoadSubclasses {
   0xCAFEBABE;
@@ -47,7 +46,7 @@ class NoLoadSubclasses {
     Utf8 "NoLoadSubclasses.java"; // #12     at 0x73
     Utf8 "PermittedSubclasses"; // #13     at 0x89
     class #15; // #14     at 0x9D
-    Utf8 "iDontExist"; // #15     at 0xA0
+    Utf8 "OldClassFile"; // #15     at 0xA0
     class #17; // #16     at 0xAA
     Utf8 "I/Dont/Exist/Either"; // #17     at 0xAD
   } // Constant Pool

--- a/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclassesTest.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclassesTest.java
@@ -50,7 +50,7 @@ public class GetPermittedSubclassesTest {
     final class Final4 {}
 
     public static void testSealedInfo(Class<?> c, String[] expected) {
-        Object[] permitted = c.permittedSubclasses();
+        Object[] permitted = c.getPermittedSubclasses();
 
         if (permitted.length != expected.length) {
             throw new RuntimeException(
@@ -65,7 +65,7 @@ public class GetPermittedSubclassesTest {
             // Create ArrayList of permitted subclasses class names.
             ArrayList<String> permittedNames = new ArrayList<String>();
             for (int i = 0; i < permitted.length; i++) {
-                permittedNames.add(((ClassDesc)permitted[i]).descriptorString());
+                permittedNames.add(((Class)permitted[i]).getName());
             }
 
             if (permittedNames.size() != expected.length) {
@@ -102,10 +102,11 @@ public class GetPermittedSubclassesTest {
     }
 
     public static void main(String... args) throws Throwable {
-        testSealedInfo(SealedI1.class, new String[] {"LGetPermittedSubclassesTest$NotSealed;",
-                                                     "LGetPermittedSubclassesTest$Sub1;",
-                                                     "LGetPermittedSubclassesTest$Extender;"});
-        testSealedInfo(Sealed1.class, new String[] {"LGetPermittedSubclassesTest$Sub1;"});
+        testSealedInfo(SealedI1.class, new String[] {"GetPermittedSubclassesTest$NotSealed",
+                                                     "GetPermittedSubclassesTest$Sub1",
+                                                     "GetPermittedSubclassesTest$Extender"});
+
+        testSealedInfo(Sealed1.class, new String[] {"GetPermittedSubclassesTest$Sub1"});
         testSealedInfo(Final4.class, new String[] { });
         testSealedInfo(NotSealed.class, new String[] { });
 
@@ -115,8 +116,8 @@ public class GetPermittedSubclassesTest {
         // Test class with an empty PermittedSubclasses attribute.
         testBadSealedClass("NoSubclasses", "PermittedSubclasses attribute is empty");
 
-        // Test returning names of non-existing classes.
-        testSealedInfo(NoLoadSubclasses.class, new String[]{"LiDontExist;", "LI/Dont/Exist/Either;"});
+        // Test returning only names of existing classes.
+        testSealedInfo(NoLoadSubclasses.class, new String[]{"OldClassFile" });
 
         // Test that loading a class with a corrupted PermittedSubclasses attribute
         // causes a ClassFormatError.

--- a/test/jdk/java/lang/reflect/sealed_classes/SealedClassesReflectionTest.java
+++ b/test/jdk/java/lang/reflect/sealed_classes/SealedClassesReflectionTest.java
@@ -86,8 +86,8 @@ public class SealedClassesReflectionTest {
     public void testSealedClasses(Class<?> cls) {
         assertTrue(cls.isSealed());
         assertTrue(!Modifier.isFinal(cls.getModifiers()));
-        assertTrue(cls.permittedSubclasses() != null);
-        assertTrue(cls.permittedSubclasses().length > 0);
+        assertTrue(cls.getPermittedSubclasses() != null);
+        assertTrue(cls.getPermittedSubclasses().length > 0);
     }
 
     @DataProvider(name = "notSealedClasses")
@@ -110,8 +110,8 @@ public class SealedClassesReflectionTest {
     @Test(dataProvider = "notSealedClasses")
     public void testNotSealedClasses(Class<?> cls) {
         assertTrue(!cls.isSealed());
-        assertTrue(cls.permittedSubclasses() != null);
-        assertTrue(cls.permittedSubclasses().length == 0);
+        assertTrue(cls.getPermittedSubclasses() != null);
+        assertTrue(cls.getPermittedSubclasses().length == 0);
     }
 
     @DataProvider(name = "non_sealedClasses")
@@ -128,8 +128,8 @@ public class SealedClassesReflectionTest {
         assertTrue(!cls.isSealed());
         assertTrue(!Modifier.isFinal(cls.getModifiers()));
         assertTrue((cls.getSuperclass() != null && cls.getSuperclass().isSealed()) || Arrays.stream(cls.getInterfaces()).anyMatch(Class::isSealed));
-        assertTrue(cls.permittedSubclasses() != null);
-        assertTrue(cls.permittedSubclasses().length == 0);
+        assertTrue(cls.getPermittedSubclasses() != null);
+        assertTrue(cls.getPermittedSubclasses().length == 0);
     }
 
     @DataProvider(name = "reflectionData")
@@ -215,10 +215,10 @@ public class SealedClassesReflectionTest {
             throws ReflectiveOperationException
     {
         assertTrue(sealedClass.isSealed());
-        assertTrue(sealedClass.permittedSubclasses().length == numberOfSubclasses);
+        assertTrue(sealedClass.getPermittedSubclasses().length == numberOfSubclasses);
         int i = 0;
-        for (ClassDesc cd : sealedClass.permittedSubclasses()) {
-            assertTrue(cd.displayName().equals(subclassDescriptors[i]), "expected: " + subclassDescriptors[i] + " found: " + cd.displayName());
+        for (Class<?> cd : sealedClass.getPermittedSubclasses()) {
+            assertTrue(cd.getName().equals(subclassDescriptors[i]), "expected: " + subclassDescriptors[i] + " found: " + cd.getName());
             i++;
         }
         i = 0;

--- a/test/langtools/tools/javac/sealed/SealedCompilationTests.java
+++ b/test/langtools/tools/javac/sealed/SealedCompilationTests.java
@@ -468,6 +468,26 @@ public class SealedCompilationTests extends CompilationTestCase {
                         final class D extends C { }
                     }
                 }
+                """,
+                """
+                sealed class C {
+                    void m() {
+                        class L {
+                            final class D extends C { }
+                        }
+                    }
+                }
+                """,
+                """
+                sealed class C {
+                    void m() {
+                        class L {
+                            void foo() {
+                                final class D extends C { }
+                            }
+                        }
+                    }
+                }
                 """))
             assertFail("compiler.err.local.classes.cant.extend.sealed", s);
     }
@@ -613,7 +633,7 @@ public class SealedCompilationTests extends CompilationTestCase {
             float.class, float[].class, double.class, double[].class, char.class, char[].class, boolean.class, boolean[].class, void.class,
             String[].class}) {
             Assert.check(!c.isSealed());
-            Assert.check(c.permittedSubclasses().length == 0);
+            Assert.check(c.getPermittedSubclasses().length == 0);
         }
     }
 
@@ -952,6 +972,271 @@ public class SealedCompilationTests extends CompilationTestCase {
                 }
             }
             """
+        )) {
+            assertOK(s);
+        }
+    }
+
+    public void testDoNotAllowSealedAnnotation() {
+        for (String s : List.of(
+            """
+            sealed @interface A {}
+            non-sealed interface I extends A {}
+            """
+        )) {
+            assertFail("compiler.err.expected4", s);
+        }
+    }
+
+    public void testNarrowConversion() {
+        for (String s : List.of(
+                """
+                interface I {}
+                sealed class C permits D {}
+                final class D extends C {}
+
+                class Test {
+                    void test () {
+                        C c = null;
+                        I i = (I) c;
+                    }
+                }
+                """,
+                """
+                sealed interface I permits C {}
+                final class C implements I {}
+                interface J {}
+
+                class Test {
+                    void test () {
+                        I i = null;
+                        J j = (J) i;
+                    }
+                }
+                """,
+                """
+                interface I {}
+                sealed interface J permits C {}
+                final class C implements J {}
+
+                class Test {
+                    void test () {
+                        I i = null;
+                        J j = (J) i;
+                    }
+                }
+                """,
+                """
+                sealed interface I permits A {}
+                sealed interface J permits B {}
+                final class A implements I {}
+                final class B implements J {}
+
+                class Test {
+                    void test () {
+                        I i = null;
+                        J j = (J) i;
+                    }
+                }
+                """,
+                """
+                class C {}
+                sealed interface I permits A {}
+                final class A implements I {}
+
+                class Test {
+                    void test () {
+                        C c = null;
+                        I i = (I) c;
+                    }
+                }
+                """,
+                """
+                final class C {}
+                interface I {}
+
+                class Test {
+                    void test () {
+                        C c = null;
+                        I i = (I) c;
+                    }
+                }
+                """,
+                """
+                final class C {}
+                sealed interface I permits D {}
+                final class D implements I {}
+
+                class Test {
+                    void test () {
+                        C c = null;
+                        I i = (I) c;
+                    }
+                }
+                """,
+                """
+                sealed class C permits D {}
+                final class D extends C {}
+                non-sealed interface I {}
+
+                class Test {
+                    void test () {
+                        C c = null;
+                        I i = (I) c;
+                    }
+                }
+                """,
+                """
+                sealed class C permits D {}
+                final class D {}
+                sealed interface I permits E {}
+                final class E {}
+
+                class Test {
+                    void test () {
+                        C c = null;
+                        I i = (I) c;
+                    }
+                }
+                """,
+                """
+                sealed class C permits D {}
+                sealed class D permits NS {}
+                non-sealed class NS extends D {}
+                sealed interface I permits E {}
+                final class E {}
+
+                class Test {
+                    void test () {
+                        C c = null;
+                        I i = (I) c;
+                    }
+                }
+                """,
+                """
+                interface I {}
+                final class C {}
+
+                class Test {
+                    void test () {
+                        I i = null;
+                        C c = (C) i;
+                    }
+                }
+                """,
+                """
+                interface I {}
+                sealed class C permits D {}
+                final class D {}
+
+                class Test {
+                    void test () {
+                        I i = null;
+                        C c = (C) i;
+                    }
+                }
+                """,
+                """
+                sealed interface I permits D {}
+                final class D {}
+                class C {}
+
+                class Test {
+                    void test () {
+                        I i = null;
+                        C c = (C) i;
+                    }
+                }
+                """,
+                """
+                sealed interface I permits D {}
+                final class D implements I {}
+                final class C {}
+
+                class Test {
+                    void test () {
+                        I i = null;
+                        C c = (C) i;
+                    }
+                }
+                """,
+                """
+                sealed interface I permits D {}
+                final class D implements I {}
+                sealed class C permits E {}
+                final class E extends C {}
+
+                class Test {
+                    void test () {
+                        I i = null;
+                        C c = (C) i;
+                    }
+                }
+                """
+        )) {
+            assertFail("compiler.err.prob.found.req", s);
+        }
+
+        for (String s : List.of(
+                """
+                interface I {}
+                sealed class C permits D, E {}
+                non-sealed class D extends C {}
+                final class E extends C {}
+
+                class Test {
+                    void test () {
+                        C c = null;
+                        I i = (I) c;
+                    }
+                }
+                """,
+                """
+                interface I {}
+                interface J {}
+
+                class Test {
+                    void test () {
+                        I i = null;
+                        J j = (J) i;
+                    }
+                }
+                """,
+                """
+                class C {}
+                interface I {}
+
+                class Test {
+                    void test () {
+                        C c = null;
+                        I i = (I) c;
+                    }
+                }
+                """,
+                """
+                interface I {}
+                class C {}
+
+                class Test {
+                    void test () {
+                        I i = null;
+                        C c = (C) i;
+                    }
+                }
+                """,
+                """
+                sealed class C permits D {}
+                sealed class D extends C permits NS {}
+                non-sealed class NS extends D {}
+                interface I {}
+
+                class Test {
+                    void test () {
+                        C c = null;
+                        I i = (I) c;
+                    }
+                }
+                """
         )) {
             assertOK(s);
         }


### PR DESCRIPTION
Please review the code for the second iteration of sealed classes. In this iteration we are:

- Enhancing narrowing reference conversion to allow for stricter checking of cast conversions with respect to sealed type hierarchies
- Also local classes are not considered when determining implicitly declared permitted direct subclasses of a sealed class or sealed interface
- renaming Class::permittedSubclasses to Class::getPermittedSubclasses, still in the same method, the return type has been changed to Class<?>[] instead of the previous ClassDesc[]
- adding code to make sure that annotations can't be sealed
- improving some tests

TIA

Related specs:
[Sealed Classes JSL](http://cr.openjdk.java.net/~gbierman/jep397/jep397-20201104/specs/sealed-classes-jls.html)
[Sealed Classes JVMS](http://cr.openjdk.java.net/~gbierman/jep397/jep397-20201104/specs/sealed-classes-jvms.html)
[Additional: Contextual Keywords](http://cr.openjdk.java.net/~gbierman/jep397/jep397-20201104/specs/contextual-keywords-jls.html)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8246778](https://bugs.openjdk.java.net/browse/JDK-8246778): Compiler implementation for Sealed Classes (Second Preview)


### Contributors
 * Vicente Romero `<vromero@openjdk.org>`
 * Harold Seigel `<hseigel@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1227/head:pull/1227`
`$ git checkout pull/1227`
