### PR TITLE
JDK-8256501: libTestMainKeyWindow fails to build with Xcode 12.2

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -78,7 +78,7 @@ endif
 ifeq ($(call isTargetOs, macosx), true)
   BUILD_JDK_JTREG_EXCLUDE += exelauncher.c
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libTestMainKeyWindow := -ObjC
-  BUILD_JDK_JTREG_LIBRARIES_LIBS_libTestMainKeyWindow := -framework JavaVM \
+  BUILD_JDK_JTREG_LIBRARIES_LIBS_libTestMainKeyWindow := \
       -framework Cocoa -framework JavaNativeFoundation
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeJniInvocationTest := -ljli
 else


### PR DESCRIPTION
In Xcode 12.2, the framework JavaVM was removed in the sysroot and all (relevant) frameworks inside were just moved one step up so we still find things like JavaNativeFoundation and JavaRuntimeSupport. There is however one test that currently links explicitly to JavaVM, which fails the build. The fix seems to be to simply remove this from the linker flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256501](https://bugs.openjdk.java.net/browse/JDK-8256501): libTestMainKeyWindow fails to build with Xcode 12.2


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1275/head:pull/1275`
`$ git checkout pull/1275`
