### PR TITLE
8256670: Zero: enable compressed oops support back

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1678,7 +1678,6 @@ size_t Arguments::max_heap_for_compressed_oops() {
 }
 
 void Arguments::set_use_compressed_oops() {
-#ifndef ZERO
 #ifdef _LP64
   // MaxHeapSize is not set up properly at this point, but
   // the only value that can override MaxHeapSize if we are
@@ -1699,14 +1698,12 @@ void Arguments::set_use_compressed_oops() {
     }
   }
 #endif // _LP64
-#endif // ZERO
 }
 
 
 // NOTE: set_use_compressed_klass_ptrs() must be called after calling
 // set_use_compressed_oops().
 void Arguments::set_use_compressed_klass_ptrs() {
-#ifndef ZERO
 #ifdef _LP64
   // On some architectures, the use of UseCompressedClassPointers implies the use of
   // UseCompressedOops. The reason is that the rheap_base register of said platforms
@@ -1734,7 +1731,6 @@ void Arguments::set_use_compressed_klass_ptrs() {
     }
   }
 #endif // _LP64
-#endif // !ZERO
 }
 
 void Arguments::set_conservative_max_heap_alignment() {
@@ -1753,7 +1749,6 @@ jint Arguments::set_ergonomics_flags() {
 
   set_conservative_max_heap_alignment();
 
-#ifndef ZERO
 #ifdef _LP64
   set_use_compressed_oops();
 
@@ -1764,7 +1759,6 @@ jint Arguments::set_ergonomics_flags() {
   // Also checks that certain machines are slower with compressed oops
   // in vm_version initialization code.
 #endif // _LP64
-#endif // !ZERO
 
   return JNI_OK;
 }
@@ -4194,8 +4188,6 @@ jint Arguments::apply_ergo() {
   // Clear flags not supported on zero.
   FLAG_SET_DEFAULT(ProfileInterpreter, false);
   FLAG_SET_DEFAULT(UseBiasedLocking, false);
-  LP64_ONLY(FLAG_SET_DEFAULT(UseCompressedOops, false));
-  LP64_ONLY(FLAG_SET_DEFAULT(UseCompressedClassPointers, false));
 #endif // ZERO
 
   if (PrintAssembly && FLAG_IS_DEFAULT(DebugNonSafepoints)) {


### PR DESCRIPTION
UseCompressedOops was disabled for C++ interpreter by JDK-6909153, and it eventually morphed to disabled UseCompressedOops for all Zero configurations. I see nothing that actually prevents Zero from using compressed oops: all local/stack operands are always unpacked (like they are in non-interpreted modes), all heap accesses are calling into utility methods that handle compressed oops, there are no raw accesses to oops anywhere.

Additional testing:
 - [x] Ad-hoc benchmark tests
 - [x] `hotspot_gc_shenandoah` with Zero, now passing compressed oops tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256670](https://bugs.openjdk.java.net/browse/JDK-8256670): Zero: enable compressed oops support back


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1320/head:pull/1320`
`$ git checkout pull/1320`
