### PR TITLE
8033441: print line numbers with -XX:+PrintOptoAssembly

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -406,17 +406,23 @@ static void format_helper( PhaseRegAlloc *regalloc, outputStream* st, Node *n, c
   }
 }
 
+//---------------------print_method_with_lineno--------------------------------
+void JVMState::print_method_with_lineno(outputStream* st, bool show_name) const {
+  if (show_name) _method->print_short_name(st);
+
+  int lineno = _method->line_number_from_bci(_bci);
+  if (lineno != -1) {
+    st->print(" @ bci:%d (line %d)", _bci, lineno);
+  } else {
+    st->print(" @ bci:%d", _bci);
+  }
+}
+
 //------------------------------format-----------------------------------------
 void JVMState::format(PhaseRegAlloc *regalloc, const Node *n, outputStream* st) const {
   st->print("        #");
   if (_method) {
-    _method->print_short_name(st);
-    int lineno = _method->line_number_from_bci(_bci);
-    if (lineno != -1) {
-      st->print(" @ bci:%d (line %d) ", _bci, lineno);
-    } else {
-      st->print(" @ bci:%d ", _bci);
-    }
+    print_method_with_lineno(st, true);
   } else {
     st->print_cr(" runtime stub ");
     return;
@@ -542,14 +548,7 @@ void JVMState::dump_spec(outputStream *st) const {
         printed = true;
       }
     }
-    if (!printed)
-      _method->print_short_name(st);
-    int lineno = _method->line_number_from_bci(_bci);
-    if (lineno != -1) {
-      st->print(" @ bci:%d (line %d)", _bci, lineno);
-    } else {
-      st->print(" @ bci:%d", _bci);
-    }
+    print_method_with_lineno(st, !printed);
     if(_reexecute == Reexecute_True)
       st->print(" reexecute");
   } else {

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -411,7 +411,12 @@ void JVMState::format(PhaseRegAlloc *regalloc, const Node *n, outputStream* st) 
   st->print("        #");
   if (_method) {
     _method->print_short_name(st);
-    st->print(" @ bci:%d ",_bci);
+    int lineno = _method->line_number_from_bci(_bci);
+    if (lineno != -1) {
+      st->print(" @ bci:%d (line %d) ", _bci, lineno);
+    } else {
+      st->print(" @ bci:%d ", _bci);
+    }
   } else {
     st->print_cr(" runtime stub ");
     return;
@@ -539,7 +544,12 @@ void JVMState::dump_spec(outputStream *st) const {
     }
     if (!printed)
       _method->print_short_name(st);
-    st->print(" @ bci:%d",_bci);
+    int lineno = _method->line_number_from_bci(_bci);
+    if (lineno != -1) {
+      st->print(" @ bci:%d (line %d)", _bci, lineno);
+    } else {
+      st->print(" @ bci:%d", _bci);
+    }
     if(_reexecute == Reexecute_True)
       st->print(" reexecute");
   } else {

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -306,6 +306,7 @@ public:
   int       interpreter_frame_size() const;
 
 #ifndef PRODUCT
+  void      print_method_with_lineno(outputStream* st, bool show_name) const;
   void      format(PhaseRegAlloc *regalloc, const Node *n, outputStream* st) const;
   void      dump_spec(outputStream *st) const;
   void      dump_on(outputStream* st) const;

--- a/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8033441
+ * @summary Test to ensure that line numbers are now present with the -XX:+PrintOptoAssembly command line option
+ *
+ * @requires vm.debug == true
+ *
+ * @library /compiler/patches /test/lib
+ * @run main/othervm compiler.arguments.TestPrintOptoAssemblyLineNumbers
+*/
+
+package compiler.arguments;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestPrintOptoAssemblyLineNumbers {
+    public static void main(String[] args) throws Throwable {
+        // create subprocess to run some code with -XX:+PrintOptoAssembly enabled
+        String[] procArgs = new String[]{
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:-TieredCompilation",
+            "-XX:+PrintOptoAssembly",
+            "compiler.arguments.TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly"
+            };
+
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(procArgs);
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        // ensure output includes line numbers:
+       output.shouldMatch(".*TestPrintOptoAssemblyLineNumbers\\$CheckC2OptoAssembly::main @ bci:11 \\(line 64\\).*");
+    }
+
+    public static class CheckC2OptoAssembly{ // contents of this class serves to just invoke C2
+        public static boolean foo(String arg){
+            return arg.contains("45");
+        }
+
+        public static void main(String[] args){
+            int count = 0;
+            for(int x = 0; x < 200_000; x++){
+                if(foo("something" + x)){ // <- test expects this line of code to be on line 64
+                    count += 1;
+                }
+            }
+            System.out.println("count: " + count);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
@@ -34,6 +34,7 @@
 
 package compiler.arguments;
 
+import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
@@ -48,9 +49,12 @@ public class TestPrintOptoAssemblyLineNumbers {
             };
 
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(procArgs);
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        // ensure output includes line numbers:
-       output.shouldMatch(".*TestPrintOptoAssemblyLineNumbers\\$CheckC2OptoAssembly::main @ bci:11 \\(line 64\\).*");
+        String output = new OutputAnalyzer(pb.start()).getOutput();
+
+        if(output.contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11")){ 
+            // if C2 optimizer invoked ensure output includes line numbers:
+            Asserts.assertTrue(output.contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11 (line 68)"));
+        }
     }
 
     public static class CheckC2OptoAssembly{ // contents of this class serves to just invoke C2
@@ -61,7 +65,7 @@ public class TestPrintOptoAssemblyLineNumbers {
         public static void main(String[] args){
             int count = 0;
             for(int x = 0; x < 200_000; x++){
-                if(foo("something" + x)){ // <- test expects this line of code to be on line 64
+                if(foo("something" + x)){ // <- test expects this line of code to be on line 68
                     count += 1;
                 }
             }

--- a/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
@@ -51,7 +51,7 @@ public class TestPrintOptoAssemblyLineNumbers {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(procArgs);
         String output = new OutputAnalyzer(pb.start()).getOutput();
 
-        if(output.contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11")){ 
+        if(output.contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11")){
             // if C2 optimizer invoked ensure output includes line numbers:
             Asserts.assertTrue(output.contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11 (line 68)"));
         }

--- a/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
@@ -26,7 +26,7 @@
  * @bug 8033441
  * @summary Test to ensure that line numbers are now present with the -XX:+PrintOptoAssembly command line option
  *
- * @requires vm.debug == true
+ * @requires vm.compiler2.enabled & vm.debug == true
  *
  * @library /compiler/patches /test/lib
  * @run main/othervm compiler.arguments.TestPrintOptoAssemblyLineNumbers


### PR DESCRIPTION
Hi all,

Here is a patch which adds line number information to the `-XX:+PrintOptoAssembly` cmd line option output.

A new unit test is provided for this functionality. Note that the build must have debugging enabled for the test to be relevant and enabled.

Here is an example output:-
before:
```
        # Tryme::foo @ bci:3  L[0]=_ STK[0]=#NULL STK[1]=#Ptr0x0000ffff340089c0
```

after:
```
        # Tryme::foo @ bci:3 (line 12)  L[0]=_ STK[0]=#NULL STK[1]=#Ptr0x0000ffff1008fd80
```

Testing:
I have run tier 1/2 on linux on x86 and aarch64. With a `--enable-debug` build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8033441](https://bugs.openjdk.java.net/browse/JDK-8033441): print line numbers with -XX:+PrintOptoAssembly


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer) ⚠️ Review applies to 468f1cbfd39ba2c812ea73f4b8b2047c100e1dea
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1272/head:pull/1272`
`$ git checkout pull/1272`
