### PR TITLE
6508941: java.awt.Desktop.open causes VM to crash with video files sporadically

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,13 +85,24 @@ JNIEXPORT jstring JNICALL Java_sun_awt_windows_WDesktopPeer_ShellExecute
 
     // 6457572: ShellExecute possibly changes FPU control word - saving it here
     unsigned oldcontrol87 = _control87(0, 0);
-    HINSTANCE retval = ::ShellExecute(NULL, verb_c, fileOrUri_c, NULL, NULL, SW_SHOWNORMAL);
-    DWORD error = ::GetLastError();
+    HRESULT hr = ::CoInitializeEx(NULL, COINIT_APARTMENTTHREADED |
+                                        COINIT_DISABLE_OLE1DDE);
+    HINSTANCE retval;
+    DWORD error;
+    if (SUCCEEDED(hr)) {
+        retval = ::ShellExecute(NULL, verb_c, fileOrUri_c, NULL, NULL,
+                                SW_SHOWNORMAL);
+        error = ::GetLastError();
+        ::CoUninitialize();
+    }
     _control87(oldcontrol87, 0xffffffff);
 
     JNU_ReleaseStringPlatformChars(env, fileOrUri_j, fileOrUri_c);
     JNU_ReleaseStringPlatformChars(env, verb_j, verb_c);
 
+    if (FAILED(hr)) {
+        return JNU_NewStringPlatform(env, L"CoInitializeEx() failed.");
+    }
     if ((int)((intptr_t)retval) <= 32) {
         // ShellExecute failed.
         LPTSTR buffer = NULL;


### PR DESCRIPTION
The report of this bug quite outdated so can be closed but I found that in the documentation:
https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shellexecutea

> Because ShellExecute can delegate execution to Shell extensions (data sources, context menu handlers, verb implementations) that are activated using Component Object Model (COM), COM should be initialized before ShellExecute is called. Some Shell extensions require the COM single-threaded apartment (STA) type. In that case, COM should be initialized as shown here: CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)

But this CoInitializeEx is missed in the Desktop class. Absent of this initialization caused some other crashes in past, see JDK-6950553 for example:
https://bugs.openjdk.java.net/browse/JDK-6950553

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6508941](https://bugs.openjdk.java.net/browse/JDK-6508941): java.awt.Desktop.open causes VM to crash with video files sporadically


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1369/head:pull/1369`
`$ git checkout pull/1369`
