### PR TITLE
8256414: add optimized build to submit workflow

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -134,7 +134,7 @@ jobs:
             flags: --enable-debug --disable-precompiled-headers --with-jvm-variants=minimal
             build-target: hotspot
           - flavor: build hotspot optimized
-            flags: --with-debug-level=optimized
+            flags: --with-debug-level=optimized --disable-precompiled-headers
             build-target: hotspot
 
     env:

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -119,6 +119,7 @@ jobs:
           - build hotspot no-pch
           - build hotspot zero
           - build hotspot minimal
+          - build hotspot optimized
         include:
           - flavor: build debug
             flags: --enable-debug
@@ -131,6 +132,9 @@ jobs:
             build-target: hotspot
           - flavor: build hotspot minimal
             flags: --enable-debug --disable-precompiled-headers --with-jvm-variants=minimal
+            build-target: hotspot
+          - flavor: build hotspot optimized
+            flags: --with-debug-level=optimized
             build-target: hotspot
 
     env:


### PR DESCRIPTION
Hi all,

Could you please review this small and trivial patch which adds `linux-x64-optimized` build to submit workflow so breakages of this build flavor would be easier to spot?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (3/6 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8256414](https://bugs.openjdk.java.net/browse/JDK-8256414): add optimized build to submit workflow


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to bad0582fc3fb926f4ca99aa091b3103faad2aeda
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to bad0582fc3fb926f4ca99aa091b3103faad2aeda


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1233/head:pull/1233`
`$ git checkout pull/1233`
