### PR TITLE
8256427: Test com/sun/jndi/dns/ConfigTests/PortUnreachable.java does not work on AIX

### DIFF
--- a/test/jdk/com/sun/jndi/dns/ConfigTests/PortUnreachable.java
+++ b/test/jdk/com/sun/jndi/dns/ConfigTests/PortUnreachable.java
@@ -32,6 +32,8 @@ import javax.naming.directory.InitialDirContext;
  *          Unreachable packet is received, we fail quickly and don't wait for
  *          the full timeout interval. This could be caused, for example, by a
  *          dead DNS server or a flakey router.
+ *          On AIX, no ICMP Destination Unreachable is received, so skip test.
+ * @requires os.family != "aix"
  * @library ../lib/
  * @modules java.base/sun.security.util
  * @run main/othervm -Djdk.net.usePlainDatagramSocketImpl=false PortUnreachable


### PR DESCRIPTION
The test com/sun/jndi/dns/ConfigTests/PortUnreachable.java is not working on AIX.

It tests that when a DNS server is unreachable it fails quickly with a PortUnreachableException due to ICMP Destination Unreachable packets received and not having to wait for the full timeout interval.
Unfortunately, on AIX such ICMP packets are not received, so the only exception cause will be the timeout. Hence, this test can't work on AIX, so it should not be executed there.

At SAP, we had this test excluded for a long time already in our private exclude list for AIX. I suggest this test update to be the final solution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256427](https://bugs.openjdk.java.net/browse/JDK-8256427): Test com/sun/jndi/dns/ConfigTests/PortUnreachable.java does not work on AIX


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer)
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1241/head:pull/1241`
`$ git checkout pull/1241`
