### PR TITLE
8256370: Add asserts to Reference.getInactive()

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/Finalizer.java
+++ b/src/java.base/share/classes/java/lang/ref/Finalizer.java
@@ -83,7 +83,8 @@ final class Finalizer extends FinalReference<Object> { /* Package-private; must 
 
         try {
             Object finalizee = this.getInactive();
-            if (finalizee != null && !(finalizee instanceof java.lang.Enum)) {
+            assert finalizee != null;
+            if (!(finalizee instanceof java.lang.Enum)) {
                 jla.invokeFinalize(finalizee);
 
                 // Clear stack slot containing this variable, to decrease

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -353,6 +353,8 @@ public abstract class Reference<T> {
      * null, and would subsequently not finalize the referent/finalizee.
      */
     T getInactive() {
+        assert this instanceof FinalReference;
+        assert next == this; // I.e. FinalReference is inactive
         return this.referent;
     }
 


### PR DESCRIPTION
A follow-up to JDK-8256106, this is adding two asserts to check that the API is used as it should be, i.e. only on inactive FinalReferences. Also, in Finalizer, where getInactive() is used, there is a null-check. The GC must never clean the referent, and Java code doesn't clean it either, it would be a bug if we ever see null there. I think it's better to fail there (with assert or NPE) when that happens instead of silently accepting it.

Testing:
 - [x] tier1
 - [x] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256370](https://bugs.openjdk.java.net/browse/JDK-8256370): Add asserts to Reference.getInactive()


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1231/head:pull/1231`
`$ git checkout pull/1231`
