### PR TITLE
8256383: PlatformMutex::try_lock has different semantics on Windows and Posix

### DIFF
--- a/src/hotspot/os/posix/os_posix.hpp
+++ b/src/hotspot/os/posix/os_posix.hpp
@@ -207,7 +207,10 @@ class PlatformParker : public CHeapObj<mtSynchronizer> {
 #define PLATFORM_MONITOR_IMPL_INDIRECT 0
 #endif
 
-// Platform specific implementations that underpin VM Mutex/Monitor classes
+// Platform specific implementations that underpin VM Mutex/Monitor classes.
+// Note that we use "normal" pthread_mutex_t attributes so that recursive
+// locking is not supported, which matches the expected semantics of the
+// VM Mutex class.
 
 class PlatformMutex : public CHeapObj<mtSynchronizer> {
 #if PLATFORM_MONITOR_IMPL_INDIRECT

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -187,7 +187,10 @@ class PlatformParker : public CHeapObj<mtSynchronizer> {
 
 } ;
 
-// Platform specific implementations that underpin VM Mutex/Monitor classes
+// Platform specific implementations that underpin VM Mutex/Monitor classes.
+// Note that CRITICAL_SECTION supports recursive locking, while the semantics
+// of the VM Mutex class does not. It is up to the Mutex class to hide this
+// difference in behaviour.
 
 class PlatformMutex : public CHeapObj<mtSynchronizer> {
   NONCOPYABLE(PlatformMutex);

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -137,14 +137,15 @@ void Mutex::lock_without_safepoint_check() {
 
 
 // Returns true if thread succeeds in grabbing the lock, otherwise false.
-// Checking for a NULL owner avoids the call into platform code and hides the
-// potential difference in recursive locking behaviour on some platforms.
 bool Mutex::try_lock() {
   Thread * const self = Thread::current();
   // Some safepoint_check_always locks use try_lock, so cannot check
   // safepoint state, but can check blocking state.
   check_block_state(self);
-  if (_owner == NULL && _lock.try_lock()) {
+  // Checking the owner hides the potential difference in recursive locking behaviour
+  // on some platforms.
+  if (_owner != self && _lock.try_lock()) {
+    assert_owner(NULL);
     set_owner(self);
     return true;
   }

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -137,14 +137,14 @@ void Mutex::lock_without_safepoint_check() {
 
 
 // Returns true if thread succeeds in grabbing the lock, otherwise false.
-
+// Checking for a NULL owner avoids the call into platform code and hides the
+// potential difference in recursive locking behaviour on some platforms.
 bool Mutex::try_lock() {
   Thread * const self = Thread::current();
   // Some safepoint_check_always locks use try_lock, so cannot check
   // safepoint state, but can check blocking state.
   check_block_state(self);
-  if (_lock.try_lock()) {
-    assert_owner(NULL);
+  if (_owner == NULL && _lock.try_lock()) {
     set_owner(self);
     return true;
   }

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -32,6 +32,12 @@
 // variable that supports lock ownership tracking, lock ranking for deadlock
 // detection and coordinates with the safepoint protocol.
 
+// Locking is non-recursive: if you try to lock a mutex you already own then you
+// will get an assertion failure in a debug build (which should suffice to expose
+// usage bugs). If you call try_lock on a mutex you already own it will return false.
+// The underlying PlatformMutex may support recursive locking but this is not exposed
+// and we account for that possibility in try_lock.
+
 // The default length of mutex name was originally chosen to be 64 to avoid
 // false sharing. Now, PaddedMutex and PaddedMonitor are available for this purpose.
 // TODO: Check if _name[MUTEX_NAME_LEN] should better get replaced by const char*.


### PR DESCRIPTION
Mutex::try_lock has to allow for the possibility that the PlatformMutex::try_lock allows recursive locking.

Added additional commentary on the semantics provided by Mutex and the PlatformMutex classes.

Testing: GHA, mach5 tiers 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256383](https://bugs.openjdk.java.net/browse/JDK-8256383): PlatformMutex::try_lock has different semantics on Windows and Posix


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to b9abcb97f1a428a8c30a0f6bab7ce317e987dc07
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1247/head:pull/1247`
`$ git checkout pull/1247`
