### PR TITLE
8256364: vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t002 failed with "assert(handle != __null) failed: JNI handle should not be null"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,6 +107,7 @@ public class cm01t002 extends DebugeeClass {
 class cm01t002Thread extends Thread {
     public Object startingMonitor = new Object();
     private Object waitingMonitor = new Object();
+    private boolean timeToDie = false;
 
     public cm01t002Thread(String name) {
         super(name);
@@ -128,7 +129,14 @@ class cm01t002Thread extends Thread {
 
             // wait on monitor
             try {
-                waitingMonitor.wait(cm01t002.timeout);
+                long maxTime = System.currentTimeMillis() + cm01t002.timeout;
+                while (!timeToDie) {
+                    long timeout = maxTime - System.currentTimeMillis();
+                    if (timeout <= 0) {
+                        break;
+                    }
+                    waitingMonitor.wait(timeout);
+                }
             } catch (InterruptedException ignore) {
                 // just finish
             }
@@ -144,6 +152,7 @@ class cm01t002Thread extends Thread {
 
     public void letFinish() {
         synchronized (waitingMonitor) {
+            timeToDie = true;
             waitingMonitor.notify();
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t002/cm01t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t002/cm01t002.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,6 +98,11 @@ static int prepare() {
     /* deallocate threads list */
     if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
+
+    if (thread == NULL) {
+        nsk_lcomplain(__FILE__, __LINE__, "tested thread not found\n");
+        return NSK_FALSE;
+    }
 
     /* get tested thread class */
     if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))


### PR DESCRIPTION
Resending the RFR without unexpected extra commits

- fixed java part of the test to handle spurious wakeups in the debuggee thread;
- fixed native part of the test to detect and report the case when debuggee thread not found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256364](https://bugs.openjdk.java.net/browse/JDK-8256364): vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t002 failed with "assert(handle != __null) failed: JNI handle should not be null"


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1361/head:pull/1361`
`$ git checkout pull/1361`
