### PR TITLE
8227400: Adjust jib profiles to make 3rd party tools for creating installers available on Mach5 test machines

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Executor.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Executor.java
@@ -218,7 +218,7 @@ final public class Executor {
         StringBuilder sb = new StringBuilder();
         sb.append((quiet) ? pb.command().get(0) : pb.command());
         if (pb.directory() != null) {
-            sb.append(String.format("in %s", pb.directory().getAbsolutePath()));
+            sb.append(String.format(" in %s", pb.directory().getAbsolutePath()));
         }
         return sb.toString();
     }

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -43,6 +43,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -833,6 +834,19 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
             }
             return str;
         }).collect(Collectors.joining(" "));
+    }
+
+    public static Stream<String> stripTimestamps(Stream<String> stream) {
+        // [HH:mm:ss.SSS]
+        final Pattern timestampRegexp = Pattern.compile(
+                "^\\[\\d\\d:\\d\\d:\\d\\d.\\d\\d\\d\\] ");
+        return stream.map(str -> {
+            Matcher m = timestampRegexp.matcher(str);
+            if (m.find()) {
+                str = str.substring(m.end());
+            }
+            return str;
+        });
     }
 
     @Override

--- a/test/jdk/tools/jpackage/windows/WinResourceTest.java
+++ b/test/jdk/tools/jpackage/windows/WinResourceTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import jdk.jpackage.test.TKit;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
+import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.Annotations.Parameters;
 import java.util.List;
@@ -85,7 +86,8 @@ public class WinResourceTest {
             // examining its output
             TKit.assertTextStream(expectedLogMessage)
                     .predicate(String::startsWith)
-                    .apply(result.getOutput().stream());
+                    .apply(JPackageCommand.stripTimestamps(
+                            result.getOutput().stream()));
             TKit.assertTextStream("error CNDL0104 : Not a valid source file")
                     .apply(result.getOutput().stream());
         })

--- a/test/jdk/tools/jpackage/windows/WinScriptTest.java
+++ b/test/jdk/tools/jpackage/windows/WinScriptTest.java
@@ -124,18 +124,18 @@ public class WinScriptTest {
         }
 
         void assertJPackageOutput(List<String> output) {
-            TKit.assertTextStream(String.format("jp: %s", echoText))
+            TKit.assertTextStream(String.format("    jp: %s", echoText))
                     .predicate(String::equals)
                     .apply(output.stream());
 
-            String cwdPattern = String.format("jp: CWD(%s)=", envVarName);
+            String cwdPattern = String.format("    jp: CWD(%s)=", envVarName);
             TKit.assertTextStream(cwdPattern)
                     .predicate(String::startsWith)
                     .apply(output.stream());
             String cwd = output.stream().filter(line -> line.startsWith(
                     cwdPattern)).findFirst().get().substring(cwdPattern.length());
 
-            String envVarPattern = String.format("jp: %s=", envVarName);
+            String envVarPattern = String.format("    jp: %s=", envVarName);
             TKit.assertTextStream(envVarPattern)
                     .predicate(String::startsWith)
                     .apply(output.stream());


### PR DESCRIPTION
Fix test failures. They didn't fail in Mach5 test runs as WiX was not available on test machines and these tests were not executed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8227400](https://bugs.openjdk.java.net/browse/JDK-8227400): Adjust jib profiles to make 3rd party tools for creating installers available on Mach5 test machines


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1298/head:pull/1298`
`$ git checkout pull/1298`
