### PR TITLE
JDK-8255055: Create two phase test for case with different names, and fix linux DTI

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -462,7 +462,7 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
     public Path appLauncherPath(String launcherName) {
         verifyNotRuntime();
         if (launcherName == null) {
-            launcherName = name();
+            launcherName = getApplicationName();
         }
 
         if (TKit.isWindows()) {
@@ -470,6 +470,16 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
         }
 
         return appLayout().launchersDirectory().resolve(launcherName);
+    }
+
+    String getApplicationName() {
+        if (!hasArgument("--app-image")) {
+            return name();
+        }
+        // if this is an installer built from an app image, it would more
+        // accurate to extract the application name from the app-image, but in
+        // all cases where we use --app-image the application name is default name
+        return TKit.getCurrentDefaultAppName();
     }
 
     /**
@@ -500,7 +510,7 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
     public Path appLauncherCfgPath(String launcherName) {
         verifyNotRuntime();
         if (launcherName == null) {
-            launcherName = name();
+            launcherName = getApplicationName();
         }
         return appLayout().appDirectory().resolve(launcherName + ".cfg");
     }

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LinuxHelper.java
@@ -62,7 +62,7 @@ public class LinuxHelper {
         cmd.verifyIsOfType(PackageType.LINUX);
         String desktopFileName = String.format("%s-%s.desktop", getPackageName(
                 cmd), Optional.ofNullable(launcherName).orElseGet(
-                        () -> cmd.name()).replaceAll("\\s+", "_"));
+                        () -> cmd.getApplicationName()).replaceAll("\\s+", "_"));
         return cmd.appLayout().destktopIntegrationDirectory().resolve(
                 desktopFileName);
     }
@@ -211,7 +211,7 @@ public class LinuxHelper {
     static Path getLauncherPath(JPackageCommand cmd) {
         cmd.verifyIsOfType(PackageType.LINUX);
 
-        final String launcherName = cmd.name();
+        final String launcherName = cmd.getApplicationName();
         final String launcherRelativePath = Path.of("/bin", launcherName).toString();
 
         return getPackageFiles(cmd).filter(path -> path.toString().endsWith(

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacHelper.java
@@ -61,7 +61,7 @@ public class MacHelper {
 
         final Path mountPoint = Path.of(plist.queryValue("mount-point"));
         try {
-            Path dmgImage = mountPoint.resolve(cmd.name() + ".app");
+            Path dmgImage = mountPoint.resolve(cmd.getApplicationName() + ".app");
             TKit.trace(String.format("Exploded [%s] in [%s] directory",
                     cmd.outputBundle(), dmgImage));
             ThrowingConsumer.toConsumer(consumer).accept(dmgImage);
@@ -189,7 +189,7 @@ public class MacHelper {
     static Path getInstallationDirectory(JPackageCommand cmd) {
         cmd.verifyIsOfType(PackageType.MAC);
         return Path.of(cmd.getArgumentValue("--install-dir", () -> "/Applications"))
-                .resolve(cmd.name() + ".app");
+                .resolve(cmd.getApplicationName() + ".app");
     }
 
     private static String getPackageName(JPackageCommand cmd) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -139,7 +139,7 @@ public class WindowsHelper {
         DesktopIntegrationVerifier(JPackageCommand cmd, String name) {
             cmd.verifyIsOfType(PackageType.WINDOWS);
             this.cmd = cmd;
-            this.name = (name == null ? cmd.name() : name);
+            this.name = (name == null ? cmd.getApplicationName() : name);
             verifyStartMenuShortcut();
             verifyDesktopShortcut();
             verifyFileAssociationsRegistry();

--- a/test/jdk/tools/jpackage/share/MultiLauncherTwoPhaseTest.java
+++ b/test/jdk/tools/jpackage/share/MultiLauncherTwoPhaseTest.java
@@ -76,6 +76,8 @@ public class MultiLauncherTwoPhaseTest {
                 .addInitializer(cmd -> {
                     cmd.addArguments("--app-image", appImageCmd.outputBundle());
                     cmd.removeArgumentWithValue("--input");
+                    cmd.removeArgumentWithValue("--name");
+                    cmd.addArguments("--name", appImageCmd.name() + "-I");
                 })
                 .forTypes(PackageType.WINDOWS)
                 .addInitializer(cmd -> {


### PR DESCRIPTION
… fix linux DTI

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255055](https://bugs.openjdk.java.net/browse/JDK-8255055): Create two phase test for case with different names, and fix linux DTI


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1229/head:pull/1229`
`$ git checkout pull/1229`
