### PR TITLE
8256843: [PPC64] runtime/logging/RedefineClasses.java fails with assert: registers not saved on stack

### DIFF
--- a/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
+++ b/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
@@ -479,7 +479,7 @@ void trace_method_handle_stub(const char* adaptername,
 
   bool has_mh = (strstr(adaptername, "/static") == NULL &&
                  strstr(adaptername, "linkTo") == NULL);    // static linkers don't have MH
-  const char* mh_reg_name = has_mh ? "R23_method_handle" : "G23";
+  const char* mh_reg_name = has_mh ? "R23_method_handle" : "R23";
   tty->print_cr("MH %s %s=" INTPTR_FORMAT " sp=" INTPTR_FORMAT,
                 adaptername, mh_reg_name, p2i(mh), p2i(entry_sp));
 

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -64,7 +64,7 @@
 // put OS-includes here
 # include <ucontext.h>
 
-address os::current_stack_pointer() {
+NOINLINE address os::current_stack_pointer() {
   address csp;
 
 #if !defined(USE_XLC_BUILTINS)
@@ -160,8 +160,12 @@ frame os::get_sender_for_C_frame(frame* fr) {
 
 NOINLINE frame os::current_frame() {
   intptr_t* csp = (intptr_t*) *((intptr_t*) os::current_stack_pointer());
+  // hack.
   frame topframe(csp, (address)0x8);
-  return os::get_sender_for_C_frame(&topframe);
+  // Return sender of sender of current topframe which hopefully
+  // both have pc != NULL.
+  frame tmp = os::get_sender_for_C_frame(&topframe);
+  return os::get_sender_for_C_frame(&tmp);
 }
 
 bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -158,14 +158,10 @@ frame os::get_sender_for_C_frame(frame* fr) {
 }
 
 
-frame os::current_frame() {
+NOINLINE frame os::current_frame() {
   intptr_t* csp = (intptr_t*) *((intptr_t*) os::current_stack_pointer());
-  // hack.
   frame topframe(csp, (address)0x8);
-  // Return sender of sender of current topframe which hopefully
-  // both have pc != NULL.
-  frame tmp = os::get_sender_for_C_frame(&topframe);
-  return os::get_sender_for_C_frame(&tmp);
+  return os::get_sender_for_C_frame(&topframe);
 }
 
 bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -77,7 +77,7 @@
 # include <ucontext.h>
 
 
-address os::current_stack_pointer() {
+NOINLINE address os::current_stack_pointer() {
   intptr_t* csp;
 
   // inline assembly `mr regno(csp), R1_SP':
@@ -180,8 +180,12 @@ frame os::get_sender_for_C_frame(frame* fr) {
 
 NOINLINE frame os::current_frame() {
   intptr_t* csp = (intptr_t*) *((intptr_t*) os::current_stack_pointer());
+  // hack.
   frame topframe(csp, (address)0x8);
-  return os::get_sender_for_C_frame(&topframe);
+  // Return sender of sender of current topframe which hopefully
+  // both have pc != NULL.
+  frame tmp = os::get_sender_for_C_frame(&topframe);
+  return os::get_sender_for_C_frame(&tmp);
 }
 
 bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -178,14 +178,10 @@ frame os::get_sender_for_C_frame(frame* fr) {
 }
 
 
-frame os::current_frame() {
+NOINLINE frame os::current_frame() {
   intptr_t* csp = (intptr_t*) *((intptr_t*) os::current_stack_pointer());
-  // hack.
   frame topframe(csp, (address)0x8);
-  // Return sender of sender of current topframe which hopefully
-  // both have pc != NULL.
-  frame tmp = os::get_sender_for_C_frame(&topframe);
-  return os::get_sender_for_C_frame(&tmp);
+  return os::get_sender_for_C_frame(&topframe);
 }
 
 bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,


### PR DESCRIPTION
Method handle logging is broken in fastdebug builds. Problem is that os::current_frame() doesn't return the right frame in fastdebug builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8256843](https://bugs.openjdk.java.net/browse/JDK-8256843): [PPC64] runtime/logging/RedefineClasses.java fails with assert: registers not saved on stack


### Reviewers
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - Committer) ⚠️ Review applies to 99f9a85bde274c3bf492c4b73e0d68a59785235f


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1394/head:pull/1394`
`$ git checkout pull/1394`
