### PR TITLE
8256536: Newer AMD 19h (EPYC) Processor family defaults

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1311,9 +1311,10 @@ void VM_Version::get_processor_features() {
     }
 #endif // COMPILER2
 
-    // Some defaults for AMD family 17h || Hygon family 18h
-    if (cpu_family() == 0x17 || cpu_family() == 0x18) {
-      // On family 17h processors use XMM and UnalignedLoadStores for Array Copy
+    // Some defaults for AMD family >= 17h && Hygon family 18h
+    if (cpu_family() >= 0x17) {
+      // On family >=17h processors use XMM and UnalignedLoadStores
+      // for Array Copy
       if (supports_sse2() && FLAG_IS_DEFAULT(UseXMMForArrayCopy)) {
         FLAG_SET_DEFAULT(UseXMMForArrayCopy, true);
       }
@@ -1484,6 +1485,14 @@ void VM_Version::get_processor_features() {
   } else if (UseFastStosb) {
     warning("fast-string operations are not available on this CPU");
     FLAG_SET_DEFAULT(UseFastStosb, false);
+  }
+
+  // For AMD Processors use XMM/YMM MOVDQU instructions
+  // for Object Initialization as default
+  if (is_amd() && cpu_family() >= 0x19) {
+    if (FLAG_IS_DEFAULT(UseFastStosb)) {
+      UseFastStosb = false;
+    }
   }
 
   // Use XMM/YMM MOVDQU instruction for Object Initialization


### PR DESCRIPTION
This patch sets the following flags as defaults for newer AMD 19h (EPYC) processors.
      bool UseFPUForSpilling               = true   
      bool UseUnalignedLoadStores    = true   
      bool UseXMMForArrayCopy        = true   
      bool UseXMMForObjInit             = true   
      bool UseFastStosb                       = false  
      bool AlignVector                          = false  

Additional testing: make run-test TEST="tier1 tier2" JTREG="JOBS=128" CONF=linux-x86_64-server-fastdebug

Please review this change.

Thanks,
Rohit

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256536](https://bugs.openjdk.java.net/browse/JDK-8256536): Newer AMD 19h (EPYC) Processor family defaults


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1288/head:pull/1288`
`$ git checkout pull/1288`
