### PR TITLE
8256664: Shenandoah: Cleanup after JDK-8212879

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1690,7 +1690,9 @@ void ShenandoahHeap::op_final_mark() {
     // Notify JVMTI that the tagmap table will need cleaning.
     JvmtiTagMap::set_needs_cleaning();
 
-    parallel_cleaning(false /* full gc*/);
+    if (is_degenerated_gc_in_progress()) {
+      parallel_cleaning(false /* full gc*/);
+    }
 
     if (ShenandoahVerify) {
       verifier()->verify_roots_no_forwarded();
@@ -1761,10 +1763,8 @@ void ShenandoahHeap::op_final_mark() {
       if (ShenandoahVerify) {
         // If OOM while evacuating/updating of roots, there is no guarantee of their consistencies
         if (!cancelled_gc()) {
-          // We only evacuate/update thread and serial weak roots at this pause
-          ShenandoahRootVerifier::RootTypes types = ShenandoahRootVerifier::combine(ShenandoahRootVerifier::ThreadRoots,
-                                                                                    ShenandoahRootVerifier::SerialWeakRoots);
-          verifier()->verify_roots_no_forwarded(types);
+          // We only evacuate/update thread roots at this pause
+          verifier()->verify_roots_no_forwarded(ShenandoahRootVerifier::ThreadRoots);
         }
         verifier()->verify_during_evacuation();
       }
@@ -2411,12 +2411,11 @@ void ShenandoahHeap::stop() {
 
 void ShenandoahHeap::stw_unload_classes(bool full_gc) {
   if (!unload_classes()) return;
-
   // Unload classes and purge SystemDictionary.
   {
     ShenandoahGCPhase phase(full_gc ?
                             ShenandoahPhaseTimings::full_gc_purge_class_unload :
-                            ShenandoahPhaseTimings::purge_class_unload);
+                            ShenandoahPhaseTimings::degen_gc_purge_class_unload);
     bool purged_class = SystemDictionary::do_unloading(gc_timer());
 
     ShenandoahIsAliveSelector is_alive;
@@ -2428,7 +2427,7 @@ void ShenandoahHeap::stw_unload_classes(bool full_gc) {
   {
     ShenandoahGCPhase phase(full_gc ?
                             ShenandoahPhaseTimings::full_gc_purge_cldg :
-                            ShenandoahPhaseTimings::purge_cldg);
+                            ShenandoahPhaseTimings::degen_gc_purge_cldg);
     ClassLoaderDataGraph::purge(/*at_safepoint*/true);
   }
   // Resize and verify metaspace
@@ -2443,11 +2442,11 @@ void ShenandoahHeap::stw_unload_classes(bool full_gc) {
 void ShenandoahHeap::stw_process_weak_roots(bool full_gc) {
   ShenandoahGCPhase root_phase(full_gc ?
                                ShenandoahPhaseTimings::full_gc_purge :
-                               ShenandoahPhaseTimings::purge);
+                               ShenandoahPhaseTimings::degen_gc_purge);
   uint num_workers = _workers->active_workers();
   ShenandoahPhaseTimings::Phase timing_phase = full_gc ?
                                                ShenandoahPhaseTimings::full_gc_purge_weak_par :
-                                               ShenandoahPhaseTimings::purge_weak_par;
+                                               ShenandoahPhaseTimings::degen_gc_purge_weak_par;
   ShenandoahGCPhase phase(timing_phase);
   ShenandoahGCWorkerPhase worker_phase(timing_phase);
 
@@ -2456,17 +2455,17 @@ void ShenandoahHeap::stw_process_weak_roots(bool full_gc) {
     ShenandoahForwardedIsAliveClosure is_alive;
     ShenandoahUpdateRefsClosure keep_alive;
     ShenandoahParallelWeakRootsCleaningTask<ShenandoahForwardedIsAliveClosure, ShenandoahUpdateRefsClosure>
-      cleaning_task(timing_phase, &is_alive, &keep_alive, num_workers, is_stw_gc_in_progress());
+      cleaning_task(timing_phase, &is_alive, &keep_alive, num_workers);
     _workers->run_task(&cleaning_task);
   } else {
     ShenandoahIsAliveClosure is_alive;
 #ifdef ASSERT
     ShenandoahAssertNotForwardedClosure verify_cl;
     ShenandoahParallelWeakRootsCleaningTask<ShenandoahIsAliveClosure, ShenandoahAssertNotForwardedClosure>
-      cleaning_task(timing_phase, &is_alive, &verify_cl, num_workers, is_stw_gc_in_progress());
+      cleaning_task(timing_phase, &is_alive, &verify_cl, num_workers);
 #else
     ShenandoahParallelWeakRootsCleaningTask<ShenandoahIsAliveClosure, DoNothingClosure>
-      cleaning_task(timing_phase, &is_alive, &do_nothing_cl, num_workers, is_stw_gc_in_progress());
+      cleaning_task(timing_phase, &is_alive, &do_nothing_cl, num_workers);
 #endif
     _workers->run_task(&cleaning_task);
   }
@@ -2474,10 +2473,9 @@ void ShenandoahHeap::stw_process_weak_roots(bool full_gc) {
 
 void ShenandoahHeap::parallel_cleaning(bool full_gc) {
   assert(SafepointSynchronize::is_at_safepoint(), "Must be at a safepoint");
+  assert(is_stw_gc_in_progress(), "Only for Degenerated and Full GC");
   stw_process_weak_roots(full_gc);
-  if (!ShenandoahConcurrentRoots::should_do_concurrent_class_unloading()) {
-    stw_unload_classes(full_gc);
-  }
+  stw_unload_classes(full_gc);
 }
 
 void ShenandoahHeap::set_has_forwarded_objects(bool cond) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.hpp
@@ -40,14 +40,12 @@ protected:
   WeakProcessor::Task       _weak_processing_task;
   IsAlive*                  _is_alive;
   KeepAlive*                _keep_alive;
-  bool                      _include_concurrent_roots;
 
 public:
   ShenandoahParallelWeakRootsCleaningTask(ShenandoahPhaseTimings::Phase phase,
                                           IsAlive* is_alive,
                                           KeepAlive* keep_alive,
-                                          uint num_workers,
-                                          bool include_concurrent_roots);
+                                          uint num_workers);
   ~ShenandoahParallelWeakRootsCleaningTask();
 
   void work(uint worker_id);

--- a/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.inline.hpp
@@ -36,11 +36,10 @@ template<typename IsAlive, typename KeepAlive>
 ShenandoahParallelWeakRootsCleaningTask<IsAlive, KeepAlive>::ShenandoahParallelWeakRootsCleaningTask(ShenandoahPhaseTimings::Phase phase,
                                                                                                      IsAlive* is_alive,
                                                                                                      KeepAlive* keep_alive,
-                                                                                                     uint num_workers,
-                                                                                                     bool include_concurrent_roots) :
+                                                                                                     uint num_workers) :
   AbstractGangTask("Shenandoah Weak Root Cleaning"),
   _phase(phase), _weak_processing_task(num_workers),
-  _is_alive(is_alive), _keep_alive(keep_alive), _include_concurrent_roots(include_concurrent_roots) {
+  _is_alive(is_alive), _keep_alive(keep_alive) {
   assert(SafepointSynchronize::is_at_safepoint(), "Must be at a safepoint");
 
   if (ShenandoahStringDedup::is_enabled()) {
@@ -53,16 +52,12 @@ ShenandoahParallelWeakRootsCleaningTask<IsAlive, KeepAlive>::~ShenandoahParallel
   if (StringDedup::is_enabled()) {
     StringDedup::gc_epilogue();
   }
-  if (_include_concurrent_roots) {
-    _weak_processing_task.report_num_dead();
-  }
+  _weak_processing_task.report_num_dead();
 }
 
 template<typename IsAlive, typename KeepAlive>
 void ShenandoahParallelWeakRootsCleaningTask<IsAlive, KeepAlive>::work(uint worker_id) {
-  if (_include_concurrent_roots) {
-    _weak_processing_task.work<IsAlive, KeepAlive>(worker_id, _is_alive, _keep_alive);
-  }
+  _weak_processing_task.work<IsAlive, KeepAlive>(worker_id, _is_alive, _keep_alive);
 
   if (ShenandoahStringDedup::is_enabled()) {
     ShenandoahStringDedup::parallel_oops_do(_phase, _is_alive, _keep_alive, worker_id);

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
@@ -108,8 +108,8 @@ bool ShenandoahPhaseTimings::is_worker_phase(Phase phase) {
     case full_gc_scan_conc_roots:
     case full_gc_purge_class_unload:
     case full_gc_purge_weak_par:
-    case purge_class_unload:
-    case purge_weak_par:
+    case degen_gc_purge_class_unload:
+    case degen_gc_purge_weak_par:
     case heap_iteration_roots:
     case conc_mark_roots:
     case conc_weak_roots_work:

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -66,12 +66,6 @@ class outputStream;
   f(finish_queues,                                  "  Finish Queues")                 \
   f(weakrefs,                                       "  Weak References")               \
   f(weakrefs_process,                               "    Process")                     \
-  f(purge,                                          "  System Purge")                  \
-  f(purge_class_unload,                             "    Unload Classes")              \
-  SHENANDOAH_PAR_PHASE_DO(purge_cu_par_,            "      CU: ", f)                   \
-  f(purge_weak_par,                                 "    Weak Roots")                  \
-  SHENANDOAH_PAR_PHASE_DO(purge_weak_par_,          "      WR: ", f)                   \
-  f(purge_cldg,                                     "    CLDG")                        \
   f(final_update_region_states,                     "  Update Region States")          \
   f(final_manage_labs,                              "  Manage GC/TLABs")               \
   f(choose_cset,                                    "  Choose Collection Set")         \
@@ -124,6 +118,12 @@ class outputStream;
   f(degen_gc,                                       "Pause Degenerated GC (N)")        \
   f(degen_gc_scan_conc_roots,                       "  Degen Mark Roots")              \
   SHENANDOAH_PAR_PHASE_DO(degen_gc_conc_mark_,      "    DM: ", f)                     \
+  f(degen_gc_purge,                                  "   System Purge")                \
+  f(degen_gc_purge_class_unload,                     "     Unload Classes")            \
+  SHENANDOAH_PAR_PHASE_DO(degen_gc_purge_cu_par_,    "       DCU: ", f)                \
+  f(degen_gc_purge_weak_par,                         "     Weak Roots")                \
+  SHENANDOAH_PAR_PHASE_DO(degen_gc_purge_weak_p_,    "       DWR: ", f)                \
+  f(degen_gc_purge_cldg,                             "     CLDG")                      \
   f(degen_gc_update_roots,                          "  Degen Update Roots")            \
   SHENANDOAH_PAR_PHASE_DO(degen_gc_update_,         "    DU: ", f)                     \
                                                                                        \

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
@@ -169,8 +169,6 @@ void ShenandoahRootEvacuator::roots_do(uint worker_id, OopClosure* oops) {
   // Always disarm on-stack nmethods, because we are evacuating/updating them
   // here
   ShenandoahCodeBlobAndDisarmClosure codeblob_cl(oops);
-
-  // Process light-weight/limited parallel roots then
   _thread_roots.oops_do(oops, &codeblob_cl, worker_id);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -99,9 +99,7 @@ void ShenandoahRootVerifier::oops_do(OopClosure* oops) {
 
   if (verify(WeakRoots)) {
     shenandoah_assert_safepoint();
-    concurrent_weak_roots_do(oops);
-  } else if (verify(ConcurrentWeakRoots)) {
-    concurrent_weak_roots_do(oops);
+    weak_roots_do(oops);
   }
 
   if (ShenandoahStringDedup::is_enabled() && verify(StringDedupRoots)) {
@@ -155,7 +153,7 @@ void ShenandoahRootVerifier::strong_roots_do(OopClosure* oops) {
   Threads::possibly_parallel_oops_do(true, oops, &blobs);
 }
 
-void ShenandoahRootVerifier::concurrent_weak_roots_do(OopClosure* cl) {
+void ShenandoahRootVerifier::weak_roots_do(OopClosure* cl) {
   for (OopStorageSet::Iterator it = OopStorageSet::weak_iterator(); !it.is_end(); ++it) {
     OopStorage* storage = *it;
     storage->oops_do<OopClosure>(cl);

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
@@ -47,11 +47,9 @@ public:
     ThreadRoots         = 1 << 1,
     CodeRoots           = 1 << 2,
     CLDGRoots           = 1 << 3,
-    SerialWeakRoots     = 1 << 4,
-    ConcurrentWeakRoots = 1 << 5,
-    WeakRoots           = (SerialWeakRoots | ConcurrentWeakRoots),
-    StringDedupRoots    = 1 << 6,
-    JNIHandleRoots      = 1 << 7,
+    WeakRoots           = 1 << 4,
+    StringDedupRoots    = 1 << 5,
+    JNIHandleRoots      = 1 << 6,
     AllRoots            = (SerialRoots | ThreadRoots | CodeRoots | CLDGRoots | WeakRoots | StringDedupRoots | JNIHandleRoots)
   };
 
@@ -72,7 +70,7 @@ public:
 private:
   bool verify(RootTypes type) const;
 
-  void concurrent_weak_roots_do(OopClosure* cl);
+  void weak_roots_do(OopClosure* cl);
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHROOTVERIFIER_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -715,19 +715,6 @@ void ShenandoahVerifier::verify_at_safepoint(const char *label,
   size_t count_reachable = 0;
   if (ShenandoahVerifyLevel >= 2) {
     ShenandoahRootVerifier verifier;
-    switch (weak_roots) {
-      case _verify_serial_weak_roots:
-        verifier.excludes(ShenandoahRootVerifier::ConcurrentWeakRoots);
-        break;
-      case _verify_concurrent_weak_roots:
-        verifier.excludes(ShenandoahRootVerifier::SerialWeakRoots);
-        break;
-      case _verify_all_weak_roots:
-        break;
-      default:
-        ShouldNotReachHere();
-    }
-
     ShenandoahVerifierReachableTask task(_verification_bit_map, ld, &verifier, label, options);
     _heap->workers()->run_task(&task);
     count_reachable = task.processed();


### PR DESCRIPTION
JDK-8212879 removed last serial weak roots, that means:

1) Concurrent GC no longer needs to cleanup any weak roots at pause
2) Root verifier no longer needs to distinguish concurrent/serial weak roots.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x64 (hs/tier1 runtime)](https://github.com/zhengyu123/jdk/runs/1428124297)

### Issue
 * [JDK-8256664](https://bugs.openjdk.java.net/browse/JDK-8256664): Shenandoah: Cleanup after JDK-8212879


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1336/head:pull/1336`
`$ git checkout pull/1336`
