### PR TITLE
8256567: ProblemList java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java for Xcomp testing

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -28,3 +28,4 @@
 #############################################################################
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java 8256368 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java for Xcomp testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256567](https://bugs.openjdk.java.net/browse/JDK-8256567): ProblemList java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java for Xcomp testing


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1297/head:pull/1297`
`$ git checkout pull/1297`
