### PR TITLE
8256430: add linux-x64-optimized to regular testing

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -268,6 +268,12 @@ var getJibProfilesCommon = function (input, data) {
         configure_args: ["--with-debug-level=slowdebug"],
         labels: "slowdebug"
     };
+    // Extra settings for optimized profiles
+    common.optimized_suffix = "-optimized";
+    common.optimized_profile_base = {
+        configure_args: ["--with-debug-level=optimized"],
+        labels: "optimized"
+    };
     // Extra settings for openjdk only profiles
     common.open_suffix = "-open";
     common.open_profile_base = {
@@ -509,6 +515,12 @@ var getJibProfilesProfiles = function (input, common, data) {
         var debugName = name + common.slowdebug_suffix;
         profiles[debugName] = concatObjects(profiles[name],
                                             common.slowdebug_profile_base);
+    });
+    // Generate optimized versions of all the main profiles
+    common.main_profile_names.forEach(function (name) {
+        var optName = name + common.optimized_suffix;
+        profiles[optName] = concatObjects(profiles[name],
+                                          common.optimized_profile_base);
     });
     // Generate testmake profiles for the main profile of each build host
     // platform. This profile only runs the makefile tests.

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -272,7 +272,7 @@ var getJibProfilesCommon = function (input, data) {
     common.optimized_suffix = "-optimized";
     common.optimized_profile_base = {
         configure_args: ["--with-debug-level=optimized"],
-        labels: "optimized"
+        labels: "optimized",
     };
     // Extra settings for openjdk only profiles
     common.open_suffix = "-open";
@@ -521,6 +521,7 @@ var getJibProfilesProfiles = function (input, common, data) {
         var optName = name + common.optimized_suffix;
         profiles[optName] = concatObjects(profiles[name],
                                           common.optimized_profile_base);
+        profiles[optName].default_make_targets = [ "hotspot" ];
     });
     // Generate testmake profiles for the main profile of each build host
     // platform. This profile only runs the makefile tests.


### PR DESCRIPTION
Hi all,


[8256414](https://bugs.openjdk.java.net/browse/JDK-8256414) /  #1233 added similar profile to submit workflow, this patch defines `linux-x64-optimized` profile in jib-profile so it can be used by mach5 and added to tier1? 

Thanks
-- Igor

/label hotspot-compiler hotspot build
cc-ing @dcubed-ojdk

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (3/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8256430](https://bugs.openjdk.java.net/browse/JDK-8256430): add linux-x64-optimized to regular testing


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 05c735be7c4baf9fc61f4baf3e1e712729894091
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to 05c735be7c4baf9fc61f4baf3e1e712729894091
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to 05c735be7c4baf9fc61f4baf3e1e712729894091
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1244/head:pull/1244`
`$ git checkout pull/1244`
