### PR TITLE
8256476: Assert in vmIntrinsics::flags_for with -XX:+Verbose

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -723,28 +723,28 @@ inline jlong intrinsic_info(vmIntrinsics::ID id) {
 vmSymbolID vmIntrinsics::class_for(vmIntrinsics::ID id) {
   jlong info = intrinsic_info(id);
   int shift = 2*vmSymbols::log2_SID_LIMIT + log2_FLAG_LIMIT, mask = right_n_bits(vmSymbols::log2_SID_LIMIT);
-  assert(((ID4(1021,1022,1023,15) >> shift) & mask) == 1021, "");
+  assert(((ID4(1021,1022,1023,7) >> shift) & mask) == 1021, "");
   return vmSymbols::as_SID( (info >> shift) & mask );
 }
 
 vmSymbolID vmIntrinsics::name_for(vmIntrinsics::ID id) {
   jlong info = intrinsic_info(id);
   int shift = vmSymbols::log2_SID_LIMIT + log2_FLAG_LIMIT, mask = right_n_bits(vmSymbols::log2_SID_LIMIT);
-  assert(((ID4(1021,1022,1023,15) >> shift) & mask) == 1022, "");
+  assert(((ID4(1021,1022,1023,7) >> shift) & mask) == 1022, "");
   return vmSymbols::as_SID( (info >> shift) & mask );
 }
 
 vmSymbolID vmIntrinsics::signature_for(vmIntrinsics::ID id) {
   jlong info = intrinsic_info(id);
   int shift = log2_FLAG_LIMIT, mask = right_n_bits(vmSymbols::log2_SID_LIMIT);
-  assert(((ID4(1021,1022,1023,15) >> shift) & mask) == 1023, "");
+  assert(((ID4(1021,1022,1023,7) >> shift) & mask) == 1023, "");
   return vmSymbols::as_SID( (info >> shift) & mask );
 }
 
 vmIntrinsics::Flags vmIntrinsics::flags_for(vmIntrinsics::ID id) {
   jlong info = intrinsic_info(id);
   int shift = 0, mask = right_n_bits(log2_FLAG_LIMIT);
-  assert(((ID4(1021,1022,1023,15) >> shift) & mask) == 15, "");
+  assert(((ID4(1021,1022,1023,7) >> shift) & mask) == 7, "");
   return Flags( (info >> shift) & mask );
 }
 #endif // !PRODUCT


### PR DESCRIPTION
Please review this trivial fix.

The bug was introduced by [JDK-8254855](https://bugs.openjdk.java.net/browse/JDK-8254855). `log2_FLAG_LIMIT` [1] is changed from 4 to 3. So the hard-coded value 15 in `vmIntrinsics::flags_for()` should be changed to 7.

Tests: passed tier-1

[1] https://github.com/openjdk/jdk/blame/0570cc10b579580f37b8978f2498459bdd4c870b/src/hotspot/share/classfile/vmIntrinsics.hpp#L1043

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256476](https://bugs.openjdk.java.net/browse/JDK-8256476): Assert in vmIntrinsics::flags_for with -XX:+Verbose


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1270/head:pull/1270`
`$ git checkout pull/1270`
