### PR TITLE
8238174: migrate ObjectMonitor::_owner field away from C++ volatile semantics

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -147,13 +147,13 @@ class ObjectMonitor : public CHeapObj<mtInternal> {
                         sizeof(WeakHandle));
   // Used by async deflation as a marker in the _owner field:
   #define DEFLATER_MARKER reinterpret_cast<void*>(-1)
-  void* volatile _owner;            // pointer to owning thread OR BasicLock
+  void* _owner;                     // pointer to owning thread OR BasicLock
   volatile jlong _previous_owner_tid;  // thread id of the previous owner of the monitor
   // Separate _owner and _next_om on different cache lines since
   // both can have busy multi-threaded access. _previous_owner_tid is only
   // changed by ObjectMonitor::exit() so it is a good choice to share the
   // cache line with _owner.
-  DEFINE_PAD_MINUS_SIZE(1, OM_CACHE_LINE_SIZE, sizeof(void* volatile) +
+  DEFINE_PAD_MINUS_SIZE(1, OM_CACHE_LINE_SIZE, sizeof(void*) +
                         sizeof(volatile jlong));
   ObjectMonitor* _next_om;          // Next ObjectMonitor* linkage
   volatile intx _recursions;        // recursion count, 0 for first entry
@@ -242,8 +242,8 @@ class ObjectMonitor : public CHeapObj<mtInternal> {
     if (contentions() > 0) {
       ret_code |= contentions();
     }
-    if (_owner != DEFLATER_MARKER) {
-      ret_code |= intptr_t(_owner);
+    if (!owner_is_DEFLATER_MARKER()) {
+      ret_code |= intptr_t(owner_raw());
     }
     return ret_code;
   }
@@ -252,8 +252,9 @@ class ObjectMonitor : public CHeapObj<mtInternal> {
   intptr_t  is_entered(Thread* current) const;
 
   void*     owner() const;  // Returns NULL if DEFLATER_MARKER is observed.
+  void*     owner_raw() const;
   // Returns true if owner field == DEFLATER_MARKER and false otherwise.
-  bool      owner_is_DEFLATER_MARKER();
+  bool      owner_is_DEFLATER_MARKER() const;
   // Returns true if 'this' is being async deflated and false otherwise.
   bool      is_being_async_deflated();
   // Clear _owner field; current value must match old_value.

--- a/src/hotspot/share/runtime/objectMonitor.inline.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.inline.hpp
@@ -31,7 +31,8 @@
 #include "runtime/synchronizer.hpp"
 
 inline intptr_t ObjectMonitor::is_entered(TRAPS) const {
-  if (THREAD == owner_raw() || THREAD->is_lock_owned((address) owner_raw())) {
+  void* owner = owner_raw();
+  if (THREAD == owner || THREAD->is_lock_owned((address)owner)) {
     return 1;
   }
   return 0;
@@ -67,7 +68,7 @@ inline void* ObjectMonitor::owner_raw() const {
 // This accessor is called when we really need to know if the owner
 // field == DEFLATER_MARKER and any non-NULL value won't do the trick.
 inline bool ObjectMonitor::owner_is_DEFLATER_MARKER() const {
-  return Atomic::load(&_owner) == DEFLATER_MARKER;
+  return owner_raw() == DEFLATER_MARKER;
 }
 
 // Returns true if 'this' is being async deflated and false otherwise.

--- a/src/hotspot/share/runtime/objectMonitor.inline.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.inline.hpp
@@ -31,7 +31,7 @@
 #include "runtime/synchronizer.hpp"
 
 inline intptr_t ObjectMonitor::is_entered(TRAPS) const {
-  if (THREAD == _owner || THREAD->is_lock_owned((address) _owner)) {
+  if (THREAD == owner_raw() || THREAD->is_lock_owned((address) owner_raw())) {
     return 1;
   }
   return 0;
@@ -55,14 +55,18 @@ inline jint ObjectMonitor::waiters() const {
 
 // Returns NULL if DEFLATER_MARKER is observed.
 inline void* ObjectMonitor::owner() const {
-  void* owner = _owner;
+  void* owner = owner_raw();
   return owner != DEFLATER_MARKER ? owner : NULL;
+}
+
+inline void* ObjectMonitor::owner_raw() const {
+  return Atomic::load(&_owner);
 }
 
 // Returns true if owner field == DEFLATER_MARKER and false otherwise.
 // This accessor is called when we really need to know if the owner
 // field == DEFLATER_MARKER and any non-NULL value won't do the trick.
-inline bool ObjectMonitor::owner_is_DEFLATER_MARKER() {
+inline bool ObjectMonitor::owner_is_DEFLATER_MARKER() const {
   return Atomic::load(&_owner) == DEFLATER_MARKER;
 }
 

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -341,7 +341,7 @@ bool ObjectSynchronizer::quick_enter(oop obj, Thread* self,
     if (m->object_peek() == NULL) {
       return false;
     }
-    Thread* const owner = (Thread *) m->_owner;
+    Thread* const owner = (Thread *) m->owner_raw();
 
     // Lock contention and Transactional Lock Elision (TLE) diagnostics
     // and observability


### PR DESCRIPTION
Drop volatile from the ObjectMonitor::_owner field. Update all naked
field loads to use the new owner_raw() accessor or the existing
owner_is_DEFLATER_MARKER() accessor.

Testing: Mach5 Tier1,2,3; only unrelated, known test failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8238174](https://bugs.openjdk.java.net/browse/JDK-8238174): migrate ObjectMonitor::_owner field away from C++ volatile semantics


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1278/head:pull/1278`
`$ git checkout pull/1278`
