### PR TITLE
8256538: Fix annoying awk warning in configure for java versions

### DIFF
--- a/make/autoconf/boot-jdk.m4
+++ b/make/autoconf/boot-jdk.m4
@@ -516,7 +516,7 @@ AC_DEFUN([BOOTJDK_CHECK_BUILD_JDK],
       else
         # Oh, this is looking good! We probably have found a proper JDK. Is it the correct version?
         # Additional [] needed to keep m4 from mangling shell constructs.
-        [ BUILD_JDK_VERSION=`"$BUILD_JDK/bin/java" -version 2>&1 | $AWK '/version \"[0-9a-zA-Z\._\-]+\"/{print $ 0; exit;}'` ]
+        [ BUILD_JDK_VERSION=`"$BUILD_JDK/bin/java" -version 2>&1 | $AWK '/version "[0-9a-zA-Z\._\-]+"/ {print $ 0; exit;}'` ]
 
         # Extra M4 quote needed to protect [] in grep expression.
         [FOUND_CORRECT_VERSION=`echo $BUILD_JDK_VERSION | $EGREP "\"$VERSION_FEATURE([\.+-].*)?\""`]

--- a/make/autoconf/boot-jdk.m4
+++ b/make/autoconf/boot-jdk.m4
@@ -75,7 +75,7 @@ AC_DEFUN([BOOTJDK_DO_CHECK],
         else
           # Oh, this is looking good! We probably have found a proper JDK. Is it the correct version?
           # Additional [] needed to keep m4 from mangling shell constructs.
-          [ BOOT_JDK_VERSION=`"$BOOT_JDK/bin/java$EXE_SUFFIX" $USER_BOOT_JDK_OPTIONS -version 2>&1 | $AWK '/version \"[0-9a-zA-Z\._\-]+\"/{print $ 0; exit;}'` ]
+          [ BOOT_JDK_VERSION=`"$BOOT_JDK/bin/java$EXE_SUFFIX" $USER_BOOT_JDK_OPTIONS -version 2>&1 | $AWK '/version "[0-9a-zA-Z\._\-]+"/ {print $ 0; exit;}'` ]
           if [ [[ "$BOOT_JDK_VERSION" =~ "Picked up" ]] ]; then
             AC_MSG_NOTICE([You have _JAVA_OPTIONS or JAVA_TOOL_OPTIONS set. This can mess up the build. Please use --with-boot-jdk-jvmargs instead.])
             AC_MSG_NOTICE([Java reports: "$BOOT_JDK_VERSION".])


### PR DESCRIPTION
The change from grep to awk in JDK-8244248 and further bug fixed in JDK-8244756 still has invalid syntax. This causes some awk (most notably gawk, the most commonly used) to complain:

gawk: cmd. line:1: warning: regexp escape sequence `\"' is not a known regexp operator

This is annoying and should be fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256538](https://bugs.openjdk.java.net/browse/JDK-8256538): Fix annoying awk warning in configure for java versions


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 9d5fd4fcabf7bdf580e2fff8e12c2cf130ef44c9


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1285/head:pull/1285`
`$ git checkout pull/1285`
