### PR TITLE
8256633: Fix product build on Windows+Arm64

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -504,8 +504,9 @@ class Address {
         if (size == 0) // It's a byte
           i->f(_ext.shift() >= 0, 12);
         else {
-          if (_ext.shift() > 0)
+          if (_ext.shift() > 0) {
             assert(_ext.shift() == (int)size, "bad shift");
+          }
           i->f(_ext.shift() > 0, 12);
         }
         i->f(0b10, 11, 10);

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -504,9 +504,7 @@ class Address {
         if (size == 0) // It's a byte
           i->f(_ext.shift() >= 0, 12);
         else {
-          if (_ext.shift() > 0) {
-            assert(_ext.shift() == (int)size, "bad shift");
-          }
+          assert(_ext.shift() <= 0 || _ext.shift() == (int)size, "bad shift");
           i->f(_ext.shift() > 0, 12);
         }
         i->f(0b10, 11, 10);


### PR DESCRIPTION
Fix this warning:
```
C:\work\openjdk-jdk\src\hotspot\cpu\aarch64\assembler_aarch64.hpp(508): error C2220: the following warning is treated as an error
C:\work\openjdk-jdk\src\hotspot\cpu\aarch64\assembler_aarch64.hpp(508): warning C4390: ';': empty controlled statement found; is this the intent?
```

Thanks to @magicus to bring that to my attention.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (6/6 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8256633](https://bugs.openjdk.java.net/browse/JDK-8256633): Fix product build on Windows+Arm64


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1312/head:pull/1312`
`$ git checkout pull/1312`
