### PR TITLE
8256489: Make gtest for long path names on Windows more resilient in the presence of virus scanners

### DIFF
--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -135,14 +135,14 @@ static void create_rel_directory_w(const wchar_t* path) {
 static void delete_empty_rel_directory_w(const wchar_t* path) {
   WITH_ABS_PATH(path);
   EXPECT_TRUE(file_exists_w(abs_path)) << "Can't delete directory: \"" << path << "\" does not exists";
-  const int max_wait_time = 20;
+  const int retry_count = 20;
 
-  // If the directory cannot be deleted directly, a file in it might be
-  // kept by a virus scanner. Try a few times, since this should be temporary.
-  for (int i = 0; i <= max_wait_time; ++i) {
+  // If the directory cannot be deleted directly, a file in it might be kept
+  // open by a virus scanner. Try a few times, since this should be temporary.
+  for (int i = 0; i <= retry_count; ++i) {
     BOOL result = RemoveDirectoryW(abs_path);
 
-    if (!result && (i < max_wait_time)) {
+    if (!result && (i < retry_count)) {
       Sleep(1);
     } else {
       EXPECT_TRUE(result) << "Failed to delete directory \"" << path << "\": " << GetLastError();


### PR DESCRIPTION
Hi,

a virus scanner can keep a file open on Windows, so that a DeleteFile command returns successful, but the file is actually not removed when the call returns. In the gtest for long path names on Windows this can lead to failures when a directory is tried to be removed, but the file inside it is still kept by the virus scanner.

Since this is an error which only occurs very infrequently, we just retry the deletion a few times. 

Best regards,
Ralf

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256489](https://bugs.openjdk.java.net/browse/JDK-8256489): Make gtest for long path names on Windows more resilient in the presence of virus scanners


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1380/head:pull/1380`
`$ git checkout pull/1380`
