### PR TITLE
JDK-8257401: Use switch expressions in jdk.internal.net.http and java.net.http

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1HeaderParser.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1HeaderParser.java
@@ -116,15 +116,15 @@ class Http1HeaderParser {
 
         while (canContinueParsing(input)) {
             switch (state) {
-                case INITIAL ->                                     state = State.STATUS_LINE;
-                case STATUS_LINE ->                                 readResumeStatusLine(input);
+                case INITIAL                                    ->  state = State.STATUS_LINE;
+                case STATUS_LINE                                ->  readResumeStatusLine(input);
                 case STATUS_LINE_FOUND_CR, STATUS_LINE_FOUND_LF ->  readStatusLineFeed(input);
-                case STATUS_LINE_END ->                             maybeStartHeaders(input);
-                case STATUS_LINE_END_CR, STATUS_LINE_END_LF ->      maybeEndHeaders(input);
-                case HEADER ->                                      readResumeHeader(input);
-                case HEADER_FOUND_CR, HEADER_FOUND_LF ->            resumeOrLF(input);
-                case HEADER_FOUND_CR_LF ->                          resumeOrSecondCR(input);
-                case HEADER_FOUND_CR_LF_CR ->                       resumeOrEndHeaders(input);
+                case STATUS_LINE_END                            ->  maybeStartHeaders(input);
+                case STATUS_LINE_END_CR, STATUS_LINE_END_LF     ->  maybeEndHeaders(input);
+                case HEADER                                     ->  readResumeHeader(input);
+                case HEADER_FOUND_CR, HEADER_FOUND_LF           ->  resumeOrLF(input);
+                case HEADER_FOUND_CR_LF                         ->  resumeOrSecondCR(input);
+                case HEADER_FOUND_CR_LF_CR                      ->  resumeOrEndHeaders(input);
 
                 default -> throw new InternalError("Unexpected state: " + state);
             }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1HeaderParser.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1HeaderParser.java
@@ -116,15 +116,16 @@ class Http1HeaderParser {
 
         while (canContinueParsing(input)) {
             switch (state) {
-                case INITIAL -> state = State.STATUS_LINE;
-                case STATUS_LINE -> readResumeStatusLine(input);
-                case STATUS_LINE_FOUND_CR, STATUS_LINE_FOUND_LF -> readStatusLineFeed(input);
-                case STATUS_LINE_END -> maybeStartHeaders(input);
-                case STATUS_LINE_END_CR, STATUS_LINE_END_LF -> maybeEndHeaders(input);
-                case HEADER -> readResumeHeader(input);
-                case HEADER_FOUND_CR, HEADER_FOUND_LF -> resumeOrLF(input);
-                case HEADER_FOUND_CR_LF -> resumeOrSecondCR(input);
-                case HEADER_FOUND_CR_LF_CR -> resumeOrEndHeaders(input);
+                case INITIAL ->                                     state = State.STATUS_LINE;
+                case STATUS_LINE ->                                 readResumeStatusLine(input);
+                case STATUS_LINE_FOUND_CR, STATUS_LINE_FOUND_LF ->  readStatusLineFeed(input);
+                case STATUS_LINE_END ->                             maybeStartHeaders(input);
+                case STATUS_LINE_END_CR, STATUS_LINE_END_LF ->      maybeEndHeaders(input);
+                case HEADER ->                                      readResumeHeader(input);
+                case HEADER_FOUND_CR, HEADER_FOUND_LF ->            resumeOrLF(input);
+                case HEADER_FOUND_CR_LF ->                          resumeOrSecondCR(input);
+                case HEADER_FOUND_CR_LF_CR ->                       resumeOrEndHeaders(input);
+
                 default -> throw new InternalError("Unexpected state: " + state);
             }
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1HeaderParser.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1HeaderParser.java
@@ -116,42 +116,16 @@ class Http1HeaderParser {
 
         while (canContinueParsing(input)) {
             switch (state) {
-                case INITIAL:
-                    state = State.STATUS_LINE;
-                    break;
-                case STATUS_LINE:
-                    readResumeStatusLine(input);
-                    break;
-                // fallthrough
-                case STATUS_LINE_FOUND_CR:
-                case STATUS_LINE_FOUND_LF:
-                    readStatusLineFeed(input);
-                    break;
-                case STATUS_LINE_END:
-                    maybeStartHeaders(input);
-                    break;
-                // fallthrough
-                case STATUS_LINE_END_CR:
-                case STATUS_LINE_END_LF:
-                    maybeEndHeaders(input);
-                    break;
-                case HEADER:
-                    readResumeHeader(input);
-                    break;
-                // fallthrough
-                case HEADER_FOUND_CR:
-                case HEADER_FOUND_LF:
-                    resumeOrLF(input);
-                    break;
-                case HEADER_FOUND_CR_LF:
-                    resumeOrSecondCR(input);
-                    break;
-                case HEADER_FOUND_CR_LF_CR:
-                    resumeOrEndHeaders(input);
-                    break;
-                default:
-                    throw new InternalError(
-                            "Unexpected state: " + String.valueOf(state));
+                case INITIAL -> state = State.STATUS_LINE;
+                case STATUS_LINE -> readResumeStatusLine(input);
+                case STATUS_LINE_FOUND_CR, STATUS_LINE_FOUND_LF -> readStatusLineFeed(input);
+                case STATUS_LINE_END -> maybeStartHeaders(input);
+                case STATUS_LINE_END_CR, STATUS_LINE_END_LF -> maybeEndHeaders(input);
+                case HEADER -> readResumeHeader(input);
+                case HEADER_FOUND_CR, HEADER_FOUND_LF -> resumeOrLF(input);
+                case HEADER_FOUND_CR_LF -> resumeOrSecondCR(input);
+                case HEADER_FOUND_CR_LF_CR -> resumeOrEndHeaders(input);
+                default -> throw new InternalError("Unexpected state: " + state);
             }
         }
 
@@ -161,13 +135,11 @@ class Http1HeaderParser {
     private boolean canContinueParsing(ByteBuffer buffer) {
         // some states don't require any input to transition
         // to the next state.
-        switch (state) {
-            case FINISHED: return false;
-            case STATUS_LINE_FOUND_LF: return true;
-            case STATUS_LINE_END_LF: return true;
-            case HEADER_FOUND_LF: return true;
-            default: return buffer.hasRemaining();
-        }
+        return switch (state) {
+            case FINISHED -> false;
+            case STATUS_LINE_FOUND_LF, STATUS_LINE_END_LF, HEADER_FOUND_LF -> true;
+            default -> buffer.hasRemaining();
+        };
     }
 
     /**

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
@@ -578,7 +578,8 @@ class Http1Response<T> {
     Receiver<?> receiver(State state) {
         return switch (state) {
             case READING_HEADERS -> headersReader;
-            case READING_BODY -> bodyReader;
+            case READING_BODY ->    bodyReader;
+
             default -> null;
         };
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
@@ -577,8 +577,8 @@ class Http1Response<T> {
 
     Receiver<?> receiver(State state) {
         return switch (state) {
-            case READING_HEADERS -> headersReader;
-            case READING_BODY ->    bodyReader;
+            case READING_HEADERS    -> headersReader;
+            case READING_BODY       -> bodyReader;
 
             default -> null;
         };

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
@@ -576,11 +576,11 @@ class Http1Response<T> {
     }
 
     Receiver<?> receiver(State state) {
-        switch(state) {
-            case READING_HEADERS: return headersReader;
-            case READING_BODY: return bodyReader;
-            default: return null;
-        }
+        return switch (state) {
+            case READING_HEADERS -> headersReader;
+            case READING_BODY -> bodyReader;
+            default -> null;
+        };
 
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -866,10 +866,11 @@ class Http2Connection  {
         throws IOException
     {
         switch (frame.type()) {
-            case SettingsFrame.TYPE -> handleSettings((SettingsFrame) frame);
-            case PingFrame.TYPE -> handlePing((PingFrame) frame);
-            case GoAwayFrame.TYPE -> handleGoAway((GoAwayFrame) frame);
-            case WindowUpdateFrame.TYPE -> handleWindowUpdate((WindowUpdateFrame) frame);
+            case SettingsFrame.TYPE ->      handleSettings((SettingsFrame) frame);
+            case PingFrame.TYPE ->          handlePing((PingFrame) frame);
+            case GoAwayFrame.TYPE ->        handleGoAway((GoAwayFrame) frame);
+            case WindowUpdateFrame.TYPE ->  handleWindowUpdate((WindowUpdateFrame) frame);
+
             default -> protocolError(ErrorFrame.PROTOCOL_ERROR);
         }
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -866,20 +866,11 @@ class Http2Connection  {
         throws IOException
     {
         switch (frame.type()) {
-          case SettingsFrame.TYPE:
-              handleSettings((SettingsFrame)frame);
-              break;
-          case PingFrame.TYPE:
-              handlePing((PingFrame)frame);
-              break;
-          case GoAwayFrame.TYPE:
-              handleGoAway((GoAwayFrame)frame);
-              break;
-          case WindowUpdateFrame.TYPE:
-              handleWindowUpdate((WindowUpdateFrame)frame);
-              break;
-          default:
-            protocolError(ErrorFrame.PROTOCOL_ERROR);
+            case SettingsFrame.TYPE -> handleSettings((SettingsFrame) frame);
+            case PingFrame.TYPE -> handlePing((PingFrame) frame);
+            case GoAwayFrame.TYPE -> handleGoAway((GoAwayFrame) frame);
+            case WindowUpdateFrame.TYPE -> handleWindowUpdate((WindowUpdateFrame) frame);
+            default -> protocolError(ErrorFrame.PROTOCOL_ERROR);
         }
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -866,10 +866,10 @@ class Http2Connection  {
         throws IOException
     {
         switch (frame.type()) {
-            case SettingsFrame.TYPE ->      handleSettings((SettingsFrame) frame);
-            case PingFrame.TYPE ->          handlePing((PingFrame) frame);
-            case GoAwayFrame.TYPE ->        handleGoAway((GoAwayFrame) frame);
-            case WindowUpdateFrame.TYPE ->  handleWindowUpdate((WindowUpdateFrame) frame);
+            case SettingsFrame.TYPE     -> handleSettings((SettingsFrame) frame);
+            case PingFrame.TYPE         -> handlePing((PingFrame) frame);
+            case GoAwayFrame.TYPE       -> handleGoAway((GoAwayFrame) frame);
+            case WindowUpdateFrame.TYPE -> handleWindowUpdate((WindowUpdateFrame) frame);
 
             default -> protocolError(ErrorFrame.PROTOCOL_ERROR);
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/MultiExchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/MultiExchange.java
@@ -476,13 +476,10 @@ class MultiExchange<T> implements Cancelable {
     /** Returns true is given request has an idempotent method. */
     private static boolean isIdempotentRequest(HttpRequest request) {
         String method = request.method();
-        switch (method) {
-            case "GET" :
-            case "HEAD" :
-                return true;
-            default :
-                return false;
-        }
+        return switch (method) {
+            case "GET", "HEAD" -> true;
+            default -> false;
+        };
     }
 
     /** Returns true if the given request can be automatically retried. */

--- a/src/java.net.http/share/classes/jdk/internal/net/http/RedirectFilter.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/RedirectFilter.java
@@ -75,9 +75,10 @@ class RedirectFilter implements HeaderFilter {
 
     private static String redirectedMethod(int statusCode, String orig) {
         return switch (statusCode) {
-            case 301, 302 -> orig.equals("POST") ? "GET" : orig;
-            case 303 -> "GET";
-            case 307, 308 -> orig;
+            case 301, 302 ->    orig.equals("POST") ? "GET" : orig;
+            case 303 ->         "GET";
+            case 307, 308 ->    orig;
+
             default -> orig; // unexpected but return orig
         };
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/RedirectFilter.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/RedirectFilter.java
@@ -74,19 +74,12 @@ class RedirectFilter implements HeaderFilter {
     }
 
     private static String redirectedMethod(int statusCode, String orig) {
-        switch (statusCode) {
-            case 301:
-            case 302:
-                return orig.equals("POST") ? "GET" : orig;
-            case 303:
-                return "GET";
-            case 307:
-            case 308:
-                return orig;
-            default:
-                // unexpected but return orig
-                return orig;
-        }
+        return switch (statusCode) {
+            case 301, 302 -> orig.equals("POST") ? "GET" : orig;
+            case 303 -> "GET";
+            case 307, 308 -> orig;
+            default -> orig; // unexpected but return orig
+        };
     }
 
     private static boolean isRedirecting(int statusCode) {
@@ -95,23 +88,16 @@ class RedirectFilter implements HeaderFilter {
         // 309-399 Unassigned => don't follow
         // > 399: not a redirect code
         if (statusCode > 308) return false;
-        switch (statusCode) {
+
+        return switch (statusCode) {
             // 300: MultipleChoice => don't follow
-            case 300:
-                return false;
             // 304: Not Modified => don't follow
-            case 304:
-                return false;
             // 305: Proxy Redirect => don't follow.
-            case 305:
-                return false;
             // 306: Unused => don't follow
-            case 306:
-                return false;
+            case 300, 304, 305, 306 -> false;
             // 301, 302, 303, 307, 308: OK to follow.
-            default:
-                return true;
-        }
+            default -> true;
+        };
     }
 
     /**
@@ -158,16 +144,11 @@ class RedirectFilter implements HeaderFilter {
     private boolean canRedirect(URI redir) {
         String newScheme = redir.getScheme();
         String oldScheme = uri.getScheme();
-        switch (policy) {
-            case ALWAYS:
-                return true;
-            case NEVER:
-                return false;
-            case NORMAL:
-                return newScheme.equalsIgnoreCase(oldScheme)
-                        || newScheme.equalsIgnoreCase("https");
-            default:
-                throw new InternalError();
-        }
+        return switch (policy) {
+            case ALWAYS -> true;
+            case NEVER -> false;
+            case NORMAL -> newScheme.equalsIgnoreCase(oldScheme)
+                    || newScheme.equalsIgnoreCase("https");
+        };
     }
 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/RedirectFilter.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/RedirectFilter.java
@@ -75,9 +75,9 @@ class RedirectFilter implements HeaderFilter {
 
     private static String redirectedMethod(int statusCode, String orig) {
         return switch (statusCode) {
-            case 301, 302 ->    orig.equals("POST") ? "GET" : orig;
-            case 303 ->         "GET";
-            case 307, 308 ->    orig;
+            case 301, 302   -> orig.equals("POST") ? "GET" : orig;
+            case 303        -> "GET";
+            case 307, 308   -> orig;
 
             default -> orig; // unexpected but return orig
         };

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -452,8 +452,8 @@ class Stream<T> extends ExchangeImpl<T> {
     void otherFrame(Http2Frame frame) throws IOException {
         switch (frame.type()) {
             case WindowUpdateFrame.TYPE ->  incoming_windowUpdate((WindowUpdateFrame) frame);
-            case ResetFrame.TYPE ->         incoming_reset((ResetFrame) frame);
-            case PriorityFrame.TYPE ->      incoming_priority((PriorityFrame) frame);
+            case ResetFrame.TYPE        ->  incoming_reset((ResetFrame) frame);
+            case PriorityFrame.TYPE     ->  incoming_priority((PriorityFrame) frame);
 
             default -> throw new IOException("Unexpected frame: " + frame.toString());
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -451,9 +451,10 @@ class Stream<T> extends ExchangeImpl<T> {
 
     void otherFrame(Http2Frame frame) throws IOException {
         switch (frame.type()) {
-            case WindowUpdateFrame.TYPE -> incoming_windowUpdate((WindowUpdateFrame) frame);
-            case ResetFrame.TYPE -> incoming_reset((ResetFrame) frame);
-            case PriorityFrame.TYPE -> incoming_priority((PriorityFrame) frame);
+            case WindowUpdateFrame.TYPE ->  incoming_windowUpdate((WindowUpdateFrame) frame);
+            case ResetFrame.TYPE ->         incoming_reset((ResetFrame) frame);
+            case PriorityFrame.TYPE ->      incoming_priority((PriorityFrame) frame);
+
             default -> throw new IOException("Unexpected frame: " + frame.toString());
         }
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -451,18 +451,10 @@ class Stream<T> extends ExchangeImpl<T> {
 
     void otherFrame(Http2Frame frame) throws IOException {
         switch (frame.type()) {
-            case WindowUpdateFrame.TYPE:
-                incoming_windowUpdate((WindowUpdateFrame) frame);
-                break;
-            case ResetFrame.TYPE:
-                incoming_reset((ResetFrame) frame);
-                break;
-            case PriorityFrame.TYPE:
-                incoming_priority((PriorityFrame) frame);
-                break;
-            default:
-                String msg = "Unexpected frame: " + frame.toString();
-                throw new IOException(msg);
+            case WindowUpdateFrame.TYPE -> incoming_windowUpdate((WindowUpdateFrame) frame);
+            case ResetFrame.TYPE -> incoming_reset((ResetFrame) frame);
+            case PriorityFrame.TYPE -> incoming_priority((PriorityFrame) frame);
+            default -> throw new IOException("Unexpected frame: " + frame.toString());
         }
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
@@ -1022,7 +1022,8 @@ public class SSLFlowDelegate {
         int x = s & ~TASK_BITS;
         switch (x) {
             case NOT_HANDSHAKING -> sb.append(" NOT_HANDSHAKING ");
-            case HANDSHAKING -> sb.append(" HANDSHAKING ");
+            case HANDSHAKING ->     sb.append(" HANDSHAKING ");
+
             default -> throw new InternalError();
         }
         if ((s & DOING_TASKS) > 0)

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
@@ -1021,8 +1021,8 @@ public class SSLFlowDelegate {
         StringBuilder sb = new StringBuilder();
         int x = s & ~TASK_BITS;
         switch (x) {
-            case NOT_HANDSHAKING -> sb.append(" NOT_HANDSHAKING ");
-            case HANDSHAKING ->     sb.append(" HANDSHAKING ");
+            case NOT_HANDSHAKING    -> sb.append(" NOT_HANDSHAKING ");
+            case HANDSHAKING        -> sb.append(" HANDSHAKING ");
 
             default -> throw new InternalError();
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
@@ -1021,14 +1021,9 @@ public class SSLFlowDelegate {
         StringBuilder sb = new StringBuilder();
         int x = s & ~TASK_BITS;
         switch (x) {
-            case NOT_HANDSHAKING:
-                sb.append(" NOT_HANDSHAKING ");
-                break;
-            case HANDSHAKING:
-                sb.append(" HANDSHAKING ");
-                break;
-            default:
-                throw new InternalError();
+            case NOT_HANDSHAKING -> sb.append(" NOT_HANDSHAKING ");
+            case HANDSHAKING -> sb.append(" HANDSHAKING ");
+            default -> throw new InternalError();
         }
         if ((s & DOING_TASKS) > 0)
             sb.append("|DOING_TASKS");

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/DataFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/DataFrame.java
@@ -71,13 +71,11 @@ public class DataFrame extends Http2Frame {
 
     @Override
     public String flagAsString(int flag) {
-        switch (flag) {
-        case END_STREAM:
-            return "END_STREAM";
-        case PADDED:
-            return "PADDED";
-        }
-        return super.flagAsString(flag);
+        return switch (flag) {
+            case END_STREAM -> "END_STREAM";
+            case PADDED -> "PADDED";
+            default -> super.flagAsString(flag);
+        };
     }
 
     public List<ByteBuffer> getData() {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/DataFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/DataFrame.java
@@ -73,7 +73,7 @@ public class DataFrame extends Http2Frame {
     public String flagAsString(int flag) {
         return switch (flag) {
             case END_STREAM ->  "END_STREAM";
-            case PADDED ->      "PADDED";
+            case PADDED     ->  "PADDED";
 
             default -> super.flagAsString(flag);
         };

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/DataFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/DataFrame.java
@@ -72,8 +72,9 @@ public class DataFrame extends Http2Frame {
     @Override
     public String flagAsString(int flag) {
         return switch (flag) {
-            case END_STREAM -> "END_STREAM";
-            case PADDED -> "PADDED";
+            case END_STREAM ->  "END_STREAM";
+            case PADDED ->      "PADDED";
+
             default -> super.flagAsString(flag);
         };
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/FramesEncoder.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/FramesEncoder.java
@@ -60,16 +60,17 @@ public class FramesEncoder {
 
     public List<ByteBuffer> encodeFrame(Http2Frame frame) {
         return switch (frame.type()) {
-            case DataFrame.TYPE -> encodeDataFrame((DataFrame) frame);
-            case HeadersFrame.TYPE -> encodeHeadersFrame((HeadersFrame) frame);
-            case PriorityFrame.TYPE -> encodePriorityFrame((PriorityFrame) frame);
-            case ResetFrame.TYPE -> encodeResetFrame((ResetFrame) frame);
-            case SettingsFrame.TYPE -> encodeSettingsFrame((SettingsFrame) frame);
-            case PushPromiseFrame.TYPE -> encodePushPromiseFrame((PushPromiseFrame) frame);
-            case PingFrame.TYPE -> encodePingFrame((PingFrame) frame);
-            case GoAwayFrame.TYPE -> encodeGoAwayFrame((GoAwayFrame) frame);
-            case WindowUpdateFrame.TYPE -> encodeWindowUpdateFrame((WindowUpdateFrame) frame);
-            case ContinuationFrame.TYPE -> encodeContinuationFrame((ContinuationFrame) frame);
+            case DataFrame.TYPE ->          encodeDataFrame((DataFrame) frame);
+            case HeadersFrame.TYPE ->       encodeHeadersFrame((HeadersFrame) frame);
+            case PriorityFrame.TYPE ->      encodePriorityFrame((PriorityFrame) frame);
+            case ResetFrame.TYPE ->         encodeResetFrame((ResetFrame) frame);
+            case SettingsFrame.TYPE ->      encodeSettingsFrame((SettingsFrame) frame);
+            case PushPromiseFrame.TYPE ->   encodePushPromiseFrame((PushPromiseFrame) frame);
+            case PingFrame.TYPE ->          encodePingFrame((PingFrame) frame);
+            case GoAwayFrame.TYPE ->        encodeGoAwayFrame((GoAwayFrame) frame);
+            case WindowUpdateFrame.TYPE ->  encodeWindowUpdateFrame((WindowUpdateFrame) frame);
+            case ContinuationFrame.TYPE ->  encodeContinuationFrame((ContinuationFrame) frame);
+
             default -> throw new UnsupportedOperationException("Not supported frame " + frame.type() + " (" + frame.getClass().getName() + ")");
         };
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/FramesEncoder.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/FramesEncoder.java
@@ -59,30 +59,19 @@ public class FramesEncoder {
     }
 
     public List<ByteBuffer> encodeFrame(Http2Frame frame) {
-        switch (frame.type()) {
-            case DataFrame.TYPE:
-                return encodeDataFrame((DataFrame) frame);
-            case HeadersFrame.TYPE:
-                return encodeHeadersFrame((HeadersFrame) frame);
-            case PriorityFrame.TYPE:
-                return encodePriorityFrame((PriorityFrame) frame);
-            case ResetFrame.TYPE:
-                return encodeResetFrame((ResetFrame) frame);
-            case SettingsFrame.TYPE:
-                return encodeSettingsFrame((SettingsFrame) frame);
-            case PushPromiseFrame.TYPE:
-                return encodePushPromiseFrame((PushPromiseFrame) frame);
-            case PingFrame.TYPE:
-                return encodePingFrame((PingFrame) frame);
-            case GoAwayFrame.TYPE:
-                return encodeGoAwayFrame((GoAwayFrame) frame);
-            case WindowUpdateFrame.TYPE:
-                return encodeWindowUpdateFrame((WindowUpdateFrame) frame);
-            case ContinuationFrame.TYPE:
-                return encodeContinuationFrame((ContinuationFrame) frame);
-            default:
-                throw new UnsupportedOperationException("Not supported frame "+frame.type()+" ("+frame.getClass().getName()+")");
-        }
+        return switch (frame.type()) {
+            case DataFrame.TYPE -> encodeDataFrame((DataFrame) frame);
+            case HeadersFrame.TYPE -> encodeHeadersFrame((HeadersFrame) frame);
+            case PriorityFrame.TYPE -> encodePriorityFrame((PriorityFrame) frame);
+            case ResetFrame.TYPE -> encodeResetFrame((ResetFrame) frame);
+            case SettingsFrame.TYPE -> encodeSettingsFrame((SettingsFrame) frame);
+            case PushPromiseFrame.TYPE -> encodePushPromiseFrame((PushPromiseFrame) frame);
+            case PingFrame.TYPE -> encodePingFrame((PingFrame) frame);
+            case GoAwayFrame.TYPE -> encodeGoAwayFrame((GoAwayFrame) frame);
+            case WindowUpdateFrame.TYPE -> encodeWindowUpdateFrame((WindowUpdateFrame) frame);
+            case ContinuationFrame.TYPE -> encodeContinuationFrame((ContinuationFrame) frame);
+            default -> throw new UnsupportedOperationException("Not supported frame " + frame.type() + " (" + frame.getClass().getName() + ")");
+        };
     }
 
     private static final int NO_FLAGS = 0;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/HeaderFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/HeaderFrame.java
@@ -51,7 +51,8 @@ public abstract class HeaderFrame extends Http2Frame {
     public String flagAsString(int flag) {
         return switch (flag) {
             case END_HEADERS -> "END_HEADERS";
-            case END_STREAM -> "END_STREAM";
+            case END_STREAM ->  "END_STREAM";
+
             default -> super.flagAsString(flag);
         };
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/HeaderFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/HeaderFrame.java
@@ -51,7 +51,7 @@ public abstract class HeaderFrame extends Http2Frame {
     public String flagAsString(int flag) {
         return switch (flag) {
             case END_HEADERS -> "END_HEADERS";
-            case END_STREAM ->  "END_STREAM";
+            case END_STREAM  -> "END_STREAM";
 
             default -> super.flagAsString(flag);
         };

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/HeaderFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/HeaderFrame.java
@@ -49,13 +49,11 @@ public abstract class HeaderFrame extends Http2Frame {
 
     @Override
     public String flagAsString(int flag) {
-        switch (flag) {
-            case END_HEADERS:
-                return "END_HEADERS";
-            case END_STREAM:
-                return "END_STREAM";
-        }
-        return super.flagAsString(flag);
+        return switch (flag) {
+            case END_HEADERS -> "END_HEADERS";
+            case END_STREAM -> "END_STREAM";
+            default -> super.flagAsString(flag);
+        };
     }
 
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/HeadersFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/HeadersFrame.java
@@ -73,9 +73,10 @@ public class HeadersFrame extends HeaderFrame {
     @Override
     public String flagAsString(int flag) {
         return switch (flag) {
-            case END_STREAM -> "END_STREAM";
-            case PADDED -> "PADDED";
-            case PRIORITY -> "PRIORITY";
+            case END_STREAM ->  "END_STREAM";
+            case PADDED ->      "PADDED";
+            case PRIORITY ->    "PRIORITY";
+
             default -> super.flagAsString(flag);
         };
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/HeadersFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/HeadersFrame.java
@@ -73,9 +73,9 @@ public class HeadersFrame extends HeaderFrame {
     @Override
     public String flagAsString(int flag) {
         return switch (flag) {
-            case END_STREAM ->  "END_STREAM";
-            case PADDED ->      "PADDED";
-            case PRIORITY ->    "PRIORITY";
+            case END_STREAM -> "END_STREAM";
+            case PADDED     -> "PADDED";
+            case PRIORITY   -> "PRIORITY";
 
             default -> super.flagAsString(flag);
         };

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/HeadersFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/HeadersFrame.java
@@ -72,15 +72,12 @@ public class HeadersFrame extends HeaderFrame {
 
     @Override
     public String flagAsString(int flag) {
-        switch (flag) {
-            case END_STREAM:
-                return "END_STREAM";
-            case PADDED:
-                return "PADDED";
-            case PRIORITY:
-                return "PRIORITY";
-        }
-        return super.flagAsString(flag);
+        return switch (flag) {
+            case END_STREAM -> "END_STREAM";
+            case PADDED -> "PADDED";
+            case PRIORITY -> "PRIORITY";
+            default -> super.flagAsString(flag);
+        };
     }
 
     public void setPadLength(int padLength) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/Http2Frame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/Http2Frame.java
@@ -81,16 +81,16 @@ public abstract class Http2Frame {
 
     public static String asString(int type) {
         return switch (type) {
-            case DataFrame.TYPE ->          "DATA";
-            case HeadersFrame.TYPE ->       "HEADERS";
-            case ContinuationFrame.TYPE ->  "CONTINUATION";
-            case ResetFrame.TYPE ->         "RESET";
-            case PriorityFrame.TYPE ->      "PRIORITY";
-            case SettingsFrame.TYPE ->      "SETTINGS";
-            case GoAwayFrame.TYPE ->        "GOAWAY";
-            case PingFrame.TYPE ->          "PING";
-            case PushPromiseFrame.TYPE ->   "PUSH_PROMISE";
-            case WindowUpdateFrame.TYPE ->  "WINDOW_UPDATE";
+            case DataFrame.TYPE         -> "DATA";
+            case HeadersFrame.TYPE      -> "HEADERS";
+            case ContinuationFrame.TYPE -> "CONTINUATION";
+            case ResetFrame.TYPE        -> "RESET";
+            case PriorityFrame.TYPE     -> "PRIORITY";
+            case SettingsFrame.TYPE     -> "SETTINGS";
+            case GoAwayFrame.TYPE       -> "GOAWAY";
+            case PingFrame.TYPE         -> "PING";
+            case PushPromiseFrame.TYPE  -> "PUSH_PROMISE";
+            case WindowUpdateFrame.TYPE -> "WINDOW_UPDATE";
 
             default -> "UNKNOWN";
         };

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/Http2Frame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/Http2Frame.java
@@ -80,30 +80,19 @@ public abstract class Http2Frame {
 
 
     public static String asString(int type) {
-        switch (type) {
-          case DataFrame.TYPE:
-            return "DATA";
-          case HeadersFrame.TYPE:
-            return "HEADERS";
-          case ContinuationFrame.TYPE:
-            return "CONTINUATION";
-          case ResetFrame.TYPE:
-            return "RESET";
-          case PriorityFrame.TYPE:
-            return "PRIORITY";
-          case SettingsFrame.TYPE:
-            return "SETTINGS";
-          case GoAwayFrame.TYPE:
-            return "GOAWAY";
-          case PingFrame.TYPE:
-            return "PING";
-          case PushPromiseFrame.TYPE:
-            return "PUSH_PROMISE";
-          case WindowUpdateFrame.TYPE:
-            return "WINDOW_UPDATE";
-          default:
-            return "UNKNOWN";
-        }
+        return switch (type) {
+            case DataFrame.TYPE -> "DATA";
+            case HeadersFrame.TYPE -> "HEADERS";
+            case ContinuationFrame.TYPE -> "CONTINUATION";
+            case ResetFrame.TYPE -> "RESET";
+            case PriorityFrame.TYPE -> "PRIORITY";
+            case SettingsFrame.TYPE -> "SETTINGS";
+            case GoAwayFrame.TYPE -> "GOAWAY";
+            case PingFrame.TYPE -> "PING";
+            case PushPromiseFrame.TYPE -> "PUSH_PROMISE";
+            case WindowUpdateFrame.TYPE -> "WINDOW_UPDATE";
+            default -> "UNKNOWN";
+        };
     }
 
     @Override

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/Http2Frame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/Http2Frame.java
@@ -81,16 +81,17 @@ public abstract class Http2Frame {
 
     public static String asString(int type) {
         return switch (type) {
-            case DataFrame.TYPE -> "DATA";
-            case HeadersFrame.TYPE -> "HEADERS";
-            case ContinuationFrame.TYPE -> "CONTINUATION";
-            case ResetFrame.TYPE -> "RESET";
-            case PriorityFrame.TYPE -> "PRIORITY";
-            case SettingsFrame.TYPE -> "SETTINGS";
-            case GoAwayFrame.TYPE -> "GOAWAY";
-            case PingFrame.TYPE -> "PING";
-            case PushPromiseFrame.TYPE -> "PUSH_PROMISE";
-            case WindowUpdateFrame.TYPE -> "WINDOW_UPDATE";
+            case DataFrame.TYPE ->          "DATA";
+            case HeadersFrame.TYPE ->       "HEADERS";
+            case ContinuationFrame.TYPE ->  "CONTINUATION";
+            case ResetFrame.TYPE ->         "RESET";
+            case PriorityFrame.TYPE ->      "PRIORITY";
+            case SettingsFrame.TYPE ->      "SETTINGS";
+            case GoAwayFrame.TYPE ->        "GOAWAY";
+            case PingFrame.TYPE ->          "PING";
+            case PushPromiseFrame.TYPE ->   "PUSH_PROMISE";
+            case WindowUpdateFrame.TYPE ->  "WINDOW_UPDATE";
+
             default -> "UNKNOWN";
         };
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/PingFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/PingFrame.java
@@ -53,11 +53,10 @@ public class PingFrame extends Http2Frame {
 
     @Override
     public String flagAsString(int flag) {
-        switch (flag) {
-        case ACK:
-            return "ACK";
-        }
-        return super.flagAsString(flag);
+        return switch (flag) {
+            case ACK -> "ACK";
+            default -> super.flagAsString(flag);
+        };
     }
 
     public byte[] getData() {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/PushPromiseFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/PushPromiseFrame.java
@@ -66,7 +66,7 @@ public class PushPromiseFrame extends HeaderFrame {
     @Override
     public String flagAsString(int flag) {
         return switch (flag) {
-            case PADDED ->      "PADDED";
+            case PADDED      -> "PADDED";
             case END_HEADERS -> "END_HEADERS";
 
             default -> super.flagAsString(flag);

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/PushPromiseFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/PushPromiseFrame.java
@@ -66,8 +66,9 @@ public class PushPromiseFrame extends HeaderFrame {
     @Override
     public String flagAsString(int flag) {
         return switch (flag) {
-            case PADDED -> "PADDED";
+            case PADDED ->      "PADDED";
             case END_HEADERS -> "END_HEADERS";
+
             default -> super.flagAsString(flag);
         };
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/PushPromiseFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/PushPromiseFrame.java
@@ -65,13 +65,11 @@ public class PushPromiseFrame extends HeaderFrame {
 
     @Override
     public String flagAsString(int flag) {
-        switch (flag) {
-            case PADDED:
-                return "PADDED";
-            case END_HEADERS:
-                return "END_HEADERS";
-        }
-        return super.flagAsString(flag);
+        return switch (flag) {
+            case PADDED -> "PADDED";
+            case END_HEADERS -> "END_HEADERS";
+            default -> super.flagAsString(flag);
+        };
     }
 
     public void setPadLength(int padLength) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/SettingsFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/SettingsFrame.java
@@ -39,11 +39,10 @@ public class SettingsFrame extends Http2Frame {
 
     @Override
     public String flagAsString(int flag) {
-        switch (flag) {
-        case ACK:
-            return "ACK";
-        }
-        return super.flagAsString(flag);
+        return switch (flag) {
+            case ACK -> "ACK";
+            default -> super.flagAsString(flag);
+        };
     }
 
     @Override
@@ -72,21 +71,15 @@ public class SettingsFrame extends Http2Frame {
     public static final int MAX_HEADER_LIST_SIZE = 0x6;
 
     private String name(int i) {
-        switch (i+1) {
-        case HEADER_TABLE_SIZE:
-            return "HEADER_TABLE_SIZE";
-        case ENABLE_PUSH:
-            return "ENABLE_PUSH";
-        case MAX_CONCURRENT_STREAMS:
-            return "MAX_CONCURRENT_STREAMS";
-        case INITIAL_WINDOW_SIZE:
-            return "INITIAL_WINDOW_SIZE";
-        case MAX_FRAME_SIZE:
-            return "MAX_FRAME_SIZE";
-        case MAX_HEADER_LIST_SIZE:
-            return "MAX_HEADER_LIST_SIZE";
-        }
-        return "unknown parameter";
+        return switch (i + 1) {
+            case HEADER_TABLE_SIZE -> "HEADER_TABLE_SIZE";
+            case ENABLE_PUSH -> "ENABLE_PUSH";
+            case MAX_CONCURRENT_STREAMS -> "MAX_CONCURRENT_STREAMS";
+            case INITIAL_WINDOW_SIZE -> "INITIAL_WINDOW_SIZE";
+            case MAX_FRAME_SIZE -> "MAX_FRAME_SIZE";
+            case MAX_HEADER_LIST_SIZE -> "MAX_HEADER_LIST_SIZE";
+            default -> "unknown parameter";
+        };
     }
     public static final int MAX_PARAM = 0x6;
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/SettingsFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/SettingsFrame.java
@@ -72,12 +72,13 @@ public class SettingsFrame extends Http2Frame {
 
     private String name(int i) {
         return switch (i + 1) {
-            case HEADER_TABLE_SIZE -> "HEADER_TABLE_SIZE";
-            case ENABLE_PUSH -> "ENABLE_PUSH";
-            case MAX_CONCURRENT_STREAMS -> "MAX_CONCURRENT_STREAMS";
-            case INITIAL_WINDOW_SIZE -> "INITIAL_WINDOW_SIZE";
-            case MAX_FRAME_SIZE -> "MAX_FRAME_SIZE";
-            case MAX_HEADER_LIST_SIZE -> "MAX_HEADER_LIST_SIZE";
+            case HEADER_TABLE_SIZE ->       "HEADER_TABLE_SIZE";
+            case ENABLE_PUSH ->             "ENABLE_PUSH";
+            case MAX_CONCURRENT_STREAMS ->  "MAX_CONCURRENT_STREAMS";
+            case INITIAL_WINDOW_SIZE ->     "INITIAL_WINDOW_SIZE";
+            case MAX_FRAME_SIZE ->          "MAX_FRAME_SIZE";
+            case MAX_HEADER_LIST_SIZE ->    "MAX_HEADER_LIST_SIZE";
+            
             default -> "unknown parameter";
         };
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/SettingsFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/SettingsFrame.java
@@ -72,13 +72,13 @@ public class SettingsFrame extends Http2Frame {
 
     private String name(int i) {
         return switch (i + 1) {
-            case HEADER_TABLE_SIZE ->       "HEADER_TABLE_SIZE";
-            case ENABLE_PUSH ->             "ENABLE_PUSH";
-            case MAX_CONCURRENT_STREAMS ->  "MAX_CONCURRENT_STREAMS";
-            case INITIAL_WINDOW_SIZE ->     "INITIAL_WINDOW_SIZE";
-            case MAX_FRAME_SIZE ->          "MAX_FRAME_SIZE";
-            case MAX_HEADER_LIST_SIZE ->    "MAX_HEADER_LIST_SIZE";
-            
+            case HEADER_TABLE_SIZE      -> "HEADER_TABLE_SIZE";
+            case ENABLE_PUSH            -> "ENABLE_PUSH";
+            case MAX_CONCURRENT_STREAMS -> "MAX_CONCURRENT_STREAMS";
+            case INITIAL_WINDOW_SIZE    -> "INITIAL_WINDOW_SIZE";
+            case MAX_FRAME_SIZE         -> "MAX_FRAME_SIZE";
+            case MAX_HEADER_LIST_SIZE   -> "MAX_HEADER_LIST_SIZE";
+
             default -> "unknown parameter";
         };
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/hpack/Decoder.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/hpack/Decoder.java
@@ -257,26 +257,13 @@ public final class Decoder {
     private void proceed(ByteBuffer input, DecodingCallback action)
             throws IOException {
         switch (state) {
-            case READY:
-                resumeReady(input);
-                break;
-            case INDEXED:
-                resumeIndexed(input, action);
-                break;
-            case LITERAL:
-                resumeLiteral(input, action);
-                break;
-            case LITERAL_WITH_INDEXING:
-                resumeLiteralWithIndexing(input, action);
-                break;
-            case LITERAL_NEVER_INDEXED:
-                resumeLiteralNeverIndexed(input, action);
-                break;
-            case SIZE_UPDATE:
-                resumeSizeUpdate(input, action);
-                break;
-            default:
-                throw new InternalError("Unexpected decoder state: " + state);
+            case READY -> resumeReady(input);
+            case INDEXED -> resumeIndexed(input, action);
+            case LITERAL -> resumeLiteral(input, action);
+            case LITERAL_WITH_INDEXING -> resumeLiteralWithIndexing(input, action);
+            case LITERAL_NEVER_INDEXED -> resumeLiteralNeverIndexed(input, action);
+            case SIZE_UPDATE -> resumeSizeUpdate(input, action);
+            default -> throw new InternalError("Unexpected decoder state: " + state);
         }
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/hpack/Decoder.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/hpack/Decoder.java
@@ -257,12 +257,13 @@ public final class Decoder {
     private void proceed(ByteBuffer input, DecodingCallback action)
             throws IOException {
         switch (state) {
-            case READY -> resumeReady(input);
-            case INDEXED -> resumeIndexed(input, action);
-            case LITERAL -> resumeLiteral(input, action);
-            case LITERAL_WITH_INDEXING -> resumeLiteralWithIndexing(input, action);
-            case LITERAL_NEVER_INDEXED -> resumeLiteralNeverIndexed(input, action);
-            case SIZE_UPDATE -> resumeSizeUpdate(input, action);
+            case READY ->                   resumeReady(input);
+            case INDEXED ->                 resumeIndexed(input, action);
+            case LITERAL ->                 resumeLiteral(input, action);
+            case LITERAL_WITH_INDEXING ->   resumeLiteralWithIndexing(input, action);
+            case LITERAL_NEVER_INDEXED ->   resumeLiteralNeverIndexed(input, action);
+            case SIZE_UPDATE ->             resumeSizeUpdate(input, action);
+
             default -> throw new InternalError("Unexpected decoder state: " + state);
         }
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/hpack/Decoder.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/hpack/Decoder.java
@@ -257,12 +257,12 @@ public final class Decoder {
     private void proceed(ByteBuffer input, DecodingCallback action)
             throws IOException {
         switch (state) {
-            case READY ->                   resumeReady(input);
-            case INDEXED ->                 resumeIndexed(input, action);
-            case LITERAL ->                 resumeLiteral(input, action);
-            case LITERAL_WITH_INDEXING ->   resumeLiteralWithIndexing(input, action);
-            case LITERAL_NEVER_INDEXED ->   resumeLiteralNeverIndexed(input, action);
-            case SIZE_UPDATE ->             resumeSizeUpdate(input, action);
+            case READY                  ->  resumeReady(input);
+            case INDEXED                ->  resumeIndexed(input, action);
+            case LITERAL                ->  resumeLiteral(input, action);
+            case LITERAL_WITH_INDEXING  ->  resumeLiteralWithIndexing(input, action);
+            case LITERAL_NEVER_INDEXED  ->  resumeLiteralNeverIndexed(input, action);
+            case SIZE_UPDATE            ->  resumeSizeUpdate(input, action);
 
             default -> throw new InternalError("Unexpected decoder state: " + state);
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/websocket/StatusCodes.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/websocket/StatusCodes.java
@@ -49,19 +49,11 @@ final class StatusCodes {
             return false;
         }
         // Codes below are not allowed to be sent using a WebSocket client API
-        switch (code) {
-            case PROTOCOL_ERROR:
-            case NOT_CONSISTENT:
-            case 1003:
-            case 1009:
-            case 1010:
-            case 1012:  // code sent by servers
-            case 1013:  // code sent by servers
-            case 1014:  // code sent by servers
-                return false;
-            default:
-                return true;
-        }
+        return switch (code) {
+            // 1012, 1013, 1014: codes sent by servers
+            case PROTOCOL_ERROR, NOT_CONSISTENT, 1003, 1009, 1010, 1012, 1013, 1014 -> false;
+            default -> true;
+        };
     }
 
     static boolean isLegalToReceiveFromServer(int code) {
@@ -84,13 +76,9 @@ final class StatusCodes {
         }
         // Codes below cannot appear on the wire. It's always an error either
         // to send a frame with such a code or to receive one.
-        switch (code) {
-            case NO_STATUS_CODE:
-            case CLOSED_ABNORMALLY:
-            case 1015:
-                return false;
-            default:
-                return true;
-        }
+        return switch (code) {
+            case NO_STATUS_CODE, CLOSED_ABNORMALLY, 1015 -> false;
+            default -> true;
+        };
     }
 }


### PR DESCRIPTION
Hi!
Kindly review this patch to replace switch statements with switch expressions (where it makes sense) in the http client modules. The rationale is to improve readability of the code.
Regards,
Kartik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257401](https://bugs.openjdk.java.net/browse/JDK-8257401): Use switch expressions in jdk.internal.net.http and java.net.http


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to 3e66742742df0cf2e87740940a5a3cf2240d9281
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * pconcannon - Committer ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1364/head:pull/1364`
`$ git checkout pull/1364`
