### PR TITLE
8256692: Zero: remove obsolete block from ZeroInterpreter::native_entry

### DIFF
--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -290,26 +290,6 @@ int ZeroInterpreter::native_entry(Method* method, intptr_t UNUSED, TRAPS) {
   interpreterState istate = frame->interpreter_state();
   intptr_t *locals = istate->locals();
 
-#if 0
-  // Update the invocation counter
-  if ((UseCompiler || CountCompiledCalls) && !method->is_synchronized()) {
-    MethodCounters* mcs = method->method_counters();
-    if (mcs == NULL) {
-      CALL_VM_NOCHECK(mcs = InterpreterRuntime::build_method_counters(thread, method));
-      if (HAS_PENDING_EXCEPTION)
-        goto unwind_and_return;
-    }
-    InvocationCounter *counter = mcs->invocation_counter();
-    counter->increment();
-    if (counter->reached_InvocationLimit(mcs->backedge_counter())) {
-      CALL_VM_NOCHECK(
-        InterpreterRuntime::frequency_counter_overflow(thread, NULL));
-      if (HAS_PENDING_EXCEPTION)
-        goto unwind_and_return;
-    }
-  }
-#endif
-
   // Lock if necessary
   BasicObjectLock *monitor;
   monitor = NULL;


### PR DESCRIPTION
There is a block that is protected by #if 0. Seems to be protected by it after [JDK-8239782](https://bugs.openjdk.java.net/browse/JDK-8256692), and it is completely unnecessary after [JDK-8255617](https://bugs.openjdk.java.net/browse/JDK-8255617).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ⏳ (1/9 running) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256692](https://bugs.openjdk.java.net/browse/JDK-8256692): Zero: remove obsolete block from ZeroInterpreter::native_entry


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1328/head:pull/1328`
`$ git checkout pull/1328`
