### PR TITLE
8256736: Zero: GTest tests fail with "unsuppported vm variant"

### DIFF
--- a/test/hotspot/jtreg/gtest/GTestWrapper.java
+++ b/test/hotspot/jtreg/gtest/GTestWrapper.java
@@ -118,8 +118,10 @@ public class GTestWrapper {
             return "client";
         } else if (Platform.isMinimal()) {
             return "minimal";
+        } else if (Platform.isZero()) {
+            return "zero";
         } else {
-            throw new Error("TESTBUG: unsuppported vm variant");
+            throw new Error("TESTBUG: unsupported vm variant");
         }
     }
 }


### PR DESCRIPTION
Manifests as `tier1` test:

```
$ CONF=linux-x86_64-zero-fastdebug make exploded-test TEST=jtreg:gtest/MetaspaceGtests.java

00:16:40 java.lang.Error: TESTBUG: unsuppported vm variant
00:16:40 at GTestWrapper.getJVMVariantSubDir(GTestWrapper.java:122)
00:16:40 at GTestWrapper.main(GTestWrapper.java:50)
00:16:40 at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
00:16:40 at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
00:16:40 at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
00:16:40 at java.base/java.lang.reflect.Method.invoke(Method.java:564)
00:16:40 at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:298)
00:16:40 at java.base/java.lang.Thread.run(Thread.java:831)
```

Let's make the wrapper know about the Zero variant.

Additional testing:
 - [x] Affected tests (they still fail, but because of Zero problems)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256736](https://bugs.openjdk.java.net/browse/JDK-8256736): Zero: GTest tests fail with "unsuppported vm variant"


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1344/head:pull/1344`
`$ git checkout pull/1344`
