### PR TITLE
8256419: ZGC: Remove "Heap Used Before/After Mark/Relocation" samplers

### DIFF
--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -47,10 +47,6 @@
 #include "runtime/thread.hpp"
 #include "utilities/debug.hpp"
 
-static const ZStatSampler ZSamplerHeapUsedBeforeMark("Memory", "Heap Used Before Mark", ZStatUnitBytes);
-static const ZStatSampler ZSamplerHeapUsedAfterMark("Memory", "Heap Used After Mark", ZStatUnitBytes);
-static const ZStatSampler ZSamplerHeapUsedBeforeRelocation("Memory", "Heap Used Before Relocation", ZStatUnitBytes);
-static const ZStatSampler ZSamplerHeapUsedAfterRelocation("Memory", "Heap Used After Relocation", ZStatUnitBytes);
 static const ZStatCounter ZCounterUndoPageAllocation("Memory", "Undo Page Allocation", ZStatUnitOpsPerSecond);
 static const ZStatCounter ZCounterOutOfMemory("Memory", "Out Of Memory", ZStatUnitOpsPerSecond);
 
@@ -245,9 +241,6 @@ void ZHeap::flip_to_remapped() {
 void ZHeap::mark_start() {
   assert(SafepointSynchronize::is_at_safepoint(), "Should be at safepoint");
 
-  // Update statistics
-  ZStatSample(ZSamplerHeapUsedBeforeMark, used());
-
   // Flip address view
   flip_to_marked();
 
@@ -294,7 +287,6 @@ bool ZHeap::mark_end() {
   ZVerify::after_mark();
 
   // Update statistics
-  ZStatSample(ZSamplerHeapUsedAfterMark, used());
   ZStatHeap::set_at_mark_end(capacity(), allocated(), used());
 
   // Block resurrection of weak/phantom references
@@ -443,7 +435,6 @@ void ZHeap::relocate_start() {
   ZGlobalPhase = ZPhaseRelocate;
 
   // Update statistics
-  ZStatSample(ZSamplerHeapUsedBeforeRelocation, used());
   ZStatHeap::set_at_relocate_start(capacity(), allocated(), used());
 
   // Remap/Relocate roots
@@ -455,7 +446,6 @@ void ZHeap::relocate() {
   const bool success = _relocate.relocate(&_relocation_set);
 
   // Update statistics
-  ZStatSample(ZSamplerHeapUsedAfterRelocation, used());
   ZStatRelocation::set_at_relocate_end(success);
   ZStatHeap::set_at_relocate_end(capacity(), allocated(), reclaimed(),
                                  used(), used_high(), used_low());


### PR DESCRIPTION
I propose that we remove the following stat samplers:

- Heap Used Before Mark
- Heap Used After
- Heap Used Before Relocation
- Heap Used After Relocation

The simple reason is that they aren't very useful. Looking at the heap statistics table gives a much better overview of what the heap usage has looked like.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256419](https://bugs.openjdk.java.net/browse/JDK-8256419): ZGC: Remove "Heap Used Before/After Mark/Relocation" samplers


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1239/head:pull/1239`
`$ git checkout pull/1239`
