### PR TITLE
8256376: The javax/swing/JSpinner/SerializationTest.java fails on headful windows

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaSpinnerUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaSpinnerUI.java
@@ -22,24 +22,67 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package com.apple.laf;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.beans.*;
-import java.text.*;
+import java.awt.AWTEvent;
+import java.awt.Component;
+import java.awt.ComponentOrientation;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.FocusTraversalPolicy;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.KeyboardFocusManager;
+import java.awt.LayoutManager;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.text.AttributedCharacterIterator;
 import java.text.AttributedCharacterIterator.Attribute;
+import java.text.CharacterIterator;
+import java.text.DateFormat;
+import java.text.Format;
 import java.text.Format.Field;
-import java.util.*;
+import java.text.ParseException;
+import java.util.Calendar;
+import java.util.Map;
 
-import javax.swing.*;
+import javax.swing.AbstractAction;
+import javax.swing.AbstractButton;
+import javax.swing.ActionMap;
+import javax.swing.ButtonModel;
+import javax.swing.InputMap;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFormattedTextField;
+import javax.swing.JSpinner;
 import javax.swing.JSpinner.DefaultEditor;
-import javax.swing.plaf.*;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+import javax.swing.LookAndFeel;
+import javax.swing.SpinnerDateModel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.plaf.ActionMapUIResource;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.FontUIResource;
+import javax.swing.plaf.SpinnerUI;
+import javax.swing.plaf.UIResource;
 import javax.swing.text.InternationalFormatter;
 
-import apple.laf.*;
-import apple.laf.JRSUIConstants.*;
-
+import apple.laf.JRSUIConstants.BooleanValue;
+import apple.laf.JRSUIConstants.Size;
+import apple.laf.JRSUIConstants.State;
+import apple.laf.JRSUIState;
+import apple.laf.JRSUIStateFactory;
 import com.apple.laf.AquaUtils.RecyclableSingleton;
 import com.apple.laf.AquaUtils.RecyclableSingletonFromDefaultConstructor;
 
@@ -169,6 +212,7 @@ public class AquaSpinnerUI extends SpinnerUI {
     }
 
     protected void uninstallDefaults() {
+        LookAndFeel.uninstallBorder(spinner);
         spinner.setLayout(null);
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSpinnerUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSpinnerUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,21 +25,57 @@
 
 package javax.swing.plaf.basic;
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.AWTEvent;
+import java.awt.Component;
+import java.awt.ComponentOrientation;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.FocusTraversalPolicy;
+import java.awt.Font;
+import java.awt.Insets;
+import java.awt.KeyboardFocusManager;
+import java.awt.LayoutManager;
+import java.awt.event.ActionEvent;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.text.AttributedCharacterIterator;
+import java.text.CharacterIterator;
+import java.text.DateFormat;
+import java.text.Format;
 import java.text.ParseException;
+import java.util.Calendar;
+import java.util.Map;
 
-import javax.swing.*;
-import javax.swing.border.*;
-import javax.swing.event.*;
-import javax.swing.plaf.*;
-import javax.swing.text.*;
+import javax.swing.AbstractAction;
+import javax.swing.ButtonModel;
+import javax.swing.InputMap;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFormattedTextField;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+import javax.swing.LookAndFeel;
+import javax.swing.SpinnerDateModel;
+import javax.swing.SpinnerModel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.border.Border;
+import javax.swing.border.CompoundBorder;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.FontUIResource;
+import javax.swing.plaf.SpinnerUI;
+import javax.swing.plaf.UIResource;
+import javax.swing.text.InternationalFormatter;
 
-import java.beans.*;
-import java.text.*;
-import java.util.*;
 import sun.swing.DefaultLookup;
-
 
 /**
  * The default Spinner UI delegate.
@@ -236,6 +272,7 @@ public class BasicSpinnerUI extends SpinnerUI
      * @see #uninstallUI
      */
     protected void uninstallDefaults() {
+        LookAndFeel.uninstallBorder(spinner);
         spinner.setLayout(null);
     }
 

--- a/test/jdk/javax/swing/JSpinner/SerializationTest.java
+++ b/test/jdk/javax/swing/JSpinner/SerializationTest.java
@@ -37,8 +37,11 @@ import static javax.swing.UIManager.getInstalledLookAndFeels;
 
 /**
  * @test
- * @bug 7124397
+ * @bug 7124397 8256376
+ * @key headful
  * @summary Verifies that JSpinner can be serialized/deserialized correctly.
+ * @run main/othervm SerializationTest
+ * @run main/othervm -Djava.awt.headless=true SerializationTest
  */
 public final class SerializationTest {
 


### PR DESCRIPTION
The Windows L&F uses the windows specific class XPStyle as part of the border in the JSpinner. This class cannot be serialized and causes an exception during serialization. The root cause is that BasicSpinnerUI forgot to reset the border in uninstallUI() by the LookAndFeel.uninstallBorder(). I have found one more place where the LookAndFeel.installBorder() is not followed by the LookAndFeel.uninstallBorder() in the AquaSpinnerUI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256376](https://bugs.openjdk.java.net/browse/JDK-8256376): The javax/swing/JSpinner/SerializationTest.java fails on headful windows


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1234/head:pull/1234`
`$ git checkout pull/1234`
