### PR TITLE
8253299: Manifest bytes are read twice when verifying a signed JAR

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -739,6 +739,7 @@ public class JarFile extends ZipFile {
             List<String> names = JUZFA.getManifestAndSignatureRelatedFiles(this);
             for (String name : names) {
                 JarEntry e = getJarEntry(name);
+                byte[] b;
                 if (e == null) {
                     throw new JarException("corrupted jar file");
                 }
@@ -746,7 +747,11 @@ public class JarFile extends ZipFile {
                     mev = new ManifestEntryVerifier
                         (getManifestFromReference());
                 }
-                byte[] b = getBytes(e);
+                if (name.equals(MANIFEST_NAME)) {
+                    b = jv.manifestRawBytes;
+                } else {
+                    b = getBytes(e);
+                }
                 if (b != null && b.length > 0) {
                     jv.beginEntry(e, mev);
                     jv.update(b.length, b, 0, b.length, mev);


### PR DESCRIPTION
Small change to retrieve the raw bytes of manifest during verifying signed JAR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8253299](https://bugs.openjdk.java.net/browse/JDK-8253299): Manifest bytes are read twice when verifying a signed JAR


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1299/head:pull/1299`
`$ git checkout pull/1299`
