### PR TITLE
8256484: ZGC: Rename ZRelocationSetSelector::register_garbage_page()

### DIFF
--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -361,13 +361,13 @@ void ZHeap::process_non_strong_references() {
   _reference_processor.enqueue_references();
 }
 
-void ZHeap::free_garbage_pages(ZRelocationSetSelector* selector, int bulk) {
-  // Freeing garbage pages in bulk is an optimization to avoid grabbing
+void ZHeap::free_empty_pages(ZRelocationSetSelector* selector, int bulk) {
+  // Freeing empty pages in bulk is an optimization to avoid grabbing
   // the page allocator lock, and trying to satisfy stalled allocations
   // too frequently.
-  if (selector->should_free_garbage_pages(bulk)) {
-    free_pages(selector->garbage_pages(), true /* reclaimed */);
-    selector->clear_garbage_pages();
+  if (selector->should_free_empty_pages(bulk)) {
+    free_pages(selector->empty_pages(), true /* reclaimed */);
+    selector->clear_empty_pages();
   }
 }
 
@@ -388,16 +388,16 @@ void ZHeap::select_relocation_set() {
       // Register live page
       selector.register_live_page(page);
     } else {
-      // Register garbage page
-      selector.register_garbage_page(page);
+      // Register empty page
+      selector.register_empty_page(page);
 
-      // Reclaim garbage pages in bulk
-      free_garbage_pages(&selector, 64 /* bulk */);
+      // Reclaim empty pages in bulk
+      free_empty_pages(&selector, 64 /* bulk */);
     }
   }
 
-  // Reclaim remaining garbage pages
-  free_garbage_pages(&selector, 0 /* bulk */);
+  // Reclaim remaining empty pages
+  free_empty_pages(&selector, 0 /* bulk */);
 
   // Allow pages to be deleted
   _page_allocator.disable_deferred_delete();

--- a/src/hotspot/share/gc/z/zHeap.hpp
+++ b/src/hotspot/share/gc/z/zHeap.hpp
@@ -65,7 +65,7 @@ private:
   void flip_to_marked();
   void flip_to_remapped();
 
-  void free_garbage_pages(ZRelocationSetSelector* selector, int bulk);
+  void free_empty_pages(ZRelocationSetSelector* selector, int bulk);
 
   void out_of_memory();
 

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
@@ -74,7 +74,7 @@ private:
   const size_t                     _page_size;
   const size_t                     _object_size_limit;
   const size_t                     _fragmentation_limit;
-  ZArray<ZPage*>                   _registered_pages;
+  ZArray<ZPage*>                   _live_pages;
   size_t                           _forwarding_entries;
   ZRelocationSetSelectorGroupStats _stats;
 
@@ -90,7 +90,7 @@ public:
                               size_t object_size_limit);
 
   void register_live_page(ZPage* page);
-  void register_garbage_page(ZPage* page);
+  void register_empty_page(ZPage* page);
   void select();
 
   const ZArray<ZPage*>* selected() const;
@@ -104,7 +104,7 @@ private:
   ZRelocationSetSelectorGroup _small;
   ZRelocationSetSelectorGroup _medium;
   ZRelocationSetSelectorGroup _large;
-  ZArray<ZPage*>              _garbage_pages;
+  ZArray<ZPage*>              _empty_pages;
 
   size_t total() const;
   size_t empty() const;
@@ -115,11 +115,11 @@ public:
   ZRelocationSetSelector();
 
   void register_live_page(ZPage* page);
-  void register_garbage_page(ZPage* page);
+  void register_empty_page(ZPage* page);
 
-  bool should_free_garbage_pages(int bulk) const;
-  const ZArray<ZPage*>* garbage_pages() const;
-  void clear_garbage_pages();
+  bool should_free_empty_pages(int bulk) const;
+  const ZArray<ZPage*>* empty_pages() const;
+  void clear_empty_pages();
 
   void select();
 

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.inline.hpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.inline.hpp
@@ -75,7 +75,7 @@ inline void ZRelocationSetSelectorGroup::register_live_page(ZPage* page) {
   const size_t garbage = size - live;
 
   if (garbage > _fragmentation_limit) {
-    _registered_pages.append(page);
+    _live_pages.append(page);
   }
 
   _stats._npages++;
@@ -84,7 +84,7 @@ inline void ZRelocationSetSelectorGroup::register_live_page(ZPage* page) {
   _stats._garbage += garbage;
 }
 
-inline void ZRelocationSetSelectorGroup::register_garbage_page(ZPage* page) {
+inline void ZRelocationSetSelectorGroup::register_empty_page(ZPage* page) {
   const size_t size = page->size();
 
   _stats._npages++;
@@ -94,7 +94,7 @@ inline void ZRelocationSetSelectorGroup::register_garbage_page(ZPage* page) {
 }
 
 inline const ZArray<ZPage*>* ZRelocationSetSelectorGroup::selected() const {
-  return &_registered_pages;
+  return &_live_pages;
 }
 
 inline size_t ZRelocationSetSelectorGroup::forwarding_entries() const {
@@ -117,30 +117,30 @@ inline void ZRelocationSetSelector::register_live_page(ZPage* page) {
   }
 }
 
-inline void ZRelocationSetSelector::register_garbage_page(ZPage* page) {
+inline void ZRelocationSetSelector::register_empty_page(ZPage* page) {
   const uint8_t type = page->type();
 
   if (type == ZPageTypeSmall) {
-    _small.register_garbage_page(page);
+    _small.register_empty_page(page);
   } else if (type == ZPageTypeMedium) {
-    _medium.register_garbage_page(page);
+    _medium.register_empty_page(page);
   } else {
-    _large.register_garbage_page(page);
+    _large.register_empty_page(page);
   }
 
-  _garbage_pages.append(page);
+  _empty_pages.append(page);
 }
 
-inline bool ZRelocationSetSelector::should_free_garbage_pages(int bulk) const {
-  return _garbage_pages.length() >= bulk && _garbage_pages.is_nonempty();
+inline bool ZRelocationSetSelector::should_free_empty_pages(int bulk) const {
+  return _empty_pages.length() >= bulk && _empty_pages.is_nonempty();
 }
 
-inline const ZArray<ZPage*>* ZRelocationSetSelector::garbage_pages() const {
-  return &_garbage_pages;
+inline const ZArray<ZPage*>* ZRelocationSetSelector::empty_pages() const {
+  return &_empty_pages;
 }
 
-inline void ZRelocationSetSelector::clear_garbage_pages() {
-  return _garbage_pages.clear();
+inline void ZRelocationSetSelector::clear_empty_pages() {
+  return _empty_pages.clear();
 }
 
 inline size_t ZRelocationSetSelector::total() const {


### PR DESCRIPTION
This came up in a review of a separate change. `ZRelocationSetSelector::register_garbage_page()` is a slightly misleading name, since "live pages" can also contain garbage. A better name is `ZRelocationSetSelector::register_empty_page()`. To keep the names consistent I propose that we also rename `_registered_pages` to `_live_pages`, to match better `ZRelocationSetSelector::register_live_page()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ❌ (1/2 failed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (build release)](https://github.com/pliden/jdk/runs/1413609892)

### Issue
 * [JDK-8256484](https://bugs.openjdk.java.net/browse/JDK-8256484): ZGC: Rename ZRelocationSetSelector::register_garbage_page()


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1264/head:pull/1264`
`$ git checkout pull/1264`
