### PR TITLE
8256818: SSLSocket that is never bound or connected leaks socket resources

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -562,7 +562,7 @@ public final class SSLSocketImpl
         }
 
         try {
-            if (isConnected() || isBound()) {
+            if (isConnected()) {
                 // shutdown output bound, which may have been closed previously.
                 if (!isOutputShutdown()) {
                     duplexCloseOutput();

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -553,7 +553,7 @@ public final class SSLSocketImpl
     // locks may be deadlocked.
     @Override
     public void close() throws IOException {
-        if (tlsIsClosed) {
+        if (isClosed()) {
             return;
         }
 
@@ -562,19 +562,16 @@ public final class SSLSocketImpl
         }
 
         try {
-            // shutdown output bound, which may have been closed previously.
-            if (!isOutputShutdown()) {
-                duplexCloseOutput();
-            }
+            if (isConnected() || isBound()) {
+                // shutdown output bound, which may have been closed previously.
+                if (!isOutputShutdown()) {
+                    duplexCloseOutput();
+                }
 
-            // shutdown input bound, which may have been closed previously.
-            if (!isInputShutdown()) {
-                duplexCloseInput();
-            }
-
-            if (!isClosed()) {
-                // close the connection directly
-                closeSocket(false);
+                // shutdown input bound, which may have been closed previously.
+                if (!isInputShutdown()) {
+                    duplexCloseInput();
+                }
             }
         } catch (IOException ioe) {
             // ignore the exception
@@ -582,7 +579,19 @@ public final class SSLSocketImpl
                 SSLLogger.warning("SSLSocket duplex close failed", ioe);
             }
         } finally {
-            tlsIsClosed = true;
+            if (!isClosed()) {
+                // close the connection directly
+                try {
+                    closeSocket(false);
+                } catch (IOException ioe) {
+                    // ignore the exception
+                    if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
+                        SSLLogger.warning("SSLSocket close failed", ioe);
+                    }
+                } finally {
+                    tlsIsClosed = true;
+                }
+            }
         }
     }
 

--- a/test/jdk/java/lang/ProcessBuilder/checkHandles/CheckHandles.java
+++ b/test/jdk/java/lang/ProcessBuilder/checkHandles/CheckHandles.java
@@ -27,32 +27,30 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.ProcessHandle;
 
+import jdk.test.lib.util.FileUtils;
+
 /*
  * @test
  * @bug 8239893
  * @summary Verify that handles for processes that terminate do not accumulate
  * @requires ((os.family == "windows") & (vm.compMode != "Xcomp"))
+ * @library /test/lib
  * @run main/othervm/native -Xint CheckHandles
  */
 public class CheckHandles {
 
-    // Return the current process handle count
-    private static native long getProcessHandleCount();
-
     public static void main(String[] args) throws Exception {
-        System.loadLibrary("CheckHandles");
-
         System.out.println("mypid: " + ProcessHandle.current().pid());
 
         // Warmup the process launch mechanism and vm to stabilize the number of handles in use
         int MAX_WARMUP = 20;
-        long prevCount = getProcessHandleCount();
+        long prevCount = FileUtils.getProcessHandleCount();
         for (int i = 0; i < MAX_WARMUP; i++) {
             oneProcess();
             System.gc();        // an opportunity to close unreferenced handles
             sleep(10);
 
-            long count = getProcessHandleCount();
+            long count = FileUtils.getProcessHandleCount();
             if (count < 0)
                 throw new AssertionError("getProcessHandleCount failed");
             System.out.println("warmup handle delta: " + (count - prevCount));
@@ -61,7 +59,7 @@ public class CheckHandles {
         System.out.println("Warmup done");
         System.out.println();
 
-        prevCount = getProcessHandleCount();
+        prevCount = FileUtils.getProcessHandleCount();
         long startHandles = prevCount;
         long maxHandles = startHandles;
         int MAX_SPAWN = 50;
@@ -70,7 +68,7 @@ public class CheckHandles {
             System.gc();        // an opportunity to close unreferenced handles
             sleep(10);
 
-            long count = getProcessHandleCount();
+            long count = FileUtils.getProcessHandleCount();
             if (count < 0)
                 throw new AssertionError("getProcessHandleCount failed");
             System.out.println("handle delta: " + (count - prevCount));

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java
@@ -23,7 +23,6 @@
 
 import java.io.IOException;
 
-import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
 import jdk.test.lib.util.FileUtils;
@@ -45,9 +44,7 @@ public class SSLSocketLeak {
         System.out.println("FDs at the beginning: " + fds_start);
 
         for (int i = 0; i < NUM_TEST_SOCK; i++) {
-            SSLSocket sslSocket = (SSLSocket)SSLSocketFactory.getDefault().createSocket();
-            sslSocket.getSSLParameters();
-            sslSocket.close();
+            SSLSocketFactory.getDefault().createSocket().close();
         }
 
         long fds_end = FileUtils.getProcessHandleCount();

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java
@@ -23,6 +23,7 @@
 
 import java.io.IOException;
 
+import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocketFactory;
 
 import jdk.test.lib.util.FileUtils;
@@ -43,8 +44,9 @@ public class SSLSocketLeak {
         long fds_start = FileUtils.getProcessHandleCount();
         System.out.println("FDs at the beginning: " + fds_start);
 
+        SocketFactory f = SSLSocketFactory.getDefault();
         for (int i = 0; i < NUM_TEST_SOCK; i++) {
-            SSLSocketFactory.getDefault().createSocket().close();
+            f.createSocket().close();
         }
 
         long fds_end = FileUtils.getProcessHandleCount();

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+import jdk.test.lib.util.FileUtils;
+
+/*
+ * @test
+ * @bug 8256818
+ * @summary Test that creating and closing SSL Sockets without bind/connect
+ *          will not leave leaking socket file descriptors
+ * @library /test/lib
+ * @run main/othervm SSLSocketLeak
+ */
+public class SSLSocketLeak {
+
+    private static final int NUM_TEST_SOCK = 500;
+
+    public static void main(String[] args) throws IOException {
+        long fds_start = FileUtils.getProcessHandleCount();
+        System.out.println("FDs at the beginning: " + fds_start);
+
+        for (int i = 0; i < NUM_TEST_SOCK; i++) {
+            SSLSocket sslSocket = (SSLSocket)SSLSocketFactory.getDefault().createSocket();
+            sslSocket.getSSLParameters();
+            sslSocket.close();
+        }
+
+        long fds_end = FileUtils.getProcessHandleCount();
+        System.out.println("FDs in the end: " + fds_end);
+
+        if ((fds_end - fds_start) > (NUM_TEST_SOCK / 10)) {
+            throw new RuntimeException("Too many open file descriptors. Looks leaky.");
+        }
+    }
+}

--- a/test/lib/jdk/test/lib/util/libFileUtils.c
+++ b/test/lib/jdk/test/lib/util/libFileUtils.c
@@ -29,7 +29,7 @@
 #include "jni.h"
 #include <windows.h>
 
-JNIEXPORT jlong JNICALL Java_CheckHandles_getProcessHandleCount(JNIEnv *env)
+JNIEXPORT jlong JNICALL Java_jdk_test_lib_util_FileUtils_getWinProcessHandleCount(JNIEnv *env)
 {
     DWORD handleCount;
     HANDLE handle = GetCurrentProcess();


### PR DESCRIPTION
There is a flaw in sun.security.ssl.SSLSocketImpl::close() which leads to leaking socket resources after JDK-8224829.

The close method calls duplexCloseOutput() and duplexCloseInput(). In case of an exception in any of these methods, the call to closeSocket() is bypassed, and the underlying Socket may not be closed.

This manifests in a real life leak after JDK-8224829 has introduced a call to getSoLinger() on the path of duplexCloseOutput -> closeNotify. If socket impl / OS socket hadn't been created yet it is done at that place. But then after duplexCloseOutput eventually fails with a SocketException since the socket wasn't connected, closing fails to call Socket::close().

This problem can be reproduced by this code:
		        SSLSocket sslSocket = (SSLSocket)SSLSocketFactory.getDefault().createSocket();
		        sslSocket.getSSLParameters();
		        sslSocket.close();

This is what happens when SSLContext.getDefault().getDefaultSSLParameters() is called, with close() being eventually called by the finalizer.

I'll open this PR as draft for now to start discussion. I'll create a testcase to reproduce the issue and add it soon.

I propose to modify the close method such that duplexClose is only done on a connected/bound socket. Maybe it even suffices to only do it when connected.

Secondly, I'm proposing to improve exception handling a bit. So in case there's an IOException on the path of duplexClose, it is caught and logged. But the real close moves to the finally block since it should be done unconditionally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256818](https://bugs.openjdk.java.net/browse/JDK-8256818): SSLSocket that is never bound or connected leaks socket resources


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1363/head:pull/1363`
`$ git checkout pull/1363`
