### PR TITLE
8244535: JavaDoc search is overly strict with letter case

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js
@@ -86,7 +86,7 @@ function createSearchPattern(term) {
             pattern += $.ui.autocomplete.escapeRegex(s);
             isWordToken =  /\w$/.test(s);
             if (isWordToken) {
-                pattern += "([a-z0-9_$<>\\[\\]]*)";
+                pattern += "([a-z0-9_$<>\\[\\]]*?)";
             }
         }
     });

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js
@@ -192,7 +192,6 @@ function rankMatch(match, category) {
     var input = match.input;
     var leftBoundaryMatch = 2;
     var periferalMatch = 0;
-    var delta = 0;
     // make sure match is anchored on a left word boundary
     if (index === 0 || /\W/.test(input[index - 1]) || "_" === input[index]) {
         leftBoundaryMatch = 0;
@@ -201,9 +200,9 @@ function rankMatch(match, category) {
     }
     var matchEnd = index + match[0].length;
     var leftParen = input.indexOf("(");
+    var endOfName = leftParen > -1 ? leftParen : input.length;
     // exclude peripheral matches
     if (category !== catModules && category !== catSearchTags) {
-        var endOfName = leftParen > -1 ? leftParen : input.length;
         var delim = category === catPackages ? "/" : ".";
         if (leftParen > -1 && leftParen < index) {
             periferalMatch += 2;
@@ -211,6 +210,7 @@ function rankMatch(match, category) {
             periferalMatch += 2;
         }
     }
+    var delta = match[0].length === endOfName ? 0 : 1; // rank full match higher than partial match
     for (var i = 1; i < match.length; i++) {
         // lower ranking if parts of the name are missing
         if (match[i])

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
@@ -563,9 +563,15 @@ main, nav, header, footer, section {
     padding:7px 0 7px 3px;
     background-color:#4D7A97;
     color:#FFFFFF;
+    display: block;
+    white-space: nowrap;
+    float: left;
+    width: 100%;
 }
 .result-item {
     font-size:13px;
+    white-space: nowrap;
+    float: left;
 }
 .ui-autocomplete {
     max-height:85%;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
@@ -563,15 +563,9 @@ main, nav, header, footer, section {
     padding:7px 0 7px 3px;
     background-color:#4D7A97;
     color:#FFFFFF;
-    display: block;
-    white-space: nowrap;
-    float: left;
-    width: 100%;
 }
 .result-item {
     font-size:13px;
-    white-space: nowrap;
-    float: left;
 }
 .ui-autocomplete {
     max-height:85%;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
@@ -172,7 +172,9 @@ public class IndexBuilder {
         }
 
         itemsByCategory.computeIfAbsent(item.getCategory(),
-                    c -> new TreeSet<>(mainComparator))
+                    c -> new TreeSet<>(c == IndexItem.Category.TYPES
+                            ? makeTypeSearchIndexComparator()
+                            : makeGenericSearchIndexComparator()))
                 .add(item);
     }
 
@@ -344,4 +346,28 @@ public class IndexBuilder {
         };
     }
 
+    /**
+     * Returns a Comparator for IndexItems in the types category of the search index.
+     * Items are compared by short name, falling back to the main comparator if names are equal.
+     *
+     * @return a Comparator
+     */
+    public Comparator<IndexItem> makeTypeSearchIndexComparator() {
+        Comparator<IndexItem> simpleNameComparator =
+                (ii1, ii2) -> utils.compareStrings(ii1.getSimpleName(), ii2.getSimpleName());
+        return simpleNameComparator.thenComparing(mainComparator);
+    }
+
+    /**
+     * Returns a Comparator for IndexItems in the modules, packages, members, and search tags
+     * categories of the search index.
+     * Items are compared by label, falling back to the main comparator if names are equal.
+     *
+     * @return a Comparator
+     */
+    public Comparator<IndexItem> makeGenericSearchIndexComparator() {
+        Comparator<IndexItem> labelComparator =
+                (ii1, ii2) -> utils.compareStrings(ii1.getLabel(), ii2.getLabel());
+        return labelComparator.thenComparing(mainComparator);
+    }
 }

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -712,7 +712,7 @@ public class TestSearch extends JavadocTester {
 
     void checkSearchJS() {
         checkOutput("search.js", true,
-                "function appendResults(newResults) {",
+                "function searchIndexWithMatcher(indexArray, matcher, category, nameFunc) {",
                 """
                     search.on('click keydown paste', function() {
                             if ($(this).val() === watermark) {

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -712,10 +712,10 @@ public class TestSearch extends JavadocTester {
 
     void checkSearchJS() {
         checkOutput("search.js", true,
-                "function concatResults(a1, a2) {",
+                "function appendResults(newResults) {",
                 """
-                    $("#search").on('click keydown paste', function() {
-                            if ($(this).val() == watermark) {
+                    search.on('click keydown paste', function() {
+                            if ($(this).val() === watermark) {
                                 $(this).val('').removeClass('watermark');
                             }
                         });""",
@@ -737,7 +737,6 @@ public class TestSearch extends JavadocTester {
                                     }
                                 });
                             }
-                            return urlPrefix;
                         }
                         return urlPrefix;
                     }""",

--- a/test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java
@@ -109,11 +109,12 @@ public class TestSearchScript extends JavadocTester {
                                         "mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)", "mappkg.system.property"));
         checkSearch(inv, "Map", List.of("mapmodule", "mapmodule/mappkg", "mapmodule/mappkg.impl", "mappkg.Map", "mappkg.impl.MyMap",
                                         "mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)", "mappkg.system.property"));
-        checkSearch(inv, "MAP", List.of("mapmodule", "mapmodule/mappkg", "mapmodule/mappkg.impl", "mappkg.Map", "mappkg.system.property"));
+        checkSearch(inv, "MAP", List.of("mapmodule", "mapmodule/mappkg", "mapmodule/mappkg.impl", "mappkg.Map", "mappkg.impl.MyMap",
+                                        "mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)", "mappkg.system.property"));
         checkSearch(inv, "value", List.of("mappkg.impl.MyMap.OTHER_VALUE", "mappkg.impl.MyMap.some_value"));
-        checkSearch(inv, "VALUE", List.of("mappkg.impl.MyMap.OTHER_VALUE"));
+        checkSearch(inv, "VALUE", List.of("mappkg.impl.MyMap.OTHER_VALUE", "mappkg.impl.MyMap.some_value"));
         checkSearch(inv, "map.other", List.of("mappkg.impl.MyMap.OTHER_VALUE"));
-        checkSearch(inv, "Map.some_", List.of("mappkg.impl.MyMap.some_value"));
+        checkSearch(inv, "Map.Some_", List.of("mappkg.impl.MyMap.some_value"));
 
         checkSearch(inv, "Mm", List.of());
         checkSearch(inv, "mym", List.of("mappkg.impl.MyMap", "mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)"));
@@ -286,7 +287,7 @@ public class TestSearchScript extends JavadocTester {
         checkSearch(inv, "Some", List.of("listpkg.Nolist.SOME_INT_CONSTANT"));
         checkSearch(inv, "int", List.of("listpkg.Nolist.SOME_INT_CONSTANT"));
         checkSearch(inv, "INT", List.of("listpkg.Nolist.SOME_INT_CONSTANT"));
-        checkSearch(inv, "Int", List.of());
+        checkSearch(inv, "Int", List.of("listpkg.Nolist.SOME_INT_CONSTANT"));
         checkSearch(inv, "int_con", List.of("listpkg.Nolist.SOME_INT_CONSTANT"));
         checkSearch(inv, "INT_CON", List.of("listpkg.Nolist.SOME_INT_CONSTANT"));
         checkSearch(inv, "NT", List.of());

--- a/test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java
@@ -93,23 +93,23 @@ public class TestSearchScript extends JavadocTester {
         // exact match, case sensitivity
         checkSearch(inv, "mapmodule", List.of("mapmodule"));
         checkSearch(inv, "mappkg", List.of("mapmodule/mappkg", "mapmodule/mappkg.impl", "mappkg.system.property"));
-        checkSearch(inv, "Mapmodule", List.of());
-        checkSearch(inv, "Mappkg", List.of());
+        checkSearch(inv, "Mapmodule", List.of("mapmodule"));
+        checkSearch(inv, "Mappkg", List.of("mapmodule/mappkg", "mapmodule/mappkg.impl", "mappkg.system.property"));
         checkSearch(inv, "mymap", List.of("mappkg.impl.MyMap", "mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)"));
         checkSearch(inv, "MyMap", List.of("mappkg.impl.MyMap", "mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)"));
         checkSearch(inv, "mymap(", List.of("mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)"));
         checkSearch(inv, "MyMap(", List.of("mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)"));
         checkSearch(inv, "mymap()", List.of("mappkg.impl.MyMap.MyMap()"));
         checkSearch(inv, "MyMap()", List.of("mappkg.impl.MyMap.MyMap()"));
-        checkSearch(inv, "Mymap", List.of());
-        checkSearch(inv, "Mymap()", List.of());
+        checkSearch(inv, "Mymap", List.of("mappkg.impl.MyMap", "mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)"));
+        checkSearch(inv, "Mymap()", List.of("mappkg.impl.MyMap.MyMap()"));
 
         // left boundaries, ranking
         checkSearch(inv, "map", List.of("mapmodule", "mapmodule/mappkg", "mapmodule/mappkg.impl", "mappkg.Map", "mappkg.impl.MyMap",
                                         "mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)", "mappkg.system.property"));
-        checkSearch(inv, "Map", List.of("mappkg.Map", "mappkg.impl.MyMap", "mappkg.impl.MyMap.MyMap()",
-                                        "mappkg.impl.MyMap.MyMap(Map)"));
-        checkSearch(inv, "MAP", List.of());
+        checkSearch(inv, "Map", List.of("mapmodule", "mapmodule/mappkg", "mapmodule/mappkg.impl", "mappkg.Map", "mappkg.impl.MyMap",
+                                        "mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)", "mappkg.system.property"));
+        checkSearch(inv, "MAP", List.of("mapmodule", "mapmodule/mappkg", "mapmodule/mappkg.impl", "mappkg.Map", "mappkg.system.property"));
         checkSearch(inv, "value", List.of("mappkg.impl.MyMap.OTHER_VALUE", "mappkg.impl.MyMap.some_value"));
         checkSearch(inv, "VALUE", List.of("mappkg.impl.MyMap.OTHER_VALUE"));
         checkSearch(inv, "map.other", List.of("mappkg.impl.MyMap.OTHER_VALUE"));
@@ -123,12 +123,12 @@ public class TestSearchScript extends JavadocTester {
         // camel case
         checkSearch(inv, "MM", List.of("mappkg.impl.MyMap", "mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)"));
         checkSearch(inv, "MyM", List.of("mappkg.impl.MyMap", "mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)"));
-        checkSearch(inv, "Mym", List.of());
+        checkSearch(inv, "Mym", List.of("mappkg.impl.MyMap", "mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)"));
         checkSearch(inv, "i.MyM.MyM(", List.of("mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)"));
         checkSearch(inv, "i.MMa.MMa(", List.of("mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)"));
         checkSearch(inv, "i.MyM.MyM(Ma", List.of("mappkg.impl.MyMap.MyMap(Map)"));
         checkSearch(inv, "i.MMa.MMa(M", List.of("mappkg.impl.MyMap.MyMap(Map)"));
-        checkSearch(inv, "i.Mym.MyM(", List.of());
+        checkSearch(inv, "i.Mym.MyM(", List.of("mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)"));
         checkSearch(inv, "i.Mym.Ma(", List.of());
 
         checkSearch(inv, "mapm", List.of("mapmodule"));
@@ -142,13 +142,14 @@ public class TestSearchScript extends JavadocTester {
         checkSearch(inv, "mapmod.", List.of());
         checkSearch(inv, "mappkg.", List.of("mapmodule/mappkg.impl", "mappkg.Map", "mappkg.system.property"));
         checkSearch(inv, "mappkg.", List.of("mapmodule/mappkg.impl", "mappkg.Map", "mappkg.system.property"));
-        checkSearch(inv, "Map.", List.of("mappkg.Map.contains(Object)", "mappkg.Map.get(Object)", "mappkg.Map.iterate()",
-                                         "mappkg.Map.put(Object, Object)", "mappkg.Map.remove(Object)",
-                                         "mappkg.impl.MyMap.contains(Object)", "mappkg.impl.MyMap.get(Object)",
-                                         "mappkg.impl.MyMap.iterate()", "mappkg.impl.MyMap.MyMap()",
-                                         "mappkg.impl.MyMap.MyMap(Map)", "mappkg.impl.MyMap.OTHER_VALUE",
-                                         "mappkg.impl.MyMap.put(Object, Object)", "mappkg.impl.MyMap.remove(Object)",
-                                         "mappkg.impl.MyMap.some_value"));
+        checkSearch(inv, "Map.", List.of("mapmodule/mappkg.impl", "mappkg.Map", "mappkg.Map.contains(Object)",
+                                         "mappkg.Map.get(Object)", "mappkg.Map.iterate()", "mappkg.Map.put(Object, Object)",
+                                         "mappkg.Map.remove(Object)", "mappkg.impl.MyMap.contains(Object)",
+                                         "mappkg.impl.MyMap.get(Object)", "mappkg.impl.MyMap.iterate()",
+                                         "mappkg.impl.MyMap.MyMap()", "mappkg.impl.MyMap.MyMap(Map)",
+                                         "mappkg.impl.MyMap.OTHER_VALUE", "mappkg.impl.MyMap.put(Object, Object)",
+                                         "mappkg.impl.MyMap.remove(Object)", "mappkg.impl.MyMap.some_value",
+                                         "mappkg.system.property"));
         checkSearch(inv, "mym.", List.of("mappkg.impl.MyMap.contains(Object)", "mappkg.impl.MyMap.get(Object)",
                                          "mappkg.impl.MyMap.iterate()", "mappkg.impl.MyMap.MyMap()",
                                          "mappkg.impl.MyMap.MyMap(Map)", "mappkg.impl.MyMap.OTHER_VALUE",
@@ -197,12 +198,11 @@ public class TestSearchScript extends JavadocTester {
                                          "listpkg.MyListFactory.createList(ListProvider, MyListFactory)",
                                          "listpkg.ListProvider.makeNewList()",
                                          "listpkg.MyList.MyList()", "listpkg.MyListFactory.MyListFactory()"));
-        checkSearch(inv, "List", List.of("listpkg.List", "listpkg.ListProvider", "listpkg.MyList",
+        checkSearch(inv, "List", List.of("listpkg", "listpkg.List", "listpkg.ListProvider", "listpkg.MyList",
                                          "listpkg.MyListFactory", "listpkg.ListProvider.ListProvider()",
                                          "listpkg.MyListFactory.createList(ListProvider, MyListFactory)",
                                          "listpkg.ListProvider.makeNewList()",
                                          "listpkg.MyList.MyList()", "listpkg.MyListFactory.MyListFactory()"));
-
         // partial match
         checkSearch(inv, "fact", List.of("listpkg.MyListFactory", "listpkg.MyListFactory.MyListFactory()"));
         checkSearch(inv, "pro", List.of("listpkg.ListProvider", "listpkg.ListProvider.ListProvider()"));
@@ -230,7 +230,9 @@ public class TestSearchScript extends JavadocTester {
                 List.of("listpkg.List.of()", "listpkg.List.of(E)", "listpkg.List.of(E, E)",
                         "listpkg.List.of(E, E, E)", "listpkg.List.of(E, E, E, E)",
                         "listpkg.List.of(E, E, E, E, E)", "listpkg.List.of(E...)"));
-        checkSearch(inv, "L.l.o", List.of());
+        checkSearch(inv, "L.l.o", List.of("listpkg.List.of()", "listpkg.List.of(E)", "listpkg.List.of(E, E)",
+                        "listpkg.List.of(E, E, E)", "listpkg.List.of(E, E, E, E)", "listpkg.List.of(E, E, E, E, E)",
+                        "listpkg.List.of(E...)"));
 
         // whitespace
         checkSearch(inv, "(e,e,e",
@@ -281,7 +283,7 @@ public class TestSearchScript extends JavadocTester {
         // _ word boundaries and case sensitivity
         checkSearch(inv, "some", List.of("listpkg.Nolist.SOME_INT_CONSTANT"));
         checkSearch(inv, "SOME", List.of("listpkg.Nolist.SOME_INT_CONSTANT"));
-        checkSearch(inv, "Some", List.of());
+        checkSearch(inv, "Some", List.of("listpkg.Nolist.SOME_INT_CONSTANT"));
         checkSearch(inv, "int", List.of("listpkg.Nolist.SOME_INT_CONSTANT"));
         checkSearch(inv, "INT", List.of("listpkg.Nolist.SOME_INT_CONSTANT"));
         checkSearch(inv, "Int", List.of());
@@ -295,7 +297,7 @@ public class TestSearchScript extends JavadocTester {
         // Test for all packages, all classes links
         checkSearch(inv, "all", List.of("All Packages", "All Classes"));
         checkSearch(inv, "All", List.of("All Packages", "All Classes"));
-        checkSearch(inv, "ALL", List.of());
+        checkSearch(inv, "ALL", List.of("All Packages", "All Classes"));
 
         // test for generic types, var-arg and array args
         checkSearch(inv, "(map<string, ? ext collection>)",

--- a/test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java
@@ -167,8 +167,8 @@ public class TestSearchScript extends JavadocTester {
         checkSearch(inv, "operty", List.of());
 
         // search tag
-        checkSearch(inv, "search tag", List.of("multiline search tag", "search tag"));
-        checkSearch(inv, "search   tag", List.of("multiline search tag", "search tag"));
+        checkSearch(inv, "search tag", List.of("search tag", "multiline search tag"));
+        checkSearch(inv, "search   tag", List.of("search tag", "multiline search tag"));
         checkSearch(inv, "search ", List.of("multiline search tag", "search tag"));
         checkSearch(inv, "tag", List.of("multiline search tag", "search tag"));
         checkSearch(inv, "sea", List.of("multiline search tag", "search tag"));

--- a/test/langtools/jdk/javadoc/doclet/testSearchScript/javadoc-search.js
+++ b/test/langtools/jdk/javadoc/doclet/testSearchScript/javadoc-search.js
@@ -47,6 +47,16 @@ function tryLoad(docsPath, file) {
     }
 }
 
+var updateSearchResults = function() {};
+
+function indexFilesLoaded() {
+    return moduleSearchIndex
+        && packageSearchIndex
+        && typeSearchIndex
+        && memberSearchIndex
+        && tagSearchIndex;
+}
+
 var $ = function(f) {
     if (typeof f === "function") {
         f();


### PR DESCRIPTION
This PR softens the case-sensitivity rules in Javadoc searches by including results of case-insensitive search if a case-sensitive yields no or very few results. 

Changes also include some restructuring of the search.js code along with minor changes that improve compliance with the specification (Segments separated by `_` are ranked the same way as segments of CamelCase identifiers, and matches on such segments are ranked lower than matches for whole identifiers, which wasn't always the case previously)

The `TestSearchScript.java` test, which has been disabled with the removal of Nashorn, has been updated to run without failure. In the process, I noticed that the recent IndexBuilder|Writer|Item refactoring, comparators have been unified to the point that the same item order is used in HTML index pages and the search index JSON files. However, there used to be slight differences in the sorting between the two. This change restores the original order by adding two simple search index comparators to `IndexBuilder.java`.

API documentation generated with this PR applied can be viewed and tested here: 
http://cr.openjdk.java.net/~hannesw/8244535/api.01/

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8244535](https://bugs.openjdk.java.net/browse/JDK-8244535): JavaDoc search is overly strict with letter case


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1354/head:pull/1354`
`$ git checkout pull/1354`
