### PR TITLE
8256829: GNU hash style is not available on MIPS

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -66,7 +66,7 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
     # Add -z,defs, to forbid undefined symbols in object files.
     # add -z,relro (mark relocations read only) for all libs
     # add -z,now ("full relro" - more of the Global Offset Table GOT is marked read only)
-    BASIC_LDFLAGS="-Wl,--hash-style=gnu -Wl,-z,defs -Wl,-z,relro -Wl,-z,now"
+    BASIC_LDFLAGS="-Wl,-z,defs -Wl,-z,relro -Wl,-z,now"
     # Linux : remove unused code+data in link step
     if test "x$ENABLE_LINKTIME_GC" = xtrue; then
       if test "x$OPENJDK_TARGET_CPU" = xs390x; then
@@ -162,6 +162,16 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_CPU_DEP],
     elif test "x$OPENJDK_$1_CPU" = xarm; then
       $1_CPU_LDFLAGS_JVM_ONLY="${$1_CPU_LDFLAGS_JVM_ONLY} -fsigned-char"
       $1_CPU_LDFLAGS="$ARM_ARCH_TYPE_FLAGS $ARM_FLOAT_TYPE_FLAGS"
+    fi
+
+    # MIPS ABI does not support GNU hash style
+    if test "x${OPENJDK_$1_CPU}" = xmips ||
+       test "x${OPENJDK_$1_CPU}" = xmipsel ||
+       test "x${OPENJDK_$1_CPU}" = xmips64 ||
+       test "x${OPENJDK_$1_CPU}" = xmips64el; then
+      $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=sysv"
+    else
+      $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=gnu"
     fi
 
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then


### PR DESCRIPTION
For fun, I tried to build `linux-mips64el-zero-fastdebug`, and it cannot be built, because linker complains:

```
/usr/lib/gcc-cross/mips64el-linux-gnuabi64/6/../../../../mips64el-linux-gnuabi64/bin/ld: .gnu.hash is incompatible with the MIPS ABI
collect2: error: ld returned 1 exit status
```

I believe it is a regression in 16, as GNU hash style was forced with [JDK-8200738](https://bugs.openjdk.java.net/browse/JDK-8200738). The way out is to special-case MIPS hash-style to `sysv`. This enumerates all MIPS targets that `make/autoconf/platform.m4` knows about.

Attention @DamonFool, who must be running into this problem for their MIPS builds?

Testing:
 - [x] Linux mipsel zero fastdebug build (requires additional unrelated fixes)
 - [x] Linux mips64el zero fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256829](https://bugs.openjdk.java.net/browse/JDK-8256829): GNU hash style is not available on MIPS


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * aoqi - Author ⚠️ Added manually
 * glaubitz - Committer ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1374/head:pull/1374`
`$ git checkout pull/1374`
