### PR TITLE
8256754: Deoptimization::revoke_for_object_deoptimization: stack processing start call is redundant

### DIFF
--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1651,10 +1651,6 @@ void Deoptimization::revoke_for_object_deoptimization(JavaThread* deoptee_thread
     return;
   }
   GrowableArray<Handle>* objects_to_revoke = new GrowableArray<Handle>();
-  if (deoptee_thread != thread) {
-    // Process stack of deoptee thread as we will access oops during object deoptimization.
-    StackWatermarkSet::start_processing(deoptee_thread, StackWatermarkKind::gc);
-  }
   // Collect monitors but only those with eliminated locking.
   get_monitors_from_stack(objects_to_revoke, deoptee_thread, fr, map, true);
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -63,6 +63,7 @@
 #include "runtime/handles.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/jniHandles.inline.hpp"
+#include "runtime/keepStackGCProcessed.hpp"
 #include "runtime/objectMonitor.inline.hpp"
 #include "runtime/safepointVerifiers.hpp"
 #include "runtime/sharedRuntime.hpp"
@@ -1651,6 +1652,7 @@ void Deoptimization::revoke_for_object_deoptimization(JavaThread* deoptee_thread
     return;
   }
   GrowableArray<Handle>* objects_to_revoke = new GrowableArray<Handle>();
+  assert(KeepStackGCProcessedMark::stack_is_kept_gc_processed(deoptee_thread), "must be");
   // Collect monitors but only those with eliminated locking.
   get_monitors_from_stack(objects_to_revoke, deoptee_thread, fr, map, true);
 

--- a/src/hotspot/share/runtime/keepStackGCProcessed.hpp
+++ b/src/hotspot/share/runtime/keepStackGCProcessed.hpp
@@ -43,6 +43,8 @@ class KeepStackGCProcessedMark : public StackObj {
 public:
   KeepStackGCProcessedMark(JavaThread* jt);
   ~KeepStackGCProcessedMark();
+
+  static bool stack_is_kept_gc_processed(JavaThread* jt) NOT_DEBUG({ return true; }) ;
 };
 
 

--- a/src/hotspot/share/runtime/stackWatermark.hpp
+++ b/src/hotspot/share/runtime/stackWatermark.hpp
@@ -130,6 +130,7 @@ public:
   void set_next(StackWatermark* n) { _next = n; }
 
   void link_watermark(StackWatermark* watermark);
+  DEBUG_ONLY(StackWatermark* linked_watermark() const { return _linked_watermark; })
 
   uintptr_t watermark();
   uintptr_t last_processed();


### PR DESCRIPTION
This is a XS clean-up of Deoptimization::revoke_for_object_deoptimization() which removes the StackWatermarkSet::start_processing() call.

This is correct because all paths leading to revoke_for_object_deoptimization() are equipped with a KeepStackGCProcessedMark.

Call Tree:

```
StackWatermarkSet::start_processing(JavaThread *, enum StackWatermarkKind) : void
    Deoptimization::revoke_for_object_deoptimization(JavaThread *, frame, RegisterMap *, JavaThread *) : void
        Deoptimization::deoptimize_objects_internal(JavaThread *, GrowableArray<compiledVFrame *> *, bool &) : bool
            EscapeBarrier::deoptimize_objects_internal(JavaThread *, intptr_t *) : bool
                EscapeBarrier::deoptimize_objects_all_threads() : bool                     // has KeepStackGCProcessedMark
                EscapeBarrier::deoptimize_objects(intptr_t *) : bool
                    EscapeBarrier::deoptimize_objects(int, int) : bool                     // has KeepStackGCProcessedMark 
```

Testing: hotspot_serviceability, jdk_svc, jdk_jdi, vmTestbase_nsk_jdi, vmTestbase_nsk_jvmti, vmTestbase_nsk_jdwp with -XX:+UseZGC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256754](https://bugs.openjdk.java.net/browse/JDK-8256754): Deoptimization::revoke_for_object_deoptimization: stack processing start call is redundant


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to f09aaf9b2d96b50872fbcea302c10d57f16671d1


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1381/head:pull/1381`
`$ git checkout pull/1381`
