### PR TITLE
8256189: Exact VarHandle tests should test withInvokeBehavior() works as expected

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleMemoryAccess.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleMemoryAccess.java.template
@@ -39,7 +39,7 @@ import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase {
 
     static final boolean BE = UNSAFE.isBigEndian();
-    
+
     static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 
     static final int VM_ALIGN = $BoxType$.BYTES - 1;
@@ -66,7 +66,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
     public MemoryAccessVarHandle$Type$Helper withInvokeBehavior() {
         return !hasInvokeExactBehavior() ?
                 this :
-                new MemoryAccessVarHandle$Type$Helper(skipAlignmentMaskCheck, be, length, alignmentMask, true);
+                new MemoryAccessVarHandle$Type$Helper(skipAlignmentMaskCheck, be, length, alignmentMask, false);
     }
 
 #if[floatingPoint]

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
@@ -24,16 +24,31 @@
 /*
  * @test
  * @modules jdk.incubator.foreign
+ *          java.base/jdk.internal.access.foreign
  *
- * @run testng/othervm -Xverify:all VarHandleTestExact
- * @run testng/othervm -Xverify:all -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestExact
- * @run testng/othervm -Xverify:all -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestExact
- * @run testng/othervm -Xverify:all -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestExact
+ * @run testng/othervm -Xverify:all
+ *   -Djdk.internal.foreign.SHOULD_ADAPT_HANDLES=false
+ *   VarHandleTestExact
+ * @run testng/othervm -Xverify:all
+ *   -Djdk.internal.foreign.SHOULD_ADAPT_HANDLES=false
+ *   -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true
+ *   -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true
+ *   VarHandleTestExact
+ * @run testng/othervm -Xverify:all
+ *   -Djdk.internal.foreign.SHOULD_ADAPT_HANDLES=false
+ *   -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false
+ *   -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false
+ *   VarHandleTestExact
+ * @run testng/othervm -Xverify:all
+ *   -Djdk.internal.foreign.SHOULD_ADAPT_HANDLES=false
+ *   -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false
+ *   -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true
+ *   VarHandleTestExact
  */
 
-import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.internal.access.foreign.MemorySegmentProxy;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -160,7 +175,7 @@ public class VarHandleTestExact {
             doTest(vh,
                 tvh -> tvh.set(seg, 0L, testValue),
                 tvh -> setter.set(tvh, seg, 0L, testValue),
-                ".*\\Qexpected (MemorySegment,long," + carrier.getSimpleName() + ")void \\E.*");
+                ".*\\Qexpected (MemorySegmentProxy,long," + carrier.getSimpleName() + ")void \\E.*");
         }
     }
 
@@ -225,7 +240,7 @@ public class VarHandleTestExact {
     }
 
     private interface SetSegmentX {
-        void set(VarHandle vh, MemorySegment segment, long offser, Object testValue);
+        void set(VarHandle vh, MemorySegment segment, long offset, Object testValue);
     }
 
     private static void consume(Object o) {}
@@ -362,11 +377,11 @@ public class VarHandleTestExact {
         List<Object[]> cases = new ArrayList<>();
 
         // create a bunch of different sig-poly call sites
-        testCaseSegmentSet(cases, long.class, 1234,         (vh, seg, off, tv) -> vh.set(seg, off, (int) tv));
-        testCaseSegmentSet(cases, long.class, (char) 1234,  (vh, seg, off, tv) -> vh.set(seg, off, (char) tv));
-        testCaseSegmentSet(cases, long.class, (short) 1234, (vh, seg, off, tv) -> vh.set(seg, off, (short) tv));
-        testCaseSegmentSet(cases, long.class, (byte) 1234,  (vh, seg, off, tv) -> vh.set(seg, off, (byte) tv));
-        testCaseSegmentSet(cases, double.class, 1234F,      (vh, seg, off, tv) -> vh.set(seg, off, (float) tv));
+        testCaseSegmentSet(cases, long.class, 1234,         (vh, seg, off, tv) -> vh.set((MemorySegmentProxy) seg, off, (int) tv));
+        testCaseSegmentSet(cases, long.class, (char) 1234,  (vh, seg, off, tv) -> vh.set((MemorySegmentProxy) seg, off, (char) tv));
+        testCaseSegmentSet(cases, long.class, (short) 1234, (vh, seg, off, tv) -> vh.set((MemorySegmentProxy) seg, off, (short) tv));
+        testCaseSegmentSet(cases, long.class, (byte) 1234,  (vh, seg, off, tv) -> vh.set((MemorySegmentProxy) seg, off, (byte) tv));
+        testCaseSegmentSet(cases, double.class, 1234F,      (vh, seg, off, tv) -> vh.set((MemorySegmentProxy) seg, off, (float) tv));
 
         return cases.toArray(Object[][]::new);
     }


### PR DESCRIPTION
This PR sharpens the testing done by test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java after @mcimadamore reported that the test was not catching an issue with memory access var handles; namely that the implementation of withInvokeBehavior was incorrect.

After some debugging it turned out that the test never actually tested:
(1) going back to invoke behavior from a var handle with invoke exact behavior
(2) the memory access handle implementation of withInvoke(Exact)Behavior, due to memory handles always being adapted.

The patch adds testing for (1), and adds a flag to jdk.internal.foreign.Utils to turn off the adaptation, so that we can test the 'naked' memory access var handles as well for (2).

I've also tried to reduce some of the code duplication by creating the higher order doTest function, that does most of the testing (besides setting up var handles and test values).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256189](https://bugs.openjdk.java.net/browse/JDK-8256189): Exact VarHandle tests should test withInvokeBehavior() works as expected


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1267/head:pull/1267`
`$ git checkout pull/1267`
