### PR TITLE
8256385: C2: fatal error: modified node is not on IGVN._worklist

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -656,6 +656,7 @@ SafePointNode* PhaseIdealLoop::find_safepoint(Node* back_control, Node* x, Ideal
     MergeMemNode* mm = NULL;
     if (mem->is_MergeMem()) {
       mm = mem->clone()->as_MergeMem();
+      _igvn._worklist.push(mm);
       for (MergeMemStream mms(mem->as_MergeMem()); mms.next_non_empty(); ) {
         if (mms.alias_idx() != Compile::AliasIdxBot && loop != get_loop(ctrl_or_self(mms.memory()))) {
           mm->set_memory_at(mms.alias_idx(), mem->as_MergeMem()->base_memory());

--- a/test/hotspot/jtreg/compiler/c2/TestDeadNodeDuringIGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDeadNodeDuringIGVN.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8256385
+ * @requires vm.debug == true & vm.flavor == "server"
+ * @summary Test for dead nodes that are not added to the IGVN worklist for removal.
+ * @run main/othervm -Xbatch compiler.c2.TestDeadNodeDuringIGVN
+ */
+package compiler.c2;
+
+public class TestDeadNodeDuringIGVN {
+    static int res;
+
+    static void test(int len) {
+        int array[] = new int[len];
+        for (long l = 0; l < 10; l++) {
+            float e = 1;
+            do { } while (++e < 2);
+            res += l;
+        }
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 40_000; ++i) {
+            res = 0;
+            test(1);
+            if (res != 45) {
+                throw new RuntimeException("Test failed: res = " + res);
+            }
+        }
+    }
+}


### PR DESCRIPTION
`PhaseIdealLoop::find_safepoint` creates a temporary MergeMemNode that is not removed if we bail out from the optimization early (see `return NULL` statements). The fix is to simply add the MergeMem to the worklist to make sure it is always reclaimed by IGVN.

Interestingly this code path was not triggered by any of our tests but only with a test case generated by the Java Fuzzer. I've added a simplified version of that test case.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256385](https://bugs.openjdk.java.net/browse/JDK-8256385): C2: fatal error: modified node is not on IGVN._worklist


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1252/head:pull/1252`
`$ git checkout pull/1252`
