### PR TITLE
8256825: Cleanup WeakProcessorPhaseTimes

### DIFF
--- a/src/hotspot/share/gc/shared/weakProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/weakProcessorPhaseTimes.cpp
@@ -172,27 +172,27 @@ static const char* indent_str(size_t i) {
 
 #define TIME_FORMAT "%.1lfms"
 
-void WeakProcessorPhaseTimes::log_mt_phase_summary(WeakProcessorPhase phase,
-                                                   uint indent) const {
+void WeakProcessorPhaseTimes::log_phase_summary(WeakProcessorPhase phase,
+                                                uint indent) const {
   LogTarget(Debug, gc, phases) lt;
   LogStream ls(lt);
   ls.print("%s", indents[indent]);
   worker_data(phase)->print_summary_on(&ls, true);
-  log_mt_phase_details(worker_data(phase), indent + 1);
+  log_phase_details(worker_data(phase), indent + 1);
 
   for (uint i = 0; i < worker_data(phase)->MaxThreadWorkItems; i++) {
     WorkerDataArray<size_t>* work_items = worker_data(phase)->thread_work_items(i);
     if (work_items != NULL) {
       ls.print("%s", indents[indent + 1]);
       work_items->print_summary_on(&ls, true);
-      log_mt_phase_details(work_items, indent + 1);
+      log_phase_details(work_items, indent + 1);
     }
   }
 }
 
 template <typename T>
-void WeakProcessorPhaseTimes::log_mt_phase_details(WorkerDataArray<T>* data,
-                                                   uint indent) const {
+void WeakProcessorPhaseTimes::log_phase_details(WorkerDataArray<T>* data,
+                                                uint indent) const {
   LogTarget(Trace, gc, phases) lt;
   if (lt.is_enabled()) {
     LogStream ls(lt);
@@ -205,7 +205,7 @@ void WeakProcessorPhaseTimes::log_print_phases(uint indent) const {
   if (log_is_enabled(Debug, gc, phases)) {
     typedef WeakProcessorPhases::Iterator Iterator;
     for (Iterator it = WeakProcessorPhases::oopstorage_iterator(); !it.is_end(); ++it) {
-      log_mt_phase_summary(*it, indent);
+      log_phase_summary(*it, indent);
     }
   }
 }

--- a/src/hotspot/share/gc/shared/weakProcessorPhaseTimes.hpp
+++ b/src/hotspot/share/gc/shared/weakProcessorPhaseTimes.hpp
@@ -32,7 +32,7 @@
 
 template<typename T> class WorkerDataArray;
 
-class WeakProcessorPhaseTimes : public CHeapObj<mtGC> {
+class WeakProcessorPhaseTimes {
   enum {
     DeadItems,
     TotalItems
@@ -49,10 +49,9 @@ class WeakProcessorPhaseTimes : public CHeapObj<mtGC> {
 
   WorkerDataArray<double>* worker_data(WeakProcessorPhase phase) const;
 
-  void log_st_phase(WeakProcessorPhase phase, uint indent) const;
-  void log_mt_phase_summary(WeakProcessorPhase phase, uint indent) const;
+  void log_phase_summary(WeakProcessorPhase phase, uint indent) const;
   template <typename T>
-  void log_mt_phase_details(WorkerDataArray<T>* data, uint indent) const;
+  void log_phase_details(WorkerDataArray<T>* data, uint indent) const;
 
 public:
   WeakProcessorPhaseTimes(uint max_threads);
@@ -63,12 +62,9 @@ public:
   void set_active_workers(uint n);
 
   double total_time_sec() const;
-  double phase_time_sec(WeakProcessorPhase phase) const;
   double worker_time_sec(uint worker_id, WeakProcessorPhase phase) const;
 
   void record_total_time_sec(double time_sec);
-  void record_phase_time_sec(WeakProcessorPhase phase, double time_sec);
-  void record_phase_items(WeakProcessorPhase phase, size_t num_dead, size_t num_total);
   void record_worker_time_sec(uint worker_id, WeakProcessorPhase phase, double time_sec);
   void record_worker_items(uint worker_id, WeakProcessorPhase phase, size_t num_dead, size_t num_total);
 


### PR DESCRIPTION
Please review this cleanup of WeakProcessorPhaseTimes.  After JDK-8212879
there are several functions declared but no longer used or even defined.
There are also some naming conventions that no longer make sense.

Testing:
mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256825](https://bugs.openjdk.java.net/browse/JDK-8256825): Cleanup WeakProcessorPhaseTimes


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1367/head:pull/1367`
`$ git checkout pull/1367`
