### PR TITLE
8256565: ProblemList jdk/jfr/api/recording/event/TestReEnableName.java on windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -843,6 +843,7 @@ javax/script/Test7.java                                         8239361 generic-
 
 # jdk_jfr
 
+jdk/jfr/api/recording/event/TestReEnableName.java               8256482 windows-all
 jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java          8228990,8229370    generic-all
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209    generic-all
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all


### PR DESCRIPTION
This is a trivial fix to ProblemList jdk/jfr/api/recording/event/TestReEnableName.java on windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256565](https://bugs.openjdk.java.net/browse/JDK-8256565): ProblemList jdk/jfr/api/recording/event/TestReEnableName.java on windows


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1295/head:pull/1295`
`$ git checkout pull/1295`
