### PR TITLE
8198390: Test MultiResolutionDrawImageWithTransformTest.java fails when -esa is passed

### DIFF
--- a/src/java.desktop/share/classes/sun/java2d/SunGraphics2D.java
+++ b/src/java.desktop/share/classes/sun/java2d/SunGraphics2D.java
@@ -3180,8 +3180,6 @@ public final class SunGraphics2D
 
                         if (xform != null) {
                             assert dx1 == 0 && dy1 == 0;
-                            assert dx2 == img.getWidth(observer);
-                            assert dy2 == img.getHeight(observer);
                             AffineTransform renderTX = new AffineTransform(xform);
                             renderTX.scale(1 / widthScale, 1 / heightScale);
                             return transformImage(img, renderTX, observer);

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -255,7 +255,6 @@ java/awt/image/DrawImage/IncorrectClipXorModeSW2Surface.java 8196025 windows-all
 java/awt/image/DrawImage/IncorrectClipXorModeSurface2Surface.java 8196025 windows-all
 java/awt/image/DrawImage/IncorrectSourceOffset.java 8196086 windows-all
 java/awt/image/DrawImage/BlitRotateClippedArea.java 8255724 linux-all
-java/awt/image/MultiResolutionImage/MultiResolutionDrawImageWithTransformTest.java 8198390 generic-all
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8169187 macosx-all,windows-all
 java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all
 java/awt/print/PrinterJob/TestPgfmtSetMPA.java 8198343 generic-all

--- a/test/jdk/java/awt/image/MultiResolutionImage/MultiResolutionDrawImageWithTransformTest.java
+++ b/test/jdk/java/awt/image/MultiResolutionImage/MultiResolutionDrawImageWithTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,7 @@ import sun.java2d.loops.SurfaceType;
 
 /**
  * @test
- * @bug 8073320
- * @author Alexander Scherbatiy
+ * @bug 8073320 8198390
  * @summary Windows HiDPI support
  * @modules java.desktop/sun.java2d java.desktop/sun.java2d.loops
  * @run main MultiResolutionDrawImageWithTransformTest


### PR DESCRIPTION
The method in which the assertion fails called from the different places, sometimes bounds are passed(dx/dy) and the transform only once here:
https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/sun/java2d/SunGraphics2D.java#L3571

For the case when the transform is passed we have an assertion that checks some assumptions about the(dx/dy):
 - The dx1/dy1 should be equal to 0, which means both values are not changed by the method.
 - The dx2/dy2 should be equal to the image size(MRI) -> are not changed by the method as well.
 
The second assertion is wrong. The dx2/dy2 passed to the method contains the size of the initial image(MRI), and an assertion checks it against the size of the "resolution variant" which may have a different DPI/resolution/size.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8198390](https://bugs.openjdk.java.net/browse/JDK-8198390): Test MultiResolutionDrawImageWithTransformTest.java fails when -esa is passed


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1333/head:pull/1333`
`$ git checkout pull/1333`
