### PR TITLE
8256569: Add C2 compiler stress flags to CTW

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -257,6 +257,7 @@ public class CtwRunner {
     private String[] cmd(long classStart, long classStop) {
         String phase = phaseName(classStart);
         Path file = Paths.get(phase + ".cmd");
+        var rng = Utils.getRandomInstance();
         try {
             Files.write(file, List.of(
                     "-Xbatch",
@@ -283,6 +284,13 @@ public class CtwRunner {
                     String.format("-XX:ReplayDataFile=replay_%s_%%p.log", phase),
                     // MethodHandle MUST NOT be compiled
                     "-XX:CompileCommand=exclude,java/lang/invoke/MethodHandle.*",
+                    // Stress* are c2-specific stress flags, so IgnoreUnrecognizedVMOptions is needed
+                    "-XX:+IgnoreUnrecognizedVMOptions",
+                    "-XX:+StressLCM",
+                    "-XX:+StressGCM",
+                    "-XX:+StressIGVN",
+                    // StressSeed is uint
+                    "-XX:StressSeed=" + Math.abs(rng.nextLong()),
                     // CTW entry point
                     CompileTheWorld.class.getName(),
                     target));


### PR DESCRIPTION
Hi all,

Could you please review this small patch which adds `-XX:+StressLCM`, `-XX:+StressGCM`, and `-XX:+StressIGVN` flags to the CTW test library? these flags have been found instrumental in increasing the probability to find C2 bugs. The patch also specifies `-XX:StressSeed` flag to keep CTW testing deterministic and reproducible.

testing:
* [x] `test/hotspot/jtreg/applications/ctw/modules/java_base.java` on `macos-x64`
* [x] `test/hotspot/jtreg/testlibrary_tests/ctw/` on `macos-x64`

Cheers,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256569](https://bugs.openjdk.java.net/browse/JDK-8256569): Add C2 compiler stress flags to CTW


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 9201384b9be0c779cd3f88c4ffdc03720cba4956
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 9201384b9be0c779cd3f88c4ffdc03720cba4956
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 9201384b9be0c779cd3f88c4ffdc03720cba4956


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1332/head:pull/1332`
`$ git checkout pull/1332`
