### PR TITLE
8256152: tests fail because of ambiguous method resolution

### DIFF
--- a/test/jdk/java/util/stream/boottest/java.base/java/util/stream/DoubleNodeTest.java
+++ b/test/jdk/java/util/stream/boottest/java.base/java/util/stream/DoubleNodeTest.java
@@ -66,7 +66,7 @@ public class DoubleNodeTest extends OpTestCase {
     private static void assertEqualsListDoubleArray(List<Double> list, double[] array) {
         assertEquals(list.size(), array.length);
         for (int i = 0; i < array.length; i++)
-            assertEquals((Object) array[i], list.get(i));
+            assertEquals(array[i], (double) list.get(i));
     }
 
     private List<Double> toList(double[] a) {

--- a/test/jdk/java/util/stream/boottest/java.base/java/util/stream/DoubleNodeTest.java
+++ b/test/jdk/java/util/stream/boottest/java.base/java/util/stream/DoubleNodeTest.java
@@ -66,7 +66,7 @@ public class DoubleNodeTest extends OpTestCase {
     private static void assertEqualsListDoubleArray(List<Double> list, double[] array) {
         assertEquals(list.size(), array.length);
         for (int i = 0; i < array.length; i++)
-            assertEquals(array[i], list.get(i));
+            assertEquals((Object) array[i], list.get(i));
     }
 
     private List<Double> toList(double[] a) {


### PR DESCRIPTION
Added a cast in the right place, thanks to @jonathan-gibbons.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256152](https://bugs.openjdk.java.net/browse/JDK-8256152): tests fail because of ambiguous method resolution


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1274/head:pull/1274`
`$ git checkout pull/1274`
