### PR TITLE
6232281: -XX:-UseLoopSafepoints causes assert(v_false,"Parse::remove_useless_nodes missed this node")

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -960,7 +960,9 @@ PhaseIterGVN::PhaseIterGVN( PhaseGVN *gvn ) : PhaseGVN(gvn),
     Node *n = _table.at(i);
     if(n != NULL && n != _table.sentinel() && n->outcnt() == 0) {
       if( n->is_top() ) continue;
-      assert( false, "Parse::remove_useless_nodes missed this node");
+      // If remove_useless_nodes() has run, we expect no such nodes left.
+      assert(!UseLoopSafepoints || !OptoRemoveUseless,
+             "remove_useless_nodes missed this node");
       hash_delete(n);
     }
   }

--- a/test/hotspot/jtreg/compiler/arguments/TestDisableUseLoopSafepoints.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestDisableUseLoopSafepoints.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 6232281
+ * @requires vm.debug == true & vm.compiler2.enabled
+ * @summary Tests that C2 does not crash trivially with a "remove_useless_nodes
+ *          missed this node" message when UseLoopSafepoints is disabled. Note
+ *          that other parts of C2 assume that this option is enabled and might
+ *          fail in more subtle ways otherwise.
+ * @run main/othervm -Xcomp -Xbatch -XX:-TieredCompilation
+        -XX:CompileOnly=TestDisableUseLoopSafepoints -XX:-UseLoopSafepoints
+ *      compiler.arguments.TestDisableUseLoopSafepoints
+ */
+
+package compiler.arguments;
+
+public class TestDisableUseLoopSafepoints {
+    public static void main(String[] args) {
+        System.out.println("Passed");
+    }
+}

--- a/test/hotspot/jtreg/compiler/arguments/TestDisableUseLoopSafepoints.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestDisableUseLoopSafepoints.java
@@ -27,7 +27,7 @@
  * @requires vm.debug == true & vm.compiler2.enabled
  * @summary Tests that C2 does not crash trivially with a "remove_useless_nodes
  *          missed this node" message when UseLoopSafepoints is disabled.
- * @run main/othervm -Xcomp -Xbatch -XX:-TieredCompilation
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
         -XX:CompileOnly=TestDisableUseLoopSafepoints -XX:-UseLoopSafepoints
  *      compiler.arguments.TestDisableUseLoopSafepoints
  */

--- a/test/hotspot/jtreg/compiler/arguments/TestDisableUseLoopSafepoints.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestDisableUseLoopSafepoints.java
@@ -26,9 +26,7 @@
  * @bug 6232281
  * @requires vm.debug == true & vm.compiler2.enabled
  * @summary Tests that C2 does not crash trivially with a "remove_useless_nodes
- *          missed this node" message when UseLoopSafepoints is disabled. Note
- *          that other parts of C2 assume that this option is enabled and might
- *          fail in more subtle ways otherwise.
+ *          missed this node" message when UseLoopSafepoints is disabled.
  * @run main/othervm -Xcomp -Xbatch -XX:-TieredCompilation
         -XX:CompileOnly=TestDisableUseLoopSafepoints -XX:-UseLoopSafepoints
  *      compiler.arguments.TestDisableUseLoopSafepoints


### PR DESCRIPTION
Check for nodes missed by `remove_useless_nodes()` only if PhaseRemoveUseless has actually been run. This makes it possible to use `-XX:-UseLoopSafepoints` without crashing trivially, although implicit assumptions in other parts of C2 about the existence of loop safepoints might lead to more subtle failures for more complex methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-6232281](https://bugs.openjdk.java.net/browse/JDK-6232281): -XX:-UseLoopSafepoints causes assert(v_false,"Parse::remove_useless_nodes missed this node")


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1311/head:pull/1311`
`$ git checkout pull/1311`
