### PR TITLE
8256418: Jittester make build is broken.

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/Makefile
+++ b/test/hotspot/jtreg/testlibrary/jittester/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/testlibrary/jittester/Makefile
+++ b/test/hotspot/jtreg/testlibrary/jittester/Makefile
@@ -73,6 +73,7 @@ TESTLIBRARY_SRC_DIR = ../../../../lib/jdk/test/lib
 TESTLIBRARY_SRC_FILES = $(TESTLIBRARY_SRC_DIR)/Asserts.java \
                         $(TESTLIBRARY_SRC_DIR)/JDKToolFinder.java \
                         $(TESTLIBRARY_SRC_DIR)/JDKToolLauncher.java \
+                        $(TESTLIBRARY_SRC_DIR)/NetworkConfiguration.java \
                         $(TESTLIBRARY_SRC_DIR)/Platform.java \
                         $(TESTLIBRARY_SRC_DIR)/Utils.java \
                         $(TESTLIBRARY_SRC_DIR)/process/OutputAnalyzer.java \


### PR DESCRIPTION
The Utils.java in lib depends on NetworkConfiguration.java now. So NetworkConfiguration.java should be added to the list.

Verified locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256418](https://bugs.openjdk.java.net/browse/JDK-8256418): Jittester make build is broken.


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**) ⚠️ Review applies to 2bf55e28c092e292f83ca1a7587374ae1b8beb4c


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1238/head:pull/1238`
`$ git checkout pull/1238`
