### PR TITLE
8256411: Based anonymous classes have a weird end position

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2550,7 +2550,7 @@ public class Attr extends JCTree.Visitor {
                                                  ((JCIdent) clazzid).name);
 
             EndPosTable endPosTable = this.env.toplevel.endPositions;
-            endPosTable.storeEnd(clazzid1, tree.getEndPosition(endPosTable));
+            endPosTable.storeEnd(clazzid1, clazzid.getEndPosition(endPosTable));
             if (clazz.hasTag(ANNOTATED_TYPE)) {
                 JCAnnotatedType annoType = (JCAnnotatedType) clazz;
                 List<JCAnnotation> annos = annoType.annotations;

--- a/test/langtools/tools/javac/parser/JavacParserTest.java
+++ b/test/langtools/tools/javac/parser/JavacParserTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774
+ * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411
  * @summary tests error and diagnostics positions
  * @author  Jan Lahoda
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -84,6 +84,7 @@ import javax.tools.ToolProvider;
 
 import com.sun.source.tree.CaseTree;
 import com.sun.source.util.TreePathScanner;
+import java.util.Objects;
 
 public class JavacParserTest extends TestCase {
     static final JavaCompiler tool = ToolProvider.getSystemJavaCompiler();
@@ -1609,6 +1610,40 @@ public class JavacParserTest extends TestCase {
                      Test.java:5:17: compiler.err.expected: token.identifier
                      Test.java:5:16: compiler.err.not.stmt
                      """);
+    }
+
+    @Test //JDK-8256411
+    void testBasedAnonymous() throws IOException {
+        String code = """
+                      package t;
+                      class Test {
+                          class I {}
+                          static Object I = new Test().new I() {};
+                      }
+                      """;
+        StringWriter out = new StringWriter();
+        JavacTaskImpl ct = (JavacTaskImpl) tool.getTask(out, fm, null, null,
+                null, Arrays.asList(new MyFileObject(code)));
+        CompilationUnitTree cut = ct.parse().iterator().next();
+        Trees trees = Trees.instance(ct);
+        SourcePositions sp = trees.getSourcePositions();
+        ct.analyze();
+        List<String> span = new ArrayList<>();
+        new TreeScanner<Void, Void>() {
+            public Void visitClass(ClassTree ct, Void v) {
+                if (ct.getExtendsClause() != null) {
+                    int start = (int) sp.getStartPosition(cut,
+                                                           ct.getExtendsClause());
+                    int end   = (int) sp.getEndPosition(cut,
+                                                        ct.getExtendsClause());
+                    span.add(code.substring(start, end));
+                }
+                return super.visitClass(ct, v);
+            }
+        }.scan(cut, null);
+        if (!Objects.equals(span, Arrays.asList("I"))) {
+            throw new AssertionError("Unexpected span: " + span);
+        }
     }
 
     void run(String[] args) throws Exception {

--- a/test/langtools/tools/javac/positions/TreeEndPosTest.java
+++ b/test/langtools/tools/javac/positions/TreeEndPosTest.java
@@ -127,8 +127,8 @@ public class TreeEndPosTest {
     }
 
     static void testUninitializedVariable() throws IOException {
-        compile(JavaSource.createJavaSource("Object o = new A().new B(); class A { }",
-                "B()"));
+        compile(JavaSource.createJavaSource("Object o = new A().new BT(); class A { }",
+                "BT"));
     }
     static void testMissingAnnotationValue() throws IOException {
         compile(JavaSource.createJavaSource("@Foo(\"vvvv\")",


### PR DESCRIPTION
Consider code like this:

```
package t;
class Test {
    class I {}
    static Object S = new Test().new I() {};
}
```

There is a synthetically generated `Test.I` in the extends clause of the anonymous class. The current end position for it is the end of the whole anonymous class (i.e. at '}'), which does not make much sense. The proposal is that the end position should be the end position of the "I" identifier, which is the same as if the anonymous class would not be based on an enclosing instance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256411](https://bugs.openjdk.java.net/browse/JDK-8256411): Based anonymous classes have a weird end position


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1232/head:pull/1232`
`$ git checkout pull/1232`
