### PR TITLE
8256746: gc/CriticalNativeArgs.java fails without -XX:-CriticalJNINatives

### DIFF
--- a/test/hotspot/jtreg/gc/CriticalNativeArgs.java
+++ b/test/hotspot/jtreg/gc/CriticalNativeArgs.java
@@ -32,7 +32,12 @@ package gc;
  * @requires os.arch =="x86_64" | os.arch == "amd64" | os.arch=="x86" | os.arch=="i386"
  * @requires vm.gc.Epsilon
  * @summary test argument unpacking nmethod wrapper of critical native method
- * @run main/othervm/native -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xcomp -Xmx256M -XX:+CriticalJNINatives gc.CriticalNativeArgs
+ * @run main/othervm/native -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xcomp -Xmx256M
+ *                          -XX:-CriticalJNINatives
+ *                          gc.CriticalNativeArgs
+ * @run main/othervm/native -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xcomp -Xmx256M
+ *                          -XX:+CriticalJNINatives
+ *                          gc.CriticalNativeArgs
  */
 
 /*
@@ -42,14 +47,38 @@ package gc;
  * @requires os.arch =="x86_64" | os.arch == "amd64" | os.arch=="x86" | os.arch=="i386"
  * @requires vm.gc.Shenandoah
  * @summary test argument unpacking nmethod wrapper of critical native method
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive    -XX:+ShenandoahDegeneratedGC -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.CriticalNativeArgs
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive    -XX:-ShenandoahDegeneratedGC -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.CriticalNativeArgs
  *
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.CriticalNativeArgs
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xcomp -Xmx512M
+ *                          -XX:+UseShenandoahGC
+ *                          -XX:-CriticalJNINatives
+ *                          gc.CriticalNativeArgs
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xcomp -Xmx512M
+ *                          -XX:+UseShenandoahGC
+ *                          -XX:+CriticalJNINatives
+ *                          gc.CriticalNativeArgs
  *
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC                                                                        -Xcomp -Xmx256M -XX:+CriticalJNINatives gc.CriticalNativeArgs
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+UnlockExperimentalVMOptions -XX:ShenandoahGCMode=iu        -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.CriticalNativeArgs
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+UnlockExperimentalVMOptions -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.CriticalNativeArgs
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xcomp -Xmx512M
+ *                          -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive -XX:+ShenandoahDegeneratedGC
+ *                          -XX:+CriticalJNINatives
+ *                          gc.CriticalNativeArgs
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xcomp -Xmx512M
+ *                          -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive -XX:-ShenandoahDegeneratedGC
+ *                          -XX:+CriticalJNINatives
+ *                          gc.CriticalNativeArgs
+ *
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xcomp -Xmx512M
+ *                          -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
+ *                          -XX:+CriticalJNINatives
+ *                          gc.CriticalNativeArgs
+ *
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xcomp -Xmx512M
+ *                          -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
+ *                          -XX:+CriticalJNINatives
+ *                          gc.CriticalNativeArgs
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xcomp -Xmx512M
+ *                          -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
+ *                          -XX:+CriticalJNINatives
+ *                          gc.CriticalNativeArgs
  */
 
 /*
@@ -58,7 +87,12 @@ package gc;
  * @library /
  * @requires os.arch =="x86_64" | os.arch == "amd64" | os.arch=="x86" | os.arch=="i386" | os.arch=="ppc64" | os.arch=="ppc64le" | os.arch=="s390x"
  * @summary test argument unpacking nmethod wrapper of critical native method
- * @run main/othervm/native -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.CriticalNativeArgs
+ * @run main/othervm/native -Xcomp -Xmx512M
+ *                          -XX:-CriticalJNINatives
+ *                          gc.CriticalNativeArgs
+ * @run main/othervm/native -Xcomp -Xmx512M
+ *                          -XX:+CriticalJNINatives
+ *                          gc.CriticalNativeArgs
  */
 public class CriticalNativeArgs {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/gc/libCriticalNative.c
+++ b/test/hotspot/jtreg/gc/libCriticalNative.c
@@ -120,10 +120,10 @@ JNIEXPORT jboolean JNICALL JavaCritical_gc_CriticalNative_isNull
 
 JNIEXPORT jboolean JNICALL Java_gc_CriticalNative_isNull
   (JNIEnv *env, jclass jclazz, jintArray a) {
-  jboolean is_null;
+  if (a == NULL) return JNI_TRUE;
   jsize len = (*env)->GetArrayLength(env, a);
   jint* arr = (jint*)(*env)->GetPrimitiveArrayCritical(env, a, 0);
-  is_null = (arr == NULL) && (len == 0);
+  jboolean is_null = (arr == NULL) && (len == 0);
   (*env)->ReleasePrimitiveArrayCritical(env, a, arr, 0);
   return is_null;
 }


### PR DESCRIPTION
Found this with Zero testing, but the failure is not Zero-specific. It affects platforms that do not have `CriticalJNINatives` enabled. The issue is that the [fallback (non-critical)](https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/gc/libCriticalNative.c#L124) native version of the code calls `GetArrayLength` on [known `NULL` array](https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/gc/CriticalNativeArgs.java#L71).

```
$ CONF=linux-x86_64-zero-fastdebug make exploded-test TEST=gc/CriticalNativeArgs.java
#
# Internal Error (/home/shade/trunks/jdk/src/hotspot/share/runtime/jniHandles.inline.hpp:91), pid=1909139, tid=1909217
# assert(handle != __null) failed: JNI handle should not be null
```

It was exposed by [JDK-8233343](https://bugs.openjdk.java.net/browse/JDK-8233343) that added the generic test configuration, and then by [JDK-8256499](https://bugs.openjdk.java.net/browse/JDK-8256499) that enabled Zero+Epsilon. Before that, the test was only enabled for specific GCs and arches where `CriticalJNINatives` are known to work, and thus we never took that (broken) fallback in this test.

Note that `CriticalJNINatives` is a deprecated flag, and I expect the test to go away together with the flag later. Meanwhile, let's make sure it runs properly. I also reformatted the run configs a bit to make them more readable, and added `-XX:-CriticalJNINatives` to expose the affected path in most configurations.

Additional testing:
 - [x] Affected test with Zero (+Epsilon, +Shenandoah)
 - [x] Affected test with Server (+Epsilon, +Shenandoah)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256746](https://bugs.openjdk.java.net/browse/JDK-8256746): gc/CriticalNativeArgs.java fails without -XX:-CriticalJNINatives


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1349/head:pull/1349`
`$ git checkout pull/1349`
