### PR TITLE
8256860: S390 builds broken after JDK-8254231

### DIFF
--- a/src/hotspot/cpu/s390/foreign_globals_s390.cpp
+++ b/src/hotspot/cpu/s390/foreign_globals_s390.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016 SAP SE. All rights reserved.
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,35 +19,18 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
- *
  */
 
 #include "precompiled.hpp"
-#include "asm/assembler.hpp"
-#include "code/vmreg.hpp"
+#include "prims/foreign_globals.hpp"
+#include "utilities/debug.hpp"
 
-void VMRegImpl::set_regName() {
-  // Not clear why we have this duplication (triplication?)
-  Register reg = ::as_Register(0);
-  int i;
-  for (i = 0; i < ConcreteRegisterImpl::max_gpr;) {
-    regName[i++] = reg->name();
-    regName[i++] = reg->name();
-    reg = reg->successor();
-  }
-
-  FloatRegister freg = ::as_FloatRegister(0);
-  for (; i < ConcreteRegisterImpl::max_fpr;) {
-    regName[i++] = freg->name();
-    regName[i++] = freg->name();
-    freg = freg->successor();
-  }
-  for (; i < ConcreteRegisterImpl::number_of_registers; i ++) {
-    regName[i] = "NON-GPR-XMM";
-  }
+const ABIDescriptor ForeignGlobals::parse_abi_descriptor_impl(jobject jabi) const {
+  Unimplemented();
+  return {};
 }
 
-VMReg VMRegImpl::vmStorageToVMReg(int type, int index) {
+const BufferLayout ForeignGlobals::parse_buffer_layout_impl(jobject jlayout) const {
   Unimplemented();
-  return VMRegImpl::Bad();
+  return {};
 }

--- a/src/hotspot/cpu/s390/foreign_globals_s390.hpp
+++ b/src/hotspot/cpu/s390/foreign_globals_s390.hpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016 SAP SE. All rights reserved.
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,35 +19,12 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
- *
  */
 
-#include "precompiled.hpp"
-#include "asm/assembler.hpp"
-#include "code/vmreg.hpp"
+#ifndef CPU_S390_VM_FOREIGN_GLOBALS_S390_HPP
+#define CPU_S390_VM_FOREIGN_GLOBALS_S390_HPP
 
-void VMRegImpl::set_regName() {
-  // Not clear why we have this duplication (triplication?)
-  Register reg = ::as_Register(0);
-  int i;
-  for (i = 0; i < ConcreteRegisterImpl::max_gpr;) {
-    regName[i++] = reg->name();
-    regName[i++] = reg->name();
-    reg = reg->successor();
-  }
+class BufferLayout {};
+class ABIDescriptor {};
 
-  FloatRegister freg = ::as_FloatRegister(0);
-  for (; i < ConcreteRegisterImpl::max_fpr;) {
-    regName[i++] = freg->name();
-    regName[i++] = freg->name();
-    freg = freg->successor();
-  }
-  for (; i < ConcreteRegisterImpl::number_of_registers; i ++) {
-    regName[i] = "NON-GPR-XMM";
-  }
-}
-
-VMReg VMRegImpl::vmStorageToVMReg(int type, int index) {
-  Unimplemented();
-  return VMRegImpl::Bad();
-}
+#endif // CPU_S390_VM_FOREIGN_GLOBALS_S390_HPP

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -639,6 +639,11 @@ int MachCallRuntimeNode::ret_addr_offset() {
   return 12 + MacroAssembler::call_far_patchable_ret_addr_offset();
 }
 
+int MachCallNativeNode::ret_addr_offset() {
+  Unimplemented();
+  return -1;
+}
+
 // Compute padding required for nodes which need alignment
 //
 // The addresses of the call instructions needs to be 4-byte aligned to

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -3463,3 +3463,11 @@ extern "C"
 int SpinPause() {
   return 0;
 }
+
+BufferBlob* SharedRuntime::make_native_invoker(address call_target,
+                                               int shadow_space_bytes,
+                                               const GrowableArray<VMReg>& input_registers,
+                                               const GrowableArray<VMReg>& output_registers) {
+  Unimplemented();
+  return nullptr;
+}

--- a/src/hotspot/cpu/s390/universalNativeInvoker_s390.cpp
+++ b/src/hotspot/cpu/s390/universalNativeInvoker_s390.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016 SAP SE. All rights reserved.
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,35 +19,13 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
- *
  */
 
 #include "precompiled.hpp"
-#include "asm/assembler.hpp"
-#include "code/vmreg.hpp"
+#include "prims/universalNativeInvoker.hpp"
+#include "utilities/debug.hpp"
 
-void VMRegImpl::set_regName() {
-  // Not clear why we have this duplication (triplication?)
-  Register reg = ::as_Register(0);
-  int i;
-  for (i = 0; i < ConcreteRegisterImpl::max_gpr;) {
-    regName[i++] = reg->name();
-    regName[i++] = reg->name();
-    reg = reg->successor();
-  }
-
-  FloatRegister freg = ::as_FloatRegister(0);
-  for (; i < ConcreteRegisterImpl::max_fpr;) {
-    regName[i++] = freg->name();
-    regName[i++] = freg->name();
-    freg = freg->successor();
-  }
-  for (; i < ConcreteRegisterImpl::number_of_registers; i ++) {
-    regName[i] = "NON-GPR-XMM";
-  }
-}
-
-VMReg VMRegImpl::vmStorageToVMReg(int type, int index) {
+address ProgrammableInvoker::generate_adapter(jobject jabi, jobject jlayout) {
   Unimplemented();
-  return VMRegImpl::Bad();
+  return nullptr;
 }

--- a/src/hotspot/cpu/s390/universalUpcallHandle_s390.cpp
+++ b/src/hotspot/cpu/s390/universalUpcallHandle_s390.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016 SAP SE. All rights reserved.
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,35 +19,13 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
- *
  */
 
 #include "precompiled.hpp"
-#include "asm/assembler.hpp"
-#include "code/vmreg.hpp"
+#include "prims/universalUpcallHandler.hpp"
+#include "utilities/debug.hpp"
 
-void VMRegImpl::set_regName() {
-  // Not clear why we have this duplication (triplication?)
-  Register reg = ::as_Register(0);
-  int i;
-  for (i = 0; i < ConcreteRegisterImpl::max_gpr;) {
-    regName[i++] = reg->name();
-    regName[i++] = reg->name();
-    reg = reg->successor();
-  }
-
-  FloatRegister freg = ::as_FloatRegister(0);
-  for (; i < ConcreteRegisterImpl::max_fpr;) {
-    regName[i++] = freg->name();
-    regName[i++] = freg->name();
-    freg = freg->successor();
-  }
-  for (; i < ConcreteRegisterImpl::number_of_registers; i ++) {
-    regName[i] = "NON-GPR-XMM";
-  }
-}
-
-VMReg VMRegImpl::vmStorageToVMReg(int type, int index) {
+address ProgrammableUpcallHandler::generate_upcall_stub(jobject rec, jobject jabi, jobject jlayout) {
   Unimplemented();
-  return VMRegImpl::Bad();
+  return nullptr;
 }


### PR DESCRIPTION
Foreign linker integration broke S390 builds. This change stubs out the new entry points, without implementing the actual support yet.

Additional testing:
 - [x] Linux s390x fastdebug cross-compilation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ❌ (1/1 failed) | ❌ (1/1 failed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) |    |  ⏳ (8/9 running) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux arm (build hotspot no-pch)](https://github.com/shipilev/jdk/runs/1443166743)
- [Linux ppc64le (build hotspot no-pch)](https://github.com/shipilev/jdk/runs/1443166843)
- [Linux x86 (build debug)](https://github.com/shipilev/jdk/runs/1442916525)
- [Linux x86 (build release)](https://github.com/shipilev/jdk/runs/1442916510)

### Issue
 * [JDK-8256860](https://bugs.openjdk.java.net/browse/JDK-8256860): S390 builds broken after JDK-8254231


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1392/head:pull/1392`
`$ git checkout pull/1392`
