### PR TITLE
8256862: Several java/foreign tests fail on x86_32 platforms

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -95,7 +95,7 @@ import static jdk.internal.foreign.PlatformLayouts.*;
  * {@link #asVarArg(MemoryLayout)} is used to create the memory layouts for each parameter corresponding to a variadic
  * argument in a specialized function descriptor.
  *
- * <p>Note that on unsupported platforms, this class will fail to initialize.
+ * <p>On unsupported platforms this class will fail to initialize with an {@link ExceptionInInitializerError}.
  *
  * <p> Unless otherwise specified, passing a {@code null} argument, or an array argument containing one or more {@code null}
  * elements to a method in this class causes a {@link NullPointerException NullPointerException} to be thrown. </p>

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -95,6 +95,8 @@ import static jdk.internal.foreign.PlatformLayouts.*;
  * {@link #asVarArg(MemoryLayout)} is used to create the memory layouts for each parameter corresponding to a variadic
  * argument in a specialized function descriptor.
  *
+ * <p>Note that on unsupported platforms, this class will fail to initialize.
+ *
  * <p> Unless otherwise specified, passing a {@code null} argument, or an array argument containing one or more {@code null}
  * elements to a method in this class causes a {@link NullPointerException NullPointerException} to be thrown. </p>
  *

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CABI.java
@@ -25,6 +25,10 @@
  */
 package jdk.internal.foreign;
 
+import jdk.internal.foreign.abi.SharedUtils;
+
+import static jdk.incubator.foreign.MemoryLayouts.ADDRESS;
+
 public enum CABI {
     SysV,
     Win64,
@@ -35,7 +39,10 @@ public enum CABI {
     static {
         String arch = System.getProperty("os.arch");
         String os = System.getProperty("os.name");
-        if (arch.equals("amd64") || arch.equals("x86_64")) {
+        long addressSize = ADDRESS.bitSize();
+        // might be running in a 32-bit VM on a 64-bit platform.
+        // addressSize will be correctly 32
+        if ((arch.equals("amd64") || arch.equals("x86_64")) && addressSize == 64) {
             if (os.startsWith("Windows")) {
                 current = Win64;
             } else {
@@ -44,7 +51,8 @@ public enum CABI {
         } else if (arch.equals("aarch64")) {
             current = AArch64;
         } else {
-            throw new ExceptionInInitializerError("Unsupported os or arch: " + os + ", " + arch);
+            throw new ExceptionInInitializerError(
+                "Unsupported os, arch, or address size: " + os + ", " + arch + ", " + addressSize);
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
@@ -141,7 +141,7 @@ public class PlatformLayouts {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = ofPointer(LITTLE_ENDIAN, ADDRESS.bitSize());
+        public static final ValueLayout C_POINTER = ofPointer(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code va_list} native type, as it is passed to a function.
@@ -201,7 +201,7 @@ public class PlatformLayouts {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = ofPointer(LITTLE_ENDIAN, ADDRESS.bitSize());
+        public static final ValueLayout C_POINTER = ofPointer(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code va_list} native type, as it is passed to a function.
@@ -266,7 +266,7 @@ public class PlatformLayouts {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = ofPointer(LITTLE_ENDIAN, ADDRESS.bitSize());
+        public static final ValueLayout C_POINTER = ofPointer(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code va_list} native type, as it is passed to a function.

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @requires sun.arch.data.model == "64"
  * @run testng/othervm -Dforeign.restricted=permit StdLibTest
  */
 

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @run testng/othervm -Dforeign.restricted=permit StdLibTest
  */
 

--- a/test/jdk/java/foreign/TestCircularInit1.java
+++ b/test/jdk/java/foreign/TestCircularInit1.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @run testng/othervm TestCircularInit1
  */

--- a/test/jdk/java/foreign/TestCircularInit2.java
+++ b/test/jdk/java/foreign/TestCircularInit2.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @requires sun.arch.data.model == "64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @run testng/othervm TestCircularInit2
  */

--- a/test/jdk/java/foreign/TestCircularInit2.java
+++ b/test/jdk/java/foreign/TestCircularInit2.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @run testng/othervm TestCircularInit2
  */

--- a/test/jdk/java/foreign/TestCondy.java
+++ b/test/jdk/java/foreign/TestCondy.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- *
+ * @requires sun.arch.data.model == "64"
  * @run testng TestCondy
  */
 

--- a/test/jdk/java/foreign/TestCondy.java
+++ b/test/jdk/java/foreign/TestCondy.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @run testng TestCondy
  */
 

--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @requires sun.arch.data.model == "64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *

--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *

--- a/test/jdk/java/foreign/TestFunctionDescriptor.java
+++ b/test/jdk/java/foreign/TestFunctionDescriptor.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @requires sun.arch.data.model == "64"
  * @run testng TestFunctionDescriptor
  */
 

--- a/test/jdk/java/foreign/TestFunctionDescriptor.java
+++ b/test/jdk/java/foreign/TestFunctionDescriptor.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @run testng TestFunctionDescriptor
  */
 

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- *
+ * @requires sun.arch.data.model == "64"
  * @run testng/othervm -Dforeign.restricted=permit TestIllegalLink
  */
 

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @run testng/othervm -Dforeign.restricted=permit TestIllegalLink
  */
 

--- a/test/jdk/java/foreign/TestLibraryLookup.java
+++ b/test/jdk/java/foreign/TestLibraryLookup.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @requires sun.arch.data.model == "64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @run testng/othervm -Dforeign.restricted=permit TestLibraryLookup
  */
@@ -41,6 +42,11 @@ import java.util.List;
 
 import static org.testng.Assert.*;
 
+// FYI this test is run on 64-bit platforms only for now,
+// since the windows 32-bit linker fails and there
+// is some fallback behaviour to use the 64-bit linker,
+// where cygwin gets in the way and we accidentally pick up its
+// link.exe
 public class TestLibraryLookup {
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Library not found.*")

--- a/test/jdk/java/foreign/TestLibraryLookup.java
+++ b/test/jdk/java/foreign/TestLibraryLookup.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @run testng/othervm -Dforeign.restricted=permit TestLibraryLookup
  */

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @requires sun.arch.data.model == "64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @run testng/othervm -Dforeign.restricted=permit TestNative
  */

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @run testng/othervm -Dforeign.restricted=permit TestNative
  */

--- a/test/jdk/java/foreign/TestNativeScope.java
+++ b/test/jdk/java/foreign/TestNativeScope.java
@@ -59,6 +59,7 @@ import static org.testng.Assert.*;
 public class TestNativeScope {
 
     final static int ELEMS = 128;
+    final static Class<?> ADDRESS_CARRIER = MemoryLayouts.ADDRESS.bitSize() == 64 ? long.class : int.class;
 
     @Test(dataProvider = "nativeScopes")
     public <Z> void testAllocation(Z value, ScopeFactory scopeFactory, ValueLayout layout, AllocationFunction<Z> allocationFunction, Function<MemoryLayout, VarHandle> handleFactory) {
@@ -221,7 +222,7 @@ public class TestNativeScope {
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(double.class) },
                 { MemoryAddress.ofLong(42), (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.ADDRESS.withOrder(ByteOrder.BIG_ENDIAN),
                         (AllocationFunction<MemoryAddress>) NativeScope::allocate,
-                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(long.class)) },
+                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(ADDRESS_CARRIER)) },
 
                 { (byte)42, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_8_LE,
                         (AllocationFunction<Byte>) NativeScope::allocate,
@@ -247,7 +248,7 @@ public class TestNativeScope {
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(double.class) },
                 { MemoryAddress.ofLong(42), (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.ADDRESS.withOrder(ByteOrder.LITTLE_ENDIAN),
                         (AllocationFunction<MemoryAddress>) NativeScope::allocate,
-                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(long.class)) },
+                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(ADDRESS_CARRIER)) },
 
                 { (byte)42, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_8_BE,
                         (AllocationFunction<Byte>) NativeScope::allocate,
@@ -273,7 +274,7 @@ public class TestNativeScope {
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(double.class) },
                 { MemoryAddress.ofLong(42), (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.ADDRESS.withOrder(ByteOrder.BIG_ENDIAN),
                         (AllocationFunction<MemoryAddress>) NativeScope::allocate,
-                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(long.class)) },
+                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(ADDRESS_CARRIER)) },
 
                 { (byte)42, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_8_LE,
                         (AllocationFunction<Byte>) NativeScope::allocate,
@@ -299,7 +300,7 @@ public class TestNativeScope {
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(double.class) },
                 { MemoryAddress.ofLong(42), (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.ADDRESS.withOrder(ByteOrder.LITTLE_ENDIAN),
                         (AllocationFunction<MemoryAddress>) NativeScope::allocate,
-                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(long.class)) },
+                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(ADDRESS_CARRIER)) },
         };
     }
 

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules java.base/jdk.internal.ref
  *          jdk.incubator.foreign
  * @run testng/othervm -Dforeign.restricted=permit TestNulls

--- a/test/jdk/java/foreign/TestUnsupportedPlatform.java
+++ b/test/jdk/java/foreign/TestUnsupportedPlatform.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -16,30 +16,39 @@
  *  2 along with this work; if not, write to the Free Software Foundation,
  *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  *  or visit www.oracle.com if you need additional information or have any
  *  questions.
+ *
  */
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires sun.arch.data.model == "32"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @run testng/othervm TestCircularInit1
+ * @run testng/othervm -Dforeign.restricted=permit TestUnsupportedPlatform
  */
 
 import jdk.incubator.foreign.CLinker;
-import jdk.internal.foreign.PlatformLayouts;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.NativeScope;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertNotNull;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 
-public class TestCircularInit1 {
+import static jdk.incubator.foreign.MemoryAddress.NULL;
+import static jdk.incubator.foreign.MemoryLayouts.JAVA_BYTE;
+import static org.testng.Assert.assertNull;
 
-    @Test
-    public void testCircularInit() {
-        System.out.println(PlatformLayouts.Win64.C_CHAR); // trigger clinit
-        assertNotNull(CLinker.C_CHAR); // should not be null
+// tests run on 32-bit platforms, which are currently not supported
+public class TestUnsupportedPlatform {
+
+    @Test(expectedExceptions = ExceptionInInitializerError.class)
+    public void testNoInitialization() {
+        CLinker.getInstance(); // trigger initialization
     }
 
 }

--- a/test/jdk/java/foreign/TestUnsupportedPlatform.java
+++ b/test/jdk/java/foreign/TestUnsupportedPlatform.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "32"
+ * @requires !(((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64")
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @run testng/othervm -Dforeign.restricted=permit TestUnsupportedPlatform
  */

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @requires sun.arch.data.model == "64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @requires sun.arch.data.model == "64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *

--- a/test/jdk/java/foreign/TestUpcallStubs.java
+++ b/test/jdk/java/foreign/TestUpcallStubs.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @requires sun.arch.data.model == "64"
  * @run testng/othervm -Dforeign.restricted=permit TestUpcallStubs
  */
 

--- a/test/jdk/java/foreign/TestUpcallStubs.java
+++ b/test/jdk/java/foreign/TestUpcallStubs.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @run testng/othervm -Dforeign.restricted=permit TestUpcallStubs
  */
 

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @requires sun.arch.data.model == "64"
  * @run testng/othervm -Dforeign.restricted=permit TestVarArgs
  */
 

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @run testng/othervm -Dforeign.restricted=permit TestVarArgs
  */
 

--- a/test/jdk/java/foreign/stackwalk/TestStackWalk.java
+++ b/test/jdk/java/foreign/stackwalk/TestStackWalk.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @requires sun.arch.data.model == "64"
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/jdk/java/foreign/stackwalk/TestStackWalk.java
+++ b/test/jdk/java/foreign/stackwalk/TestStackWalk.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @requires sun.arch.data.model == "64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  *          jdk.incubator.foreign/jdk.internal.foreign.abi
  *          jdk.incubator.foreign/jdk.internal.foreign.abi.aarch64

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @requires sun.arch.data.model == "64"
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  *          jdk.incubator.foreign/jdk.internal.foreign.abi
  *          jdk.incubator.foreign/jdk.internal.foreign.abi.aarch64


### PR DESCRIPTION
This patch fixes several failures on x86_32 of java/foreign tests.

This is mostly done by disabling the failing tests, but the impl of CLinker is also adjusted ton properly detect 32 bit platforms as unsupported.

CLinker is specified to fail in the initializer on unsupported platforms, and a test is added to verify this as well.

Note that this adds requires clauses to the failing tests that explicitly enumerate all available platforms, so this should fix the test failures on other platforms as well.

https://bugs.openjdk.java.net/browse/JDK-8256757 is filed for the remaining failure in TestStringLatin1IndexOfChar.

CSR link: https://bugs.openjdk.java.net/browse/JDK-8256863

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x86 (hs/tier1 compiler)](https://github.com/JornVernee/jdk/runs/1456125527)

### Issue
 * [JDK-8256862](https://bugs.openjdk.java.net/browse/JDK-8256862): Several java/foreign tests fail on x86_32 platforms


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1386/head:pull/1386`
`$ git checkout pull/1386`
