### PR TITLE
8256806: Shenandoah: optimize shenandoah/jni/TestPinnedGarbage.java test

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/jni/TestPinnedGarbage.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/TestPinnedGarbage.java
@@ -28,12 +28,12 @@
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx512m
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx128m
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
  *      -XX:+ShenandoahVerify -XX:+ShenandoahDegeneratedGC
  *      TestPinnedGarbage
  *
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx512m
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx128m
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
  *      -XX:+ShenandoahVerify -XX:-ShenandoahDegeneratedGC
  *      TestPinnedGarbage
@@ -45,11 +45,11 @@
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx512m
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx128m
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
  *      TestPinnedGarbage
  *
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx512m
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx128m
  *      -XX:+UseShenandoahGC
  *      -XX:+ShenandoahVerify
  *      TestPinnedGarbage
@@ -65,26 +65,26 @@ public class TestPinnedGarbage {
     }
 
     private static final int NUM_RUNS      = 1_000;
-    private static final int OBJS_COUNT    = 1_000;
-    private static final int GARBAGE_COUNT = 1_000_000;
+    private static final int OBJS_COUNT    = 1 << 10;
+    private static final int GARBAGE_COUNT = 1 << 18;
 
     private static native void pin(int[] a);
     private static native void unpin(int[] a);
 
     public static void main(String[] args) {
+        Random rng = Utils.getRandomInstance();
         for (int i = 0; i < NUM_RUNS; i++) {
-            test();
+            test(rng);
         }
     }
 
-    private static void test() {
+    private static void test(Random rng) {
         Object[] objs = new Object[OBJS_COUNT];
         for (int i = 0; i < OBJS_COUNT; i++) {
             objs[i] = new MyClass();
         }
 
         int[] cog = new int[10];
-        Random rng = Utils.getRandomInstance();
         int cogIdx = rng.nextInt(OBJS_COUNT);
         objs[cogIdx] = cog;
         pin(cog);


### PR DESCRIPTION
This test is way too slow for Zero configuration, taking about 2 hours. No reasonable timeout factor accounts for this. We can clean the test up and make it more lenient. It would also improve server testing time.

Current proposal cuts down the test heap 4x, and thus the number of objects it needs to handle 4x as well. Additionally, moving `Random` initialization out of tested method marginally improves the times. I also went back to remember why this test even exists, and it has to do with [Full GC handling pinned objects specially](http://hg.openjdk.java.net/shenandoah/jdk8/hotspot/rev/bc0f0cfed315). I injected the bug back, and the test still caught it.

Additional testing:
 - [x] Linux x86_64 Zero fastdebug, affected test
 - [x] Linux x86_64 Server fastdebug, affected test
 - [x] Linux x86_32 Server fastdebug, affected test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x64 (hs/tier1 runtime)](https://github.com/shipilev/jdk/runs/1433088933)

### Issue
 * [JDK-8256806](https://bugs.openjdk.java.net/browse/JDK-8256806): Shenandoah: optimize shenandoah/jni/TestPinnedGarbage.java test


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1358/head:pull/1358`
`$ git checkout pull/1358`
