### PR TITLE
8256154: Some TestNG tests require default constructors

### DIFF
--- a/test/jdk/java/lang/Package/GetPackages.java
+++ b/test/jdk/java/lang/Package/GetPackages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,12 @@ public class GetPackages {
     GetPackages(TestClassLoader loader) throws ClassNotFoundException {
         this.loader = loader;
         this.fooClass = loader.loadClass("foo.Foo");
+    }
+
+    /** For TestNG */
+    public GetPackages() {
+        loader = null;
+        fooClass = null;
     }
 
     /*

--- a/test/jdk/java/lang/StackWalker/Basic.java
+++ b/test/jdk/java/lang/StackWalker/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,6 +109,11 @@ public class Basic {
     private final int depth;
     Basic(int depth) {
         this.depth = depth;
+    }
+
+    /** For TestNG */
+    public Basic() {
+        depth = 0;
     }
 
     /*


### PR DESCRIPTION
In TestNG 7, it is a requirement that TestNG is able to create a Test object using a default constructor. 

This simple fix addresses two such classes so that this requirement is satisfied by inserting default construtors. Example: `public GetPackages() { ... }`

test/jdk/java/lang/Package/GetPackages.java
test/jdk/java/lang/StackWalker/Basic.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ❌ (1/1 failed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux aarch64 (build hotspot no-pch)](https://github.com/c-cleary/jdk/runs/1424209680)

### Issue
 * [JDK-8256154](https://bugs.openjdk.java.net/browse/JDK-8256154): Some TestNG tests require default constructors


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1317/head:pull/1317`
`$ git checkout pull/1317`
