### PR TITLE
8255987: JDI tests fail with com.sun.jdi.ObjectCollectedException

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayType/newInstance/newinstance001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayType/newInstance/newinstance001.java
@@ -209,9 +209,17 @@ public class newinstance001 {
                 switch (i2) {
 
                 case 0:                 // boolean[]
-                        ArrayType blArray =
-                            (ArrayType) execClass.getValue(fsbl).type();
-                        ArrayReference newBlArray = blArray.newInstance(arraylength);
+                        ArrayType blArray = (ArrayType) execClass.getValue(fsbl).type();
+                        ArrayReference newBlArray = null;
+
+                        while (newBlArray == null) {
+                            newBlArray = blArray.newInstance(arraylength);
+                            try {
+                                newBlArray.disableCollection();
+                            } catch (ObjectCollectedException e) {
+                                newBlArray = null;
+                            }
+                        }
 
                         if (newBlArray.length() != arraylength) {
                             log3("ERROR : newBlArray.length() != arraylength   " + newBlArray.length());
@@ -225,12 +233,21 @@ public class newinstance001 {
                             break;
                         }
 
+                        newBlArray.enableCollection();
                         break;
 
                 case 1:                 // byte[]
-                        ArrayType btArray =
-                            (ArrayType) execClass.getValue(fsbt).type();
-                        ArrayReference newBtArray = btArray.newInstance(arraylength);
+                        ArrayType btArray = (ArrayType) execClass.getValue(fsbt).type();
+                        ArrayReference newBtArray = null;
+
+                        while (newBtArray == null) {
+                            newBtArray = btArray.newInstance(arraylength);
+                            try {
+                                newBtArray.disableCollection();
+                            } catch (ObjectCollectedException e) {
+                                newBtArray = null;
+                            }
+                        }
 
                         if (newBtArray.length() != arraylength) {
                             log3("ERROR : newBtArray.length() != arraylength   " + newBtArray.length());
@@ -243,12 +260,22 @@ public class newinstance001 {
                             expresult = 1;
                             break;
                         }
+
+                        newBtArray.enableCollection();
                         break;
 
                 case 2:                 // char[]
-                        ArrayType chArray =
-                            (ArrayType) execClass.getValue(fsch).type();
-                        ArrayReference newChArray = chArray.newInstance(arraylength);
+                        ArrayType chArray = (ArrayType) execClass.getValue(fsch).type();
+                        ArrayReference newChArray = null;
+
+                        while (newChArray == null) {
+                            newChArray = chArray.newInstance(arraylength);
+                            try {
+                                newChArray.disableCollection();
+                            } catch (ObjectCollectedException e) {
+                                newChArray = null;
+                            }
+                        }
 
                         if (newChArray.length() != arraylength) {
                             log3("ERROR : newChArray.length() != arraylength   " + newChArray.length());
@@ -261,12 +288,22 @@ public class newinstance001 {
                             expresult = 1;
                             break;
                         }
+
+                        newChArray.enableCollection();
                         break;
 
                 case 3:                 // double[]
-                        ArrayType dbArray =
-                            (ArrayType) execClass.getValue(fsdb).type();
-                        ArrayReference newDbArray = dbArray.newInstance(arraylength);
+                        ArrayType dbArray = (ArrayType) execClass.getValue(fsdb).type();
+                        ArrayReference newDbArray = null;
+
+                        while (newDbArray == null) {
+                            newDbArray = dbArray.newInstance(arraylength);
+                            try {
+                                newDbArray.disableCollection();
+                            } catch (ObjectCollectedException e) {
+                                newDbArray = null;
+                            }
+                        }
 
                         if (newDbArray.length() != arraylength) {
                             log3("ERROR : newDBArray.length() != arraylength   " + newDbArray.length());
@@ -279,12 +316,22 @@ public class newinstance001 {
                             expresult = 1;
                             break;
                         }
+
+                        newDbArray.enableCollection();
                         break;
 
                 case 4:                 // float[]
-                        ArrayType flArray =
-                            (ArrayType) execClass.getValue(fsfl).type();
-                        ArrayReference newFlArray = flArray.newInstance(arraylength);
+                        ArrayType flArray = (ArrayType) execClass.getValue(fsfl).type();
+                        ArrayReference newFlArray = null;
+
+                        while (newFlArray == null) {
+                            newFlArray = flArray.newInstance(arraylength);
+                            try {
+                                newFlArray.disableCollection();
+                            } catch (ObjectCollectedException e) {
+                                newFlArray = null;
+                            }
+                        }
 
                         if (newFlArray.length() != arraylength) {
                             log3("ERROR : newFlArray.length() != arraylength   " + newFlArray.length());
@@ -297,12 +344,22 @@ public class newinstance001 {
                             expresult = 1;
                             break;
                         }
+
+                        newFlArray.enableCollection();
                         break;
 
                 case 5:                 // int[]
-                        ArrayType inArray =
-                            (ArrayType) execClass.getValue(fsin).type();
-                        ArrayReference newInArray = inArray.newInstance(arraylength);
+                        ArrayType inArray = (ArrayType) execClass.getValue(fsin).type();
+                        ArrayReference newInArray = null;
+
+                        while (newInArray == null) {
+                            newInArray = inArray.newInstance(arraylength);
+                            try {
+                                newInArray.disableCollection();
+                            } catch (ObjectCollectedException e) {
+                                newInArray = null;
+                            }
+                        }
 
                         if (newInArray.length() != arraylength) {
                             log3("ERROR : newInArray.length() != arraylength   " + newInArray.length());
@@ -315,12 +372,22 @@ public class newinstance001 {
                             expresult = 1;
                             break;
                         }
+
+                        newInArray.enableCollection();
                         break;
 
                 case 6:                 // long[]
-                        ArrayType lnArray =
-                            (ArrayType) execClass.getValue(fsln).type();
-                        ArrayReference newLnArray = lnArray.newInstance(arraylength);
+                        ArrayType lnArray = (ArrayType) execClass.getValue(fsln).type();
+                        ArrayReference newLnArray = null;
+
+                        while (newLnArray == null) {
+                            newLnArray = lnArray.newInstance(arraylength);
+                            try {
+                                newLnArray.disableCollection();
+                            } catch (ObjectCollectedException e) {
+                                newLnArray = null;
+                            }
+                        }
 
                         if (newLnArray.length() != arraylength) {
                             log3("ERROR : newLnArray.length() != arraylength   " + newLnArray.length());
@@ -333,12 +400,22 @@ public class newinstance001 {
                             expresult = 1;
                             break;
                         }
+
+                        newLnArray.enableCollection();
                         break;
 
                 case 7:                 // short[]
-                        ArrayType shArray =
-                            (ArrayType) execClass.getValue(fssh).type();
-                        ArrayReference newShArray = shArray.newInstance(arraylength);
+                        ArrayType shArray = (ArrayType) execClass.getValue(fssh).type();
+                        ArrayReference newShArray = null;
+
+                        while (newShArray == null) {
+                            newShArray = shArray.newInstance(arraylength);
+                            try {
+                                newShArray.disableCollection();
+                            } catch (ObjectCollectedException e) {
+                                newShArray = null;
+                            }
+                        }
 
                         if (newShArray.length() != arraylength) {
                             log3("ERROR : newShArray.length() != arraylength   " + newShArray.length());
@@ -351,6 +428,8 @@ public class newinstance001 {
                             expresult = 1;
                             break;
                         }
+
+                        newShArray.enableCollection();
                         break;
 
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayType/newInstance/newinstance002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayType/newInstance/newinstance002.java
@@ -200,7 +200,17 @@ public class newinstance002 {
 
             log2("2222222222");
 
-            ArrayReference newarrayArray = arrayArray.newInstance(arraylength);
+            ArrayReference newarrayArray = null;
+
+            while (newarrayArray == null) {
+                newarrayArray = arrayArray.newInstance(arraylength);
+                try {
+                    newarrayArray.disableCollection();
+                } catch (ObjectCollectedException e) {
+                    newarrayArray = null;
+                }
+            }
+
             if (newarrayArray == null) {
                 log3("ERROR: newarrayArray == null");
                 testExitCode = FAILED;
@@ -238,6 +248,8 @@ public class newinstance002 {
             }
 
             log2("6666666666");
+
+            newarrayArray.enableCollection();
 
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayType/newInstance/newinstance003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayType/newInstance/newinstance003.java
@@ -197,7 +197,14 @@ public class newinstance003 {
 
             ArrayReference newifaceArray = null;
             try {
-                newifaceArray = ifaceArray.newInstance(arraylength);
+                while (newifaceArray == null) {
+                    newifaceArray = ifaceArray.newInstance(arraylength);
+                    try {
+                        newifaceArray.disableCollection();
+                    } catch (ObjectCollectedException e) {
+                        newifaceArray = null;
+                   }
+                }
             } catch ( Throwable e ) {
                 log3 ("ERROR: Exception: " + e);
                 testExitCode = FAILED;
@@ -235,6 +242,8 @@ public class newinstance003 {
                 testExitCode = FAILED;
                 continue;
             }
+
+            newifaceArray.enableCollection();
 
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayType/newInstance/newinstance004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ArrayType/newInstance/newinstance004.java
@@ -184,7 +184,14 @@ public class newinstance004 {
 
             ArrayReference newclassArray = null;
             try {
-                newclassArray = classArray.newInstance(arraylength);
+                while (newclassArray == null) {
+                    newclassArray = classArray.newInstance(arraylength);
+                    try {
+                        newclassArray.disableCollection();
+                    } catch (ObjectCollectedException e) {
+                        newclassArray = null;
+                   }
+                }
             } catch ( Throwable e ) {
                 log3 ("ERROR: Exception: " + e);
                 testExitCode = FAILED;
@@ -222,6 +229,8 @@ public class newinstance004 {
                 testExitCode = FAILED;
                 continue;
             }
+
+            newclassArray.enableCollection();
 
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/instances/instances002/instances002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/instances/instances002/instances002.java
@@ -134,8 +134,15 @@ public class instances002 extends HeapwalkingDebugger {
         for (int i = 0; i < createInstanceCount; i++) {
             // instances created in this way aren't reachable for the purposes of garbage collection,
             // to make it reachable call disableCollection() for this objects
-            ArrayReference arrayReference = arrayType.newInstance(arraySize);
-            arrayReference.disableCollection();
+            ArrayReference arrayReference = null;
+            while (arrayReference == null) {
+                arrayReference = arrayType.newInstance(arraySize);
+                try {
+                    arrayReference.disableCollection();
+                } catch (ObjectCollectedException e) {
+                    arrayReference = null;
+                }
+            }
 
             objectReferences.add(arrayReference);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VMOutOfMemoryException/VMOutOfMemoryException001/VMOutOfMemoryException001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VMOutOfMemoryException/VMOutOfMemoryException001/VMOutOfMemoryException001.java
@@ -79,7 +79,11 @@ public class VMOutOfMemoryException001 extends TestDebuggerType2 {
             // create array in debuggee VM till VMOutOfMemoryException
             while (true) {
                 ArrayReference array = referenceType.newInstance(100000);
-                array.disableCollection();
+                try {
+                    array.disableCollection();
+                } catch (ObjectCollectedException e) {
+                    continue;
+                }
                 objects.add(array);
             }
         } catch (VMOutOfMemoryException e) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/toString/tostring001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/toString/tostring001.java
@@ -136,7 +136,14 @@ public class tostring001 {
         Method ctor = debuggee.methodByName(debuggeeClass, "<init>");
 
         try {
-            testedObject = testedClass.newInstance(thread, ctor, params, 0);
+            while (testedObject == null) {
+               testedObject = testedClass.newInstance(thread, ctor, params, 0);
+               try {
+                    testedObject.disableCollection();
+                } catch (ObjectCollectedException e) {
+                    testedObject = null;
+               }
+            }
         } catch (Exception e) {
             throw new Failure("unexpected " + e + " when invoking debuggee's constructor");
         }
@@ -173,6 +180,8 @@ public class tostring001 {
             }
 
         }
+
+        testedObject.enableCollection();
 
         display("Checking of debuggee's void value methods completed!");
         debuggee.resume();

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/sde/SDEDebuggee.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/sde/SDEDebuggee.java
@@ -23,6 +23,7 @@
 package nsk.share.jdi.sde;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import nsk.share.TestBug;
 import nsk.share.jdi.*;
 
@@ -67,11 +68,18 @@ public class SDEDebuggee extends AbstractJDIDebuggee {
         return false;
     }
 
+    private static ArrayList<Object> keepAlive = new ArrayList<>();
+
     // create instance of given class and execute all methods which names start
     // with 'sde_testMethod'
     private void executeTestMethods(String className) {
         TestClassLoader classLoader = new TestClassLoader();
         classLoader.setClassPath(classpath);
+
+        // Keep class loader alive to avoid ObjectCollectedException
+        // on the debugger side, in case the GC unloads the class and
+        // invalidates code locations.
+        keepAlive.add(classLoader);
 
         try {
             Class<?> klass = classLoader.loadClass(className);


### PR DESCRIPTION
A number of JDI tests create objects on the debugger side with calls to `newInstance()`. However, on the debugee side, these new instances will only be held on to by a `JNIGlobalWeakRef`, which means they could be collected at any time, even before `newInstace()` returns. A number of JDI tests don't take this into account, and can hence get spurious `ObjectCollectedException` thrown at them, which results in test failures. To make these objects stick around, a call to `disableCollection()` is needed (but also note that the object could have been collected by the time we call `disableCollection()`).

In addition, `SDEDebuggee::executeTestMethods()` creates class loaders, which shortly after dies (and potentially gets collected). This creates problems on the debugger side, since code locations in this (now potentially unloaded class/method) gets invalidated. We must ensure that these class loaders stay alive to avoid these problems.

Normally, these problems are fairly hard to provoke, since you have to be unlucky and get the timing of a GC just right. However, it's fairly easy to provoke by forcing GC cycles to happen all the time (e.g. using ZGC with -XX:ZCollectionInterval=0.01) and/or inserting `Thread.sleep()` calls right after calls to `newInstance()`.

This patch fixes all instances of this problem that I managed to find.

Testing: All `vmTestbase/nsk/jdi/` tests now pass, even when using the above described measures to try to provoke the problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x64 (hs/tier1 runtime)](https://github.com/pliden/jdk/runs/1431237637)

### Issue
 * [JDK-8255987](https://bugs.openjdk.java.net/browse/JDK-8255987): JDI tests fail with com.sun.jdi.ObjectCollectedException


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1348/head:pull/1348`
`$ git checkout pull/1348`
