### PR TITLE
8256406: G1 x86 C1/Interpreter post write barrier always uses 32 bit to access variable sized PtrQueue::_index

### DIFF
--- a/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
@@ -32,6 +32,7 @@
 #include "gc/g1/heapRegion.hpp"
 #include "interpreter/interp_masm.hpp"
 #include "runtime/sharedRuntime.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/macros.hpp"
 #ifdef COMPILER1
 #include "c1/c1_LIRAssembler.hpp"
@@ -264,6 +265,8 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
                                                   Register thread,
                                                   Register tmp,
                                                   Register tmp2) {
+  // Generated code assumes that buffer index is pointer sized.
+  STATIC_ASSERT(in_bytes(SATBMarkQueue::byte_width_of_index()) == sizeof(intptr_t));
 #ifdef _LP64
   assert(thread == r15_thread, "must be");
 #endif // _LP64
@@ -314,18 +317,13 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
 
   __ movb(Address(card_addr, 0), (int)G1CardTable::dirty_card_val());
 
-  __ cmpl(queue_index, 0);
+  __ movptr(tmp2, queue_index);
+  __ testptr(tmp2, tmp2);
   __ jcc(Assembler::equal, runtime);
-  __ subl(queue_index, wordSize);
-  __ movptr(tmp2, buffer);
-#ifdef _LP64
-  __ movslq(rscratch1, queue_index);
-  __ addq(tmp2, rscratch1);
-  __ movq(Address(tmp2, 0), card_addr);
-#else
-  __ addl(tmp2, queue_index);
-  __ movl(Address(tmp2, 0), card_addr);
-#endif
+  __ subptr(tmp2, wordSize);
+  __ movptr(queue_index, tmp2);
+  __ addptr(tmp2, buffer);
+  __ movptr(Address(tmp2, 0), card_addr);
   __ jmp(done);
 
   __ bind(runtime);
@@ -453,6 +451,9 @@ void G1BarrierSetAssembler::gen_post_barrier_stub(LIR_Assembler* ce, G1PostBarri
 #define __ sasm->
 
 void G1BarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAssembler* sasm) {
+  // Generated code assumes that buffer index is pointer sized.
+  STATIC_ASSERT(in_bytes(SATBMarkQueue::byte_width_of_index()) == sizeof(intptr_t));
+
   __ prologue("g1_pre_barrier", false);
   // arg0 : previous value of memory
 

--- a/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
@@ -319,7 +319,7 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
 
   __ movptr(tmp2, queue_index);
   __ testptr(tmp2, tmp2);
-  __ jcc(Assembler::equal, runtime);
+  __ jcc(Assembler::zero, runtime);
   __ subptr(tmp2, wordSize);
   __ movptr(queue_index, tmp2);
   __ addptr(tmp2, buffer);

--- a/src/hotspot/share/gc/shared/ptrQueue.hpp
+++ b/src/hotspot/share/gc/shared/ptrQueue.hpp
@@ -178,7 +178,7 @@ protected:
     return byte_offset_of(Derived, _index);
   }
 
-  static ByteSize byte_width_of_index() { return in_ByteSize(sizeof(size_t)); }
+  static constexpr ByteSize byte_width_of_index() { return in_ByteSize(sizeof(size_t)); }
 
   template<typename Derived>
   static ByteSize byte_offset_of_buf() {


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes benign issues with the G1 C1/interpreter barriers that on x64 only used the lower 32 bit word of the 64 bit PtrQueue::_index member?

Testing: tier1, linux-x86 builds

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256406](https://bugs.openjdk.java.net/browse/JDK-8256406): G1 x86 C1/Interpreter post write barrier always uses 32 bit to access variable sized PtrQueue::_index


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1257/head:pull/1257`
`$ git checkout pull/1257`
