### PR TITLE
8250888: nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java fails

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java
@@ -62,15 +62,17 @@
  */
 
 import sun.hotspot.code.Compiler;
+import sun.hotspot.WhiteBox;
+import sun.hotspot.gc.GC;
 
 public class TestDriver {
     public static void main(String[] args) throws Exception {
-        sun.hotspot.WhiteBox wb = sun.hotspot.WhiteBox.getWhiteBox();
+        WhiteBox wb = WhiteBox.getWhiteBox();
         Boolean isExplicitGCInvokesConcurrentOn = wb.getBooleanVMFlag("ExplicitGCInvokesConcurrent");
-        Boolean isUseG1GCon = wb.getBooleanVMFlag("UseG1GC");
-        Boolean isUseZGCon = wb.getBooleanVMFlag("UseZGC");
-        Boolean isShenandoahGCon = wb.getBooleanVMFlag("UseShenandoahGC");
-        Boolean isUseEpsilonGCon = wb.getBooleanVMFlag("UseEpsilonGC");
+        boolean isUseG1GCon = GC.G1.isSupported();
+        boolean isUseZGCon = GC.Z.isSupported();
+        boolean isShenandoahGCon = GC.Shenandoah.isSupported();
+        boolean isUseEpsilonGCon = GC.Epsilon.isSupported();
 
         if (Compiler.isGraalEnabled() &&
             (isUseZGCon || isUseEpsilonGCon || isShenandoahGCon)) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java
@@ -69,10 +69,10 @@ public class TestDriver {
     public static void main(String[] args) throws Exception {
         WhiteBox wb = WhiteBox.getWhiteBox();
         Boolean isExplicitGCInvokesConcurrentOn = wb.getBooleanVMFlag("ExplicitGCInvokesConcurrent");
-        boolean isUseG1GCon = GC.G1.isSupported();
-        boolean isUseZGCon = GC.Z.isSupported();
-        boolean isShenandoahGCon = GC.Shenandoah.isSupported();
-        boolean isUseEpsilonGCon = GC.Epsilon.isSupported();
+        boolean isUseG1GCon = GC.G1.isSelected();
+        boolean isUseZGCon = GC.Z.isSelected();
+        boolean isShenandoahGCon = GC.Shenandoah.isSelected();
+        boolean isUseEpsilonGCon = GC.Epsilon.isSelected();
 
         if (Compiler.isGraalEnabled() &&
             (isUseZGCon || isUseEpsilonGCon || isShenandoahGCon)) {


### PR DESCRIPTION
Hi all,

`TestDriver.java` used `sun.hotspot.WhiteBox.getBooleanVMFlag("Use*GC")` which could return null.
This patch uses `sun.hotspot.gc.GC` instead of `sun.hotspot.WhiteBox` to avoid the NullPointerException.
Thank you for taking the time to review.

Best Regards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8250888](https://bugs.openjdk.java.net/browse/JDK-8250888): nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java fails


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1319/head:pull/1319`
`$ git checkout pull/1319`
