### PR TITLE
8256431: [PPC64] Implement Base64 encodeBlock() for Power64-LE

### DIFF
--- a/src/hotspot/cpu/ppc/assembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.hpp
@@ -264,6 +264,7 @@ class Assembler : public AbstractAssembler {
     SUBFME_OPCODE = (31u << OPCODE_SHIFT | 232u << 1),
     SUBFZE_OPCODE = (31u << OPCODE_SHIFT | 200u << 1),
     DIVW_OPCODE   = (31u << OPCODE_SHIFT | 491u << 1),
+    DIVWU_OPCODE  = (31u << OPCODE_SHIFT | 459u << 1),
     MULLW_OPCODE  = (31u << OPCODE_SHIFT | 235u << 1),
     MULHW_OPCODE  = (31u << OPCODE_SHIFT |  75u << 1),
     MULHWU_OPCODE = (31u << OPCODE_SHIFT |  11u << 1),
@@ -521,10 +522,13 @@ class Assembler : public AbstractAssembler {
 
     // Vector-Scalar (VSX) instruction support.
     LXV_OPCODE     = (61u << OPCODE_SHIFT |    1u     ),
+    LXVL_OPCODE    = (31u << OPCODE_SHIFT |  269u << 1),
     STXV_OPCODE    = (61u << OPCODE_SHIFT |    5u     ),
+    STXVL_OPCODE   = (31u << OPCODE_SHIFT |  397u << 1),
     LXVD2X_OPCODE  = (31u << OPCODE_SHIFT |  844u << 1),
     STXVD2X_OPCODE = (31u << OPCODE_SHIFT |  972u << 1),
     MTVSRD_OPCODE  = (31u << OPCODE_SHIFT |  179u << 1),
+    MTVSRDD_OPCODE = (31u << OPCODE_SHIFT |  435u << 1),
     MTVSRWZ_OPCODE = (31u << OPCODE_SHIFT |  243u << 1),
     MFVSRD_OPCODE  = (31u << OPCODE_SHIFT |   51u << 1),
     MTVSRWA_OPCODE = (31u << OPCODE_SHIFT |  211u << 1),
@@ -1340,6 +1344,8 @@ class Assembler : public AbstractAssembler {
   inline void divd_(  Register d, Register a, Register b);
   inline void divw(   Register d, Register a, Register b);
   inline void divw_(  Register d, Register a, Register b);
+  inline void divwu(  Register d, Register a, Register b);
+  inline void divwu_( Register d, Register a, Register b);
 
   // Fixed-Point Arithmetic Instructions with Overflow detection
   inline void addo(    Register d, Register a, Register b);
@@ -2254,6 +2260,8 @@ class Assembler : public AbstractAssembler {
   // Vector-Scalar (VSX) instructions.
   inline void lxv(      VectorSRegister d, int si16, Register a);
   inline void stxv(     VectorSRegister d, int si16, Register a);
+  inline void lxvl(     VectorSRegister d, Register a, Register b);
+  inline void stxvl(    VectorSRegister d, Register a, Register b);
   inline void lxvd2x(   VectorSRegister d, Register a);
   inline void lxvd2x(   VectorSRegister d, Register a, Register b);
   inline void stxvd2x(  VectorSRegister d, Register a);
@@ -2268,6 +2276,7 @@ class Assembler : public AbstractAssembler {
   inline void xxmrglw(  VectorSRegister d, VectorSRegister a, VectorSRegister b);
   inline void mtvsrd(   VectorSRegister d, Register a);
   inline void mfvsrd(   Register        d, VectorSRegister a);
+  inline void mtvsrdd(  VectorSRegister d, Register a, Register b);
   inline void mtvsrwz(  VectorSRegister d, Register a);
   inline void mfvsrwz(  Register        d, VectorSRegister a);
   inline void xxspltw(  VectorSRegister d, VectorSRegister b, int ui2);

--- a/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
@@ -127,6 +127,8 @@ inline void Assembler::divd(   Register d, Register a, Register b) { emit_int32(
 inline void Assembler::divd_(  Register d, Register a, Register b) { emit_int32(DIVD_OPCODE   | rt(d) | ra(a) | rb(b) | oe(0) | rc(1)); }
 inline void Assembler::divw(   Register d, Register a, Register b) { emit_int32(DIVW_OPCODE   | rt(d) | ra(a) | rb(b) | oe(0) | rc(0)); }
 inline void Assembler::divw_(  Register d, Register a, Register b) { emit_int32(DIVW_OPCODE   | rt(d) | ra(a) | rb(b) | oe(0) | rc(1)); }
+inline void Assembler::divwu(  Register d, Register a, Register b) { emit_int32(DIVWU_OPCODE  | rt(d) | ra(a) | rb(b) | oe(0) | rc(0)); }
+inline void Assembler::divwu_( Register d, Register a, Register b) { emit_int32(DIVWU_OPCODE  | rt(d) | ra(a) | rb(b) | oe(0) | rc(1)); }
 
 // Fixed-Point Arithmetic Instructions with Overflow detection
 inline void Assembler::addo(    Register d, Register a, Register b) { emit_int32(ADD_OPCODE    | rt(d) | ra(a) | rb(b) | oe(1) | rc(0)); }
@@ -781,11 +783,14 @@ inline void Assembler::lvsr(  VectorRegister d, Register s1, Register s2) { emit
 // Vector-Scalar (VSX) instructions.
 inline void Assembler::lxv(     VectorSRegister d, int ui16, Register a)     { assert(is_aligned(ui16, 16), "displacement must be a multiple of 16"); emit_int32( LXV_OPCODE  | vsrt_dq(d) | ra0mem(a) | uimm(ui16, 16)); }
 inline void Assembler::stxv(    VectorSRegister d, int ui16, Register a)     { assert(is_aligned(ui16, 16), "displacement must be a multiple of 16"); emit_int32( STXV_OPCODE  | vsrs_dq(d) | ra0mem(a) | uimm(ui16, 16)); }
+inline void Assembler::lxvl(    VectorSRegister d, Register s1, Register b)  { emit_int32( LXVL_OPCODE    | vsrt(d) | ra0mem(s1) | rb(b)); }
+inline void Assembler::stxvl(   VectorSRegister d, Register s1, Register b)  { emit_int32( STXVL_OPCODE   | vsrt(d) | ra0mem(s1) | rb(b)); }
 inline void Assembler::lxvd2x(  VectorSRegister d, Register s1)              { emit_int32( LXVD2X_OPCODE  | vsrt(d) | ra(0) | rb(s1)); }
 inline void Assembler::lxvd2x(  VectorSRegister d, Register s1, Register s2) { emit_int32( LXVD2X_OPCODE  | vsrt(d) | ra0mem(s1) | rb(s2)); }
 inline void Assembler::stxvd2x( VectorSRegister d, Register s1)              { emit_int32( STXVD2X_OPCODE | vsrs(d) | ra(0) | rb(s1)); }
 inline void Assembler::stxvd2x( VectorSRegister d, Register s1, Register s2) { emit_int32( STXVD2X_OPCODE | vsrs(d) | ra0mem(s1) | rb(s2)); }
 inline void Assembler::mtvsrd(  VectorSRegister d, Register a)               { emit_int32( MTVSRD_OPCODE  | vsrt(d)  | ra(a)); }
+inline void Assembler::mtvsrdd( VectorSRegister d, Register a, Register b)   { emit_int32( MTVSRDD_OPCODE | vsrt(d)  | ra(a) | rb(b)); }
 inline void Assembler::mfvsrd(  Register d, VectorSRegister a)               { emit_int32( MFVSRD_OPCODE  | vsrs(a)  | ra(d)); }
 inline void Assembler::mtvsrwz( VectorSRegister d, Register a)               { emit_int32( MTVSRWZ_OPCODE | vsrt(d) | ra(a)); }
 inline void Assembler::mfvsrwz( Register d, VectorSRegister a)               { emit_int32( MFVSRWZ_OPCODE | vsrs(a) | ra(d)); }

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -4147,61 +4147,76 @@ class StubGenerator: public StubCodeGenerator {
     StubCodeMark mark(this, "StubRoutines", "base64_encodeBlock");
     address start   = __ function_entry();
 
-    static const unsigned char VEC_ALIGN constant_block[160] = {
-      // expand_permute_val, offset = 0
-      ARRAY_TO_LXV_ORDER(
-      0,  4,  5,  6,
-      0,  7,  8,  9,
-      0, 10, 11, 12,
-      0, 13, 14, 15 ),
+    typedef struct {
+      unsigned char expand_permute_val[16];
+      unsigned char expand_rshift_val[16];
+      unsigned char expand_rshift_mask_val[16];
+      unsigned char expand_lshift_val[16];
+      unsigned char expand_lshift_mask_val[16];
+      unsigned char base64_00_15_val[16];
+      unsigned char base64_16_31_val[16];
+      unsigned char base64_32_47_val[16];
+      unsigned char base64_48_63_val[16];
+      unsigned char base64_48_63_URL_val[16];
+    } constant_block;
 
-      // expand_rshift_val, offset = 16
-      ARRAY_TO_LXV_ORDER(
-      0, 6, 4, 2,
-      0, 6, 4, 2,
-      0, 6, 4, 2,
-      0, 6, 4, 2 ),
+    static const constant_block VEC_ALIGN const_block = {
+      .expand_permute_val = {
+        ARRAY_TO_LXV_ORDER(
+        0,  4,  5,  6,
+        0,  7,  8,  9,
+        0, 10, 11, 12,
+        0, 13, 14, 15 ) },
 
-      // expand_rshift_mask_val, offset = 32
-      ARRAY_TO_LXV_ORDER(
-      0b00000000, 0b00000011, 0b00001111, 0b00111111,
-      0b00000000, 0b00000011, 0b00001111, 0b00111111,
-      0b00000000, 0b00000011, 0b00001111, 0b00111111,
-      0b00000000, 0b00000011, 0b00001111, 0b00111111 ),
+      .expand_rshift_val = {
+        ARRAY_TO_LXV_ORDER(
+        0, 6, 4, 2,
+        0, 6, 4, 2,
+        0, 6, 4, 2,
+        0, 6, 4, 2 ) },
 
-      // expand_lshift_val, offset = 48
-      ARRAY_TO_LXV_ORDER(
-      0, 2, 4, 0,
-      0, 2, 4, 0,
-      0, 2, 4, 0,
-      0, 2, 4, 0 ),
+      .expand_rshift_mask_val = {
+        ARRAY_TO_LXV_ORDER(
+        0b00000000, 0b00000011, 0b00001111, 0b00111111,
+        0b00000000, 0b00000011, 0b00001111, 0b00111111,
+        0b00000000, 0b00000011, 0b00001111, 0b00111111,
+        0b00000000, 0b00000011, 0b00001111, 0b00111111 ) },
 
-      // expand_lshift_mask_val, offset = 64
-      ARRAY_TO_LXV_ORDER(
-      0b00111111, 0b00111100, 0b00110000, 0b00000000,
-      0b00111111, 0b00111100, 0b00110000, 0b00000000,
-      0b00111111, 0b00111100, 0b00110000, 0b00000000,
-      0b00111111, 0b00111100, 0b00110000, 0b00000000 ),
+      .expand_lshift_val = {
+        ARRAY_TO_LXV_ORDER(
+        0, 2, 4, 0,
+        0, 2, 4, 0,
+        0, 2, 4, 0,
+        0, 2, 4, 0 ) },
 
-      // base64_00_15, offset = 80
-      ARRAY_TO_LXV_ORDER(
-      'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P' ),
+      .expand_lshift_mask_val = {
+        ARRAY_TO_LXV_ORDER(
+        0b00111111, 0b00111100, 0b00110000, 0b00000000,
+        0b00111111, 0b00111100, 0b00110000, 0b00000000,
+        0b00111111, 0b00111100, 0b00110000, 0b00000000,
+        0b00111111, 0b00111100, 0b00110000, 0b00000000 ) },
 
-      // base64_16_31, offset = 96
-      ARRAY_TO_LXV_ORDER(
-      'Q','R','S','T','U','V','W','X','Y','Z','a','b','c','d','e','f' ),
+      .base64_00_15_val = {
+        ARRAY_TO_LXV_ORDER(
+        'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P' ) },
 
-      // base64_32_47, offset = 112
-      ARRAY_TO_LXV_ORDER(
-      'g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v' ),
+      .base64_16_31_val = {
+        ARRAY_TO_LXV_ORDER(
+        'Q','R','S','T','U','V','W','X','Y','Z','a','b','c','d','e','f' ) },
 
-      // base64_48_63, offset = 128
-      ARRAY_TO_LXV_ORDER(
-      'w','x','y','z','0','1','2','3','4','5','6','7','8','9','+','/' ),
+      .base64_32_47_val = {
+        ARRAY_TO_LXV_ORDER(
+        'g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v' ) },
 
-      // base64_48_63_URL, offset = 144
-      ARRAY_TO_LXV_ORDER(
-      'w','x','y','z','0','1','2','3','4','5','6','7','8','9','-','_' ) };
+      .base64_48_63_val = {
+        ARRAY_TO_LXV_ORDER(
+        'w','x','y','z','0','1','2','3','4','5','6','7','8','9','+','/' ) },
+
+      .base64_48_63_URL_val = {
+        ARRAY_TO_LXV_ORDER(
+        'w','x','y','z','0','1','2','3','4','5','6','7','8','9','-','_' ) }
+    };
+    #define BLK_OFFSETOF(x) (offsetof(constant_block, x))
 
     // Number of bytes to process in each pass through the main loop.
     // 12 of the 16 bytes from each lxv are encoded to 16 Base64 bytes.
@@ -4270,15 +4285,15 @@ class StubGenerator: public StubCodeGenerator {
     __ clrldi(isURL, isURL, 32);
 
     // load up the constants
-    __ load_const_optimized(const_ptr, (address)&constant_block, tmp_reg);
-    __ lxv(expand_permute, 0, const_ptr);
-    __ lxv(expand_rshift->to_vsr(), 16, const_ptr);
-    __ lxv(expand_rshift_mask->to_vsr(), 32, const_ptr);
-    __ lxv(expand_lshift->to_vsr(), 48, const_ptr);
-    __ lxv(expand_lshift_mask->to_vsr(), 64, const_ptr);
-    __ lxv(vec_base64_00_15->to_vsr(), 80, const_ptr);
-    __ lxv(vec_base64_16_31->to_vsr(), 96, const_ptr);
-    __ lxv(vec_base64_32_47->to_vsr(), 112, const_ptr);
+    __ load_const_optimized(const_ptr, (address)&const_block, tmp_reg);
+    __ lxv(expand_permute,               BLK_OFFSETOF(expand_permute_val),     const_ptr);
+    __ lxv(expand_rshift->to_vsr(),      BLK_OFFSETOF(expand_rshift_val),      const_ptr);
+    __ lxv(expand_rshift_mask->to_vsr(), BLK_OFFSETOF(expand_rshift_mask_val), const_ptr);
+    __ lxv(expand_lshift->to_vsr(),      BLK_OFFSETOF(expand_lshift_val),      const_ptr);
+    __ lxv(expand_lshift_mask->to_vsr(), BLK_OFFSETOF(expand_lshift_mask_val), const_ptr);
+    __ lxv(vec_base64_00_15->to_vsr(),   BLK_OFFSETOF(base64_00_15_val),       const_ptr);
+    __ lxv(vec_base64_16_31->to_vsr(),   BLK_OFFSETOF(base64_16_31_val),       const_ptr);
+    __ lxv(vec_base64_32_47->to_vsr(),   BLK_OFFSETOF(base64_32_47_val),       const_ptr);
 
     // Splat the constants that can use xxspltib
     __ xxspltib(vec_8s->to_vsr(), 8);
@@ -4289,11 +4304,11 @@ class StubGenerator: public StubCodeGenerator {
     // setting of isURL
     __ cmpdi(CCR0, isURL, 0);
     __ beq(CCR0, not_URL);
-    __ lxv(vec_base64_48_63->to_vsr(), 144, const_ptr);
+    __ lxv(vec_base64_48_63->to_vsr(), BLK_OFFSETOF(base64_48_63_URL_val), const_ptr);
     __ b(calculate_size);
 
     __ bind(not_URL);
-    __ lxv(vec_base64_48_63->to_vsr(), 128, const_ptr);
+    __ lxv(vec_base64_48_63->to_vsr(), BLK_OFFSETOF(base64_48_63_val), const_ptr);
 
     __ bind(calculate_size);
 

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -4147,54 +4147,59 @@ class StubGenerator: public StubCodeGenerator {
     StubCodeMark mark(this, "StubRoutines", "base64_encodeBlock");
     address start   = __ function_entry();
 
-    static const __vector unsigned char expand_permute_val = {
+    static const unsigned char VEC_ALIGN constant_block[160] = {
+      // expand_permute_val, offset = 0
       ARRAY_TO_LXV_ORDER(
       0,  4,  5,  6,
       0,  7,  8,  9,
       0, 10, 11, 12,
-      0, 13, 14, 15 ) };
+      0, 13, 14, 15 ),
 
-    static const __vector unsigned char expand_rshift_val = {
+      // expand_rshift_val, offset = 16
       ARRAY_TO_LXV_ORDER(
       0, 6, 4, 2,
       0, 6, 4, 2,
       0, 6, 4, 2,
-      0, 6, 4, 2 ) };
+      0, 6, 4, 2 ),
 
-    static const __vector unsigned char expand_rshift_mask_val = {
+      // expand_rshift_mask_val, offset = 32
       ARRAY_TO_LXV_ORDER(
       0b00000000, 0b00000011, 0b00001111, 0b00111111,
       0b00000000, 0b00000011, 0b00001111, 0b00111111,
       0b00000000, 0b00000011, 0b00001111, 0b00111111,
-      0b00000000, 0b00000011, 0b00001111, 0b00111111 ) };
+      0b00000000, 0b00000011, 0b00001111, 0b00111111 ),
 
-    static const __vector unsigned char expand_lshift_val = {
+      // expand_lshift_val, offset = 48
       ARRAY_TO_LXV_ORDER(
       0, 2, 4, 0,
       0, 2, 4, 0,
       0, 2, 4, 0,
-      0, 2, 4, 0 ) };
+      0, 2, 4, 0 ),
 
-    static const __vector unsigned char expand_lshift_mask_val = {
+      // expand_lshift_mask_val, offset = 64
       ARRAY_TO_LXV_ORDER(
       0b00111111, 0b00111100, 0b00110000, 0b00000000,
       0b00111111, 0b00111100, 0b00110000, 0b00000000,
       0b00111111, 0b00111100, 0b00110000, 0b00000000,
-      0b00111111, 0b00111100, 0b00110000, 0b00000000 ) };
+      0b00111111, 0b00111100, 0b00110000, 0b00000000 ),
 
-    static const __vector unsigned char base64_00_15 = {
+      // base64_00_15, offset = 80
       ARRAY_TO_LXV_ORDER(
-      'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P' ) };
-    static const __vector unsigned char base64_16_31 = {
+      'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P' ),
+
+      // base64_16_31, offset = 96
       ARRAY_TO_LXV_ORDER(
-      'Q','R','S','T','U','V','W','X','Y','Z','a','b','c','d','e','f' ) };
-    static const __vector unsigned char base64_32_47 = {
+      'Q','R','S','T','U','V','W','X','Y','Z','a','b','c','d','e','f' ),
+
+      // base64_32_47, offset = 112
       ARRAY_TO_LXV_ORDER(
-      'g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v' ) };
-    static const __vector unsigned char base64_48_63 = {
+      'g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v' ),
+
+      // base64_48_63, offset = 128
       ARRAY_TO_LXV_ORDER(
-      'w','x','y','z','0','1','2','3','4','5','6','7','8','9','+','/' ) };
-    static const __vector unsigned char base64_48_63_URL = {
+      'w','x','y','z','0','1','2','3','4','5','6','7','8','9','+','/' ),
+
+      // base64_48_63_URL, offset = 144
       ARRAY_TO_LXV_ORDER(
       'w','x','y','z','0','1','2','3','4','5','6','7','8','9','-','_' ) };
 
@@ -4265,24 +4270,15 @@ class StubGenerator: public StubCodeGenerator {
     __ clrldi(isURL, isURL, 32);
 
     // load up the constants
-    __ load_const_optimized(const_ptr, (address)&expand_permute_val, tmp_reg);
+    __ load_const_optimized(const_ptr, (address)&constant_block, tmp_reg);
     __ lxv(expand_permute, 0, const_ptr);
-    __ load_const_optimized(const_ptr, (address)&expand_rshift_val, tmp_reg);
-    __ lxv(expand_rshift->to_vsr(), 0, const_ptr);
-    __ load_const_optimized(const_ptr, (address)&expand_rshift_mask_val, tmp_reg);
-    __ lxv(expand_rshift_mask->to_vsr(), 0, const_ptr);
-    __ load_const_optimized(const_ptr, (address)&expand_lshift_val, tmp_reg);
-    __ lxv(expand_lshift->to_vsr(), 0, const_ptr);
-    __ load_const_optimized(const_ptr, (address)&expand_lshift_mask_val, tmp_reg);
-    __ lxv(expand_lshift_mask->to_vsr(), 0, const_ptr);
-    __ load_const_optimized(const_ptr, (address)&base64_00_15, tmp_reg);
-    __ lxv(vec_base64_00_15->to_vsr(), 0, const_ptr);
-    __ load_const_optimized(const_ptr, (address)&base64_16_31, tmp_reg);
-    __ lxv(vec_base64_16_31->to_vsr(), 0, const_ptr);
-    __ load_const_optimized(const_ptr, (address)&base64_32_47, tmp_reg);
-    __ lxv(vec_base64_32_47->to_vsr(), 0, const_ptr);
-    __ load_const_optimized(const_ptr, (address)&base64_48_63, tmp_reg);
-    __ lxv(vec_base64_48_63->to_vsr(), 0, const_ptr);
+    __ lxv(expand_rshift->to_vsr(), 16, const_ptr);
+    __ lxv(expand_rshift_mask->to_vsr(), 32, const_ptr);
+    __ lxv(expand_lshift->to_vsr(), 48, const_ptr);
+    __ lxv(expand_lshift_mask->to_vsr(), 64, const_ptr);
+    __ lxv(vec_base64_00_15->to_vsr(), 80, const_ptr);
+    __ lxv(vec_base64_16_31->to_vsr(), 96, const_ptr);
+    __ lxv(vec_base64_32_47->to_vsr(), 112, const_ptr);
 
     // Splat the constants that can use xxspltib
     __ xxspltib(vec_8s->to_vsr(), 8);
@@ -4293,13 +4289,11 @@ class StubGenerator: public StubCodeGenerator {
     // setting of isURL
     __ cmpdi(CCR0, isURL, 0);
     __ beq(CCR0, not_URL);
-    __ load_const_optimized(const_ptr, (address)&base64_48_63_URL, tmp_reg);
-    __ lxv(vec_base64_48_63->to_vsr(), 0, const_ptr);
+    __ lxv(vec_base64_48_63->to_vsr(), 144, const_ptr);
     __ b(calculate_size);
 
     __ bind(not_URL);
-    __ load_const_optimized(const_ptr, (address)&base64_48_63, tmp_reg);
-    __ lxv(vec_base64_48_63->to_vsr(), 0, const_ptr);
+    __ lxv(vec_base64_48_63->to_vsr(), 128, const_ptr);
 
     __ bind(calculate_size);
 

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -4307,10 +4307,6 @@ class StubGenerator: public StubCodeGenerator {
     VectorRegister  is_A_to_Z          = VR11; // reuse lshift's register
     VectorRegister  offsets            = VR13; // reuse lshift's register
 
-    // VR variables for lxvl emulation
-    VectorRegister  lxvl_vreg_tmp1     = VR10; // reuse index's register
-    VectorRegister  lxvl_vreg_tmp2     = VR11; // reuse is_A_to_Z's register
-
     // VSR Constants
     VectorSRegister expand_permute     = VSR0;
 


### PR DESCRIPTION
Add a vector-based implementation of the Base64 encodeBlock intrinsic for Power9 and Power10, little-endian Linux only.

This implementation is based upon a paper (linked in comments) describing an Intel SSE vector-based implementation of Base64 encoding.  Although the Intel SSE instruction set and the Power VMX/VSX instruction sets are different, the method used in the paper is adaptable to Power.  In addition there are a few places in the algorithm where it's possible to gain some performance by using more optimal instruction sequences for VMX/VSX, and some additional benefit is gained from the ISA 3.1 additions available in Power10.

There is one controversial method I used in this implementation: I defined a macro to emit the instruction sequence for encoding 12 bytes in a vector to 16 bytes, because this sequence is needed in three places.  Turning it into a function would have been possible, but I would have needed to pass quite a few register numbers into the function.  I would have liked to have used a nested function, to give the function visibility to the register numbers declared in the outer scope, but alas nested functions are not possible in C++.

The overall performance advantage on Power9 is about 4.0X, based on the main/java/org/openjdk/micro/bench/java/util/Base64VarLenEncode.java benchmark.  This benchmark covers random buffer lengths from 8 to 20007 bytes.  Buffers that are short won't perform as well, approaching the performance of the pure Java code (or slightly worse for very short buffers),  Buffers that are consistently long will perform a little better than 4.0X.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256431](https://bugs.openjdk.java.net/browse/JDK-8256431): [PPC64] Implement Base64 encodeBlock() for Power64-LE


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * @michihirohorie (no known github.com user name / role)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1245/head:pull/1245`
`$ git checkout pull/1245`
