### PR TITLE
8255351: Add detection for Graviton 2 CPUs

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -174,6 +174,13 @@ void VM_Version::initialize() {
     }
   }
 
+  // Neoverse N1
+  if (_cpu == CPU_ARM && (_model == 0xd0c || _model2 == 0xd0c)) {
+    if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
+      FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
+    }
+  }
+
   if (_cpu == CPU_ARM) {
     if (FLAG_IS_DEFAULT(UseSignumIntrinsic)) {
       FLAG_SET_DEFAULT(UseSignumIntrinsic, true);


### PR DESCRIPTION
This commit adds detection for Graviton 1 (as Cortex-A72) and for Graviton 2 (as Neoverse N1) and enables UseSIMDForMemoryOps for them.

The patch passed jtreg tier1-2 and all gtest tests with linux-aarch64-server-release build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255351](https://bugs.openjdk.java.net/browse/JDK-8255351): Add detection for Graviton 2 CPUs


### Reviewers
 * [Volker Simonis](https://openjdk.java.net/census#simonis) (@simonis - **Reviewer**) ⚠️ Review applies to 204f1f683d9c1bbb6e4f27ab9b1a304c2f80ace6
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1315/head:pull/1315`
`$ git checkout pull/1315`
