### PR TITLE
JDK-8256682: JDK-8202343 is incomplete

### DIFF
--- a/test/jdk/sun/security/util/HostnameMatcher/NullHostnameCheck.java
+++ b/test/jdk/sun/security/util/HostnameMatcher/NullHostnameCheck.java
@@ -44,10 +44,10 @@ import jdk.test.lib.security.SSLContextBuilder;
  * @summary Verify hostname returns an exception instead of null pointer when
  * creating a new engine
  * @library /test/lib
- * @run main NullHostnameCheck TLSv1
- * @run main NullHostnameCheck TLSv1.1
- * @run main NullHostnameCheck TLSv1.2
- * @run main NullHostnameCheck TLSv1.3
+ * @run main/othervm NullHostnameCheck TLSv1
+ * @run main/othervm NullHostnameCheck TLSv1.1
+ * @run main/othervm NullHostnameCheck TLSv1.2
+ * @run main/othervm NullHostnameCheck TLSv1.3
  */
 
 public final class NullHostnameCheck {


### PR DESCRIPTION
The fix for disabling TLS 1.0 and 1.1 is causing intermittent failures of this test which depends on TLSv1 and v1.1. This test needs to run its own VM because it now needs to modify a security property to re-enable TLSv1 and v1.1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (3/6 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8256682](https://bugs.openjdk.java.net/browse/JDK-8256682): JDK-8202343 is incomplete


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1327/head:pull/1327`
`$ git checkout pull/1327`
