### PR TITLE
8246739: InputStream.skipNBytes could be implemented more efficiently

### DIFF
--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -602,7 +602,7 @@ public abstract class InputStream implements Closeable {
                 n -= ns;
             } else if (ns == 0) { // no bytes skipped
                 // read one byte to check for EOS
-                if (read() < 0) {
+                if (read() == -1) {
                     throw new EOFException();
                 }
                 // one byte read so decrement number to skip

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -580,7 +580,7 @@ public abstract class InputStream implements Closeable {
      * invokes {@link #skip(long) skip()} repeatedly until the requested number
      * of bytes has been skipped or an error condition occurs.  If at any
      * point the return value of {@code skip()} is negative or greater than the
-     * remaining number of bytes to be skipped, then an {@code IOException} is 
+     * remaining number of bytes to be skipped, then an {@code IOException} is
      * thrown.  If {@code skip()} ever returns zero, then {@link #read()} is
      * invoked to read a single byte, and if it returns {@code -1}, then an
      * {@code EOFException} is thrown.  Any exception thrown by {@code skip()}

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -594,20 +594,19 @@ public abstract class InputStream implements Closeable {
      * @see        java.io.InputStream#skip(long)
      */
     public void skipNBytes(long n) throws IOException {
-        if (n > 0) {
+        while (n > 0) {
             long ns = skip(n);
-            if (ns >= 0 && ns < n) { // skipped too few bytes
+            if (ns > 0 && ns <= n) {
                 // adjust number to skip
                 n -= ns;
-                // read until requested number skipped or EOS reached
-                while (n > 0 && read() != -1) {
-                    n--;
-                }
-                // if not enough skipped, then EOFE
-                if (n != 0) {
+            } else if (ns == 0) { // no bytes skipped
+                // read one byte to check for EOS
+                if (read() < 0) {
                     throw new EOFException();
                 }
-            } else if (ns != n) { // skipped negative or too many bytes
+                // one byte read so decrement number to skip
+                n--;
+            } else { // skipped negative or too many bytes
                 throw new IOException("Unable to skip exactly");
             }
         }

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -577,13 +577,14 @@ public abstract class InputStream implements Closeable {
      * @implSpec
      * If {@code n} is zero or negative, then no bytes are skipped.
      * If {@code n} is positive, the default implementation of this method
-     * invokes {@link #skip(long) skip()} with parameter {@code n}.  If the
-     * return value of {@code skip(n)} is non-negative and less than {@code n},
-     * then {@link #read()} is invoked repeatedly until the stream is {@code n}
-     * bytes beyond its position when this method was invoked or end of stream
-     * is reached.  If the return value of {@code skip(n)} is negative or
-     * greater than {@code n}, then an {@code IOException} is thrown.  Any
-     * exception thrown by {@code skip()} or {@code read()} will be propagated.
+     * invokes {@link #skip(long) skip()} repeatedly until the requested number
+     * of bytes has been skipped or an error condition occurs.  If at any
+     * point the return value of {@code skip()} is negative or greater than the
+     * remaining number of bytes to be skipped, then an {@code IOException} is 
+     * thrown.  If {@code skip()} ever returns zero, then {@link #read()} is
+     * invoked to read a single byte, and if it returns {@code -1}, then an
+     * {@code EOFException} is thrown.  Any exception thrown by {@code skip()}
+     * or {@code read()} will be propagated.
      *
      * @param      n   the number of bytes to be skipped.
      * @throws     EOFException if end of stream is encountered before the

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -577,7 +577,8 @@ public abstract class InputStream implements Closeable {
      * @implSpec
      * If {@code n} is zero or negative, then no bytes are skipped.
      * If {@code n} is positive, the default implementation of this method
-     * invokes {@link #skip(long) skip()} repeatedly until the requested number
+     * invokes {@link #skip(long) skip()} repeatedly with its parameter equal
+     * to the remaining number of bytes to skip until the requested number
      * of bytes has been skipped or an error condition occurs.  If at any
      * point the return value of {@code skip()} is negative or greater than the
      * remaining number of bytes to be skipped, then an {@code IOException} is


### PR DESCRIPTION
Please review this modification of `java.io.InputStream.skipNBytes(long)` to improve its performance when `skip(long)` skips fewer than the requested number of bytes. In the current implementation, `skip(long)` is invoked once and, if not enough bytes have been skipped, then `read()` is invoked for each of the remaining bytes to be skipped. The proposed implementation instead repeatedly invokes `skip(long)` until the requested number of bytes has been skipped, or an error condition is encountered. For cases where `skip(long)` skips fewer bytes than the number requested, the new version was measured to be up to more than one thousand times faster than the old version. When `skip(long)` actually skips the requested number of bytes, the performance difference is insignificant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246739](https://bugs.openjdk.java.net/browse/JDK-8246739): InputStream.skipNBytes could be implemented more efficiently


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to f59d7a3596838bd2a241525d834ca26902bde0e4
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to f59d7a3596838bd2a241525d834ca26902bde0e4
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to f59d7a3596838bd2a241525d834ca26902bde0e4


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1329/head:pull/1329`
`$ git checkout pull/1329`
