### PR TITLE
8256741: Reduce footprint of compiler interface data structures

### DIFF
--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1371,8 +1371,8 @@ BCEscapeAnalyzer  *ciMethod::get_bcea() {
 }
 
 ciMethodBlocks  *ciMethod::get_method_blocks() {
-  Arena *arena = CURRENT_ENV->arena();
   if (_method_blocks == NULL) {
+    Arena *arena = CURRENT_ENV->arena();
     _method_blocks = new (arena) ciMethodBlocks(arena, this);
   }
   return _method_blocks;

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -287,7 +287,7 @@ ciMetadata* ciObjectFactory::get_metadata(Metadata* key) {
 #ifdef ASSERT
   if (CIObjectFactoryVerify) {
     Metadata* last = NULL;
-    for (int j = 0; j< _ci_metadata.length(); j++) {
+    for (int j = 0; j < _ci_metadata.length(); j++) {
       Metadata* o = _ci_metadata.at(j)->constant_encoding();
       assert(last < o, "out of order");
       last = o;
@@ -688,7 +688,7 @@ void ciObjectFactory::metadata_do(MetadataClosure* f) {
 void ciObjectFactory::print_contents_impl() {
   int len = _ci_metadata.length();
   tty->print_cr("ciObjectFactory (%d) meta data contents:", len);
-  for (int i=0; i<len; i++) {
+  for (int i = 0; i < len; i++) {
     _ci_metadata.at(i)->print();
     tty->cr();
   }

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -75,30 +75,24 @@ volatile bool             ciObjectFactory::_initialized = false;
 // ------------------------------------------------------------------
 // ciObjectFactory::ciObjectFactory
 ciObjectFactory::ciObjectFactory(Arena* arena,
-                                 int expected_size) {
-
+                                 int expected_size)
+                                 : _arena(arena),
+                                   _ci_metadata(arena, expected_size, 0, NULL),
+                                   _unloaded_methods(arena, 4, 0, NULL),
+                                   _unloaded_klasses(arena, 8, 0, NULL),
+                                   _unloaded_instances(arena, 4, 0, NULL),
+                                   _return_addresses(arena, 8, 0, NULL),
+                                   _symbols(arena, 100, 0, NULL),
+                                   _next_ident(_shared_ident_limit),
+                                   _non_perm_count(0) {
   for (int i = 0; i < NON_PERM_BUCKETS; i++) {
     _non_perm_bucket[i] = NULL;
   }
-  _non_perm_count = 0;
-
-  _next_ident = _shared_ident_limit;
-  _arena = arena;
-  _ci_metadata = new (arena) GrowableArray<ciMetadata*>(arena, expected_size, 0, NULL);
 
   // If the shared ci objects exist append them to this factory's objects
-
   if (_shared_ci_metadata != NULL) {
-    _ci_metadata->appendAll(_shared_ci_metadata);
+    _ci_metadata.appendAll(_shared_ci_metadata);
   }
-
-  _unloaded_methods = new (arena) GrowableArray<ciMethod*>(arena, 4, 0, NULL);
-  _unloaded_klasses = new (arena) GrowableArray<ciKlass*>(arena, 8, 0, NULL);
-  _unloaded_instances = new (arena) GrowableArray<ciInstance*>(arena, 4, 0, NULL);
-  _return_addresses =
-    new (arena) GrowableArray<ciReturnAddress*>(arena, 8, 0, NULL);
-
-  _symbols = new (arena) GrowableArray<ciSymbol*>(arena, 100, 0, NULL);
 }
 
 // ------------------------------------------------------------------
@@ -145,8 +139,6 @@ void ciObjectFactory::init_shared_objects() {
 #endif
   }
 
-  _ci_metadata = new (_arena) GrowableArray<ciMetadata*>(_arena, 64, 0, NULL);
-
   for (int i = T_BOOLEAN; i <= T_CONFLICT; i++) {
     BasicType t = (BasicType)i;
     if (type2name(t) != NULL && !is_reference_type(t) &&
@@ -166,10 +158,10 @@ void ciObjectFactory::init_shared_objects() {
   WK_KLASSES_DO(WK_KLASS_DEFN)
 #undef WK_KLASS_DEFN
 
-  for (int len = -1; len != _ci_metadata->length(); ) {
-    len = _ci_metadata->length();
+  for (int len = -1; len != _ci_metadata.length(); ) {
+    len = _ci_metadata.length();
     for (int i2 = 0; i2 < len; i2++) {
-      ciMetadata* obj = _ci_metadata->at(i2);
+      ciMetadata* obj = _ci_metadata.at(i2);
       assert (obj->is_metadata(), "what else would it be?");
       if (obj->is_loaded() && obj->is_instance_klass()) {
         obj->as_instance_klass()->compute_nonstatic_fields();
@@ -194,8 +186,6 @@ void ciObjectFactory::init_shared_objects() {
   get_metadata(Universe::intArrayKlassObj());
   get_metadata(Universe::longArrayKlassObj());
 
-
-
   assert(_non_perm_count == 0, "no shared non-perm objects");
 
   // The shared_ident_limit is the first ident number that will
@@ -204,7 +194,7 @@ void ciObjectFactory::init_shared_objects() {
   // while the higher numbers are recycled afresh by each new ciEnv.
 
   _shared_ident_limit = _next_ident;
-  _shared_ci_metadata = _ci_metadata;
+  _shared_ci_metadata = &_ci_metadata;
 }
 
 
@@ -217,14 +207,14 @@ ciSymbol* ciObjectFactory::get_symbol(Symbol* key) {
 
   assert(vmSymbols::find_sid(key) == vmSymbolID::NO_SID, "");
   ciSymbol* s = new (arena()) ciSymbol(key, vmSymbolID::NO_SID);
-  _symbols->push(s);
+  _symbols.push(s);
   return s;
 }
 
 // Decrement the refcount when done on symbols referenced by this compilation.
 void ciObjectFactory::remove_symbols() {
-  for (int i = 0; i < _symbols->length(); i++) {
-    ciSymbol* s = _symbols->at(i);
+  for (int i = 0; i < _symbols.length(); i++) {
+    ciSymbol* s = _symbols.at(i);
     s->get_symbol()->decrement_refcount();
   }
   // Since _symbols is resource allocated we're not allowed to delete it
@@ -276,12 +266,12 @@ ciMetadata* ciObjectFactory::cached_metadata(Metadata* key) {
   ASSERT_IN_VM;
 
   bool found = false;
-  int index = _ci_metadata->find_sorted<Metadata*, ciObjectFactory::metadata_compare>(key, found);
+  int index = _ci_metadata.find_sorted<Metadata*, ciObjectFactory::metadata_compare>(key, found);
 
   if (!found) {
     return NULL;
   }
-  return _ci_metadata->at(index)->as_metadata();
+  return _ci_metadata.at(index)->as_metadata();
 }
 
 
@@ -297,20 +287,20 @@ ciMetadata* ciObjectFactory::get_metadata(Metadata* key) {
 #ifdef ASSERT
   if (CIObjectFactoryVerify) {
     Metadata* last = NULL;
-    for (int j = 0; j< _ci_metadata->length(); j++) {
-      Metadata* o = _ci_metadata->at(j)->constant_encoding();
+    for (int j = 0; j< _ci_metadata.length(); j++) {
+      Metadata* o = _ci_metadata.at(j)->constant_encoding();
       assert(last < o, "out of order");
       last = o;
     }
   }
 #endif // ASSERT
-  int len = _ci_metadata->length();
+  int len = _ci_metadata.length();
   bool found = false;
-  int index = _ci_metadata->find_sorted<Metadata*, ciObjectFactory::metadata_compare>(key, found);
+  int index = _ci_metadata.find_sorted<Metadata*, ciObjectFactory::metadata_compare>(key, found);
 #ifdef ASSERT
   if (CIObjectFactoryVerify) {
-    for (int i=0; i<_ci_metadata->length(); i++) {
-      if (_ci_metadata->at(i)->constant_encoding() == key) {
+    for (int i = 0; i < _ci_metadata.length(); i++) {
+      if (_ci_metadata.at(i)->constant_encoding() == key) {
         assert(index == i, " bad lookup");
       }
     }
@@ -324,16 +314,16 @@ ciMetadata* ciObjectFactory::get_metadata(Metadata* key) {
     init_ident_of(new_object);
     assert(new_object->is_metadata(), "must be");
 
-    if (len != _ci_metadata->length()) {
+    if (len != _ci_metadata.length()) {
       // creating the new object has recursively entered new objects
       // into the table.  We need to recompute our index.
-      index = _ci_metadata->find_sorted<Metadata*, ciObjectFactory::metadata_compare>(key, found);
+      index = _ci_metadata.find_sorted<Metadata*, ciObjectFactory::metadata_compare>(key, found);
     }
     assert(!found, "no double insert");
-    _ci_metadata->insert_before(index, new_object);
+    _ci_metadata.insert_before(index, new_object);
     return new_object;
   }
-  return _ci_metadata->at(index)->as_metadata();
+  return _ci_metadata.at(index)->as_metadata();
 }
 
 // ------------------------------------------------------------------
@@ -420,8 +410,8 @@ ciMethod* ciObjectFactory::get_unloaded_method(ciInstanceKlass* holder,
                                                ciInstanceKlass* accessor) {
   assert(accessor != NULL, "need origin of access");
   ciSignature* that = NULL;
-  for (int i = 0; i < _unloaded_methods->length(); i++) {
-    ciMethod* entry = _unloaded_methods->at(i);
+  for (int i = 0; i < _unloaded_methods.length(); i++) {
+    ciMethod* entry = _unloaded_methods.at(i);
     if (entry->holder()->equals(holder) &&
         entry->name()->equals(name) &&
         entry->signature()->as_symbol()->equals(signature)) {
@@ -445,7 +435,7 @@ ciMethod* ciObjectFactory::get_unloaded_method(ciInstanceKlass* holder,
   ciMethod* new_method = new (arena()) ciMethod(holder, name, signature, accessor);
 
   init_ident_of(new_method);
-  _unloaded_methods->append(new_method);
+  _unloaded_methods.append(new_method);
 
   return new_method;
 }
@@ -468,8 +458,8 @@ ciKlass* ciObjectFactory::get_unloaded_klass(ciKlass* accessing_klass,
     loader = accessing_klass->loader();
     domain = accessing_klass->protection_domain();
   }
-  for (int i=0; i<_unloaded_klasses->length(); i++) {
-    ciKlass* entry = _unloaded_klasses->at(i);
+  for (int i = 0; i < _unloaded_klasses.length(); i++) {
+    ciKlass* entry = _unloaded_klasses.at(i);
     if (entry->name()->equals(name) &&
         entry->loader() == loader &&
         entry->protection_domain() == domain) {
@@ -519,7 +509,7 @@ ciKlass* ciObjectFactory::get_unloaded_klass(ciKlass* accessing_klass,
     new_klass = new (arena()) ciInstanceKlass(name, loader_handle, domain_handle);
   }
   init_ident_of(new_klass);
-  _unloaded_klasses->append(new_klass);
+  _unloaded_klasses.append(new_klass);
 
   return new_klass;
 }
@@ -531,8 +521,8 @@ ciKlass* ciObjectFactory::get_unloaded_klass(ciKlass* accessing_klass,
 // Get a ciInstance representing an as-yet undetermined instance of a given class.
 //
 ciInstance* ciObjectFactory::get_unloaded_instance(ciInstanceKlass* instance_klass) {
-  for (int i=0; i<_unloaded_instances->length(); i++) {
-    ciInstance* entry = _unloaded_instances->at(i);
+  for (int i = 0; i < _unloaded_instances.length(); i++) {
+    ciInstance* entry = _unloaded_instances.at(i);
     if (entry->klass()->equals(instance_klass)) {
       // We've found a match.
       return entry;
@@ -544,7 +534,7 @@ ciInstance* ciObjectFactory::get_unloaded_instance(ciInstanceKlass* instance_kla
   ciInstance* new_instance = new (arena()) ciInstance(instance_klass);
 
   init_ident_of(new_instance);
-  _unloaded_instances->append(new_instance);
+  _unloaded_instances.append(new_instance);
 
   // make sure it looks the way we want:
   assert(!new_instance->is_loaded(), "");
@@ -611,8 +601,8 @@ ciMethodData* ciObjectFactory::get_empty_methodData() {
 //
 // Get a ciReturnAddress for a specified bci.
 ciReturnAddress* ciObjectFactory::get_return_address(int bci) {
-  for (int i=0; i<_return_addresses->length(); i++) {
-    ciReturnAddress* entry = _return_addresses->at(i);
+  for (int i = 0; i < _return_addresses.length(); i++) {
+    ciReturnAddress* entry = _return_addresses.at(i);
     if (entry->bci() == bci) {
       // We've found a match.
       return entry;
@@ -621,7 +611,7 @@ ciReturnAddress* ciObjectFactory::get_return_address(int bci) {
 
   ciReturnAddress* new_ret_addr = new (arena()) ciReturnAddress(bci);
   init_ident_of(new_ret_addr);
-  _return_addresses->append(new_ret_addr);
+  _return_addresses.append(new_ret_addr);
   return new_ret_addr;
 }
 
@@ -687,9 +677,8 @@ ciSymbol* ciObjectFactory::vm_symbol_at(vmSymbolID sid) {
 // ------------------------------------------------------------------
 // ciObjectFactory::metadata_do
 void ciObjectFactory::metadata_do(MetadataClosure* f) {
-  if (_ci_metadata == NULL) return;
-  for (int j = 0; j< _ci_metadata->length(); j++) {
-    Metadata* o = _ci_metadata->at(j)->constant_encoding();
+  for (int j = 0; j < _ci_metadata.length(); j++) {
+    Metadata* o = _ci_metadata.at(j)->constant_encoding();
     f->do_metadata(o);
   }
 }
@@ -697,10 +686,10 @@ void ciObjectFactory::metadata_do(MetadataClosure* f) {
 // ------------------------------------------------------------------
 // ciObjectFactory::print_contents_impl
 void ciObjectFactory::print_contents_impl() {
-  int len = _ci_metadata->length();
+  int len = _ci_metadata.length();
   tty->print_cr("ciObjectFactory (%d) meta data contents:", len);
   for (int i=0; i<len; i++) {
-    _ci_metadata->at(i)->print();
+    _ci_metadata.at(i)->print();
     tty->cr();
   }
 }
@@ -719,7 +708,7 @@ void ciObjectFactory::print_contents() {
 // Print debugging information about the object factory
 void ciObjectFactory::print() {
   tty->print("<ciObjectFactory oops=%d metadata=%d unloaded_methods=%d unloaded_instances=%d unloaded_klasses=%d>",
-             _non_perm_count, _ci_metadata->length(), _unloaded_methods->length(),
-             _unloaded_instances->length(),
-             _unloaded_klasses->length());
+             _non_perm_count, _ci_metadata.length(), _unloaded_methods.length(),
+             _unloaded_instances.length(),
+             _unloaded_klasses.length());
 }

--- a/src/hotspot/share/ci/ciObjectFactory.hpp
+++ b/src/hotspot/share/ci/ciObjectFactory.hpp
@@ -46,14 +46,14 @@ private:
   static ciSymbol*                 _shared_ci_symbols[];
   static int                       _shared_ident_limit;
 
-  Arena*                    _arena;
-  GrowableArray<ciMetadata*>*        _ci_metadata;
-  GrowableArray<ciMethod*>* _unloaded_methods;
-  GrowableArray<ciKlass*>* _unloaded_klasses;
-  GrowableArray<ciInstance*>* _unloaded_instances;
-  GrowableArray<ciReturnAddress*>* _return_addresses;
-  GrowableArray<ciSymbol*>* _symbols;  // keep list of symbols created
-  int                       _next_ident;
+  Arena*                           _arena;
+  GrowableArray<ciMetadata*>       _ci_metadata;
+  GrowableArray<ciMethod*>         _unloaded_methods;
+  GrowableArray<ciKlass*>          _unloaded_klasses;
+  GrowableArray<ciInstance*>       _unloaded_instances;
+  GrowableArray<ciReturnAddress*>  _return_addresses;
+  GrowableArray<ciSymbol*>         _symbols;  // keep list of symbols created
+  int                              _next_ident;
 
 public:
   struct NonPermObject : public ResourceObj {
@@ -139,7 +139,7 @@ public:
 
   ciReturnAddress* get_return_address(int bci);
 
-  GrowableArray<ciMetadata*>* get_ci_metadata() const { return _ci_metadata; }
+  GrowableArray<ciMetadata*>* get_ci_metadata() { return &_ci_metadata; }
   // RedefineClasses support
   void metadata_do(MetadataClosure* f);
 

--- a/src/hotspot/share/ci/ciSignature.hpp
+++ b/src/hotspot/share/ci/ciSignature.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/ci/ciSignature.hpp
+++ b/src/hotspot/share/ci/ciSignature.hpp
@@ -40,7 +40,7 @@ private:
   ciKlass*  _accessing_klass;
 
   GrowableArray<ciType*> _types; // parameter types
-  ciType* _return_type; // return type
+  ciType* _return_type;
   int _size;   // number of stack slots required for arguments
 
   friend class ciMethod;

--- a/src/hotspot/share/ci/ciSignature.hpp
+++ b/src/hotspot/share/ci/ciSignature.hpp
@@ -39,16 +39,15 @@ private:
   ciSymbol* _symbol;
   ciKlass*  _accessing_klass;
 
-  GrowableArray<ciType*>* _types;
+  GrowableArray<ciType*> _types; // parameter types
+  ciType* _return_type; // return type
   int _size;   // number of stack slots required for arguments
-  int _count;  // number of parameter types in the signature
 
   friend class ciMethod;
   friend class ciBytecodeStream;
   friend class ciObjectFactory;
 
   ciSignature(ciKlass* accessing_klass, const constantPoolHandle& cpool, ciSymbol* signature);
-  ciSignature(ciKlass* accessing_klass,                           ciSymbol* signature, ciMethodType* method_type);
 
   Symbol* get_symbol() const                     { return _symbol->get_symbol(); }
 
@@ -56,11 +55,11 @@ public:
   ciSymbol* as_symbol() const                    { return _symbol; }
   ciKlass*  accessing_klass() const              { return _accessing_klass; }
 
-  ciType*   return_type() const;
-  ciType*   type_at(int index) const;
+  ciType*   return_type() const                  { return _return_type; }
+  ciType*   type_at(int index) const             { return _types.at(index); }
 
   int       size() const                         { return _size; }
-  int       count() const                        { return _count; }
+  int       count() const                        { return _types.length(); }
 
   int       arg_size_for_bc(Bytecodes::Code bc)  { return size() + (Bytecodes::has_receiver(bc) ? 1 : 0); }
 

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/ci/ciTypeFlow.hpp
+++ b/src/hotspot/share/ci/ciTypeFlow.hpp
@@ -610,7 +610,6 @@ public:
 
     // Predecessors of this block (including exception edges)
     GrowableArray<Block*>* predecessors() {
-      assert(_predecessors != NULL, "must be filled in");
       return &_predecessors;
     }
 

--- a/src/hotspot/share/ci/ciTypeFlow.hpp
+++ b/src/hotspot/share/ci/ciTypeFlow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/ci/ciTypeFlow.hpp
+++ b/src/hotspot/share/ci/ciTypeFlow.hpp
@@ -104,10 +104,10 @@ public:
   // if paths are compatible.  <DISCUSSION>
   class JsrSet : public ResourceObj {
   private:
-    GrowableArray<JsrRecord*>* _set;
+    GrowableArray<JsrRecord*> _set;
 
     JsrRecord* record_at(int i) {
-      return _set->at(i);
+      return _set.at(i);
     }
 
     // Insert the given JsrRecord into the JsrSet, maintaining the order
@@ -119,6 +119,7 @@ public:
 
   public:
     JsrSet(Arena* arena, int default_len = 4);
+    JsrSet(int default_len = 4);
 
     // Copy this JsrSet.
     void copy_into(JsrSet* jsrs);
@@ -132,7 +133,7 @@ public:
                        StateVector* state);
 
     // What is the cardinality of this set?
-    int size() const { return _set->length(); }
+    int size() const { return _set.length(); }
 
     void print_on(outputStream* st) const PRODUCT_RETURN;
   };
@@ -523,7 +524,7 @@ public:
     GrowableArray<Block*>*           _exceptions;
     GrowableArray<ciInstanceKlass*>* _exc_klasses;
     GrowableArray<Block*>*           _successors;
-    GrowableArray<Block*>*           _predecessors;
+    GrowableArray<Block*>            _predecessors;
     StateVector*                     _state;
     JsrSet*                          _jsrs;
 
@@ -615,7 +616,7 @@ public:
     // Predecessors of this block (including exception edges)
     GrowableArray<Block*>* predecessors() {
       assert(_predecessors != NULL, "must be filled in");
-      return _predecessors;
+      return &_predecessors;
     }
 
     // Get the exceptional successors for this Block.
@@ -795,8 +796,6 @@ private:
 
   // For each ciBlock index, a list of Blocks which share this ciBlock.
   GrowableArray<Block*>** _idx_to_blocklist;
-  // count of ciBlocks
-  int _ciblock_count;
 
   // Tells if a given instruction is able to generate an exception edge.
   bool can_trap(ciBytecodeStream& str);

--- a/src/hotspot/share/ci/ciTypeFlow.hpp
+++ b/src/hotspot/share/ci/ciTypeFlow.hpp
@@ -36,13 +36,8 @@ class ciTypeFlow : public ResourceObj {
 private:
   ciEnv*    _env;
   ciMethod* _method;
-  ciMethodBlocks* _methodBlocks;
   int       _osr_bci;
 
-  // information cached from the method:
-  int _max_locals;
-  int _max_stack;
-  int _code_size;
   bool      _has_irreducible_entry;
 
   const char* _failure_reason;
@@ -62,10 +57,10 @@ public:
   Arena*    arena()            { return _env->arena(); }
   bool      is_osr_flow() const{ return _osr_bci != InvocationEntryBci; }
   int       start_bci() const  { return is_osr_flow()? _osr_bci: 0; }
-  int       max_locals() const { return _max_locals; }
-  int       max_stack() const  { return _max_stack; }
-  int       max_cells() const  { return _max_locals + _max_stack; }
-  int       code_size() const  { return _code_size; }
+  int       max_locals() const { return method()->max_locals(); }
+  int       max_stack() const  { return method()->max_stack(); }
+  int       max_cells() const  { return max_locals() + max_stack(); }
+  int       code_size() const  { return method()->code_size(); }
   bool      has_irreducible_entry() const { return _has_irreducible_entry; }
 
   // Represents information about an "active" jsr call.  This
@@ -871,7 +866,6 @@ private:
   Loop* _loop_tree_root;
 
   // State used for make_jsr_record
-  int _jsr_count;
   GrowableArray<JsrRecord*>* _jsr_records;
 
 public:

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -865,9 +865,8 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   nonstatic_field(ciField,                     _is_constant,                                  bool)                                  \
   nonstatic_field(ciField,                     _constant_value,                               ciConstant)                            \
                                                                                                                                      \
-  nonstatic_field(ciObjectFactory,             _ci_metadata,                                  GrowableArray<ciMetadata*>*)           \
-  nonstatic_field(ciObjectFactory,             _symbols,                                      GrowableArray<ciSymbol*>*)             \
-  nonstatic_field(ciObjectFactory,             _unloaded_methods,                             GrowableArray<ciMethod*>*)             \
+  nonstatic_field(ciObjectFactory,             _ci_metadata,                                  GrowableArray<ciMetadata*>)            \
+  nonstatic_field(ciObjectFactory,             _symbols,                                      GrowableArray<ciSymbol*>)              \
                                                                                                                                      \
   nonstatic_field(ciConstant,                  _type,                                         BasicType)                             \
   nonstatic_field(ciConstant,                  _value._int,                                   jint)                                  \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ci/ciObjectFactory.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ci/ciObjectFactory.java
@@ -45,7 +45,6 @@ public class ciObjectFactory extends VMObject {
 
   private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
     Type type      = db.lookupType("ciObjectFactory");
-    unloadedMethodsField = type.getAddressField("_unloaded_methods");
     ciMetadataField = type.getAddressField("_ci_metadata");
     symbolsField = type.getAddressField("_symbols");
 
@@ -54,7 +53,6 @@ public class ciObjectFactory extends VMObject {
     ciSymbolConstructor = new VirtualBaseConstructor<ciSymbol>(db, db.lookupType("ciSymbol"), "sun.jvm.hotspot.ci", ciSymbol.class);
   }
 
-  private static AddressField unloadedMethodsField;
   private static AddressField ciMetadataField;
   private static AddressField symbolsField;
 
@@ -75,11 +73,13 @@ public class ciObjectFactory extends VMObject {
   }
 
   public GrowableArray<ciMetadata> objects() {
-    return GrowableArray.create(ciMetadataField.getValue(getAddress()), ciMetadataConstructor);
+    Address addr = getAddress().addOffsetTo(ciMetadataField.getOffset());
+    return GrowableArray.create(addr, ciMetadataConstructor);
   }
 
   public GrowableArray<ciSymbol> symbols() {
-    return GrowableArray.create(symbolsField.getValue(getAddress()), ciSymbolConstructor);
+    Address addr = getAddress().addOffsetTo(symbolsField.getOffset());
+    return GrowableArray.create(addr, ciSymbolConstructor);
   }
 
   public ciObjectFactory(Address addr) {


### PR DESCRIPTION
A few data structure in the ci allocate unconditionally created GrowableArrays out-of-line, have fields that are newer updated/read, or are unnecessarily cached. By cleaning this up we can slightly reduce memory used for JIT compilations while slightly speeding them up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256741](https://bugs.openjdk.java.net/browse/JDK-8256741): Reduce footprint of compiler interface data structures 


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1346/head:pull/1346`
`$ git checkout pull/1346`
