### PR TITLE
8256426: Shenandoah: Remove superfluous assert is ShBS::load_reference_barrier()

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -113,7 +113,6 @@ inline oop ShenandoahBarrierSet::load_reference_barrier(oop obj, T* load_addr) {
   if ((HasDecorator<decorators, ON_WEAK_OOP_REF>::value || HasDecorator<decorators, ON_UNKNOWN_OOP_REF>::value) &&
       obj != NULL && _heap->is_concurrent_weak_root_in_progress() &&
       !_heap->marking_context()->is_marked_strong(obj)) {
-    assert(Thread::current()->is_Java_thread(), "only Java threads get here");
     return NULL;
   }
 


### PR DESCRIPTION
Some of heap walk related tests in nsk/jdi suite failed after concurrent weak reference processing.

Can be easily reproduced:
TEST_VM_OPTS="-XX:+UseShenandoahGC" make CONF=linux-x86_64-server-fastdebug run-test TEST=vmTestbase/nsk/jdi/ObjectReference/referringObjects/referringObjects001/referringObjects001.java 

It asserts that no non-Java thread accesses references with weak/unknown strength. However, JVMTI will do just that when heap-walking and I can't see how that would be problematic, as long as we don't resurrect objects, and we don't.

Testing:
 - [x] the failing test 
 - [x] vmTestbase_nsk_jdi +UseShenandoahGC
 - [x] hotspot_gc_shenandoah
 - [x] tier1 +UseShenandoahGC
 - [x] tier2 +UseShenandoahGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ⏳ (3/9 running) | ⏳ (2/9 running) |

### Issue
 * [JDK-8256426](https://bugs.openjdk.java.net/browse/JDK-8256426): Shenandoah: Remove superfluous assert is ShBS::load_reference_barrier()


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1261/head:pull/1261`
`$ git checkout pull/1261`
