### PR TITLE
8256480: Refactor ObjectInputStream field reader implementation

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -652,10 +652,12 @@ public class ObjectInputStream
         Object curObj = ctx.getObj();
         ObjectStreamClass curDesc = ctx.getDesc();
         bin.setBlockDataMode(false);
-        FieldValues vals = defaultReadFields(curObj, curDesc);
+
+        // Read fields of the current descriptor into a new FieldValues
+        FieldValues values = new FieldValues(curDesc, true);
         if (curObj != null) {
-            defaultCheckFieldValues(curObj, curDesc, vals);
-            defaultSetFieldValues(curObj, curDesc, vals);
+            values.defaultCheckFieldValues(curObj);
+            values.defaultSetFieldValues(curObj);
         }
         bin.setBlockDataMode(true);
         if (!curDesc.hasWriteObjectData()) {
@@ -695,8 +697,8 @@ public class ObjectInputStream
         ctx.checkAndSetUsed();
         ObjectStreamClass curDesc = ctx.getDesc();
         bin.setBlockDataMode(false);
-        GetFieldImpl getField = new GetFieldImpl(curDesc);
-        getField.readFields();
+        // Read fields of the current descriptor into a new FieldValues
+        FieldValues values = new FieldValues(curDesc, false);
         bin.setBlockDataMode(true);
         if (!curDesc.hasWriteObjectData()) {
             /*
@@ -706,8 +708,7 @@ public class ObjectInputStream
              */
             defaultDataEnd = true;
         }
-
-        return getField;
+        return values;
     }
 
     /**
@@ -2321,14 +2322,11 @@ public class ObjectInputStream
         if (slots.length != 1) {
             // skip any superclass stream field values
             for (int i = 0; i < slots.length-1; i++) {
-                ObjectStreamClass slotDesc = slots[i].desc;
-                if (slots[i].hasData) {
-                    defaultReadFields(null, slotDesc);
-                }
+                new FieldValues(slots[i].desc, true);
             }
         }
 
-        FieldValues fieldValues = defaultReadFields(null, desc);
+        FieldValues fieldValues = new FieldValues(desc, true);
 
         // get canonical record constructor adapted to take two arguments:
         // - byte[] primValues
@@ -2387,7 +2385,8 @@ public class ObjectInputStream
 
             if (slots[i].hasData) {
                 if (obj == null || handles.lookupException(passHandle) != null) {
-                    defaultReadFields(null, slotDesc); // skip field values
+                    // Read fields of the current descriptor into a new FieldValues and discard
+                    new FieldValues(slotDesc, true);
                 } else if (slotDesc.hasReadObjectMethod()) {
                     ThreadDeath t = null;
                     boolean reset = false;
@@ -2431,12 +2430,13 @@ public class ObjectInputStream
                      */
                     defaultDataEnd = false;
                 } else {
-                    FieldValues vals = defaultReadFields(obj, slotDesc);
+                    // Read fields of the current descriptor into a new FieldValues
+                    FieldValues values = new FieldValues(slotDesc, true);
                     if (slotValues != null) {
-                        slotValues[i] = vals;
+                        slotValues[i] = values;
                     } else if (obj != null) {
-                        defaultCheckFieldValues(obj, slotDesc, vals);
-                        defaultSetFieldValues(obj, slotDesc, vals);
+                        values.defaultCheckFieldValues(obj);
+                        values.defaultSetFieldValues(obj);
                     }
                 }
 
@@ -2460,11 +2460,11 @@ public class ObjectInputStream
             // before assigning.
             for (int i = 0; i < slots.length; i++) {
                 if (slotValues[i] != null)
-                    defaultCheckFieldValues(obj, slots[i].desc, slotValues[i]);
+                    slotValues[i].defaultCheckFieldValues(obj);
             }
             for (int i = 0; i < slots.length; i++) {
                 if (slotValues[i] != null)
-                    defaultSetFieldValues(obj, slots[i].desc, slotValues[i]);
+                    slotValues[i].defaultSetFieldValues(obj);
             }
         }
     }
@@ -2496,76 +2496,6 @@ public class ObjectInputStream
                     break;
             }
         }
-    }
-
-    /*package-private*/ class FieldValues {
-        final byte[] primValues;
-        final Object[] objValues;
-
-        FieldValues(byte[] primValues, Object[] objValues) {
-            this.primValues = primValues;
-            this.objValues = objValues;
-        }
-    }
-
-    /**
-     * Reads in values of serializable fields declared by given class
-     * descriptor. Expects that passHandle is set to obj's handle before this
-     * method is called.
-     */
-    private FieldValues defaultReadFields(Object obj, ObjectStreamClass desc)
-        throws IOException
-    {
-        Class<?> cl = desc.forClass();
-        if (cl != null && obj != null && !cl.isInstance(obj)) {
-            throw new ClassCastException();
-        }
-
-        byte[] primVals = null;
-        int primDataSize = desc.getPrimDataSize();
-        if (primDataSize > 0) {
-            primVals = new byte[primDataSize];
-            bin.readFully(primVals, 0, primDataSize, false);
-        }
-
-        Object[] objVals = null;
-        int numObjFields = desc.getNumObjFields();
-        if (numObjFields > 0) {
-            int objHandle = passHandle;
-            ObjectStreamField[] fields = desc.getFields(false);
-            objVals = new Object[numObjFields];
-            int numPrimFields = fields.length - objVals.length;
-            for (int i = 0; i < objVals.length; i++) {
-                ObjectStreamField f = fields[numPrimFields + i];
-                objVals[i] = readObject0(Object.class, f.isUnshared());
-                if (f.getField() != null) {
-                    handles.markDependency(objHandle, passHandle);
-                }
-            }
-            passHandle = objHandle;
-        }
-
-        return new FieldValues(primVals, objVals);
-    }
-
-    /** Throws ClassCastException if any value is not assignable. */
-    private void defaultCheckFieldValues(Object obj, ObjectStreamClass desc,
-                                         FieldValues values) {
-        Object[] objectValues = values.objValues;
-        if (objectValues != null)
-            desc.checkObjFieldValueTypes(obj, objectValues);
-    }
-
-    /** Sets field values in obj. */
-    private void defaultSetFieldValues(Object obj, ObjectStreamClass desc,
-                                       FieldValues values) {
-        byte[] primValues = values.primValues;
-        Object[] objectValues = values.objValues;
-
-        if (primValues != null)
-            desc.setPrimFieldValues(obj, primValues);
-        if (objectValues != null)
-            desc.setObjFieldValues(obj, objectValues);
     }
 
     /**
@@ -2607,103 +2537,121 @@ public class ObjectInputStream
     /**
      * Default GetField implementation.
      */
-    private class GetFieldImpl extends GetField {
+    private final class FieldValues extends GetField {
 
         /** class descriptor describing serializable fields */
         private final ObjectStreamClass desc;
         /** primitive field values */
-        private final byte[] primVals;
+        final byte[] primValues;
         /** object field values */
-        private final Object[] objVals;
+
+        final Object[] objValues;
         /** object field value handles */
         private final int[] objHandles;
 
         /**
-         * Creates GetFieldImpl object for reading fields defined in given
+         * Creates FieldValues object for reading fields defined in given
          * class descriptor.
+         * @param desc the ObjectStreamClass to read
+         * @param recordDependencies if true, record the dependencies
+         *                           from current PassHandle and the object's read.
          */
-        GetFieldImpl(ObjectStreamClass desc) {
+        FieldValues(ObjectStreamClass desc, boolean recordDependencies) throws IOException {
             this.desc = desc;
-            primVals = new byte[desc.getPrimDataSize()];
-            objVals = new Object[desc.getNumObjFields()];
-            objHandles = new int[objVals.length];
+            primValues = new byte[desc.getPrimDataSize()];
+            objValues = new Object[desc.getNumObjFields()];
+            objHandles = new int[objValues.length];
+
+            bin.readFully(primValues, 0, primValues.length, false);
+
+            int numObjFields = desc.getNumObjFields();
+            if (numObjFields > 0) {
+                int objHandle = passHandle;
+                ObjectStreamField[] fields = desc.getFields(false);
+                int numPrimFields = fields.length - objValues.length;
+                for (int i = 0; i < objValues.length; i++) {
+                    ObjectStreamField f = fields[numPrimFields + i];
+                    objValues[i] = readObject0(Object.class, f.isUnshared());
+                    objHandles[i] = passHandle;
+                    if (recordDependencies && f.getField() != null) {
+                        handles.markDependency(objHandle, passHandle);
+                    }
+                }
+                passHandle = objHandle;
+            }
         }
 
         public ObjectStreamClass getObjectStreamClass() {
             return desc;
         }
 
-        public boolean defaulted(String name) throws IOException {
+        public boolean defaulted(String name) {
             return (getFieldOffset(name, null) < 0);
         }
 
-        public boolean get(String name, boolean val) throws IOException {
+        public boolean get(String name, boolean val) {
             int off = getFieldOffset(name, Boolean.TYPE);
-            return (off >= 0) ? Bits.getBoolean(primVals, off) : val;
+            return (off >= 0) ? Bits.getBoolean(primValues, off) : val;
         }
 
-        public byte get(String name, byte val) throws IOException {
+        public byte get(String name, byte val) {
             int off = getFieldOffset(name, Byte.TYPE);
-            return (off >= 0) ? primVals[off] : val;
+            return (off >= 0) ? primValues[off] : val;
         }
 
-        public char get(String name, char val) throws IOException {
+        public char get(String name, char val) {
             int off = getFieldOffset(name, Character.TYPE);
-            return (off >= 0) ? Bits.getChar(primVals, off) : val;
+            return (off >= 0) ? Bits.getChar(primValues, off) : val;
         }
 
-        public short get(String name, short val) throws IOException {
+        public short get(String name, short val) {
             int off = getFieldOffset(name, Short.TYPE);
-            return (off >= 0) ? Bits.getShort(primVals, off) : val;
+            return (off >= 0) ? Bits.getShort(primValues, off) : val;
         }
 
-        public int get(String name, int val) throws IOException {
+        public int get(String name, int val) {
             int off = getFieldOffset(name, Integer.TYPE);
-            return (off >= 0) ? Bits.getInt(primVals, off) : val;
+            return (off >= 0) ? Bits.getInt(primValues, off) : val;
         }
 
-        public float get(String name, float val) throws IOException {
+        public float get(String name, float val) {
             int off = getFieldOffset(name, Float.TYPE);
-            return (off >= 0) ? Bits.getFloat(primVals, off) : val;
+            return (off >= 0) ? Bits.getFloat(primValues, off) : val;
         }
 
-        public long get(String name, long val) throws IOException {
+        public long get(String name, long val) {
             int off = getFieldOffset(name, Long.TYPE);
-            return (off >= 0) ? Bits.getLong(primVals, off) : val;
+            return (off >= 0) ? Bits.getLong(primValues, off) : val;
         }
 
-        public double get(String name, double val) throws IOException {
+        public double get(String name, double val) {
             int off = getFieldOffset(name, Double.TYPE);
-            return (off >= 0) ? Bits.getDouble(primVals, off) : val;
+            return (off >= 0) ? Bits.getDouble(primValues, off) : val;
         }
 
-        public Object get(String name, Object val) throws IOException {
+        public Object get(String name, Object val) {
             int off = getFieldOffset(name, Object.class);
             if (off >= 0) {
                 int objHandle = objHandles[off];
                 handles.markDependency(passHandle, objHandle);
                 return (handles.lookupException(objHandle) == null) ?
-                    objVals[off] : null;
+                    objValues[off] : null;
             } else {
                 return val;
             }
         }
 
-        /**
-         * Reads primitive and object field values from stream.
-         */
-        void readFields() throws IOException {
-            bin.readFully(primVals, 0, primVals.length, false);
+        /** Throws ClassCastException if any value is not assignable. */
+        void defaultCheckFieldValues(Object obj) {
+            if (objValues != null)
+                desc.checkObjFieldValueTypes(obj, objValues);
+        }
 
-            int oldHandle = passHandle;
-            ObjectStreamField[] fields = desc.getFields(false);
-            int numPrimFields = fields.length - objVals.length;
-            for (int i = 0; i < objVals.length; i++) {
-                objVals[i] =
-                    readObject0(Object.class, fields[numPrimFields + i].isUnshared());
-                objHandles[i] = passHandle;
-            }
-            passHandle = oldHandle;
+        private void defaultSetFieldValues(Object obj) {
+            if (primValues != null)
+                desc.setPrimFieldValues(obj, primValues);
+            if (objValues != null)
+                desc.setObjFieldValues(obj, objValues);
         }
 
         /**

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -2322,7 +2322,9 @@ public class ObjectInputStream
         if (slots.length != 1) {
             // skip any superclass stream field values
             for (int i = 0; i < slots.length-1; i++) {
-                new FieldValues(slots[i].desc, true);
+                if (slots[i].hasData) {
+                    new FieldValues(slots[i].desc, true);
+                }
             }
         }
 
@@ -2544,7 +2546,6 @@ public class ObjectInputStream
         /** primitive field values */
         final byte[] primValues;
         /** object field values */
-
         final Object[] objValues;
         /** object field value handles */
         private final int[] objHandles;
@@ -2558,13 +2559,16 @@ public class ObjectInputStream
          */
         FieldValues(ObjectStreamClass desc, boolean recordDependencies) throws IOException {
             this.desc = desc;
-            primValues = new byte[desc.getPrimDataSize()];
-            objValues = new Object[desc.getNumObjFields()];
-            objHandles = new int[objValues.length];
 
-            bin.readFully(primValues, 0, primValues.length, false);
+            int primDataSize = desc.getPrimDataSize();
+            primValues = (primDataSize > 0) ? new byte[primDataSize] : null;
+            if (primDataSize > 0) {
+                bin.readFully(primValues, 0, primDataSize, false);
+            }
 
             int numObjFields = desc.getNumObjFields();
+            objValues = (numObjFields > 0) ? new Object[numObjFields] : null;
+            objHandles = (numObjFields > 0) ? new int[numObjFields] : null;
             if (numObjFields > 0) {
                 int objHandle = passHandle;
                 ObjectStreamField[] fields = desc.getFields(false);


### PR DESCRIPTION
ObjectInputStream has nearly identical but separate implementations to read values from the stream.
Both implementations read primitive and object values from the stream and return an object holding the values.
OIS.readFields() uses the internal class GetFieldImpl while OIS.defaultReadObject and reading records uses the internal class FieldValues.
The behavioral difference between the two is whether dependencies are tracked in the object handle table or not. 

The classes are merged, retaining the internal FieldValues name and the behavior to track dependencies or not. 
The constructor is passed the class descriptor and flag to track or not; it reads and saves the values from the stream.
The callers are updated to call the merge FieldValues methods.

There is no change in behavior; all current tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256480](https://bugs.openjdk.java.net/browse/JDK-8256480): Refactor ObjectInputStream field reader implementation


### Reviewers
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1296/head:pull/1296`
`$ git checkout pull/1296`
