### PR TITLE
8256312: Valid anchor 'id' value not allowed

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -621,18 +621,21 @@ public class Checker extends DocTreePathScanner<Void, Void> {
             }
 
             if (attr != null) {
+                Pattern validPattern = null;
                 switch (attr) {
                     case NAME:
                         if (currTag != HtmlTag.A) {
                             break;
                         }
+                        validPattern = validName;
                         // fallthrough
                     case ID:
                         String value = getAttrValue(tree);
+                        validPattern = validPattern != null ? validPattern : validId;
                         if (value == null) {
                             env.messages.error(HTML, tree, "dc.anchor.value.missing");
                         } else {
-                            if (!validName.matcher(value).matches()) {
+                            if (!validPattern.matcher(value).matches()) {
                                 env.messages.error(HTML, tree, "dc.invalid.anchor", value);
                             }
                             if (!checkAnchor(value)) {
@@ -767,6 +770,9 @@ public class Checker extends DocTreePathScanner<Void, Void> {
 
     // http://www.w3.org/TR/html401/types.html#type-name
     private static final Pattern validName = Pattern.compile("[A-Za-z][A-Za-z0-9-_:.]*");
+
+    // https://html.spec.whatwg.org/#the-id-attribute
+    private static final Pattern validId = Pattern.compile("[^\s]+");
 
     private static final Pattern validNumber = Pattern.compile("-?[0-9]+");
 

--- a/test/langtools/tools/doclint/AnchorTest.java
+++ b/test/langtools/tools/doclint/AnchorTest.java
@@ -56,6 +56,11 @@ public class AnchorTest {
     /**
      * <a id=123 ></a>
      */
+    public void a_id_valid() { }
+
+    /**
+     * <a id="123 "></a>
+     */
     public void a_id_invalid() { }
 
     /**

--- a/test/langtools/tools/doclint/AnchorTest.out
+++ b/test/langtools/tools/doclint/AnchorTest.out
@@ -19,31 +19,28 @@ AnchorTest.java:52: error: invalid name for anchor: ""
 AnchorTest.java:52: error: anchor already defined: ""
      * <a id=></a>
           ^
-AnchorTest.java:57: error: invalid name for anchor: "123"
-     * <a id=123 ></a>
-          ^
 AnchorTest.java:57: error: anchor already defined: "123"
      * <a id=123 ></a>
           ^
-AnchorTest.java:62: error: no value given for anchor
+AnchorTest.java:62: error: invalid name for anchor: "123 "
+     * <a id="123 "></a>
+          ^
+AnchorTest.java:67: error: no value given for anchor
      * <a id ></a>
           ^
-AnchorTest.java:74: error: anchor already defined: "foo"
+AnchorTest.java:79: error: anchor already defined: "foo"
      * <p id=foo>text</p>
           ^
-AnchorTest.java:79: error: invalid name for anchor: ""
+AnchorTest.java:84: error: invalid name for anchor: ""
      * <p id=>text</p>
           ^
-AnchorTest.java:79: error: anchor already defined: ""
+AnchorTest.java:84: error: anchor already defined: ""
      * <p id=>text</p>
           ^
-AnchorTest.java:84: error: invalid name for anchor: "123"
+AnchorTest.java:89: error: anchor already defined: "123"
      * <p id=123 >text</p>
           ^
-AnchorTest.java:84: error: anchor already defined: "123"
-     * <p id=123 >text</p>
-          ^
-AnchorTest.java:89: error: no value given for anchor
+AnchorTest.java:94: error: no value given for anchor
      * <p id >text</p>
           ^
-16 errors
+15 errors


### PR DESCRIPTION
According to the W3C HTML5 spec [1][2], the id attribute is now allowed to have any value as long as it is unique, is not the empty string, and does not contain space characters.  However, DocLint still conforms to the old limitation defined in the HTML4 spec[3].

The changes consist of:
- Fixing jdk.javadoc.internal.doclint.Checker
- Updating test/langtools/doclint/AnchorTest.java

[1] https://www.w3.org/TR/html5-diff/
[2] https://html.spec.whatwg.org/#the-id-attribute
[3] https://www.w3.org/TR/html401/types.html#type-name

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8256312](https://bugs.openjdk.java.net/browse/JDK-8256312): Valid anchor 'id' value not allowed


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1308/head:pull/1308`
`$ git checkout pull/1308`
