### PR TITLE
8256479: [PPC64] C2 crashes when UseVectorByteReverseInstructionsPPC64 used without SuperwordUseVSX

### DIFF
--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -136,8 +136,13 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(UseCharacterCompareIntrinsics)) {
       FLAG_SET_ERGO(UseCharacterCompareIntrinsics, true);
     }
-    if (FLAG_IS_DEFAULT(UseVectorByteReverseInstructionsPPC64)) {
-      FLAG_SET_ERGO(UseVectorByteReverseInstructionsPPC64, true);
+    if (SuperwordUseVSX) {
+      if (FLAG_IS_DEFAULT(UseVectorByteReverseInstructionsPPC64)) {
+        FLAG_SET_ERGO(UseVectorByteReverseInstructionsPPC64, true);
+      }
+    } else if (UseVectorByteReverseInstructionsPPC64) {
+      warning("UseVectorByteReverseInstructionsPPC64 specified, but needs SuperwordUseVSX.");
+      FLAG_SET_DEFAULT(UseVectorByteReverseInstructionsPPC64, false);
     }
     if (FLAG_IS_DEFAULT(UseBASE64Intrinsics)) {
       FLAG_SET_ERGO(UseBASE64Intrinsics, true);

--- a/test/jdk/jdk/incubator/vector/Vector64ConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/Vector64ConversionTests.java
@@ -39,6 +39,17 @@ import java.util.function.IntFunction;
  *      Vector64ConversionTests
  */
 
+/*
+ * @test VectorConversionPPC64
+ * @bug 8256479
+ * @requires os.arch =="ppc64" | os.arch == "ppc64le"
+ * @summary VectorConversion on PPC64 without Vector Register usage
+ * @modules jdk.incubator.vector
+ * @modules java.base/jdk.internal.vm.annotation
+ * @run testng/othervm  -XX:-SuperwordUseVSX -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ * Vector64ConversionTests
+ */
+
 @Test
 public class Vector64ConversionTests extends AbstractVectorConversionTest {
 


### PR DESCRIPTION
C2 crashes on Power9 when using UseVectorByteReverseInstructionsPPC64 without SuperwordUseVSX. bytes_reverse_long_vecNode uses a Vector Register. See bug for more details.

The VectorConversion tests can detect the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256479](https://bugs.openjdk.java.net/browse/JDK-8256479): [PPC64] C2 crashes when UseVectorByteReverseInstructionsPPC64 used without SuperwordUseVSX


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)
 * @jrziviani (no known github.com user name / role)
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1262/head:pull/1262`
`$ git checkout pull/1262`
