### PR TITLE
8256727: ZGC: Clean out dead code after JDK-8212879

### DIFF
--- a/src/hotspot/share/gc/z/zBarrier.cpp
+++ b/src/hotspot/share/gc/z/zBarrier.cpp
@@ -198,25 +198,6 @@ uintptr_t ZBarrier::mark_barrier_on_finalizable_oop_slow_path(uintptr_t addr) {
   return mark<Follow, Finalizable, Overflow>(addr);
 }
 
-uintptr_t ZBarrier::mark_barrier_on_root_oop_slow_path(uintptr_t addr) {
-  assert(SafepointSynchronize::is_at_safepoint(), "Should be at safepoint");
-  assert(during_mark(), "Invalid phase");
-
-  // Mark
-  return mark<Follow, Strong, Publish>(addr);
-}
-
-//
-// Relocate barrier
-//
-uintptr_t ZBarrier::relocate_barrier_on_root_oop_slow_path(uintptr_t addr) {
-  assert(SafepointSynchronize::is_at_safepoint(), "Should be at safepoint");
-  assert(during_relocate(), "Invalid phase");
-
-  // Relocate
-  return relocate(addr);
-}
-
 //
 // Narrow oop variants, never used.
 //

--- a/src/hotspot/share/gc/z/zBarrier.hpp
+++ b/src/hotspot/share/gc/z/zBarrier.hpp
@@ -73,9 +73,6 @@ private:
 
   static uintptr_t mark_barrier_on_oop_slow_path(uintptr_t addr);
   static uintptr_t mark_barrier_on_finalizable_oop_slow_path(uintptr_t addr);
-  static uintptr_t mark_barrier_on_root_oop_slow_path(uintptr_t addr);
-
-  static uintptr_t relocate_barrier_on_root_oop_slow_path(uintptr_t addr);
 
 public:
   // Load barrier
@@ -112,11 +109,7 @@ public:
   // Mark barrier
   static void mark_barrier_on_oop_field(volatile oop* p, bool finalizable);
   static void mark_barrier_on_oop_array(volatile oop* p, size_t length, bool finalizable);
-  static void mark_barrier_on_root_oop_field(oop* p);
   static void mark_barrier_on_invisible_root_oop_field(oop* p);
-
-  // Relocate barrier
-  static void relocate_barrier_on_root_oop_field(oop* p);
 
   // Narrow oop variants, never used.
   static oop  load_barrier_on_oop_field(volatile narrowOop* p);

--- a/src/hotspot/share/gc/z/zBarrier.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrier.inline.hpp
@@ -407,17 +407,4 @@ inline void ZBarrier::mark_barrier_on_oop_array(volatile oop* p, size_t length, 
   }
 }
 
-inline void ZBarrier::mark_barrier_on_root_oop_field(oop* p) {
-  const oop o = *p;
-  root_barrier<is_good_or_null_fast_path, mark_barrier_on_root_oop_slow_path>(p, o);
-}
-
-//
-// Relocate barrier
-//
-inline void ZBarrier::relocate_barrier_on_root_oop_field(oop* p) {
-  const oop o = *p;
-  root_barrier<is_good_or_null_fast_path, relocate_barrier_on_root_oop_slow_path>(p, o);
-}
-
 #endif // SHARE_GC_Z_ZBARRIER_INLINE_HPP

--- a/src/hotspot/share/gc/z/zOopClosures.hpp
+++ b/src/hotspot/share/gc/z/zOopClosures.hpp
@@ -25,7 +25,6 @@
 #define SHARE_GC_Z_ZOOPCLOSURES_HPP
 
 #include "memory/iterator.hpp"
-#include "gc/z/zRootsIterator.hpp"
 
 class ZLoadBarrierOopClosure : public BasicOopIterateClosure {
 public:
@@ -53,11 +52,6 @@ public:
   virtual bool do_object_b(oop o);
 };
 
-class ZPhantomKeepAliveOopClosure : public OopClosure {
-public:
-  virtual void do_oop(oop* p);
-  virtual void do_oop(narrowOop* p);
-};
 class ZPhantomCleanOopClosure : public OopClosure {
 public:
   virtual void do_oop(oop* p);

--- a/src/hotspot/share/gc/z/zOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/z/zOopClosures.inline.hpp
@@ -76,14 +76,6 @@ inline bool ZPhantomIsAliveObjectClosure::do_object_b(oop o) {
   return ZBarrier::is_alive_barrier_on_phantom_oop(o);
 }
 
-inline void ZPhantomKeepAliveOopClosure::do_oop(oop* p) {
-  ZBarrier::keep_alive_barrier_on_phantom_oop_field(p);
-}
-
-inline void ZPhantomKeepAliveOopClosure::do_oop(narrowOop* p) {
-  ShouldNotReachHere();
-}
-
 inline void ZPhantomCleanOopClosure::do_oop(oop* p) {
   // Read the oop once, to make sure the liveness check
   // and the later clearing uses the same value.

--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -25,8 +25,7 @@
 #include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zBarrier.inline.hpp"
 #include "gc/z/zForwarding.inline.hpp"
-#include "gc/z/zHeap.hpp"
-#include "gc/z/zOopClosures.inline.hpp"
+#include "gc/z/zHeap.inline.hpp"
 #include "gc/z/zPage.inline.hpp"
 #include "gc/z/zRelocate.hpp"
 #include "gc/z/zRelocationSet.inline.hpp"
@@ -39,21 +38,9 @@
 #include "prims/jvmtiTagMap.hpp"
 
 static const ZStatCounter ZCounterRelocationContention("Contention", "Relocation Contention", ZStatUnitOpsPerSecond);
-static const ZStatSubPhase ZSubPhasePauseRootsJVMTITagMap("Pause Roots JVMTITagMap");
 
 ZRelocate::ZRelocate(ZWorkers* workers) :
     _workers(workers) {}
-
-class ZRelocateRootsIteratorClosure : public OopClosure {
-public:
-  virtual void do_oop(oop* p) {
-    ZBarrier::relocate_barrier_on_root_oop_field(p);
-  }
-
-  virtual void do_oop(narrowOop* p) {
-    ShouldNotReachHere();
-  }
-};
 
 uintptr_t ZRelocate::relocate_object_inner(ZForwarding* forwarding, uintptr_t from_index, uintptr_t from_offset) const {
   ZForwardingCursor cursor;

--- a/src/hotspot/share/gc/z/zStackWatermark.hpp
+++ b/src/hotspot/share/gc/z/zStackWatermark.hpp
@@ -26,6 +26,7 @@
 
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetNMethod.hpp"
+#include "gc/shared/threadLocalAllocBuffer.hpp"
 #include "gc/z/zOopClosures.hpp"
 #include "memory/allocation.hpp"
 #include "memory/iterator.hpp"

--- a/src/hotspot/share/gc/z/zWeakRootsProcessor.cpp
+++ b/src/hotspot/share/gc/z/zWeakRootsProcessor.cpp
@@ -23,6 +23,7 @@
 
 #include "precompiled.hpp"
 #include "gc/z/zOopClosures.inline.hpp"
+#include "gc/z/zRootsIterator.hpp"
 #include "gc/z/zTask.hpp"
 #include "gc/z/zWorkers.hpp"
 

--- a/src/hotspot/share/gc/z/zWeakRootsProcessor.hpp
+++ b/src/hotspot/share/gc/z/zWeakRootsProcessor.hpp
@@ -33,7 +33,6 @@ private:
 public:
   ZWeakRootsProcessor(ZWorkers* workers);
 
-  void process_weak_roots();
   void process_concurrent_weak_roots();
 };
 


### PR DESCRIPTION
There are some unused root processing functions after the JVMTI Tag Map was made concurrent. Clean them out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256727](https://bugs.openjdk.java.net/browse/JDK-8256727): ZGC: Clean out dead code after JDK-8212879


### Reviewers
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1340/head:pull/1340`
`$ git checkout pull/1340`
