### PR TITLE
8256858: C2: Devirtualize PhaseIterGVN-specific methods

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -191,12 +191,9 @@ Node *AddNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       set_req(1, addx);
       set_req(2, a22);
       progress = this;
-      if (add2->outcnt() == 0) {
-        PhaseIterGVN *igvn = phase->is_IterGVN();
+      if (add2->outcnt() == 0 && phase->is_IterGVN()) {
         // add disconnected.
-        if (igvn) {
-          igvn->_worklist.push(add2);
-        }
+        phase->is_IterGVN()->_worklist.push(add2);
       }
     }
   }
@@ -629,10 +626,9 @@ Node *AddPNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     if( t22->singleton() && (t22 != Type::TOP) ) {  // Right input is an add of a constant?
       set_req(Address, phase->transform(new AddPNode(in(Base),in(Address),add->in(1))));
       set_req(Offset, add->in(2));
-      PhaseIterGVN *igvn = phase->is_IterGVN();
-      if (add->outcnt() == 0 && igvn) {
+      if (add->outcnt() == 0 && phase->is_IterGVN()) {
         // add disconnected.
-        igvn->_worklist.push((Node*)add);
+        phase->is_IterGVN()->_worklist.push((Node*)add);
       }
       return this;              // Made progress
     }

--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -191,10 +191,12 @@ Node *AddNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       set_req(1, addx);
       set_req(2, a22);
       progress = this;
-      PhaseIterGVN *igvn = phase->is_IterGVN();
-      if (add2->outcnt() == 0 && igvn) {
+      if (add2->outcnt() == 0) {
+        PhaseIterGVN *igvn = phase->is_IterGVN();
         // add disconnected.
-        igvn->_worklist.push(add2);
+        if (igvn) {
+          igvn->_worklist.push(add2);
+        }
       }
     }
   }

--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -191,9 +191,10 @@ Node *AddNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       set_req(1, addx);
       set_req(2, a22);
       progress = this;
-      if (add2->outcnt() == 0 && phase->is_IterGVN()) {
+      PhaseIterGVN* igvn = phase->is_IterGVN();
+      if (add2->outcnt() == 0 && igvn) {
         // add disconnected.
-        phase->is_IterGVN()->_worklist.push(add2);
+        igvn->_worklist.push(add2);
       }
     }
   }
@@ -626,9 +627,10 @@ Node *AddPNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     if( t22->singleton() && (t22 != Type::TOP) ) {  // Right input is an add of a constant?
       set_req(Address, phase->transform(new AddPNode(in(Base),in(Address),add->in(1))));
       set_req(Offset, add->in(2));
-      if (add->outcnt() == 0 && phase->is_IterGVN()) {
+      PhaseIterGVN* igvn = phase->is_IterGVN();
+      if (add->outcnt() == 0 && igvn) {
         // add disconnected.
-        phase->is_IterGVN()->_worklist.push((Node*)add);
+        igvn->_worklist.push((Node*)add);
       }
       return this;              // Made progress
     }

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -307,7 +307,7 @@ Node *MemNode::Ideal_common(PhaseGVN *phase, bool can_reshape) {
         (cmp != NULL && igvn->_worklist.member(cmp)) ) {
       // This control path may be dead.
       // Delay this memory node transformation until the control is processed.
-      phase->is_IterGVN()->_worklist.push(this);
+      igvn->_worklist.push(this);
       return NodeSentinel; // caller will return NULL
     }
   }
@@ -319,7 +319,7 @@ Node *MemNode::Ideal_common(PhaseGVN *phase, bool can_reshape) {
   if (can_reshape && igvn != NULL && igvn->_worklist.member(mem)) {
     // This memory slice may be dead.
     // Delay this mem node transformation until the memory is processed.
-    phase->is_IterGVN()->_worklist.push(this);
+    igvn->_worklist.push(this);
     return NodeSentinel; // caller will return NULL
   }
 
@@ -350,7 +350,7 @@ Node *MemNode::Ideal_common(PhaseGVN *phase, bool can_reshape) {
        (igvn->_worklist.size() > 0 && t_adr != adr_type())) ) {
     // The address's base and type may change when the address is processed.
     // Delay this mem node transformation until the address is processed.
-    phase->is_IterGVN()->_worklist.push(this);
+    igvn->_worklist.push(this);
     return NodeSentinel; // caller will return NULL
   }
 
@@ -1721,7 +1721,7 @@ Node *LoadNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       PhaseIterGVN *igvn = phase->is_IterGVN();
       if (igvn != NULL && igvn->_worklist.member(opt_mem)) {
         // Delay this transformation until memory Phi is processed.
-        phase->is_IterGVN()->_worklist.push(this);
+        igvn->_worklist.push(this);
         return NULL;
       }
       // Split instance field load through Phi.
@@ -2632,9 +2632,12 @@ Node *StoreNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       if (st->in(MemNode::Address)->eqv_uncast(address) &&
           st->as_Store()->memory_size() <= this->memory_size()) {
         Node* use = st->raw_out(0);
-        phase->igvn_rehash_node_delayed(use);
+        PhaseIterGVN* igvn = phase->is_IterGVN();
+        if (igvn) {
+          igvn->rehash_node_delayed(use);
+        }
         if (can_reshape) {
-          use->set_req_X(MemNode::Memory, st->in(MemNode::Memory), phase->is_IterGVN());
+          use->set_req_X(MemNode::Memory, st->in(MemNode::Memory), igvn);
         } else {
           // It's OK to do this in the parser, since DU info is always accurate,
           // and the parser always refers to nodes via SafePointNode maps.
@@ -2746,14 +2749,14 @@ Node* StoreNode::Identity(PhaseGVN* phase) {
     }
   }
 
-  if (result != this && phase->is_IterGVN() != NULL) {
+  PhaseIterGVN* igvn = phase->is_IterGVN();
+  if (result != this && igvn != NULL) {
     MemBarNode* trailing = trailing_membar();
     if (trailing != NULL) {
 #ifdef ASSERT
       const TypeOopPtr* t_oop = phase->type(in(Address))->isa_oopptr();
       assert(t_oop == NULL || t_oop->is_known_instance_field(), "only for non escaping objects");
 #endif
-      PhaseIterGVN* igvn = phase->is_IterGVN();
       trailing->remove(igvn);
     }
   }
@@ -3951,7 +3954,10 @@ Node* InitializeNode::capture_store(StoreNode* st, intptr_t start,
   // if it redundantly stored the same value (or zero to fresh memory).
 
   // In any case, wire it in:
-  phase->igvn_rehash_node_delayed(this);
+  PhaseIterGVN* igvn = phase->is_IterGVN();
+  if (igvn) {
+    igvn->rehash_node_delayed(this);
+  }
   set_req(i, new_st);
 
   // The caller may now kill the old guy.

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2632,12 +2632,11 @@ Node *StoreNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       if (st->in(MemNode::Address)->eqv_uncast(address) &&
           st->as_Store()->memory_size() <= this->memory_size()) {
         Node* use = st->raw_out(0);
-        PhaseIterGVN* igvn = phase->is_IterGVN();
-        if (igvn) {
-          igvn->rehash_node_delayed(use);
+        if (phase->is_IterGVN()) {
+          phase->is_IterGVN()->rehash_node_delayed(use);
         }
         if (can_reshape) {
-          use->set_req_X(MemNode::Memory, st->in(MemNode::Memory), igvn);
+          use->set_req_X(MemNode::Memory, st->in(MemNode::Memory), phase->is_IterGVN());
         } else {
           // It's OK to do this in the parser, since DU info is always accurate,
           // and the parser always refers to nodes via SafePointNode maps.

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -654,7 +654,10 @@ static int maskShiftAmount(PhaseGVN *phase, Node *shiftNode, int nBits) {
 
   if (shift != maskedShift) {
     shiftNode->set_req(2, phase->intcon(maskedShift)); // Replace shift count with masked value.
-    phase->igvn_rehash_node_delayed(shiftNode);
+    PhaseIterGVN* igvn = phase->is_IterGVN();
+    if (igvn) {
+      igvn->rehash_node_delayed(shiftNode);
+    }
   }
 
   return maskedShift;

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -690,14 +690,15 @@ void PhaseTransform::dump_nodes_and_types_recur( const Node *n, uint depth, bool
 //=============================================================================
 //------------------------------PhaseValues------------------------------------
 // Set minimum table size to "255"
-PhaseValues::PhaseValues( Arena *arena, uint est_max_size ) : PhaseTransform(arena, GVN), _table(arena, est_max_size) {
+PhaseValues::PhaseValues( Arena *arena, uint est_max_size )
+  : PhaseTransform(arena, GVN), _table(arena, est_max_size), _iterGVN(false) {
   NOT_PRODUCT( clear_new_values(); )
 }
 
 //------------------------------PhaseValues------------------------------------
 // Set minimum table size to "255"
-PhaseValues::PhaseValues( PhaseValues *ptv ) : PhaseTransform( ptv, GVN ),
-  _table(&ptv->_table) {
+PhaseValues::PhaseValues(PhaseValues* ptv)
+  : PhaseTransform(ptv, GVN), _table(&ptv->_table), _iterGVN(false) {
   NOT_PRODUCT( clear_new_values(); )
 }
 
@@ -932,24 +933,26 @@ void PhaseGVN::dead_loop_check( Node *n ) {
 //=============================================================================
 //------------------------------PhaseIterGVN-----------------------------------
 // Initialize with previous PhaseIterGVN info; used by PhaseCCP
-PhaseIterGVN::PhaseIterGVN( PhaseIterGVN *igvn ) : PhaseGVN(igvn),
-                                                   _delay_transform(igvn->_delay_transform),
-                                                   _stack( igvn->_stack ),
-                                                   _worklist( igvn->_worklist )
+PhaseIterGVN::PhaseIterGVN(PhaseIterGVN* igvn) : PhaseGVN(igvn),
+                                                 _delay_transform(igvn->_delay_transform),
+                                                 _stack(igvn->_stack ),
+                                                 _worklist(igvn->_worklist)
 {
+  _iterGVN = true;
 }
 
 //------------------------------PhaseIterGVN-----------------------------------
 // Initialize with previous PhaseGVN info from Parser
-PhaseIterGVN::PhaseIterGVN( PhaseGVN *gvn ) : PhaseGVN(gvn),
-                                              _delay_transform(false),
+PhaseIterGVN::PhaseIterGVN(PhaseGVN* gvn) : PhaseGVN(gvn),
+                                            _delay_transform(false),
 // TODO: Before incremental inlining it was allocated only once and it was fine. Now that
 //       the constructor is used in incremental inlining, this consumes too much memory:
 //                                            _stack(C->live_nodes() >> 1),
 //       So, as a band-aid, we replace this by:
-                                              _stack(C->comp_arena(), 32),
-                                              _worklist(*C->for_igvn())
+                                            _stack(C->comp_arena(), 32),
+                                            _worklist(*C->for_igvn())
 {
+  _iterGVN = true;
   uint max;
 
   // Dead nodes in the hash table inherited from GVN were not treated as

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -371,13 +371,13 @@ public:
   PhaseValues(Arena* arena, uint est_max_size);
   PhaseValues(PhaseValues* pt);
   NOT_PRODUCT(~PhaseValues();)
-  PhaseIterGVN *is_IterGVN() { return (_iterGVN) ? (PhaseIterGVN*)this : NULL; }
+  PhaseIterGVN* is_IterGVN() { return (_iterGVN) ? (PhaseIterGVN*)this : NULL; }
 
   // Some Ideal and other transforms delete --> modify --> insert values
-  bool   hash_delete(Node *n)     { return _table.hash_delete(n); }
-  void   hash_insert(Node *n)     { _table.hash_insert(n); }
-  Node  *hash_find_insert(Node *n){ return _table.hash_find_insert(n); }
-  Node  *hash_find(const Node *n) { return _table.hash_find(n); }
+  bool   hash_delete(Node* n)     { return _table.hash_delete(n); }
+  void   hash_insert(Node* n)     { _table.hash_insert(n); }
+  Node*  hash_find_insert(Node* n){ return _table.hash_find_insert(n); }
+  Node*  hash_find(const Node* n) { return _table.hash_find(n); }
 
   // Used after parsing to eliminate values that are no longer in program
   void   remove_useless_nodes(VectorSet &useful) {
@@ -389,7 +389,7 @@ public:
   virtual ConNode* uncached_makecon(const Type* t);  // override from PhaseTransform
 
   const Type* saturate(const Type* new_type, const Type* old_type,
-                               const Type* limit_type) const
+                       const Type* limit_type) const
   { return new_type; }
 
 #ifndef PRODUCT


### PR DESCRIPTION
PhaseValues define the virtual method is_IterGVN, which is trivially returning 0(!) for all types except those derived from PhaseIterGVN. Similarly there's igvn_rehash_node_delayed which is virtual and a no-op in base types, but implemented to call rehash_node_delayed in PhaseIterGVN.

By devirtualizing we allow for more aggressive inlining and slightly better code generation in a few places. 

This increases sizeof(PhaseValues) from 2480 to 2488 on x64. Since we only go through a limited number of phases per compilation this seems acceptable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256858](https://bugs.openjdk.java.net/browse/JDK-8256858): C2: Devirtualize PhaseIterGVN-specific methods


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to ffae8ad9eebfab0a936911c24f3d7e3bfc44dddb
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1385/head:pull/1385`
`$ git checkout pull/1385`
