### PR TITLE
8256822: runtime/logging/RedefineClasses.java fails with "Error: VM option 'Verbose' is develop and is available only in debug version of VM."

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/RedefineClasses.java
+++ b/test/hotspot/jtreg/runtime/logging/RedefineClasses.java
@@ -31,7 +31,7 @@
  *          java.instrument
  * @requires vm.jvmti
  * @run main RedefineClassHelper
- * @run main/othervm -Xmx256m -XX:MaxMetaspaceSize=64m -javaagent:redefineagent.jar -XX:+Verbose -Xlog:all=trace:file=all.log RedefineClasses
+ * @run main/othervm -Xmx256m -XX:MaxMetaspaceSize=64m -javaagent:redefineagent.jar -Xlog:all=trace:file=all.log RedefineClasses
  */
 
 // package access top-level class to avoid problem with RedefineClassHelper


### PR DESCRIPTION
Remove -XX:+Verbose from this test.
I could leave it on and add -XX:+IgnoreUnrecognizedVMOptions if people prefer that.  The runtime/logging/TestMethodHandlesVerbose.java also tested JDK-8246378, but this one has some output that I was verifying manually.
thanks
Coleen

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x64 (hs/tier1 runtime)](https://github.com/coleenp/jdk/runs/1436466756)

### Issue
 * [JDK-8256822](https://bugs.openjdk.java.net/browse/JDK-8256822): runtime/logging/RedefineClasses.java fails with "Error: VM option 'Verbose' is develop and is available only in debug version of VM."


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1368/head:pull/1368`
`$ git checkout pull/1368`
