### PR TITLE
JDK-8256810: Incremental rebuild broken on Macosx

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -237,10 +237,15 @@ ifeq ($(ALLOW_ABSOLUTE_PATHS_IN_OUTPUT)-$(FILE_MACRO_CFLAGS), false-)
         ) \
       )
 
-  # When compiling with relative paths, the deps file comes out with relative
-  # paths.
+  # When compiling with relative paths, the deps file may come out with relative
+  # paths, and that path may start with './'. First remove any leading ./, then
+  # add WORKSPACE_ROOT to any line not starting with /, while allowing for
+  # leading spaces.
   define fix-deps-file
-	$(SED) -e 's|^\([ ]*\)|\1$(WORKSPACE_ROOT)|' $1.tmp > $1
+	$(SED) \
+	    -e 's|^\([ ]*\)\./|\1|' \
+	    -e '/^[ ]*[^/ ]/s|^\([ ]*\)|\1$(WORKSPACE_ROOT)/|' \
+	    $1.tmp > $1
   endef
 else
   # By default the MakeCommandRelative macro does nothing.


### PR DESCRIPTION
After fixing JDK-8256751, I noticed that the fix-deps-file macro isn't actually doing the right thing at all. It seems clang on Macosx is inconsistent with outputting relative or absolute paths in the deps files, so some files end up with double WORKSPACE_ROOT in the paths. It's also not handling the trailing slash after WORKSPACE_ROOT correctly, so some files are missing the slash between WORKSPACE_ROOT and the original relative path.

This time I have checked the output carefully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256810](https://bugs.openjdk.java.net/browse/JDK-8256810): Incremental rebuild broken on Macosx


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1360/head:pull/1360`
`$ git checkout pull/1360`
