### PR TITLE
JDK-8256751: Incremental rebuild with precompiled header fails when touching a header file

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -805,13 +805,15 @@ define SetupNativeCompilationBody
         -include $$($1_PCH_DEPS_TARGETS_FILE)
 
         $1_PCH_COMMAND := $$($1_CC) $$($1_CFLAGS) $$($1_EXTRA_CFLAGS) $$($1_SYSROOT_CFLAGS) \
-            $$($1_OPT_CFLAGS) -x c++-header -c $(C_FLAG_DEPS) $$($1_PCH_DEPS_FILE)
+            $$($1_OPT_CFLAGS) -x c++-header -c $(C_FLAG_DEPS) \
+            $$(addsuffix .tmp, $$($1_PCH_DEPS_FILE))
 
         $$($1_PCH_FILE): $$($1_PRECOMPILED_HEADER) $$($1_COMPILE_VARDEPS_FILE)
 		$$(call LogInfo, Generating precompiled header)
 		$$(call MakeDir, $$(@D))
 		$$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
 		    $$($1_PCH_COMMAND) $$< -o $$@))
+		$$(call fix-deps-file, $$($1_PCH_DEPS_FILE))
 		$(SED) $(DEPENDENCY_TARGET_SED_PATTERN) $$($1_PCH_DEPS_FILE) \
 		    > $$($1_PCH_DEPS_TARGETS_FILE)
 


### PR DESCRIPTION
When building with --disable-absolute-paths-in-output and precompiled header enabled (both of which are default in release builds), then incremental builds of Hotspot fails if a header file is touched.

This is caused by the deps file the compiler generates is now containing relative paths, but those relative paths will not resolve when make imports the file. For all normal compilation units, we post process the file to rewrite these paths to absolute paths, but that call was missed for the precompiled header compilation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256751](https://bugs.openjdk.java.net/browse/JDK-8256751): Incremental rebuild with precompiled header fails when touching a header file


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1351/head:pull/1351`
`$ git checkout pull/1351`
