### PR TITLE
8256478: C2 compilation fails with assert(t1->isa_long()) failed: Type must be a long

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -1490,13 +1490,13 @@ const Type* RotateLeftNode::Value(PhaseGVN* phase) const {
 }
 
 Node* RotateLeftNode::Ideal(PhaseGVN *phase, bool can_reshape) {
-  const Type *t1 = phase->type(in(1));
-  const Type *t2 = phase->type(in(2));
+  const Type* t1 = phase->type(in(1));
+  const Type* t2 = phase->type(in(2));
   if (t2->isa_int() && t2->is_int()->is_con()) {
     if (t1->isa_int()) {
       int lshift = t2->is_int()->get_con() & 31;
       return new RotateRightNode(in(1), phase->intcon(32 - (lshift & 31)), TypeInt::INT);
-    } else {
+    } else if (t1 != Type::TOP) {
       assert(t1->isa_long(), "Type must be a long");
       int lshift = t2->is_int()->get_con() & 63;
       return new RotateRightNode(in(1), phase->intcon(64 - (lshift & 63)), TypeLong::LONG);


### PR DESCRIPTION
The `RotateLeftNode::Ideal` transformation added by [JDK-8254872](https://bugs.openjdk.java.net/browse/JDK-8254872) should ignore a TOP `in(1)` input which will then be handled by `RotateLeftNode::Value`.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x86 (hs/tier1 compiler)](https://github.com/TobiHartmann/jdk/runs/1413161835)

### Issue
 * [JDK-8256478](https://bugs.openjdk.java.net/browse/JDK-8256478): C2 compilation fails with assert(t1->isa_long()) failed: Type must be a long


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1260/head:pull/1260`
`$ git checkout pull/1260`
