### PR TITLE
8256832: Zero: micro-optimize safepoint handling after JDK-8255384

### DIFF
--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -102,15 +102,12 @@
   There really shouldn't be any handles remaining to trash but this is cheap
   in relation to a safepoint.
 */
-#define SAFEPOINT                                                                                            \
-    {                                                                                                        \
-       /* zap freed handles rather than GC'ing them */                                                       \
-       HandleMarkCleaner __hmc(THREAD);                                                                      \
-       if (SafepointMechanism::should_process(THREAD)) {                                                     \
-         CALL_VM(SafepointMechanism::process_if_requested_with_exit_check(THREAD, true /* check asyncs */),  \
-                 handle_exception);                                                                          \
-       }                                                                                                     \
-    }
+#define SAFEPOINT                                                                                         \
+    if (SafepointMechanism::should_process(THREAD)) {                                                     \
+      HandleMarkCleaner __hmc(THREAD);                                                                    \
+      CALL_VM(SafepointMechanism::process_if_requested_with_exit_check(THREAD, true /* check asyncs */),  \
+              handle_exception);                                                                          \
+    }                                                                                                     \
 
 /*
  * VM_JAVA_ERROR - Macro for throwing a java exception from


### PR DESCRIPTION
Now that [JDK-8255384](https://bugs.openjdk.java.net/browse/JDK-8255384) effectively made the safepoints conditional for Zero, we can do `HandleMarkCleaner` under the safepoint check. This seems to improve Linux x86_64 Zero release `make bootcycle-images`: from 33.0m to 32.5m.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x64 (hs/tier1 runtime)](https://github.com/shipilev/jdk/runs/1441234485)

### Issue
 * [JDK-8256832](https://bugs.openjdk.java.net/browse/JDK-8256832): Zero: micro-optimize safepoint handling after JDK-8255384


### Reviewers
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1378/head:pull/1378`
`$ git checkout pull/1378`
