### PR TITLE
8256640: assert(!m->is_old() || ik()->is_being_redefined()) failed: old methods should not be in vtable

### DIFF
--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -561,7 +561,8 @@ bool klassVtable::update_inherited_vtable(const methodHandle& target_method,
 
 void klassVtable::put_method_at(Method* m, int index) {
   assert(!m->is_private(), "private methods should not be in vtable");
-  JVMTI_ONLY(assert(!m->is_old() || ik()->is_being_redefined(), "old methods should not be in vtable"));
+  JVMTI_ONLY(assert(!m->is_old() || ik()->is_being_redefined() ||
+                    ik()->has_redefined_this_or_super(), "old methods should not be in vtable"));
   if (is_preinitialized_vtable()) {
     // At runtime initialize_vtable is rerun as part of link_class_impl()
     // for shared class loaded by the non-boot loader to obtain the loader


### PR DESCRIPTION
Hi all,

java/lang/instrument/IsModifiableClassAgent.java fails after JDK-8256365.
The reason is that the newly added assert [1] doesn't consider the case when the super class had been redefined.

Please review it.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/oops/klassVtable.cpp#L564

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x64 (hs/tier1 runtime)](https://github.com/DamonFool/jdk/runs/1424202531)

### Issue
 * [JDK-8256640](https://bugs.openjdk.java.net/browse/JDK-8256640): assert(!m->is_old() || ik()->is_being_redefined()) failed: old methods should not be in vtable


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1313/head:pull/1313`
`$ git checkout pull/1313`
