### PR TITLE
8256738: Compiler interface clean-up

### DIFF
--- a/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
@@ -63,7 +63,7 @@ class BCEscapeAnalyzer : public ResourceObj {
   bool              _allocated_escapes;
   bool              _unknown_modified;
 
-  GrowableArray<ciMetadata *> _dependencies;
+  GrowableArray<ciMetadata*> _dependencies;
 
   ciMethodBlocks   *_methodBlocks;
 

--- a/src/hotspot/share/ci/ciArray.hpp
+++ b/src/hotspot/share/ci/ciArray.hpp
@@ -41,11 +41,8 @@ private:
   int _length;
 
 protected:
-  ciArray(    arrayHandle h_a) : ciObject(h_a), _length(h_a()->length()) {}
   ciArray( objArrayHandle h_a) : ciObject(h_a), _length(h_a()->length()) {}
   ciArray(typeArrayHandle h_a) : ciObject(h_a), _length(h_a()->length()) {}
-
-  ciArray(ciKlass* klass, int len) : ciObject(klass), _length(len) {}
 
   arrayOop get_arrayOop() const { return (arrayOop)get_oop(); }
 

--- a/src/hotspot/share/ci/ciCallProfile.hpp
+++ b/src/hotspot/share/ci/ciCallProfile.hpp
@@ -43,7 +43,6 @@ private:
   int  _morphism;             // determined call site's morphism
   int  _count;                // # times has this call been executed
   int  _receiver_count[MorphismLimit + 1]; // # times receivers have been seen
-  ciMethod* _method[MorphismLimit + 1];    // receivers methods
   ciKlass*  _receiver[MorphismLimit + 1];  // receivers (exact)
 
   ciCallProfile() {
@@ -51,7 +50,6 @@ private:
     _morphism    = 0;
     _count = -1;
     _receiver_count[0] = -1;
-    _method[0]   = NULL;
     _receiver[0] = NULL;
   }
 
@@ -70,10 +68,6 @@ public:
   float     receiver_prob(int i)  {
     assert(i < _limit, "out of Call Profile MorphismLimit");
     return (float)_receiver_count[i]/(float)_count;
-  }
-  ciMethod* method(int i)          {
-    assert(i < _limit, "out of Call Profile MorphismLimit");
-    return _method[i];
   }
   ciKlass*  receiver(int i)        {
     assert(i < _limit, "out of Call Profile MorphismLimit");

--- a/src/hotspot/share/ci/ciCallSite.cpp
+++ b/src/hotspot/share/ci/ciCallSite.cpp
@@ -44,16 +44,6 @@ bool ciCallSite::is_fully_initialized_constant_call_site() {
 }
 
 // ------------------------------------------------------------------
-// ciCallSite::get_target
-//
-// Return the target MethodHandle of this CallSite.
-ciMethodHandle* ciCallSite::get_target() const {
-  VM_ENTRY_MARK;
-  oop method_handle_oop = java_lang_invoke_CallSite::target(get_oop());
-  return CURRENT_ENV->get_object(method_handle_oop)->as_method_handle();
-}
-
-// ------------------------------------------------------------------
 // ciCallSite::print
 //
 // Print debugging information about the CallSite.

--- a/src/hotspot/share/ci/ciCallSite.hpp
+++ b/src/hotspot/share/ci/ciCallSite.hpp
@@ -42,9 +42,6 @@ class ciCallSite : public ciInstance {
 
   bool is_fully_initialized_constant_call_site();
 
-  // Return the target MethodHandle of this CallSite.
-  ciMethodHandle* get_target() const;
-
   void print();
 };
 

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -286,11 +286,9 @@ void ciEnv::cache_dtrace_flags() {
   // Need lock?
   _dtrace_extended_probes = ExtendedDTraceProbes;
   if (_dtrace_extended_probes) {
-    _dtrace_monitor_probes  = true;
     _dtrace_method_probes   = true;
     _dtrace_alloc_probes    = true;
   } else {
-    _dtrace_monitor_probes  = DTraceMonitorProbes;
     _dtrace_method_probes   = DTraceMethodProbes;
     _dtrace_alloc_probes    = DTraceAllocProbes;
   }
@@ -366,21 +364,6 @@ ciMethod* ciEnv::get_method_from_handle(Method* method) {
   VM_ENTRY_MARK;
   return get_metadata(method)->as_method();
 }
-
-// ------------------------------------------------------------------
-// ciEnv::array_element_offset_in_bytes
-int ciEnv::array_element_offset_in_bytes(ciArray* a_h, ciObject* o_h) {
-  VM_ENTRY_MARK;
-  objArrayOop a = (objArrayOop)a_h->get_oop();
-  assert(a->is_objArray(), "");
-  int length = a->length();
-  oop o = o_h->get_oop();
-  for (int i = 0; i < length; i++) {
-    if (a->obj_at(i) == o)  return i;
-  }
-  return -1;
-}
-
 
 // ------------------------------------------------------------------
 // ciEnv::check_klass_accessiblity
@@ -1125,14 +1108,6 @@ void ciEnv::register_method(ciMethod* target,
     // The CodeCache is full.
     record_failure("code cache is full");
   }
-}
-
-
-// ------------------------------------------------------------------
-// ciEnv::find_system_klass
-ciKlass* ciEnv::find_system_klass(ciSymbol* klass_name) {
-  VM_ENTRY_MARK;
-  return get_klass_by_name_impl(NULL, constantPoolHandle(), klass_name, false);
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -78,7 +78,6 @@ private:
 
   // Cache DTrace flags
   bool  _dtrace_extended_probes;
-  bool  _dtrace_monitor_probes;
   bool  _dtrace_method_probes;
   bool  _dtrace_alloc_probes;
 
@@ -355,7 +354,6 @@ public:
   // Cache DTrace flags
   void  cache_dtrace_flags();
   bool  dtrace_extended_probes() const { return _dtrace_extended_probes; }
-  bool  dtrace_monitor_probes()  const { return _dtrace_monitor_probes; }
   bool  dtrace_method_probes()   const { return _dtrace_method_probes; }
   bool  dtrace_alloc_probes()    const { return _dtrace_alloc_probes; }
 
@@ -419,7 +417,6 @@ public:
   }
   ciInstance* unloaded_ciinstance();
 
-  ciKlass*  find_system_klass(ciSymbol* klass_name);
   // Note:  To find a class from its name string, use ciSymbol::make,
   // but consider adding to vmSymbols.hpp instead.
 
@@ -428,10 +425,6 @@ public:
   // the bytecodes could be an array type.  Basically this converts
   // array types into java/lang/Object and other types stay as they are.
   static ciInstanceKlass* get_instance_klass_for_declared_method_holder(ciKlass* klass);
-
-  // Return the machine-level offset of o, which must be an element of a.
-  // This may be used to form constant-loading expressions in lieu of simpler encodings.
-  int       array_element_offset_in_bytes(ciArray* a, ciObject* o);
 
   // Access to the compile-lifetime allocation arena.
   Arena*    arena() { return _arena; }

--- a/src/hotspot/share/ci/ciExceptionHandler.hpp
+++ b/src/hotspot/share/ci/ciExceptionHandler.hpp
@@ -72,9 +72,6 @@ public:
   bool      is_in_range(int bci) {
     return start() <= bci && bci < limit();
   }
-  bool      catches(ciInstanceKlass *exc) {
-    return is_catch_all() || exc->is_subtype_of(catch_klass());
-  }
   bool      is_rethrow() { return handler_bci() == -1; }
 
   void      print();

--- a/src/hotspot/share/ci/ciInstance.hpp
+++ b/src/hotspot/share/ci/ciInstance.hpp
@@ -26,7 +26,6 @@
 #define SHARE_CI_CIINSTANCE_HPP
 
 #include "ci/ciObject.hpp"
-#include "oops/instanceOop.hpp"
 #include "oops/oop.hpp"
 
 // ciInstance
@@ -45,8 +44,6 @@ protected:
 
   ciInstance(ciKlass* klass) : ciObject(klass) {}
 
-  instanceOop get_instanceOop() { return (instanceOop)get_oop(); }
-
   const char* type_string() { return "ciInstance"; }
 
   void print_impl(outputStream* st);
@@ -61,7 +58,6 @@ public:
 
   // What kind of ciObject is this?
   bool is_instance()     { return true; }
-  bool is_java_object()  { return true; }
 
   // Constant value of a field.
   ciConstant field_value(ciField* field);

--- a/src/hotspot/share/ci/ciInstance.hpp
+++ b/src/hotspot/share/ci/ciInstance.hpp
@@ -26,6 +26,7 @@
 #define SHARE_CI_CIINSTANCE_HPP
 
 #include "ci/ciObject.hpp"
+#include "oops/instanceOop.hpp"
 #include "oops/oop.hpp"
 
 // ciInstance

--- a/src/hotspot/share/ci/ciKlass.cpp
+++ b/src/hotspot/share/ci/ciKlass.cpp
@@ -123,16 +123,6 @@ ciKlass* ciKlass::super_of_depth(juint i) {
 }
 
 // ------------------------------------------------------------------
-// ciKlass::can_be_primary_super
-bool ciKlass::can_be_primary_super() {
-  assert(is_loaded(), "must be loaded");
-
-  VM_ENTRY_MARK;
-  Klass* this_klass = get_Klass();
-  return this_klass->can_be_primary_super();
-}
-
-// ------------------------------------------------------------------
 // ciKlass::least_common_ancestor
 //
 // Get the shared parent of two klasses.

--- a/src/hotspot/share/ci/ciKlass.hpp
+++ b/src/hotspot/share/ci/ciKlass.hpp
@@ -86,7 +86,6 @@ public:
   juint super_depth();
   juint super_check_offset();
   ciKlass* super_of_depth(juint i);
-  bool can_be_primary_super();
   static juint primary_super_limit() { return Klass::primary_super_limit(); }
 
   // Is this ciObject the ciInstanceKlass representing java.lang.Object()?

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -201,7 +201,6 @@ class ciMethod : public ciMetadata {
   bool intrinsic_candidate()   const { return get_Method()->intrinsic_candidate();   }
   bool is_static_initializer() const { return get_Method()->is_static_initializer(); }
 
-  int comp_level();
   int highest_osr_comp_level();
 
   Bytecodes::Code java_code_at_bci(int bci) {
@@ -216,14 +215,11 @@ class ciMethod : public ciMetadata {
   ciMethodBlocks    *get_method_blocks();
 
   bool    has_linenumber_table() const;          // length unknown until decompression
-  u_char* compressed_linenumber_table() const;   // not preserved by gc
 
   int line_number_from_bci(int bci) const;
 
   // Runtime information.
   int           vtable_index();
-  address       native_entry();
-  address       interpreter_entry();
 
   // Analysis and profiling.
   //
@@ -258,7 +254,6 @@ class ciMethod : public ciMetadata {
   ciTypeFlow*   get_flow_analysis();
   ciTypeFlow*   get_osr_flow_analysis(int osr_bci);  // alternate entry point
   ciCallProfile call_profile_at_bci(int bci);
-  int           interpreter_call_site_count(int bci);
 
   // Does type profiling provide any useful information at this point?
   bool          argument_profiled_type(int bci, int i, ciKlass*& type, ProfilePtrKind& ptr_kind);
@@ -302,8 +297,6 @@ class ciMethod : public ciMetadata {
   bool has_option_value(const char* option, double& value);
   bool can_be_compiled();
   bool can_be_parsed() const { return _can_be_parsed; }
-  bool can_be_osr_compiled(int entry_bci);
-  void set_not_compilable(const char* reason = NULL);
   bool has_compiled_code();
   void log_nmethod_identity(xmlStream* log);
   bool is_not_reached(int bci);
@@ -340,8 +333,6 @@ class ciMethod : public ciMetadata {
   bool is_strict      () const                   { return flags().is_strict(); }
 
   // Other flags
-  bool is_empty_method() const;
-  bool is_vanilla_constructor() const;
   bool is_final_method() const                   { return is_final() || holder()->is_final(); }
   bool is_default_method() const                 { return !is_abstract() && !is_private() &&
                                                           holder()->is_interface(); }

--- a/src/hotspot/share/ci/ciMethodBlocks.hpp
+++ b/src/hotspot/share/ci/ciMethodBlocks.hpp
@@ -32,8 +32,6 @@
 
 class ciBlock;
 
-typedef short ciBlockIndex;
-
 class ciMethodBlocks : public ResourceObj {
 private:
   ciMethod *_method;

--- a/src/hotspot/share/ci/ciObjArray.hpp
+++ b/src/hotspot/share/ci/ciObjArray.hpp
@@ -39,8 +39,6 @@ class ciObjArray : public ciArray {
 protected:
   ciObjArray(objArrayHandle h_o) : ciArray(h_o) {}
 
-  ciObjArray(ciKlass* klass, int len) : ciArray(klass, len) {}
-
   objArrayOop get_objArrayOop() {
     return (objArrayOop)get_oop();
   }

--- a/src/hotspot/share/ci/ciStreams.hpp
+++ b/src/hotspot/share/ci/ciStreams.hpp
@@ -143,8 +143,6 @@ public:
   // Does this instruction contain an index which refes into the CP cache?
   bool has_cache_index() const { return Bytecodes::uses_cp_cache(cur_bc_raw()); }
 
-  bool has_optional_appendix() { return Bytecodes::has_optional_appendix(cur_bc_raw()); }
-
   int get_index_u1() const {
     return bytecode().get_index_u1(cur_bc_raw());
   }

--- a/src/hotspot/share/ci/ciSymbol.cpp
+++ b/src/hotspot/share/ci/ciSymbol.cpp
@@ -31,23 +31,12 @@
 
 // ------------------------------------------------------------------
 // ciSymbol::ciSymbol
-//
-// Preallocated symbol variant.  Used with symbols from vmSymbols.
 ciSymbol::ciSymbol(Symbol* s, vmSymbolID sid)
   : _symbol(s), _sid(sid)
 {
   assert(_symbol != NULL, "adding null symbol");
   _symbol->increment_refcount();  // increment ref count
-  assert(sid_ok(), "must be in vmSymbols");
-}
-
-// Normal case for non-famous symbols.
-ciSymbol::ciSymbol(Symbol* s)
-  : _symbol(s), _sid(vmSymbolID::NO_SID)
-{
-  assert(_symbol != NULL, "adding null symbol");
-  _symbol->increment_refcount();  // increment ref count
-  assert(sid_ok(), "must not be in vmSymbols");
+  assert(sid_ok(), "sid must be consistent with vmSymbols");
 }
 
 // ciSymbol

--- a/src/hotspot/share/ci/ciSymbol.hpp
+++ b/src/hotspot/share/ci/ciSymbol.hpp
@@ -52,8 +52,7 @@ private:
   const vmSymbolID _sid;
   DEBUG_ONLY( bool sid_ok() { return vmSymbols::find_sid(get_symbol()) == _sid; } )
 
-  ciSymbol(Symbol* s);  // normal case, for symbols not mentioned in vmSymbols
-  ciSymbol(Symbol* s, vmSymbolID sid);   // for use with vmSymbols
+  ciSymbol(Symbol* s, vmSymbolID sid = vmSymbolID::NO_SID);
 
   Symbol* get_symbol() const { return _symbol; }
 

--- a/src/hotspot/share/ci/ciType.cpp
+++ b/src/hotspot/share/ci/ciType.cpp
@@ -102,20 +102,6 @@ ciInstance* ciType::java_mirror() {
 }
 
 // ------------------------------------------------------------------
-// ciType::box_klass
-//
-ciKlass* ciType::box_klass() {
-  if (!is_primitive_type())  return this->as_klass();  // reference types are "self boxing"
-
-  // Void is "boxed" with a null.
-  if (basic_type() == T_VOID)  return NULL;
-
-  VM_ENTRY_MARK;
-  return CURRENT_THREAD_ENV->get_instance_klass(SystemDictionary::box_klass(basic_type()));
-}
-
-
-// ------------------------------------------------------------------
 // ciType::make
 //
 // Produce the ciType for a given primitive BasicType.

--- a/src/hotspot/share/ci/ciType.hpp
+++ b/src/hotspot/share/ci/ciType.hpp
@@ -60,12 +60,6 @@ public:
   // There are mirrors for instance, array, and primitive types (incl. void).
   virtual ciInstance*    java_mirror();
 
-  // Get the class which "boxes" (or "wraps") values of this type.
-  // Example:  short is boxed by java.lang.Short, etc.
-  // Returns self if it is a reference type.
-  // Returns NULL for void, since null is used in such cases.
-  ciKlass*  box_klass();
-
   // Returns true if this is not a klass or array (i.e., not a reference type).
   bool is_primitive_type() const            { return !is_reference_type(basic_type()); }
   int size() const                          { return type2size[basic_type()]; }

--- a/src/hotspot/share/ci/ciTypeArray.hpp
+++ b/src/hotspot/share/ci/ciTypeArray.hpp
@@ -39,8 +39,6 @@ class ciTypeArray : public ciArray {
 protected:
   ciTypeArray(typeArrayHandle h_t) : ciArray(h_t) {}
 
-  ciTypeArray(ciKlass* klass, int len) : ciArray(klass, len) {}
-
   typeArrayOop get_typeArrayOop() {
     return (typeArrayOop)get_oop();
   }


### PR DESCRIPTION
This patch removes dead code in the ci area.

There's also a trivial micro-optimization to is_boxing_method/is_unboxing_method

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256738](https://bugs.openjdk.java.net/browse/JDK-8256738): Compiler interface clean-up


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1345/head:pull/1345`
`$ git checkout pull/1345`
