### PR TITLE
8196086: java/awt/image/DrawImage/IncorrectSourceOffset.java fails	

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -250,10 +250,7 @@ java/awt/font/TextLayout/TextLayoutBounds.java 8169188 generic-all
 java/awt/font/StyledMetrics/BoldSpace.java 8198422 linux-all
 java/awt/FontMetrics/FontCrash.java 8198336 windows-all
 java/awt/image/BufferedImage/ICMColorDataTest/ICMColorDataTest.java 8233028 generic-all
-java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java 8056077 generic-all
-java/awt/image/DrawImage/IncorrectClipXorModeSW2Surface.java 8196025 windows-all
-java/awt/image/DrawImage/IncorrectClipXorModeSurface2Surface.java 8196025 windows-all
-java/awt/image/DrawImage/IncorrectSourceOffset.java 8196086 windows-all
+java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java 8056077 linux-all
 java/awt/image/DrawImage/BlitRotateClippedArea.java 8255724 linux-all
 java/awt/image/MultiResolutionImage/MultiResolutionDrawImageWithTransformTest.java 8198390 generic-all
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8169187 macosx-all,windows-all

--- a/test/jdk/java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java
+++ b/test/jdk/java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java
@@ -47,7 +47,10 @@ import static java.awt.image.BufferedImage.TYPE_INT_ARGB_PRE;
  * @summary Tests drawing transparent volatile image to transparent BI.
  *          Results of the blit compatibleImage to transparent BI used for
  *          comparison.
- * @author Sergey Bylokhov
+ * @run main/othervm -Dsun.java2d.uiScale=1 IncorrectAlphaSurface2SW
+ * @run main/othervm -Dsun.java2d.uiScale=2 IncorrectAlphaSurface2SW
+ * @run main/othervm -Dsun.java2d.uiScale=3 IncorrectAlphaSurface2SW
+ * @run main/othervm -Dsun.java2d.uiScale=4 IncorrectAlphaSurface2SW
  */
 public final class IncorrectAlphaSurface2SW {
 

--- a/test/jdk/java/awt/image/DrawImage/IncorrectClipXorModeSW2Surface.java
+++ b/test/jdk/java/awt/image/DrawImage/IncorrectClipXorModeSW2Surface.java
@@ -48,7 +48,9 @@ import static java.awt.geom.Rectangle2D.Double;
  * @bug 8061456
  * @summary Tests drawing BI to volatile image using different clips + xor mode.
  *          Results of the blit BI to compatibleImage is used for comparison.
- * @author Sergey Bylokhov
+ * @run main/othervm -Dsun.java2d.uiScale=1 IncorrectClipXorModeSW2Surface
+ * @run main/othervm -Dsun.java2d.uiScale=2 IncorrectClipXorModeSW2Surface
+ * @run main/othervm -Dsun.java2d.uiScale=4 IncorrectClipXorModeSW2Surface
  */
 public final class IncorrectClipXorModeSW2Surface {
 

--- a/test/jdk/java/awt/image/DrawImage/IncorrectClipXorModeSurface2Surface.java
+++ b/test/jdk/java/awt/image/DrawImage/IncorrectClipXorModeSurface2Surface.java
@@ -45,6 +45,9 @@ import static java.awt.geom.Rectangle2D.Double;
  * @summary Tests drawing volatile image to volatile image using different
  *          clips + xor mode. Results of the blit compatibleImage to
  *          compatibleImage is used for comparison.
+ * @run main/othervm -Dsun.java2d.uiScale=1 IncorrectClipXorModeSurface2Surface
+ * @run main/othervm -Dsun.java2d.uiScale=2 IncorrectClipXorModeSurface2Surface
+ * @run main/othervm -Dsun.java2d.uiScale=4 IncorrectClipXorModeSurface2Surface
  */
 public final class IncorrectClipXorModeSurface2Surface {
 

--- a/test/jdk/java/awt/image/DrawImage/IncorrectSourceOffset.java
+++ b/test/jdk/java/awt/image/DrawImage/IncorrectSourceOffset.java
@@ -39,7 +39,10 @@ import javax.imageio.ImageIO;
  * @key headful
  * @bug 8041129
  * @summary Tests asymmetric source offsets.
- * @author Sergey Bylokhov
+ * @run main/othervm -Dsun.java2d.uiScale=1 IncorrectSourceOffset
+ * @run main/othervm -Dsun.java2d.uiScale=2 IncorrectSourceOffset
+ * @run main/othervm -Dsun.java2d.uiScale=3 IncorrectSourceOffset
+ * @run main/othervm -Dsun.java2d.uiScale=4 IncorrectSourceOffset
  */
 public final class IncorrectSourceOffset {
 


### PR DESCRIPTION
These tests draw some specific pattern to the VolatileImage and to the BufferedImage, and then compare pixels.

The test uses the getSnapshot() method to get the pixels from VolatileImage, and this method produces some interpolation "artifacts" if the fractional scale is used in the system(like 125%).

The solution is to use some predefined scale to pass the tests, to reproduce initial bug scale=1 is enough.
One test fails because of the bug in the XRender pipeline.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8196086](https://bugs.openjdk.java.net/browse/JDK-8196086): java/awt/image/DrawImage/IncorrectSourceOffset.java fails


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1372/head:pull/1372`
`$ git checkout pull/1372`
