### PR TITLE
8253228: [JVMCI] provide more info on fatal JVMCI errors

### DIFF
--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -70,17 +70,17 @@ void* JVMCI::get_shared_library(char*& path, bool load) {
     char ebuf[1024];
     if (JVMCILibPath != NULL) {
       if (!os::dll_locate_lib(path, sizeof(path), JVMCILibPath, JVMCI_SHARED_LIBRARY_NAME)) {
-        vm_exit_during_initialization("Unable to locate JVMCI shared library in path specified by -XX:JVMCILibPath value", JVMCILibPath);
+        fatal("Unable to create path to JVMCI shared library based on value of JVMCILibPath (%s)", JVMCILibPath);
       }
     } else {
       if (!os::dll_locate_lib(path, sizeof(path), Arguments::get_dll_dir(), JVMCI_SHARED_LIBRARY_NAME)) {
-        vm_exit_during_initialization("Unable to create path to JVMCI shared library");
+        fatal("Unable to create path to JVMCI shared library");
       }
     }
 
     void* handle = os::dll_load(path, ebuf, sizeof ebuf);
     if (handle == NULL) {
-      vm_exit_during_initialization("Unable to load JVMCI shared library", ebuf);
+      fatal("Unable to load JVMCI shared library from %s: %s", path, ebuf);
     }
     _shared_library_handle = handle;
     _shared_library_path = strdup(path);

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -100,13 +100,13 @@ void JVMCIEnv::copy_saved_properties() {
 
   Klass* k = SystemDictionary::resolve_or_fail(vmSymbols::jdk_vm_ci_services_Services(), Handle(), Handle(), true, THREAD);
   if (HAS_PENDING_EXCEPTION) {
-    JVMCIRuntime::exit_on_pending_exception(NULL, "Error initializing jdk.vm.ci.services.Services");
+    JVMCIRuntime::fatal_exception(NULL, "Error initializing jdk.vm.ci.services.Services");
   }
   InstanceKlass* ik = InstanceKlass::cast(k);
   if (ik->should_be_initialized()) {
     ik->initialize(THREAD);
     if (HAS_PENDING_EXCEPTION) {
-      JVMCIRuntime::exit_on_pending_exception(NULL, "Error initializing jdk.vm.ci.services.Services");
+      JVMCIRuntime::fatal_exception(NULL, "Error initializing jdk.vm.ci.services.Services");
     }
   }
 
@@ -116,7 +116,7 @@ void JVMCIEnv::copy_saved_properties() {
   JavaCallArguments args;
   JavaCalls::call_static(&result, ik, serializeSavedProperties, vmSymbols::serializePropertiesToByteArray_signature(), &args, THREAD);
   if (HAS_PENDING_EXCEPTION) {
-    JVMCIRuntime::exit_on_pending_exception(NULL, "Error calling jdk.vm.ci.services.Services.serializeSavedProperties");
+    JVMCIRuntime::fatal_exception(NULL, "Error calling jdk.vm.ci.services.Services.serializeSavedProperties");
   }
   oop res = (oop) result.get_jobject();
   assert(res->is_typeArray(), "must be");
@@ -218,7 +218,7 @@ void JVMCIEnv::init_env_mode_runtime(JavaThread* thread, JNIEnv* parent_env) {
   if (result != JNI_OK) {
     char message[256];
     jio_snprintf(message, 256, "Uncaught exception pushing local frame for JVMCIEnv scope entered at %s:%d", _file, _line);
-    JVMCIRuntime::exit_on_pending_exception(this, message);
+    JVMCIRuntime::fatal_exception(this, message);
   }
   _pop_frame_on_close = true;
 }
@@ -287,7 +287,7 @@ void JVMCIEnv::translate_hotspot_exception_to_jni_exception(JavaThread* THREAD, 
                           vmSymbols::encodeThrowable_name(),
                           vmSymbols::encodeThrowable_signature(), &jargs, THREAD);
   if (HAS_PENDING_EXCEPTION) {
-    JVMCIRuntime::exit_on_pending_exception(this, "HotSpotJVMCIRuntime.encodeThrowable should not throw an exception");
+    JVMCIRuntime::fatal_exception(this, "HotSpotJVMCIRuntime.encodeThrowable should not throw an exception");
   }
 
   oop encoded_throwable_string = (oop) result.get_jobject();
@@ -328,7 +328,7 @@ JVMCIEnv::~JVMCIEnv() {
     if (has_pending_exception()) {
       char message[256];
       jio_snprintf(message, 256, "Uncaught exception exiting JVMCIEnv scope entered at %s:%d", _file, _line);
-      JVMCIRuntime::exit_on_pending_exception(this, message);
+      JVMCIRuntime::fatal_exception(this, message);
     }
 
     if (_detach_on_close) {

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1082,7 +1082,7 @@ void JVMCIRuntime::describe_pending_hotspot_exception(JavaThread* THREAD, bool c
 }
 
 
-void JVMCIRuntime::exit_on_pending_exception(JVMCIEnv* JVMCIENV, const char* message) {
+void JVMCIRuntime::fatal_exception(JVMCIEnv* JVMCIENV, const char* message) {
   JavaThread* THREAD = JavaThread::current();
 
   static volatile int report_error = 0;
@@ -1098,9 +1098,7 @@ void JVMCIRuntime::exit_on_pending_exception(JVMCIEnv* JVMCIENV, const char* mes
     // Allow error reporting thread to print the stack trace.
     THREAD->sleep(200);
   }
-
-  before_exit(THREAD);
-  vm_exit(-1);
+  fatal("Fatal exception in JVMCI: %s", message);
 }
 
 // ------------------------------------------------------------------
@@ -1454,19 +1452,6 @@ JVMCI::CodeInstallResult JVMCIRuntime::validate_compile_task_dependencies(Depend
   return JVMCI::dependencies_failed;
 }
 
-// Reports a pending exception and exits the VM.
-static void fatal_exception_in_compile(JVMCIEnv* JVMCIENV, JavaThread* thread, const char* msg) {
-  // Only report a fatal JVMCI compilation exception once
-  static volatile int report_init_failure = 0;
-  if (!report_init_failure && Atomic::cmpxchg(&report_init_failure, 0, 1) == 0) {
-      tty->print_cr("%s:", msg);
-      JVMCIENV->describe_pending_exception(true);
-  }
-  JVMCIENV->clear_pending_exception();
-  before_exit(thread);
-  vm_exit(-1);
-}
-
 void JVMCIRuntime::compile_method(JVMCIEnv* JVMCIENV, JVMCICompiler* compiler, const methodHandle& method, int entry_bci) {
   JVMCI_EXCEPTION_CONTEXT
 
@@ -1487,7 +1472,7 @@ void JVMCIRuntime::compile_method(JVMCIEnv* JVMCIENV, JVMCICompiler* compiler, c
   HandleMark hm(thread);
   JVMCIObject receiver = get_HotSpotJVMCIRuntime(JVMCIENV);
   if (JVMCIENV->has_pending_exception()) {
-    fatal_exception_in_compile(JVMCIENV, thread, "Exception during HotSpotJVMCIRuntime initialization");
+    fatal_exception(JVMCIENV, "Exception during HotSpotJVMCIRuntime initialization");
   }
   JVMCIObject jvmci_method = JVMCIENV->get_jvmci_method(method, JVMCIENV);
   if (JVMCIENV->has_pending_exception()) {
@@ -1522,7 +1507,7 @@ void JVMCIRuntime::compile_method(JVMCIEnv* JVMCIENV, JVMCICompiler* compiler, c
   } else {
     // An uncaught exception here implies failure during compiler initialization.
     // The only sensible thing to do here is to exit the VM.
-    fatal_exception_in_compile(JVMCIENV, thread, "Exception during JVMCI compiler initialization");
+    fatal_exception(JVMCIENV, "Exception during JVMCI compiler initialization");
   }
   if (compiler->is_bootstrapping()) {
     compiler->set_bootstrap_compilation_request_handled();

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -303,8 +303,8 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
                        char*                     speculations,
                        int                       speculations_len);
 
-  // Exits the VM due to an unexpected exception.
-  static void exit_on_pending_exception(JVMCIEnv* JVMCIENV, const char* message);
+  // Reports an unexpected exception and exits the VM with a fatal error.
+  static void fatal_exception(JVMCIEnv* JVMCIENV, const char* message);
 
   static void describe_pending_hotspot_exception(JavaThread* THREAD, bool clear);
 
@@ -312,7 +312,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   if (HAS_PENDING_EXCEPTION) { \
     char buf[256]; \
     jio_snprintf(buf, 256, "Uncaught exception at %s:%d", __FILE__, __LINE__); \
-    JVMCIRuntime::exit_on_pending_exception(NULL, buf); \
+    JVMCIRuntime::fatal_exception(NULL, buf); \
     return; \
   } \
   (void)(0
@@ -321,7 +321,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   if (HAS_PENDING_EXCEPTION) { \
     char buf[256]; \
     jio_snprintf(buf, 256, "Uncaught exception at %s:%d", __FILE__, __LINE__); \
-    JVMCIRuntime::exit_on_pending_exception(NULL, buf); \
+    JVMCIRuntime::fatal_exception(NULL, buf); \
     return v; \
   } \
   (void)(0
@@ -330,7 +330,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   if (JVMCIENV->has_pending_exception()) {      \
     char buf[256]; \
     jio_snprintf(buf, 256, "Uncaught exception at %s:%d", __FILE__, __LINE__); \
-    JVMCIRuntime::exit_on_pending_exception(JVMCIENV, buf); \
+    JVMCIRuntime::fatal_exception(JVMCIENV, buf); \
     return; \
   } \
   (void)(0
@@ -339,7 +339,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   if (JVMCIENV->has_pending_exception()) {      \
     char buf[256]; \
     jio_snprintf(buf, 256, "Uncaught exception at %s:%d", __FILE__, __LINE__); \
-    JVMCIRuntime::exit_on_pending_exception(JVMCIENV, buf); \
+    JVMCIRuntime::fatal_exception(JVMCIENV, buf); \
     return result; \
   } \
   (void)(0


### PR DESCRIPTION
There are a number of places in JVMCI that abort VM execution due to unexpected Java exceptions and other error conditions. Currently, a message and the exception stack (if any) is printed and then the VM is shutdown via the global `vm_exit` function.
This PR changes the behavior in this scenario to raise a fatal VM error so that a hs-err log file is produced which provides more context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8253228](https://bugs.openjdk.java.net/browse/JDK-8253228): [JVMCI] provide more info on fatal JVMCI errors


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.java.net/census#never) (@tkrodriguez - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1240/head:pull/1240`
`$ git checkout pull/1240`
