### PR TITLE
JDK-8256725: Metaspace: better blocktree and binlist asserts

### DIFF
--- a/src/hotspot/share/memory/metaspace/binList.hpp
+++ b/src/hotspot/share/memory/metaspace/binList.hpp
@@ -186,7 +186,7 @@ public:
     for (int i = 0; i < num_lists; i++) {
       const size_t s = MinWordSize + i;
       int pos = 0;
-      for (Block* b = _blocks[i]; b != NULL; b = b->_next, pos ++) {
+      for (Block* b = _blocks[i]; b != NULL; b = b->_next, pos++) {
         assert(b->_word_size == s,
                "bad block size in list[%u] at pos %d (" BLOCK_FORMAT ")",
                i, pos, BLOCK_FORMAT_ARGS(b));

--- a/src/hotspot/share/memory/metaspace/binList.hpp
+++ b/src/hotspot/share/memory/metaspace/binList.hpp
@@ -153,19 +153,17 @@ public:
     int index = index_for_word_size(word_size);
     index = index_for_next_non_empty_list(index);
     if (index != -1) {
-      assert(_blocks[index] != NULL &&
-             _blocks[index]->_word_size >= word_size, "sanity");
-
-      MetaWord* const p = (MetaWord*)_blocks[index];
+      Block* b = _blocks[index];
       const size_t real_word_size = word_size_for_index(index);
-
-      _blocks[index] = _blocks[index]->_next;
-
+      assert(b != NULL, "Sanity");
+      assert(b->_word_size >= word_size &&
+             b->_word_size == real_word_size,
+             "bad block size in list[%u] (" BLOCK_FORMAT ")", index, BLOCK_FORMAT_ARGS(b));
+      MetaWord* const p = (MetaWord*)b;
+      _blocks[index] = b->_next;
       _counter.sub(real_word_size);
       *p_real_word_size = real_word_size;
-
       return p;
-
     } else {
       *p_real_word_size = 0;
       return NULL;

--- a/src/hotspot/share/memory/metaspace/binList.hpp
+++ b/src/hotspot/share/memory/metaspace/binList.hpp
@@ -85,6 +85,9 @@ class BinListImpl {
     {}
   };
 
+#define BLOCK_FORMAT          "Block @" PTR_FORMAT ": size: " SIZE_FORMAT ", next: " PTR_FORMAT
+#define BLOCK_FORMAT_ARGS(b)  p2i(b), (b)->_word_size, p2i((b)->_next)
+
   // Smallest block size must be large enough to hold a Block structure.
   STATIC_ASSERT(smallest_word_size * sizeof(MetaWord) >= sizeof(Block));
   STATIC_ASSERT(num_lists > 0);
@@ -182,8 +185,11 @@ public:
     MemRangeCounter local_counter;
     for (int i = 0; i < num_lists; i++) {
       const size_t s = MinWordSize + i;
-      for (Block* b = _blocks[i]; b != NULL; b = b->_next) {
-        assert(b->_word_size == s, "bad block size");
+      int pos = 0;
+      for (Block* b = _blocks[i]; b != NULL; b = b->_next, pos ++) {
+        assert(b->_word_size == s,
+               "bad block size in list[%u] at pos %d (" BLOCK_FORMAT ")",
+               i, pos, BLOCK_FORMAT_ARGS(b));
         local_counter.add(s);
       }
     }

--- a/src/hotspot/share/memory/metaspace/binList.hpp
+++ b/src/hotspot/share/memory/metaspace/binList.hpp
@@ -158,12 +158,11 @@ public:
       assert(b != NULL, "Sanity");
       assert(b->_word_size >= word_size &&
              b->_word_size == real_word_size,
-             "bad block size in list[%u] (" BLOCK_FORMAT ")", index, BLOCK_FORMAT_ARGS(b));
-      MetaWord* const p = (MetaWord*)b;
+             "bad block size in list[%d] (" BLOCK_FORMAT ")", index, BLOCK_FORMAT_ARGS(b));
       _blocks[index] = b->_next;
       _counter.sub(real_word_size);
       *p_real_word_size = real_word_size;
-      return p;
+      return (MetaWord*)b;
     } else {
       *p_real_word_size = 0;
       return NULL;
@@ -186,7 +185,7 @@ public:
       int pos = 0;
       for (Block* b = _blocks[i]; b != NULL; b = b->_next, pos++) {
         assert(b->_word_size == s,
-               "bad block size in list[%u] at pos %d (" BLOCK_FORMAT ")",
+               "bad block size in list[%d] at pos %d (" BLOCK_FORMAT ")",
                i, pos, BLOCK_FORMAT_ARGS(b));
         local_counter.add(s);
       }

--- a/src/hotspot/share/memory/metaspace/blockTree.hpp
+++ b/src/hotspot/share/memory/metaspace/blockTree.hpp
@@ -77,6 +77,16 @@ class BlockTree: public CHeapObj<mtMetaspace> {
 
   struct Node {
 
+    static const intptr_t _canary_value =
+        NOT_LP64(0x4e4f4445) LP64_ONLY(0x4e4f44454e4f4445ULL); // "NODE" resp "NODENODE"
+
+    // Note: we afford us the luxury of an always-there canary value.
+    //  The space for that is there (these nodes are only used to manage larger blocks,
+    //  see FreeBlocks::MaxSmallBlocksWordSize).
+    //  It is initialized in debug and release, but only automatically tested
+    //  in debug.
+    const intptr_t _canary;
+
     // Normal tree node stuff...
     Node* _parent;
     Node* _left;
@@ -91,6 +101,7 @@ class BlockTree: public CHeapObj<mtMetaspace> {
     const size_t _word_size;
 
     Node(size_t word_size) :
+      _canary(_canary_value),
       _parent(NULL),
       _left(NULL),
       _right(NULL),

--- a/src/hotspot/share/memory/metaspace/blockTree.hpp
+++ b/src/hotspot/share/memory/metaspace/blockTree.hpp
@@ -337,6 +337,8 @@ private:
 
 #ifdef ASSERT
   void zap_range(MetaWord* p, size_t word_size);
+  // Helper for verify()
+  void verify_node_pointer(const Node* n) const;
 #endif // ASSERT
 
 public:

--- a/src/hotspot/share/memory/metaspace/freeBlocks.hpp
+++ b/src/hotspot/share/memory/metaspace/freeBlocks.hpp
@@ -69,6 +69,10 @@ class FreeBlocks : public CHeapObj<mtMetaspace> {
   // to fit into _smallblocks.
   BlockTree _tree;
 
+  // This verifies that blocks too large to go into the binlist can be
+  // kept in the blocktree.
+  STATIC_ASSERT(BinList32::MaxWordSize >= BlockTree::MinWordSize);
+
   // Cutoff point: blocks larger than this size are kept in the
   // tree, blocks smaller than or equal to this size in the bin list.
   const size_t MaxSmallBlocksWordSize = BinList32::MaxWordSize;


### PR DESCRIPTION
Hi,

may I have reviews please for this small change. 

To analyze JDK-8256572, I'd like to see more information in asserts for binlist and blocktree.

This patch:

- beefs up assertion messages when verifying binlist and blocktree
- adds a canary to the blocktree node to detect overwriters
- improves the blocktree printing
- adds a gtest death test to test the overwrite detection.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ⏳ (6/6 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (7/7 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256725](https://bugs.openjdk.java.net/browse/JDK-8256725): Metaspace: better blocktree and binlist asserts


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - Committer)
 * [Leo Korinth](https://openjdk.java.net/census#lkorinth) (@lkorinth - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1339/head:pull/1339`
`$ git checkout pull/1339`
