### PR TITLE
8256824: test/langtools/tools/javac/diags/examples/InnerClassCantHaveStatic.java has a bad copyright

### DIFF
--- a/test/langtools/tools/javac/diags/examples/InnerClassCantHaveStatic.java
+++ b/test/langtools/tools/javac/diags/examples/InnerClassCantHaveStatic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Add missing comma in copyright text for test/langtools/tools/javac/diags/examples/InnerClassCantHaveStatic.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256824](https://bugs.openjdk.java.net/browse/JDK-8256824): test/langtools/tools/javac/diags/examples/InnerClassCantHaveStatic.java has a bad copyright


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1366/head:pull/1366`
`$ git checkout pull/1366`
