### PR TITLE
8254999: Move G1RemSetSamplingTask to more appropriate location

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1705,6 +1705,9 @@ jint G1CollectedHeap::initialize() {
     return ecode;
   }
 
+  // Initialize and schedule sampling task on service thread.
+  _rem_set->initialize_sampling_task(service_thread());
+
   {
     G1DirtyCardQueueSet& dcqs = G1BarrierSet::dirty_card_queue_set();
     dcqs.set_process_cards_threshold(concurrent_refine()->yellow_zone());

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -550,12 +550,13 @@ class G1RemSetSamplingTask : public G1ServiceTask {
   // reevaluates the prediction for the remembered set scanning costs, and potentially
   // G1Policy resizes the young gen. This may do a premature GC or even
   // increase the young gen size to keep pause time length goal.
-  void sample_young_list_rs_length(SuspendibleThreadSetJoiner* sts){
+  void sample_young_list_rs_length(){
+    SuspendibleThreadSetJoiner sts;
     G1CollectedHeap* g1h = G1CollectedHeap::heap();
     G1Policy* policy = g1h->policy();
 
     if (policy->use_adaptive_young_list_length()) {
-      G1YoungRemSetSamplingClosure cl(sts);
+      G1YoungRemSetSamplingClosure cl(&sts);
 
       G1CollectionSet* g1cs = g1h->collection_set();
       g1cs->iterate(&cl);
@@ -566,36 +567,10 @@ class G1RemSetSamplingTask : public G1ServiceTask {
     }
   }
 
-  // To avoid extensive rescheduling if the task is executed a bit early. The task is
-  // only rescheduled if the expected time is more than 1ms away.
-  bool should_reschedule() {
-    return reschedule_delay_ms() > 1;
-  }
-
-  // There is no reason to do the sampling if a GC occurred recently. We use the
-  // G1ConcRefinementServiceIntervalMillis as the metric for recently and calculate
-  // the diff to the last GC. If the last GC occurred longer ago than the interval
-  // 0 is returned.
-  jlong reschedule_delay_ms() {
-    Tickspan since_last_gc = G1CollectedHeap::heap()->time_since_last_collection();
-    jlong delay = (jlong) (G1ConcRefinementServiceIntervalMillis - since_last_gc.milliseconds());
-    return MAX2<jlong>(0L, delay);
-  }
-
 public:
   G1RemSetSamplingTask(const char* name) : G1ServiceTask(name) { }
   virtual void execute() {
-    SuspendibleThreadSetJoiner sts;
-
-    // Reschedule if a GC happened too recently.
-    if (should_reschedule()) {
-      // Calculate the delay given the last GC and the interval.
-      schedule(reschedule_delay_ms());
-      return;
-    }
-
-    // Do the actual sampling.
-    sample_young_list_rs_length(&sts);
+    sample_young_list_rs_length();
     schedule(G1ConcRefinementServiceIntervalMillis);
   }
 };

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -496,9 +496,7 @@ G1RemSet::G1RemSet(G1CollectedHeap* g1h,
 
 G1RemSet::~G1RemSet() {
   delete _scan_state;
-  if (_sampling_task != NULL) {
-    delete _sampling_task;
-  }
+  delete _sampling_task;
 }
 
 void G1RemSet::initialize(uint max_reserved_regions) {

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -35,8 +35,10 @@
 #include "gc/g1/g1GCPhaseTimes.hpp"
 #include "gc/g1/g1HotCardCache.hpp"
 #include "gc/g1/g1OopClosures.inline.hpp"
+#include "gc/g1/g1Policy.hpp"
 #include "gc/g1/g1RootClosures.hpp"
 #include "gc/g1/g1RemSet.hpp"
+#include "gc/g1/g1ServiceThread.hpp"
 #include "gc/g1/g1SharedDirtyCardQueue.hpp"
 #include "gc/g1/g1_globals.hpp"
 #include "gc/g1/heapRegion.inline.hpp"
@@ -488,15 +490,120 @@ G1RemSet::G1RemSet(G1CollectedHeap* g1h,
   _g1h(g1h),
   _ct(ct),
   _g1p(_g1h->policy()),
-  _hot_card_cache(hot_card_cache) {
+  _hot_card_cache(hot_card_cache),
+  _sampling_task(NULL) {
 }
 
 G1RemSet::~G1RemSet() {
   delete _scan_state;
+  if (_sampling_task != NULL) {
+    delete _sampling_task;
+  }
 }
 
 void G1RemSet::initialize(uint max_reserved_regions) {
   _scan_state->initialize(max_reserved_regions);
+}
+
+class G1YoungRemSetSamplingClosure : public HeapRegionClosure {
+  SuspendibleThreadSetJoiner* _sts;
+  size_t _regions_visited;
+  size_t _sampled_rs_length;
+public:
+  G1YoungRemSetSamplingClosure(SuspendibleThreadSetJoiner* sts) :
+    HeapRegionClosure(), _sts(sts), _regions_visited(0), _sampled_rs_length(0) { }
+
+  virtual bool do_heap_region(HeapRegion* r) {
+    size_t rs_length = r->rem_set()->occupied();
+    _sampled_rs_length += rs_length;
+
+    // Update the collection set policy information for this region
+    G1CollectedHeap::heap()->collection_set()->update_young_region_prediction(r, rs_length);
+
+    _regions_visited++;
+
+    if (_regions_visited == 10) {
+      if (_sts->should_yield()) {
+        _sts->yield();
+        // A gc may have occurred and our sampling data is stale and further
+        // traversal of the collection set is unsafe
+        return true;
+      }
+      _regions_visited = 0;
+    }
+    return false;
+  }
+
+  size_t sampled_rs_length() const { return _sampled_rs_length; }
+};
+
+// Task handling young gen remembered set sampling.
+class G1RemSetSamplingTask : public G1ServiceTask {
+  // Sample the current length of remembered sets for young.
+  //
+  // At the end of the GC G1 determines the length of the young gen based on
+  // how much time the next GC can take, and when the next GC may occur
+  // according to the MMU.
+  //
+  // The assumption is that a significant part of the GC is spent on scanning
+  // the remembered sets (and many other components), so this thread constantly
+  // reevaluates the prediction for the remembered set scanning costs, and potentially
+  // G1Policy resizes the young gen. This may do a premature GC or even
+  // increase the young gen size to keep pause time length goal.
+  void sample_young_list_rs_length(SuspendibleThreadSetJoiner* sts){
+    G1CollectedHeap* g1h = G1CollectedHeap::heap();
+    G1Policy* policy = g1h->policy();
+
+    if (policy->use_adaptive_young_list_length()) {
+      G1YoungRemSetSamplingClosure cl(sts);
+
+      G1CollectionSet* g1cs = g1h->collection_set();
+      g1cs->iterate(&cl);
+
+      if (cl.is_complete()) {
+        policy->revise_young_list_target_length_if_necessary(cl.sampled_rs_length());
+      }
+    }
+  }
+
+  // To avoid extensive rescheduling if the task is executed a bit early. The task is
+  // only rescheduled if the expected time is more than 1ms away.
+  bool should_reschedule() {
+    return reschedule_delay_ms() > 1;
+  }
+
+  // There is no reason to do the sampling if a GC occurred recently. We use the
+  // G1ConcRefinementServiceIntervalMillis as the metric for recently and calculate
+  // the diff to the last GC. If the last GC occurred longer ago than the interval
+  // 0 is returned.
+  jlong reschedule_delay_ms() {
+    Tickspan since_last_gc = G1CollectedHeap::heap()->time_since_last_collection();
+    jlong delay = (jlong) (G1ConcRefinementServiceIntervalMillis - since_last_gc.milliseconds());
+    return MAX2<jlong>(0L, delay);
+  }
+
+public:
+  G1RemSetSamplingTask(const char* name) : G1ServiceTask(name) { }
+  virtual void execute() {
+    SuspendibleThreadSetJoiner sts;
+
+    // Reschedule if a GC happened too recently.
+    if (should_reschedule()) {
+      // Calculate the delay given the last GC and the interval.
+      schedule(reschedule_delay_ms());
+      return;
+    }
+
+    // Do the actual sampling.
+    sample_young_list_rs_length(&sts);
+    schedule(G1ConcRefinementServiceIntervalMillis);
+  }
+};
+
+void G1RemSet::initialize_sampling_task(G1ServiceThread* thread) {
+  assert(_sampling_task == NULL, "Sampling task already initialized");
+  _sampling_task = new G1RemSetSamplingTask("Remembered Set Sampling Task");
+  thread->register_task(_sampling_task);
 }
 
 // Helper class to scan and detect ranges of cards that need to be scanned on the

--- a/src/hotspot/share/gc/g1/g1RemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.hpp
@@ -49,6 +49,8 @@ class G1ParScanThreadState;
 class G1ParScanThreadStateSet;
 class G1Policy;
 class G1ScanCardClosure;
+class G1ServiceTask;
+class G1ServiceThread;
 class HeapRegionClaimer;
 
 // A G1RemSet in which each heap region has a rem set that records the
@@ -65,6 +67,7 @@ private:
   G1CardTable*           _ct;
   G1Policy*              _g1p;
   G1HotCardCache*        _hot_card_cache;
+  G1ServiceTask*         _sampling_task;
 
   void print_merge_heap_roots_stats();
 
@@ -80,6 +83,9 @@ public:
            G1CardTable* ct,
            G1HotCardCache* hot_card_cache);
   ~G1RemSet();
+
+  // Initialize and schedule young remembered set sampling task.
+  void initialize_sampling_task(G1ServiceThread* thread);
 
   // Scan all cards in the non-collection set regions that potentially contain
   // references into the current whole collection set.

--- a/src/hotspot/share/gc/g1/g1ServiceThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ServiceThread.cpp
@@ -24,14 +24,9 @@
 
 #include "precompiled.hpp"
 #include "gc/g1/g1CollectedHeap.inline.hpp"
-#include "gc/g1/g1CollectionSet.hpp"
 #include "gc/g1/g1ConcurrentMark.inline.hpp"
 #include "gc/g1/g1ConcurrentMarkThread.inline.hpp"
-#include "gc/g1/g1Policy.hpp"
 #include "gc/g1/g1ServiceThread.hpp"
-#include "gc/g1/heapRegion.inline.hpp"
-#include "gc/g1/heapRegionRemSet.hpp"
-#include "gc/shared/suspendibleThreadSet.hpp"
 #include "memory/universe.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/os.hpp"
@@ -100,75 +95,6 @@ public:
   }
 };
 
-class G1YoungRemSetSamplingClosure : public HeapRegionClosure {
-  SuspendibleThreadSetJoiner* _sts;
-  size_t _regions_visited;
-  size_t _sampled_rs_length;
-public:
-  G1YoungRemSetSamplingClosure(SuspendibleThreadSetJoiner* sts) :
-    HeapRegionClosure(), _sts(sts), _regions_visited(0), _sampled_rs_length(0) { }
-
-  virtual bool do_heap_region(HeapRegion* r) {
-    size_t rs_length = r->rem_set()->occupied();
-    _sampled_rs_length += rs_length;
-
-    // Update the collection set policy information for this region
-    G1CollectedHeap::heap()->collection_set()->update_young_region_prediction(r, rs_length);
-
-    _regions_visited++;
-
-    if (_regions_visited == 10) {
-      if (_sts->should_yield()) {
-        _sts->yield();
-        // A gc may have occurred and our sampling data is stale and further
-        // traversal of the collection set is unsafe
-        return true;
-      }
-      _regions_visited = 0;
-    }
-    return false;
-  }
-
-  size_t sampled_rs_length() const { return _sampled_rs_length; }
-};
-
-// Task handling young gen remembered set sampling.
-class G1RemSetSamplingTask : public G1ServiceTask {
-  // Sample the current length of remembered sets for young.
-  //
-  // At the end of the GC G1 determines the length of the young gen based on
-  // how much time the next GC can take, and when the next GC may occur
-  // according to the MMU.
-  //
-  // The assumption is that a significant part of the GC is spent on scanning
-  // the remembered sets (and many other components), so this thread constantly
-  // reevaluates the prediction for the remembered set scanning costs, and potentially
-  // G1Policy resizes the young gen. This may do a premature GC or even
-  // increase the young gen size to keep pause time length goal.
-  void sample_young_list_rs_length(){
-    SuspendibleThreadSetJoiner sts;
-    G1CollectedHeap* g1h = G1CollectedHeap::heap();
-    G1Policy* policy = g1h->policy();
-
-    if (policy->use_adaptive_young_list_length()) {
-      G1YoungRemSetSamplingClosure cl(&sts);
-
-      G1CollectionSet* g1cs = g1h->collection_set();
-      g1cs->iterate(&cl);
-
-      if (cl.is_complete()) {
-        policy->revise_young_list_target_length_if_necessary(cl.sampled_rs_length());
-      }
-    }
-  }
-public:
-  G1RemSetSamplingTask(const char* name) : G1ServiceTask(name) { }
-  virtual void execute() {
-    sample_young_list_rs_length();
-    schedule(G1ConcRefinementServiceIntervalMillis);
-  }
-};
-
 G1ServiceThread::G1ServiceThread() :
     ConcurrentGCThread(),
     _monitor(Mutex::nonleaf,
@@ -176,7 +102,6 @@ G1ServiceThread::G1ServiceThread() :
              true,
              Monitor::_safepoint_check_never),
     _task_queue(),
-    _remset_task(new G1RemSetSamplingTask("Remembered Set Sampling Task")),
     _periodic_gc_task(new G1PeriodicGCTask("Periodic GC Task")),
     _vtime_accum(0) {
   set_name("G1 Service");
@@ -184,7 +109,6 @@ G1ServiceThread::G1ServiceThread() :
 }
 
 G1ServiceThread::~G1ServiceThread() {
-  delete _remset_task;
   delete _periodic_gc_task;
 }
 
@@ -295,7 +219,6 @@ void G1ServiceThread::run_service() {
 
   // Register the tasks handled by the service thread.
   register_task(_periodic_gc_task);
-  register_task(_remset_task);
 
   while (!should_terminate()) {
     G1ServiceTask* task = pop_due_task();

--- a/src/hotspot/share/gc/g1/g1ServiceThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ServiceThread.hpp
@@ -29,7 +29,6 @@
 #include "runtime/mutex.hpp"
 
 class G1PeriodicGCTask;
-class G1RemSetSamplingTask;
 class G1ServiceTaskQueue;
 class G1ServiceThread;
 
@@ -106,7 +105,6 @@ class G1ServiceThread: public ConcurrentGCThread {
   Monitor _monitor;
   G1ServiceTaskQueue _task_queue;
 
-  G1RemSetSamplingTask* _remset_task;
   G1PeriodicGCTask* _periodic_gc_task;
 
   double _vtime_accum;  // Accumulated virtual time.


### PR DESCRIPTION
Please review this change that moves the `Remembered Set Sampling Task` from `g1ServiceThread.cpp` into `g1RemSet.cpp`. This is basically just a move but with a small edition that the task will reschedule itself instead of running if at start of execution the last GC happend more recently than the value of `G1ConcRefinementServiceIntervalMillis`.

This change does not cover moving the timing measurements from the service thread into the task, that will be covered by: 
[JDK-8252645](https://bugs.openjdk.java.net/browse/JDK-8252645)

Testing
Tier1-3 + local verification that the tast is scheduled as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Linux x86 (build debug)](https://github.com/kstefanj/jdk/runs/1447750536)
- [Linux x86 (build release)](https://github.com/kstefanj/jdk/runs/1447750516)
- [macOS x64 (hs/tier1 runtime)](https://github.com/kstefanj/jdk/runs/1447913827)

### Issue
 * [JDK-8254999](https://bugs.openjdk.java.net/browse/JDK-8254999): Move G1RemSetSamplingTask to more appropriate location


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author) ⚠️ Review applies to e6b7f959ce621325e80e52fd1fd24509511ac3c4


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1395/head:pull/1395`
`$ git checkout pull/1395`
