### PR TITLE
8256435: [TESTBUG] java/foreign/TestHandshake.java fails with direct buffer memory OOM

### DIFF
--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -103,9 +103,12 @@ public class TestHandshake {
             }
             long delay = System.currentTimeMillis() - start.get();
             System.out.println("Accessor #" + id + " terminated - delay (ms): " + delay);
+            cleanup();
         }
 
         abstract void doAccess();
+
+        void cleanup() {}
 
         private void backoff() {
             try {
@@ -185,6 +188,11 @@ public class TestHandshake {
         public void doAccess() {
             segment.mismatch(copy);
         }
+
+        @Override
+        void cleanup() {
+            copy.close();
+        }
     }
 
     static class BufferAccessor extends AbstractBufferAccessor {
@@ -251,7 +259,7 @@ public class TestHandshake {
         return new Object[][] {
                 { "SegmentAccessor", (AccessorFactory)SegmentAccessor::new },
                 { "SegmentCopyAccessor", (AccessorFactory)SegmentCopyAccessor::new },
-                { "SegmentMismatchAccesor", (AccessorFactory)SegmentMismatchAccessor::new },
+                { "SegmentMismatchAccessor", (AccessorFactory)SegmentMismatchAccessor::new },
                 { "SegmentFillAccessor", (AccessorFactory)SegmentFillAccessor::new },
                 { "BufferAccessor", (AccessorFactory)BufferAccessor::new },
                 { "BufferHandleAccessor", (AccessorFactory)BufferHandleAccessor::new }


### PR DESCRIPTION
I ran this test on a machine with 224 logical CPUs and it fails with:

```
  ITERATION 3
  test TestHandshake.testHandshake("SegmentMismatchAccessor", TestHandshake$$Lambda$57/0x00000001000e7968@37c4b344): failure
  java.lang.OutOfMemoryError: Cannot reserve 1000000 bytes of direct buffer memory (allocated: 536008192, limit: 536870912)
```

SegmentMismatchAccessor allocates a 1MB native segment for each CPU on
each iteration. This can quickly reach the allocation limit if there is
no intervening GC. Explicitly close the segment after each iteration to
release the memory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256435](https://bugs.openjdk.java.net/browse/JDK-8256435): [TESTBUG] java/foreign/TestHandshake.java fails with direct buffer memory OOM


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1254/head:pull/1254`
`$ git checkout pull/1254`
