### PR TITLE
8256640: assert(!m->is_old() || ik()->is_being_redefined()) failed: old methods should not be in vtable

### DIFF
--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -234,7 +234,8 @@ void klassVtable::initialize_vtable(bool checkconstraints, TRAPS) {
 
           // needs new entry
           if (needs_new_entry) {
-            // Refetch this default method in case of redefinition in safepoint above.
+            // Refetch this default method in case of redefinition that might
+            // happen during constraint checking in the update_inherited_vtable call above.
             Method* method = default_methods->at(i);
             put_method_at(method, initialized);
             if (is_preinitialized_vtable()) {
@@ -502,9 +503,9 @@ bool klassVtable::update_inherited_vtable(const methodHandle& target_method,
           allocate_new = false;
         }
 
-        // Set the vtable index before the constraint check safepoint potentially
-        // redefines this method, which is possible if it is a default method belonging
-        // to a super class or interface.
+        // Set the vtable index before the constraint check safepoint, which potentially
+        // redefines this method if this method is a default method belonging to a
+        // super class or interface.
         put_method_at(target_method(), i);
 
         // Do not check loader constraints for overpass methods because overpass

--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -222,13 +222,21 @@ void klassVtable::initialize_vtable(bool checkconstraints, TRAPS) {
           assert(def_vtable_indices->length() == len, "reinit vtable len?");
         }
         for (int i = 0; i < len; i++) {
-          methodHandle mh(THREAD, default_methods->at(i));
-          assert(!mh->is_private(), "private interface method in the default method list");
-          bool needs_new_entry = update_inherited_vtable(mh, super_vtable_len, i, checkconstraints, CHECK);
+          bool needs_new_entry;
+          {
+            // Reduce the scope of this handle so that it is fetched again.
+            // The methodHandle keeps it from being deleted by RedefineClasses while
+            // we're using it.
+            methodHandle mh(THREAD, default_methods->at(i));
+            assert(!mh->is_private(), "private interface method in the default method list");
+            needs_new_entry = update_inherited_vtable(mh, super_vtable_len, i, checkconstraints, CHECK);
+          }
 
           // needs new entry
           if (needs_new_entry) {
-            put_method_at(mh(), initialized);
+            // Refetch this default method in case of redefinition in safepoint above.
+            Method* method = default_methods->at(i);
+            put_method_at(method, initialized);
             if (is_preinitialized_vtable()) {
               // At runtime initialize_vtable is rerun for a shared class
               // (loaded by the non-boot loader) as part of link_class_impl().
@@ -494,6 +502,11 @@ bool klassVtable::update_inherited_vtable(const methodHandle& target_method,
           allocate_new = false;
         }
 
+        // Set the vtable index before the constraint check safepoint potentially
+        // redefines this method, which is possible if it is a default method belonging
+        // to a super class or interface.
+        put_method_at(target_method(), i);
+
         // Do not check loader constraints for overpass methods because overpass
         // methods are created by the jvm to throw exceptions.
         if (checkconstraints && !target_method->is_overpass()) {
@@ -531,7 +544,6 @@ bool klassVtable::update_inherited_vtable(const methodHandle& target_method,
           }
         }
 
-        put_method_at(target_method(), i);
         overrides = true;
         if (!is_default) {
           target_method->set_vtable_index(i);


### PR DESCRIPTION
I added an assert with https://bugs.openjdk.java.net/browse/JDK-8256365 to catch adding redefined methods into the vtable where they don't belong (except while redefining that class).  The assert found that CDS was restoring classes with methods in the default_methods array which can be from a redefined class.  So these methods need to be adjusted before recreating the vtable.
Also fixed is a potential bug where a Method in a methodHandle in the default_methods array can be redefined in the safepoint caused by loader constraint checking, then added to the vtable.  The window for this bug is very small so I couldn't write a test for it. This change was in my v1 patch for JDK-8256365, so reintroduced here.

The test java/lang/instrument/IsModifiableClassAgent.java now passes with this patch.  Rerunning tier1-6 tests in progress.  Built with minimal VM to verify #if INCLUDE_JVMTIs were in the right places.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (5/6 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8256640](https://bugs.openjdk.java.net/browse/JDK-8256640): assert(!m->is_old() || ik()->is_being_redefined()) failed: old methods should not be in vtable


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**) ⚠️ Review applies to 12c24a1d62a9cc4f01296016c16a0533f8348608
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1323/head:pull/1323`
`$ git checkout pull/1323`
