### PR TITLE
8249144: Potential memory leak in TypedMethodOptionMatcher

### DIFF
--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -247,6 +247,11 @@ TypedMethodOptionMatcher* TypedMethodOptionMatcher::clone() {
 }
 
 TypedMethodOptionMatcher::~TypedMethodOptionMatcher() {
+  if (type() == CcstrType) {
+    ccstr v = value<ccstr>();
+    os::free((void*)v);
+  }
+
   if (_option != NULL) {
     os::free((void*)_option);
   }


### PR DESCRIPTION
TypedMethodOptionMatcher owns ccstr value (vs. os::strdup_check_oom()), but never frees it in destructor.

It does not appear to a real issue so far, because TypedMethodOptionMatcher seems immortal. Given it releases _option 
string, it should also release ccstr value.

This patch has been reviewed https://mail.openjdk.java.net/pipermail/hotspot-dev/2020-July/042356.html, but I lost track of it during repo migration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x64 (hs/tier1 gc)](https://github.com/zhengyu123/jdk/runs/1431338783)

### Issue
 * [JDK-8249144](https://bugs.openjdk.java.net/browse/JDK-8249144): Potential memory leak in TypedMethodOptionMatcher


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1353/head:pull/1353`
`$ git checkout pull/1353`
