### PR TITLE
8256747: GitHub Actions: decouple the hotspot build-only jobs from Linux x64 testing

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -9,7 +9,7 @@ on:
       platforms:
         description: "Platform(s) to execute on"
         required: true
-        default: "Linux multiple (hotspot only), Linux x64, Linux x86, Windows x64, macOS x64"
+        default: "Linux additional (hotspot only), Linux x64, Linux x86, Windows x64, macOS x64"
 
 jobs:
   prerequisites:
@@ -18,7 +18,7 @@ jobs:
     outputs:
       should_run: ${{ steps.check_submit.outputs.should_run }}
       bundle_id: ${{ steps.check_bundle_id.outputs.bundle_id }}
-      platform_linux_x64_hotspot_only: ${{ steps.check_platforms.outputs.platform_linux_x64_hotspot_only }}
+      platform_linux_additional: ${{ steps.check_platforms.outputs.platform_linux_additional }}
       platform_linux_x64: ${{ steps.check_platforms.outputs.platform_linux_x64 }}
       platform_linux_x86: ${{ steps.check_platforms.outputs.platform_linux_x86 }}
       platform_windows_x64: ${{ steps.check_platforms.outputs.platform_windows_x64 }}
@@ -33,7 +33,7 @@ jobs:
       - name: Check which platforms should be included
         id: check_platforms
         run: |
-          echo "::set-output name=platform_linux_x64_hotspot_only::${{ contains(github.event.inputs.platforms, 'linux multiple (hotspot only)') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux multiple (hotspot only)'))) }}"
+          echo "::set-output name=platform_linux_additional::${{ contains(github.event.inputs.platforms, 'linux additional (hotspot only)') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux additional (hotspot only)'))) }}"
           echo "::set-output name=platform_linux_x64::${{ contains(github.event.inputs.platforms, 'linux x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux x64'))) }}"
           echo "::set-output name=platform_linux_x86::${{ contains(github.event.inputs.platforms, 'linux x86') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux x86'))) }}"
           echo "::set-output name=platform_windows_x64::${{ contains(github.event.inputs.platforms, 'windows x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'windows x64'))) }}"
@@ -102,7 +102,7 @@ jobs:
     name: Linux x64
     runs-on: "ubuntu-20.04"
     needs: prerequisites
-    if: needs.prerequisites.outputs.should_run != 'false' && (needs.prerequisites.outputs.platform_linux_x64 != 'false' || needs.prerequisites.outputs.platform_linux_x64_hotspot_only == 'true')
+    if: needs.prerequisites.outputs.should_run != 'false' && (needs.prerequisites.outputs.platform_linux_x64 != 'false' || needs.prerequisites.outputs.platform_linux_additional == 'true')
 
     strategy:
       fail-fast: false
@@ -377,13 +377,13 @@ jobs:
           path: ~/linux-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
         continue-on-error: true
 
-  linux_x64_hotspot_only:
-    name: Linux multiple
+  linux_additional_build:
+    name: Linux additional
     runs-on: "ubuntu-20.04"
     needs:
       - prerequisites
       - linux_x64_build
-    if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_x64_hotspot_only != 'false'
+    if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_additional != 'false'
 
     strategy:
       fail-fast: false
@@ -485,15 +485,15 @@ jobs:
         if: matrix.debian-arch == ''
 
       - name: Install cross-compilation host dependencies
-        run: sudo apt-get install gcc-10-${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}}=10.2.0-5ubuntu1~20.04cross1 g++-10-${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}}=10.2.0-5ubuntu1~20.04cross1
+        run: sudo apt-get install gcc-10-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}=10.2.0-5ubuntu1~20.04cross1 g++-10-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}=10.2.0-5ubuntu1~20.04cross1
         if: matrix.debian-arch != ''
 
       - name: Cache sysroot
         id: cache-sysroot
         uses: actions/cache@v2
         with:
-          path: ~/sysroot-${{ matrix.debian-arch}}/
-          key: sysroot-${{ matrix.debian-arch}}-${{ hashFiles('jdk/.github/workflows/submit.yml') }}
+          path: ~/sysroot-${{ matrix.debian-arch }}/
+          key: sysroot-${{ matrix.debian-arch }}-${{ hashFiles('jdk/.github/workflows/submit.yml') }}
         if: matrix.debian-arch != ''
 
       - name: Install sysroot host dependencies
@@ -503,33 +503,33 @@ jobs:
       - name: Create sysroot
         run: >
           sudo qemu-debootstrap
-          --arch=${{ matrix.debian-arch}}
+          --arch=${{ matrix.debian-arch }}
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev
           --resolve-deps
           buster
-          ~/sysroot-${{ matrix.debian-arch}}
+          ~/sysroot-${{ matrix.debian-arch }}
           http://httpredir.debian.org/debian/
         if: matrix.debian-arch != '' && steps.cache-sysroot.outputs.cache-hit != 'true'
 
       - name: Prepare sysroot for caching
         run: |
-          sudo chroot ~/sysroot-${{ matrix.debian-arch}} symlinks -cr .
-          sudo chown ${USER} -R ~/sysroot-${{ matrix.debian-arch}}
-          rm -rf ~/sysroot-${{ matrix.debian-arch}}/{dev,proc,run,sys}
+          sudo chroot ~/sysroot-${{ matrix.debian-arch }} symlinks -cr .
+          sudo chown ${USER} -R ~/sysroot-${{ matrix.debian-arch }}
+          rm -rf ~/sysroot-${{ matrix.debian-arch }}/{dev,proc,run,sys}
         if: matrix.debian-arch != '' && steps.cache-sysroot.outputs.cache-hit != 'true'
 
       - name: Configure cross-specific flags
         run: |
-          echo "CC=${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}}-gcc-10" >> $GITHUB_ENV
-          echo "CXX=${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}}-g++-10" >> $GITHUB_ENV
-          echo "cross_flags=--openjdk-target=${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}} --with-sysroot=${HOME}/sysroot-${{ matrix.debian-arch}}/ --with-toolchain-path=${HOME}/sysroot-${{ matrix.debian-arch}}/ --with-freetype-lib=${HOME}/sysroot-${{ matrix.debian-arch}}/usr/lib/${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}}/ --with-freetype-include=${HOME}/sysroot-${{ matrix.debian-arch}}/usr/include/freetype2/ --x-libraries=${HOME}/sysroot-${{ matrix.debian-arch}}/usr/lib/${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}}/" >> $GITHUB_ENV
+          echo "CC=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}-gcc-10" >> $GITHUB_ENV
+          echo "CXX=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}-g++-10" >> $GITHUB_ENV
+          echo "cross_flags=--openjdk-target=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}} --with-sysroot=${HOME}/sysroot-${{ matrix.debian-arch }}/ --with-toolchain-path=${HOME}/sysroot-${{ matrix.debian-arch }}/ --with-freetype-lib=${HOME}/sysroot-${{ matrix.debian-arch }}/usr/lib/${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}/ --with-freetype-include=${HOME}/sysroot-${{ matrix.debian-arch }}/usr/include/freetype2/ --x-libraries=${HOME}/sysroot-${{ matrix.debian-arch }}/usr/lib/${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}/" >> $GITHUB_ENV
         if: matrix.debian-arch != ''
 
       - name: Configure
         run: >
           bash configure
-          --with-conf-name=linux-x64-hotspot
+          --with-conf-name=linux-${{ matrix.gnu-arch }}-hotspot
           ${{ matrix.flags }}
           ${{ env.cross_flags }}
           --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
@@ -541,7 +541,7 @@ jobs:
         working-directory: jdk
 
       - name: Build
-        run: make CONF_NAME=linux-x64-hotspot
+        run: make CONF_NAME=linux-${{ matrix.gnu-arch }}-hotspot
         working-directory: jdk
 
   linux_x86_build:
@@ -1447,7 +1447,7 @@ jobs:
     continue-on-error: true
     needs:
       - prerequisites
-      - linux_x64_hotspot_only
+      - linux_additional_build
       - linux_x64_test
       - linux_x86_test
       - windows_x64_test

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -519,11 +519,22 @@ jobs:
           rm -rf ~/sysroot-${{ matrix.debian-arch }}/{dev,proc,run,sys}
         if: matrix.debian-arch != '' && steps.cache-sysroot.outputs.cache-hit != 'true'
 
-      - name: Configure cross-specific flags
+      - name: Configure cross compiler
         run: |
           echo "CC=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}-gcc-10" >> $GITHUB_ENV
           echo "CXX=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}-g++-10" >> $GITHUB_ENV
-          echo "cross_flags=--openjdk-target=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}} --with-sysroot=${HOME}/sysroot-${{ matrix.debian-arch }}/ --with-toolchain-path=${HOME}/sysroot-${{ matrix.debian-arch }}/ --with-freetype-lib=${HOME}/sysroot-${{ matrix.debian-arch }}/usr/lib/${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}/ --with-freetype-include=${HOME}/sysroot-${{ matrix.debian-arch }}/usr/include/freetype2/ --x-libraries=${HOME}/sysroot-${{ matrix.debian-arch }}/usr/lib/${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}/" >> $GITHUB_ENV
+        if: matrix.debian-arch != ''
+
+      - name: Configure cross specific flags
+        run: >
+          echo "cross_flags=
+          --openjdk-target=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}
+          --with-sysroot=${HOME}/sysroot-${{ matrix.debian-arch }}/
+          --with-toolchain-path=${HOME}/sysroot-${{ matrix.debian-arch }}/
+          --with-freetype-lib=${HOME}/sysroot-${{ matrix.debian-arch }}/usr/lib/${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}/
+          --with-freetype-include=${HOME}/sysroot-${{ matrix.debian-arch }}/usr/include/freetype2/
+          --x-libraries=${HOME}/sysroot-${{ matrix.debian-arch }}/usr/lib/${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}/
+          " >> $GITHUB_ENV
         if: matrix.debian-arch != ''
 
       - name: Configure

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -9,7 +9,7 @@ on:
       platforms:
         description: "Platform(s) to execute on"
         required: true
-        default: "Linux aarch64, Linux arm, Linux ppc64le, Linux s390x, Linux x64, Linux x86, Windows x64, macOS x64"
+        default: "Linux multiple (hotspot only), Linux x64, Linux x86, Windows x64, macOS x64"
 
 jobs:
   prerequisites:
@@ -18,12 +18,9 @@ jobs:
     outputs:
       should_run: ${{ steps.check_submit.outputs.should_run }}
       bundle_id: ${{ steps.check_bundle_id.outputs.bundle_id }}
-      platform_linux_aarch64: ${{ steps.check_platforms.outputs.platform_linux_aarch64 }}
-      platform_linux_arm: ${{ steps.check_platforms.outputs.platform_linux_arm }}
-      platform_linux_ppc64le: ${{ steps.check_platforms.outputs.platform_linux_ppc64le }}
-      platform_linux_s390x: ${{ steps.check_platforms.outputs.platform_linux_s390x }}
-      platform_linux_x86: ${{ steps.check_platforms.outputs.platform_linux_x86 }}
+      platform_linux_x64_hotspot_only: ${{ steps.check_platforms.outputs.platform_linux_x64_hotspot_only }}
       platform_linux_x64: ${{ steps.check_platforms.outputs.platform_linux_x64 }}
+      platform_linux_x86: ${{ steps.check_platforms.outputs.platform_linux_x86 }}
       platform_windows_x64: ${{ steps.check_platforms.outputs.platform_windows_x64 }}
       platform_macos_x64: ${{ steps.check_platforms.outputs.platform_macos_x64 }}
       dependencies: ${{ steps.check_deps.outputs.dependencies }}
@@ -36,10 +33,7 @@ jobs:
       - name: Check which platforms should be included
         id: check_platforms
         run: |
-          echo "::set-output name=platform_linux_aarch64::${{ contains(github.event.inputs.platforms, 'linux aarch64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux aarch64'))) }}"
-          echo "::set-output name=platform_linux_arm::${{ contains(github.event.inputs.platforms, 'linux arm') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux arm'))) }}"
-          echo "::set-output name=platform_linux_ppc64le::${{ contains(github.event.inputs.platforms, 'linux ppc64le') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux ppc64le'))) }}"
-          echo "::set-output name=platform_linux_s390x::${{ contains(github.event.inputs.platforms, 'linux s390x') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux s390x'))) }}"
+          echo "::set-output name=platform_linux_x64_hotspot_only::${{ contains(github.event.inputs.platforms, 'linux multiple (hotspot only)') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux multiple (hotspot only)'))) }}"
           echo "::set-output name=platform_linux_x64::${{ contains(github.event.inputs.platforms, 'linux x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux x64'))) }}"
           echo "::set-output name=platform_linux_x86::${{ contains(github.event.inputs.platforms, 'linux x86') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux x86'))) }}"
           echo "::set-output name=platform_windows_x64::${{ contains(github.event.inputs.platforms, 'windows x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'windows x64'))) }}"
@@ -108,7 +102,7 @@ jobs:
     name: Linux x64
     runs-on: "ubuntu-20.04"
     needs: prerequisites
-    if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_x64 != 'false'
+    if: needs.prerequisites.outputs.should_run != 'false' && (needs.prerequisites.outputs.platform_linux_x64 != 'false' || needs.prerequisites.outputs.platform_linux_x64_hotspot_only == 'true')
 
     strategy:
       fail-fast: false
@@ -116,26 +110,10 @@ jobs:
         flavor:
           - build release
           - build debug
-          - build hotspot no-pch
-          - build hotspot zero
-          - build hotspot minimal
-          - build hotspot optimized
         include:
           - flavor: build debug
             flags: --enable-debug
             artifact: -debug
-          - flavor: build hotspot no-pch
-            flags: --enable-debug --disable-precompiled-headers
-            build-target: hotspot
-          - flavor: build hotspot zero
-            flags: --enable-debug --disable-precompiled-headers --with-jvm-variants=zero
-            build-target: hotspot
-          - flavor: build hotspot minimal
-            flags: --enable-debug --disable-precompiled-headers --with-jvm-variants=minimal
-            build-target: hotspot
-          - flavor: build hotspot optimized
-            flags: --with-debug-level=optimized --disable-precompiled-headers
-            build-target: hotspot
 
     env:
       JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
@@ -209,7 +187,7 @@ jobs:
         working-directory: jdk
 
       - name: Build
-        run: make CONF_NAME=linux-x64 ${{ matrix.build-target }}
+        run: make CONF_NAME=linux-x64
         working-directory: jdk
 
       - name: Persist test bundles
@@ -219,7 +197,6 @@ jobs:
           path: |
             jdk/build/linux-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz
             jdk/build/linux-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin-tests${{ matrix.artifact }}.tar.gz
-        if: matrix.build-target == false
 
   linux_x64_test:
     name: Linux x64
@@ -400,24 +377,52 @@ jobs:
           path: ~/linux-x64${{ matrix.artifact }}_testsupport_${{ env.logsuffix }}.zip
         continue-on-error: true
 
-  linux_aarch64_build:
-    name: Linux aarch64
+  linux_x64_hotspot_only:
+    name: Linux multiple
     runs-on: "ubuntu-20.04"
     needs:
       - prerequisites
       - linux_x64_build
-    if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_aarch64 != 'false'
+    if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_x64_hotspot_only != 'false'
 
     strategy:
       fail-fast: false
       matrix:
         flavor:
-          - build hotspot no-pch
+          - hs x64 build only
+          - hs x64 zero build only
+          - hs x64 minimal build only
+          - hs x64 optimized build only
+          - hs aarch64 build only
+          - hs arm build only
+          - hs s390x build only
+          - hs ppc64le build only
         include:
-          - flavor: build hotspot no-pch
+          - flavor: hs x64 build only
             flags: --enable-debug --disable-precompiled-headers
-            artifact: -debug
-            build-target: hotspot
+          - flavor: hs x64 zero build only
+            flags: --enable-debug --disable-precompiled-headers --with-jvm-variants=zero
+          - flavor: hs x64 minimal build only
+            flags: --enable-debug --disable-precompiled-headers --with-jvm-variants=minimal
+          - flavor: hs x64 optimized build only
+            flags: --with-debug-level=optimized --disable-precompiled-headers
+          - flavor: hs aarch64 build only
+            flags: --enable-debug --disable-precompiled-headers
+            debian-arch: arm64
+            gnu-arch: aarch64
+          - flavor: hs arm build only
+            flags: --enable-debug --disable-precompiled-headers
+            debian-arch: armhf
+            gnu-arch: arm
+            gnu-flavor: eabihf
+          - flavor: hs s390x build only
+            flags: --enable-debug --disable-precompiled-headers
+            debian-arch: s390x
+            gnu-arch: s390x
+          - flavor: hs ppc64le build only
+            flags: --enable-debug --disable-precompiled-headers
+            debian-arch: ppc64el
+            gnu-arch: powerpc64le
 
     env:
       JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
@@ -456,143 +461,14 @@ jobs:
           path: ~/jdk-linux-x64
         continue-on-error: true
 
-      - name: Unpack jdk
-        run: |
-          mkdir -p "${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin"
-          tar -xf "${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin.tar.gz" -C "${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin"
-
-      - name: Find root of build JDK image dir
-        run: |
-          build_jdk_root=`find ${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin -name release -type f`
-          echo "build_jdk_root=`dirname ${build_jdk_root}`" >> $GITHUB_ENV
-
-      - name: Install cross-compilation host dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
-
-      - name: Cache sysroot
-        id: cache-sysroot
-        uses: actions/cache@v2
-        with:
-          path: ~/sysroot-arm64/
-          key: sysroot-arm64-${{ hashFiles('jdk/.github/workflows/submit.yml') }}
-
-      - name: Install sysroot host dependencies
-        run: |
-          sudo apt-get install debootstrap qemu-user-static
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Create sysroot
-        run: >
-          sudo qemu-debootstrap
-          --arch=arm64
-          --verbose
-          --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev
-          --resolve-deps
-          buster
-          ~/sysroot-arm64
-          http://httpredir.debian.org/debian/
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Relativize symlinks in sysroot
-        run: >
-          sudo chroot ~/sysroot-arm64 symlinks -cr .
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Fix permissions in sysroot
-        run: >
-          sudo chown ${USER} -R ~/sysroot-arm64
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Remove special directories in sysroot
-        run: >
-          rm -rf ~/sysroot-arm64/{dev,proc,run,sys}
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Configure
-        env:
-          CC: aarch64-linux-gnu-gcc
-          CXX: aarch64-linux-gnu-g++
-        run: >
-          bash configure
-          ${{ matrix.flags }}
-          --openjdk-target=aarch64-linux-gnu
-          --with-sysroot=${HOME}/sysroot-arm64/
-          --with-toolchain-path=${HOME}/sysroot-arm64/
-          --with-freetype-lib=${HOME}/sysroot-arm64/usr/lib/aarch64-linux-gnu/
-          --with-freetype-include=${HOME}/sysroot-arm64/usr/include/freetype2/
-          --x-libraries=${HOME}/sysroot-arm64/usr/lib/aarch64-linux-gnu/
-          --with-build-jdk=${{ env.build_jdk_root }}
-          --with-conf-name=linux-aarch64
-          --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
-          --with-version-build=0
-          --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}
-          --with-default-make-target="product-bundles test-bundles"
-          --with-zlib=system
-        working-directory: jdk
-
-      - name: Build
-        run: make CONF_NAME=linux-aarch64 ${{ matrix.build-target }}
-        working-directory: jdk
-
-  linux_arm_build:
-    name: Linux arm
-    runs-on: "ubuntu-20.04"
-    needs:
-      - prerequisites
-      - linux_x64_build
-    if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_arm != 'false'
-
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor:
-          - build hotspot no-pch
-        include:
-          - flavor: build hotspot no-pch
-            flags: --enable-debug --disable-precompiled-headers
-            artifact: -debug
-            build-target: hotspot
-
-    env:
-      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
-      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
-      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
-      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
-      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
-
-    steps:
-      - name: Checkout the source
-        uses: actions/checkout@v2
-        with:
-          path: jdk
-
-      - name: Restore boot JDK from cache
-        id: bootjdk
-        uses: actions/cache@v2
-        with:
-          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
-
-      - name: Download boot JDK
-        run: |
-          mkdir -p "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
-          wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
-          echo "${BOOT_JDK_SHA256} ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | sha256sum -c >/dev/null -
-          tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
-          mv "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"*/* "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"
-        if: steps.bootjdk.outputs.cache-hit != 'true'
-
-      - name: Restore build JDK
-        id: build_restore
+      - name: Restore build JDK (retry)
         uses: actions/download-artifact@v2
         with:
           name: transient_jdk-linux-x64_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-linux-x64
-        continue-on-error: true
+        if: steps.build_restore.outcome == 'failure'
 
-      - name: Unpack jdk
+      - name: Unpack build JDK
         run: |
           mkdir -p "${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin"
           tar -xf "${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin.tar.gz" -C "${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin"
@@ -602,346 +478,70 @@ jobs:
           build_jdk_root=`find ${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin -name release -type f`
           echo "build_jdk_root=`dirname ${build_jdk_root}`" >> $GITHUB_ENV
 
-      - name: Install cross-compilation host dependencies
+      - name: Install native host dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install g++-arm-linux-gnueabihf gcc-arm-linux-gnueabihf
+          sudo apt-get install gcc-10=10.2.0-5ubuntu1~20.04 g++-10=10.2.0-5ubuntu1~20.04 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+        if: matrix.debian-arch == ''
+
+      - name: Install cross-compilation host dependencies
+        run: sudo apt-get install gcc-10-${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}}=10.2.0-5ubuntu1~20.04cross1 g++-10-${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}}=10.2.0-5ubuntu1~20.04cross1
+        if: matrix.debian-arch != ''
 
       - name: Cache sysroot
         id: cache-sysroot
         uses: actions/cache@v2
         with:
-          path: ~/sysroot-armhf/
-          key: sysroot-armhf-${{ hashFiles('jdk/.github/workflows/submit.yml') }}
+          path: ~/sysroot-${{ matrix.debian-arch}}/
+          key: sysroot-${{ matrix.debian-arch}}-${{ hashFiles('jdk/.github/workflows/submit.yml') }}
+        if: matrix.debian-arch != ''
 
       - name: Install sysroot host dependencies
-        run: |
-          sudo apt-get install debootstrap qemu-user-static
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
+        run: sudo apt-get install debootstrap qemu-user-static
+        if: matrix.debian-arch != '' && steps.cache-sysroot.outputs.cache-hit != 'true'
 
       - name: Create sysroot
         run: >
           sudo qemu-debootstrap
-          --arch=armhf
+          --arch=${{ matrix.debian-arch}}
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev
           --resolve-deps
           buster
-          ~/sysroot-armhf
+          ~/sysroot-${{ matrix.debian-arch}}
           http://httpredir.debian.org/debian/
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
+        if: matrix.debian-arch != '' && steps.cache-sysroot.outputs.cache-hit != 'true'
 
-      - name: Relativize symlinks in sysroot
-        run: >
-          sudo chroot ~/sysroot-armhf symlinks -cr .
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
+      - name: Prepare sysroot for caching
+        run: |
+          sudo chroot ~/sysroot-${{ matrix.debian-arch}} symlinks -cr .
+          sudo chown ${USER} -R ~/sysroot-${{ matrix.debian-arch}}
+          rm -rf ~/sysroot-${{ matrix.debian-arch}}/{dev,proc,run,sys}
+        if: matrix.debian-arch != '' && steps.cache-sysroot.outputs.cache-hit != 'true'
 
-      - name: Fix permissions in sysroot
-        run: >
-          sudo chown ${USER} -R ~/sysroot-armhf
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Remove special directories in sysroot
-        run: >
-          rm -rf ~/sysroot-armhf/{dev,proc,run,sys}
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
+      - name: Configure cross-specific flags
+        run: |
+          echo "CC=${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}}-gcc-10" >> $GITHUB_ENV
+          echo "CXX=${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}}-g++-10" >> $GITHUB_ENV
+          echo "cross_flags=--openjdk-target=${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}} --with-sysroot=${HOME}/sysroot-${{ matrix.debian-arch}}/ --with-toolchain-path=${HOME}/sysroot-${{ matrix.debian-arch}}/ --with-freetype-lib=${HOME}/sysroot-${{ matrix.debian-arch}}/usr/lib/${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}}/ --with-freetype-include=${HOME}/sysroot-${{ matrix.debian-arch}}/usr/include/freetype2/ --x-libraries=${HOME}/sysroot-${{ matrix.debian-arch}}/usr/lib/${{ matrix.gnu-arch}}-linux-gnu${{ matrix.gnu-flavor}}/" >> $GITHUB_ENV
+        if: matrix.debian-arch != ''
 
       - name: Configure
-        env:
-          CC: arm-linux-gnueabihf-gcc
-          CXX: arm-linux-gnueabihf-g++
         run: >
           bash configure
+          --with-conf-name=linux-x64-hotspot
           ${{ matrix.flags }}
-          --openjdk-target=arm-linux-gnueabihf
-          --with-sysroot=${HOME}/sysroot-armhf/
-          --with-toolchain-path=${HOME}/sysroot-armhf/
-          --with-freetype-lib=${HOME}/sysroot-armhf/usr/lib/arm-linux-gnueabihf/
-          --with-freetype-include=${HOME}/sysroot-armhf/usr/include/freetype2/
-          --x-libraries=${HOME}/sysroot-armhf/usr/lib/arm-linux-gnueabihf/
-          --with-build-jdk=${{ env.build_jdk_root }}
-          --with-conf-name=linux-arm
+          ${{ env.cross_flags }}
           --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
           --with-version-build=0
           --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}
-          --with-default-make-target="product-bundles test-bundles"
+          --with-build-jdk=${{ env.build_jdk_root }}
+          --with-default-make-target="hotspot"
           --with-zlib=system
         working-directory: jdk
 
       - name: Build
-        run: make CONF_NAME=linux-arm ${{ matrix.build-target }}
-        working-directory: jdk
-
-  linux_s390x_build:
-    name: Linux s390x
-    runs-on: "ubuntu-20.04"
-    needs:
-      - prerequisites
-      - linux_x64_build
-    if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_s390x != 'false'
-
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor:
-          - build hotspot no-pch
-        include:
-          - flavor: build hotspot no-pch
-            flags: --enable-debug --disable-precompiled-headers
-            artifact: -debug
-            build-target: hotspot
-
-    env:
-      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
-      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
-      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
-      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
-      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
-
-    steps:
-      - name: Checkout the source
-        uses: actions/checkout@v2
-        with:
-          path: jdk
-
-      - name: Restore boot JDK from cache
-        id: bootjdk
-        uses: actions/cache@v2
-        with:
-          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
-
-      - name: Download boot JDK
-        run: |
-          mkdir -p "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
-          wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
-          echo "${BOOT_JDK_SHA256} ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | sha256sum -c >/dev/null -
-          tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
-          mv "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"*/* "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"
-        if: steps.bootjdk.outputs.cache-hit != 'true'
-
-      - name: Restore build JDK
-        id: build_restore
-        uses: actions/download-artifact@v2
-        with:
-          name: transient_jdk-linux-x64_${{ needs.prerequisites.outputs.bundle_id }}
-          path: ~/jdk-linux-x64
-        continue-on-error: true
-
-      - name: Unpack jdk
-        run: |
-          mkdir -p "${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin"
-          tar -xf "${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin.tar.gz" -C "${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin"
-
-      - name: Find root of build JDK image dir
-        run: |
-          build_jdk_root=`find ${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin -name release -type f`
-          echo "build_jdk_root=`dirname ${build_jdk_root}`" >> $GITHUB_ENV
-
-      - name: Install cross-compilation host dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install g++-s390x-linux-gnu gcc-s390x-linux-gnu
-
-      - name: Cache sysroot
-        id: cache-sysroot
-        uses: actions/cache@v2
-        with:
-          path: ~/sysroot-s390x/
-          key: sysroot-s390x-${{ hashFiles('jdk/.github/workflows/submit.yml') }}
-
-      - name: Install sysroot host dependencies
-        run: |
-          sudo apt-get install debootstrap qemu-user-static
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Create sysroot
-        run: >
-          sudo qemu-debootstrap
-          --arch=s390x
-          --verbose
-          --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev
-          --resolve-deps
-          buster
-          ~/sysroot-s390x
-          http://httpredir.debian.org/debian/
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Relativize symlinks in sysroot
-        run: >
-          sudo chroot ~/sysroot-s390x symlinks -cr .
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Fix permissions in sysroot
-        run: >
-          sudo chown ${USER} -R ~/sysroot-s390x
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Remove special directories in sysroot
-        run: >
-          rm -rf ~/sysroot-s390x/{dev,proc,run,sys}
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Configure
-        env:
-          CC: s390x-linux-gnu-gcc
-          CXX: s390x-linux-gnu-g++
-        run: >
-          bash configure
-          ${{ matrix.flags }}
-          --openjdk-target=s390x-linux-gnu
-          --with-sysroot=${HOME}/sysroot-s390x/
-          --with-toolchain-path=${HOME}/sysroot-s390x/
-          --with-freetype-lib=${HOME}/sysroot-s390x/usr/lib/s390x-linux-gnu/
-          --with-freetype-include=${HOME}/sysroot-s390x/usr/include/freetype2/
-          --x-libraries=${HOME}/sysroot-s390x/usr/lib/s390x-linux-gnu/
-          --with-build-jdk=${{ env.build_jdk_root }}
-          --with-conf-name=linux-s390x
-          --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
-          --with-version-build=0
-          --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}
-          --with-default-make-target="product-bundles test-bundles"
-          --with-zlib=system
-        working-directory: jdk
-
-      - name: Build
-        run: make CONF_NAME=linux-s390x ${{ matrix.build-target }}
-        working-directory: jdk
-
-  linux_ppc64le_build:
-    name: Linux ppc64le
-    runs-on: "ubuntu-20.04"
-    needs:
-      - prerequisites
-      - linux_x64_build
-    if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_ppc64le != 'false'
-
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor:
-          - build hotspot no-pch
-        include:
-          - flavor: build hotspot no-pch
-            flags: --enable-debug --disable-precompiled-headers
-            artifact: -debug
-            build-target: hotspot
-
-    env:
-      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
-      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
-      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
-      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
-      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
-
-    steps:
-      - name: Checkout the source
-        uses: actions/checkout@v2
-        with:
-          path: jdk
-
-      - name: Restore boot JDK from cache
-        id: bootjdk
-        uses: actions/cache@v2
-        with:
-          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
-          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
-
-      - name: Download boot JDK
-        run: |
-          mkdir -p "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
-          wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
-          echo "${BOOT_JDK_SHA256} ${HOME}/bootjdk/${BOOT_JDK_FILENAME}" | sha256sum -c >/dev/null -
-          tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk/${BOOT_JDK_VERSION}"
-          mv "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"*/* "${HOME}/bootjdk/${BOOT_JDK_VERSION}/"
-        if: steps.bootjdk.outputs.cache-hit != 'true'
-
-      - name: Restore build JDK
-        id: build_restore
-        uses: actions/download-artifact@v2
-        with:
-          name: transient_jdk-linux-x64_${{ needs.prerequisites.outputs.bundle_id }}
-          path: ~/jdk-linux-x64
-        continue-on-error: true
-
-      - name: Unpack jdk
-        run: |
-          mkdir -p "${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin"
-          tar -xf "${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin.tar.gz" -C "${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin"
-
-      - name: Find root of build JDK image dir
-        run: |
-          build_jdk_root=`find ${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin -name release -type f`
-          echo "build_jdk_root=`dirname ${build_jdk_root}`" >> $GITHUB_ENV
-
-      - name: Install cross-compilation host dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install g++-powerpc64le-linux-gnu gcc-powerpc64le-linux-gnu:
-
-      - name: Cache sysroot
-        id: cache-sysroot
-        uses: actions/cache@v2
-        with:
-          path: ~/sysroot-ppc64el/
-          key: sysroot-ppc64el-${{ hashFiles('jdk/.github/workflows/submit.yml') }}
-
-      - name: Install sysroot host dependencies
-        run: |
-          sudo apt-get install debootstrap qemu-user-static
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Create sysroot
-        run: >
-          sudo qemu-debootstrap
-          --arch=ppc64el
-          --verbose
-          --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev
-          --resolve-deps
-          buster
-          ~/sysroot-ppc64el
-          http://httpredir.debian.org/debian/
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Relativize symlinks in sysroot
-        run: >
-          sudo chroot ~/sysroot-ppc64el symlinks -cr .
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Fix permissions in sysroot
-        run: >
-          sudo chown ${USER} -R ~/sysroot-ppc64el
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Remove special directories in sysroot
-        run: >
-          rm -rf ~/sysroot-ppc64el/{dev,proc,run,sys}
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
-
-      - name: Configure
-        env:
-          CC: powerpc64le-linux-gnu-gcc
-          CXX: powerpc64le-linux-gnu-g++
-        run: >
-          bash configure
-          ${{ matrix.flags }}
-          --openjdk-target=powerpc64le-linux-gnu
-          --with-sysroot=${HOME}/sysroot-ppc64el/
-          --with-toolchain-path=${HOME}/sysroot-ppc64el/
-          --with-freetype-lib=${HOME}/sysroot-ppc64el/usr/lib/powerpc64le-linux-gnu/
-          --with-freetype-include=${HOME}/sysroot-ppc64el/usr/include/freetype2/
-          --x-libraries=${HOME}/sysroot-ppc64el/usr/lib/powerpc64le-linux-gnu/
-          --with-build-jdk=${{ env.build_jdk_root }}
-          --with-conf-name=linux-ppc64le
-          --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
-          --with-version-build=0
-          --with-boot-jdk=${HOME}/bootjdk/${BOOT_JDK_VERSION}
-          --with-default-make-target="product-bundles test-bundles"
-          --with-zlib=system
-        working-directory: jdk
-
-      - name: Build
-        run: make CONF_NAME=linux-ppc64le ${{ matrix.build-target }}
+        run: make CONF_NAME=linux-x64-hotspot
         working-directory: jdk
 
   linux_x86_build:
@@ -1040,7 +640,7 @@ jobs:
         working-directory: jdk
 
       - name: Build
-        run: make CONF_NAME=linux-x86 ${{ matrix.build-target }}
+        run: make CONF_NAME=linux-x86
         working-directory: jdk
 
       - name: Persist test bundles
@@ -1050,7 +650,6 @@ jobs:
           path: |
             jdk/build/linux-x86/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x86_bin${{ matrix.artifact }}.tar.gz
             jdk/build/linux-x86/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x86_bin-tests${{ matrix.artifact }}.tar.gz
-        if: matrix.build-target == false
 
   linux_x86_test:
     name: Linux x86
@@ -1316,8 +915,8 @@ jobs:
 
       - name: Ensure a specific version of MSVC is installed
         run: >
-          Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList 
-          'modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise" --quiet 
+          Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
+          'modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise" --quiet
           --add Microsoft.VisualStudio.Component.VC.14.27.x86.x64'
 
       - name: Configure
@@ -1341,7 +940,7 @@ jobs:
         run: |
           $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
           $env:Path = $env:Path -split ";" -match "C:\\Windows|PowerShell|cygwin" -join ";" ;
-          & make CONF_NAME=windows-x64 ${{ matrix.build-target }}
+          & make CONF_NAME=windows-x64
         working-directory: jdk
 
       - name: Persist test bundles
@@ -1352,7 +951,6 @@ jobs:
             jdk/build/windows-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }}.zip
             jdk/build/windows-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin-tests${{ matrix.artifact }}.tar.gz
             jdk/build/windows-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }}-symbols.tar.gz
-        if: matrix.build-target == false
 
   windows_x64_test:
     name: Windows x64
@@ -1646,7 +1244,7 @@ jobs:
         working-directory: jdk
 
       - name: Build
-        run: make CONF_NAME=macos-x64 ${{ matrix.build-target }}
+        run: make CONF_NAME=macos-x64
         working-directory: jdk
 
       - name: Persist test bundles
@@ -1656,7 +1254,6 @@ jobs:
           path: |
             jdk/build/macos-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin${{ matrix.artifact }}.tar.gz
             jdk/build/macos-x64/bundles/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin-tests${{ matrix.artifact }}.tar.gz
-        if: matrix.build-target == false
 
   macos_x64_test:
     name: macOS x64
@@ -1850,10 +1447,7 @@ jobs:
     continue-on-error: true
     needs:
       - prerequisites
-      - linux_aarch64_build
-      - linux_arm_build
-      - linux_ppc64le_build
-      - linux_s390x_build
+      - linux_x64_hotspot_only
       - linux_x64_test
       - linux_x86_test
       - windows_x64_test


### PR DESCRIPTION
Currently Linux x64 testing in GitHub Actions depends on a few non-relevant hotspot build-only jobs (such as zero) that prevents testing from being run if those build were to fail. As the tests only require the x64 release and debug builds to run and provide interesting feedback, we should separate these other builds into a different job.

To reduce duplicated steps, all the existing hotspot-only builds have been consolidated into a single job.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256747](https://bugs.openjdk.java.net/browse/JDK-8256747): GitHub Actions: decouple the hotspot build-only jobs from Linux x64 testing


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to c79e6ab5826cfc0943fec96817786d8e9ac895ee


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1350/head:pull/1350`
`$ git checkout pull/1350`
