### PR TITLE
8256688: Shenandoah: Lock rank inversion after JDK-8212879

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1991,9 +1991,13 @@ public:
       MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
       _nmethod_itr.nmethods_do_begin();
     }
+
+    _dedup_roots.prologue();
   }
 
   ~ShenandoahConcurrentWeakRootsEvacUpdateTask() {
+    _dedup_roots.epilogue();
+
     if (_concurrent_class_unloading) {
       MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
       _nmethod_itr.nmethods_do_end();

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
@@ -78,6 +78,9 @@ void ShenandoahStringDedupRoots::oops_do(BoolObjectClosure* is_alive, OopClosure
 
 ShenandoahConcurrentStringDedupRoots::ShenandoahConcurrentStringDedupRoots(ShenandoahPhaseTimings::Phase phase) :
   _phase(phase) {
+}
+
+void ShenandoahConcurrentStringDedupRoots::prologue() {
   if (ShenandoahStringDedup::is_enabled()) {
     StringDedupTable_lock->lock_without_safepoint_check();
     StringDedupQueue_lock->lock_without_safepoint_check();
@@ -85,7 +88,7 @@ ShenandoahConcurrentStringDedupRoots::ShenandoahConcurrentStringDedupRoots(Shena
   }
 }
 
-ShenandoahConcurrentStringDedupRoots::~ShenandoahConcurrentStringDedupRoots() {
+void ShenandoahConcurrentStringDedupRoots::epilogue() {
   if (ShenandoahStringDedup::is_enabled()) {
     StringDedup::gc_epilogue();
     StringDedupQueue_lock->unlock();
@@ -223,7 +226,12 @@ ShenandoahHeapIterationRootScanner::ShenandoahHeapIterationRootScanner() :
    _weak_roots(ShenandoahPhaseTimings::heap_iteration_roots),
    _dedup_roots(ShenandoahPhaseTimings::heap_iteration_roots),
    _code_roots(ShenandoahPhaseTimings::heap_iteration_roots) {
+   _dedup_roots.prologue();
  }
+
+ShenandoahHeapIterationRootScanner::~ShenandoahHeapIterationRootScanner() {
+  _dedup_roots.epilogue();
+}
 
  void ShenandoahHeapIterationRootScanner::roots_do(OopClosure* oops) {
    assert(Thread::current()->is_VM_thread(), "Only by VM thread");

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
@@ -93,7 +93,9 @@ private:
 
 public:
   ShenandoahConcurrentStringDedupRoots(ShenandoahPhaseTimings::Phase phase);
-  ~ShenandoahConcurrentStringDedupRoots();
+
+  void prologue();
+  void epilogue();
 
   void oops_do(BoolObjectClosure* is_alive, OopClosure* keep_alive, uint worker_id);
 };
@@ -191,6 +193,7 @@ private:
 
 public:
   ShenandoahHeapIterationRootScanner();
+  ~ShenandoahHeapIterationRootScanner();
 
   void roots_do(OopClosure* cl);
 };


### PR DESCRIPTION
After JDK-8212879, gc_notification() takes JvmtiTagMap_lock/24, while ShenandoahConcurrentWeakRootsEvacUpdateTask holds StringDedupQueue_lock/11, which results lock rank inversion during concurrent weak root processing.

This patch ensures that no lock is held when triggers gc notification.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256688](https://bugs.openjdk.java.net/browse/JDK-8256688): Shenandoah: Lock rank inversion after JDK-8212879


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1334/head:pull/1334`
`$ git checkout pull/1334`
