### PR TITLE
8255351: Add detection for Graviton 1 & 2 CPUs

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -163,6 +163,13 @@ void VM_Version::initialize() {
     }
   }
 
+  // Cortex A72
+  if (_cpu == CPU_ARM && (_model == 0xd08 || _model2 == 0xd08)) {
+    if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
+      FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
+    }
+  }
+
   // Cortex A73
   if (_cpu == CPU_ARM && (_model == 0xd09 || _model2 == 0xd09)) {
     if (FLAG_IS_DEFAULT(SoftwarePrefetchHintDistance)) {
@@ -171,6 +178,13 @@ void VM_Version::initialize() {
     // A73 is faster with short-and-easy-for-speculative-execution-loop
     if (FLAG_IS_DEFAULT(UseSimpleArrayEquals)) {
       FLAG_SET_DEFAULT(UseSimpleArrayEquals, true);
+    }
+  }
+
+  // Neoverse N1
+  if (_cpu == CPU_ARM && (_model == 0xd0c || _model2 == 0xd0c)) {
+    if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
+      FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }
   }
 

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -170,6 +170,13 @@ void VM_Version::initialize() {
     }
   }
 
+  // Cortex A72
+  if (_cpu == CPU_ARM && (_model == 0xd08 || _model2 == 0xd08)) {
+    if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
+      FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
+    }
+  }
+
   // Cortex A73
   if (_cpu == CPU_ARM && (_model == 0xd09 || _model2 == 0xd09)) {
     if (FLAG_IS_DEFAULT(SoftwarePrefetchHintDistance)) {
@@ -178,6 +185,13 @@ void VM_Version::initialize() {
     // A73 is faster with short-and-easy-for-speculative-execution-loop
     if (FLAG_IS_DEFAULT(UseSimpleArrayEquals)) {
       FLAG_SET_DEFAULT(UseSimpleArrayEquals, true);
+    }
+  }
+
+  // Neoverse N1
+  if (_cpu == CPU_ARM && (_model == 0xd0c || _model2 == 0xd0c)) {
+    if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
+      FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }
   }
 


### PR DESCRIPTION
This patch adds detection for Graviton 1 (as Cortex-A72) and for Graviton 2 (as Neoverse N1) and enables UseSIMDForMemoryOps for them. SIMD are not used for copying bytes <= 96 because there are no benefits
using them.

The patch passed jtreg tier1-2 and all gtest tests with linux-aarch64-server-release build.

JMH micro-benchmark results for Graviton2 (diff ns/op):

```
ArrayCopy.arrayCopyChar                     -26.32%
ArrayCopy.arrayCopyCharNonConst             -26.32%
ArrayCopy.arrayCopyObject                   -9.52%
ArrayCopy.arrayCopyObjectNonConst           -5.78%
ArrayCopy.arrayCopyObjectSameArraysBackward -3.13%
ArrayCopy.arrayCopyObjectSameArraysForward  -2.23%
ArrayCopyAligned.testChar               20  -5.57%
ArrayCopyAligned.testChar               70  -7.73%
ArrayCopyAligned.testChar               150 -6.10%
ArrayCopyAligned.testChar               300 -12.60%
ArrayCopyAligned.testChar               600 -15.31%
ArrayCopyAligned.testChar           1200    -15.38%
ArrayCopyAligned.testInt                10  -5.57%
ArrayCopyAligned.testInt                20  -4.43%
ArrayCopyAligned.testInt                70  -6.74%
ArrayCopyAligned.testInt                150 -13.16%
ArrayCopyAligned.testInt                300 -15.04%
ArrayCopyAligned.testInt                600 -17.64%
ArrayCopyAligned.testInt            1200    -17.60%
ArrayCopyAligned.testLong               5   -5.54%
ArrayCopyAligned.testLong               10  -9.67%
ArrayCopyAligned.testLong               70  -10.81%
ArrayCopyAligned.testLong               150 -16.70%
ArrayCopyAligned.testLong               300 -17.85%
ArrayCopyAligned.testLong               600 -17.19%
ArrayCopyAligned.testLong           1200    -18.70%
ArrayCopyUnalignedBoth.testChar         20  -5.57%
ArrayCopyUnalignedBoth.testChar         70  -2.85%
ArrayCopyUnalignedBoth.testChar         150 -10.06%
ArrayCopyUnalignedBoth.testChar         300 -7.94%
ArrayCopyUnalignedBoth.testChar         600 -15.05%
ArrayCopyUnalignedBoth.testChar     1200    -15.93%
ArrayCopyUnalignedBoth.testInt          10  -5.55%
ArrayCopyUnalignedBoth.testInt          20  -5.14%
ArrayCopyUnalignedBoth.testInt          70  -4.37%
ArrayCopyUnalignedBoth.testInt          150 -10.21%
ArrayCopyUnalignedBoth.testInt          300 -13.72%
ArrayCopyUnalignedBoth.testInt          600 -16.27%
ArrayCopyUnalignedBoth.testInt      1200    -16.95%
ArrayCopyUnalignedBoth.testLong         5   -5.55%
ArrayCopyUnalignedBoth.testLong         10  -3.81%
ArrayCopyUnalignedBoth.testLong         20  -4.60%
ArrayCopyUnalignedBoth.testLong         70  -9.73%
ArrayCopyUnalignedBoth.testLong         150 -16.01%
ArrayCopyUnalignedBoth.testLong         300 -16.11%
ArrayCopyUnalignedBoth.testLong         600 -17.24%
ArrayCopyUnalignedBoth.testLong     1200    -18.89%
ArrayCopyUnalignedDst.testChar          20  -5.54%
ArrayCopyUnalignedDst.testChar          70  -4.74%
ArrayCopyUnalignedDst.testChar          150 -4.23%
ArrayCopyUnalignedDst.testChar          300 -11.07%
ArrayCopyUnalignedDst.testChar          600 -13.55%
ArrayCopyUnalignedDst.testChar      1200    -17.39%
ArrayCopyUnalignedDst.testInt           10  -5.55%
ArrayCopyUnalignedDst.testInt           20  -4.04%
ArrayCopyUnalignedDst.testInt           70  -9.12%
ArrayCopyUnalignedDst.testInt           150 -13.68%
ArrayCopyUnalignedDst.testInt           300 -13.21%
ArrayCopyUnalignedDst.testInt           600 -18.62%
ArrayCopyUnalignedDst.testInt       1200    -18.48%
ArrayCopyUnalignedDst.testLong          5   -5.52%
ArrayCopyUnalignedDst.testLong          10  -2.62%
ArrayCopyUnalignedDst.testLong          70  -10.85%
ArrayCopyUnalignedDst.testLong          150 -15.71%
ArrayCopyUnalignedDst.testLong          300 -15.69%
ArrayCopyUnalignedDst.testLong          600 -16.83%
ArrayCopyUnalignedDst.testLong      1200    -18.14%
ArrayCopyUnalignedSrc.testChar          20  -5.73%
ArrayCopyUnalignedSrc.testChar          70  -3.23%
ArrayCopyUnalignedSrc.testChar          150 -7.25%
ArrayCopyUnalignedSrc.testChar          300 -9.99%
ArrayCopyUnalignedSrc.testChar          600 -14.81%
ArrayCopyUnalignedSrc.testChar      1200    -16.29%
ArrayCopyUnalignedSrc.testInt           10  -5.55%
ArrayCopyUnalignedSrc.testInt           20  -5.17%
ArrayCopyUnalignedSrc.testInt           70  -7.87%
ArrayCopyUnalignedSrc.testInt           150 -11.97%
ArrayCopyUnalignedSrc.testInt           300 -15.96%
ArrayCopyUnalignedSrc.testInt           600 -17.13%
ArrayCopyUnalignedSrc.testInt       1200    -17.19%
ArrayCopyUnalignedSrc.testLong          5   -5.55%
ArrayCopyUnalignedSrc.testLong          10  -3.55%
ArrayCopyUnalignedSrc.testLong          70  -11.65%
ArrayCopyUnalignedSrc.testLong          150 -13.66%
ArrayCopyUnalignedSrc.testLong          300 -17.53%
ArrayCopyUnalignedSrc.testLong          600 -18.62%
ArrayCopyUnalignedSrc.testLong      1200    -18.22%
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8255351](https://bugs.openjdk.java.net/browse/JDK-8255351): Add detection for Graviton 1 & 2 CPUs


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1294/head:pull/1294`
`$ git checkout pull/1294`
