### PR TITLE
8256416: ZGC: Lower ZMarkCompleteTimeout

### DIFF
--- a/src/hotspot/share/gc/z/zGlobals.hpp
+++ b/src/hotspot/share/gc/z/zGlobals.hpp
@@ -153,6 +153,6 @@ const size_t      ZMarkProactiveFlushMax        = 10;
 const size_t      ZMarkTerminateFlushMax        = 3;
 
 // Try complete mark timeout
-const uint64_t    ZMarkCompleteTimeout          = 1000; // us
+const uint64_t    ZMarkCompleteTimeout          = 200; // us
 
 #endif // SHARE_GC_Z_ZGLOBALS_HPP


### PR DESCRIPTION
With JEP-376 integrated, the ZMarkCompleteTimeout now essentially dictates how long the max GC pause will be in ZGC. Since our pauses are now on the order of 50-100us I propose we lower the ZMarkCompleteTimeout to 200us (instead of 1ms).

Running the usual benchmarks, I can see no difference in number of mark continues, which suggests 200us is long enough to handle all common cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256416](https://bugs.openjdk.java.net/browse/JDK-8256416): ZGC: Lower ZMarkCompleteTimeout


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1263/head:pull/1263`
`$ git checkout pull/1263`
