### PR TITLE
8256883: C2: Add a RegMask iterator

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
@@ -318,10 +318,8 @@ private:
 
 public:
   void initialize(ZLoadBarrierStubC2* stub) {
-    // Iterate over live registers
-    RegMaskIterator rmi(stub->live());
-
     // Record registers that needs to be saved/restored
+    RegMaskIterator rmi(stub->live());
     while (rmi.has_next()) {
       const OptoReg::Name opto_reg = rmi.next();
       if (OptoReg::is_reg(opto_reg)) {

--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
@@ -319,12 +319,11 @@ private:
 public:
   void initialize(ZLoadBarrierStubC2* stub) {
     // Create mask of live registers
-    RegMask live = stub->live();
+    RegMaskIterator live(stub->live());
 
     // Record registers that needs to be saved/restored
-    while (live.is_NotEmpty()) {
-      const OptoReg::Name opto_reg = live.find_first_elem();
-      live.Remove(opto_reg);
+    while (live.has_next()) {
+      const OptoReg::Name opto_reg = live.next();
       if (OptoReg::is_reg(opto_reg)) {
         const VMReg vm_reg = OptoReg::as_VMReg(opto_reg);
         if (vm_reg->is_Register()) {

--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
@@ -318,12 +318,12 @@ private:
 
 public:
   void initialize(ZLoadBarrierStubC2* stub) {
-    // Create mask of live registers
-    RegMaskIterator live(stub->live());
+    // Iterate over live registers
+    RegMaskIterator rmi(stub->live());
 
     // Record registers that needs to be saved/restored
-    while (live.has_next()) {
-      const OptoReg::Name opto_reg = live.next();
+    while (rmi.has_next()) {
+      const OptoReg::Name opto_reg = rmi.next();
       if (OptoReg::is_reg(opto_reg)) {
         const VMReg vm_reg = OptoReg::as_VMReg(opto_reg);
         if (vm_reg->is_Register()) {

--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -480,11 +480,10 @@ private:
     int xmm_spill_size = 0;
 
     // Record registers that needs to be saved/restored
-    while (live.is_NotEmpty()) {
-      const OptoReg::Name opto_reg = live.find_first_elem();
+    RegMaskIterator live_it(live);
+    while (live_it.has_next()) {
+      const OptoReg::Name opto_reg = live_it.next();
       const VMReg vm_reg = OptoReg::as_VMReg(opto_reg);
-
-      live.Remove(opto_reg);
 
       if (vm_reg->is_Register()) {
         if (caller_saved.Member(opto_reg)) {

--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -480,9 +480,9 @@ private:
     int xmm_spill_size = 0;
 
     // Record registers that needs to be saved/restored
-    RegMaskIterator live_it(live);
-    while (live_it.has_next()) {
-      const OptoReg::Name opto_reg = live_it.next();
+    RegMaskIterator rmi(live);
+    while (rmi.has_next()) {
+      const OptoReg::Name opto_reg = rmi.next();
       const VMReg vm_reg = OptoReg::as_VMReg(opto_reg);
 
       if (vm_reg->is_Register()) {

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -2855,11 +2855,10 @@ void Scheduling::verify_good_schedule( Block *b, const char *msg ) {
     int n_op = n->Opcode();
     if( n_op == Op_MachProj && n->ideal_reg() == MachProjNode::fat_proj ) {
       // Fat-proj kills a slew of registers
-      RegMask rm = n->out_RegMask();// Make local copy
-      while( rm.is_NotEmpty() ) {
-        OptoReg::Name kill = rm.find_first_elem();
-        rm.Remove(kill);
-        verify_do_def( n, kill, msg );
+      RegMaskIterator rmi(n->out_RegMask());
+      while (rmi.has_next()) {
+        OptoReg::Name kill = rmi.next();
+        verify_do_def(n, kill, msg);
       }
     } else if( n_op != Op_Node ) { // Avoid brand new antidependence nodes
       // Get DEF'd registers the normal way
@@ -3046,11 +3045,10 @@ void Scheduling::ComputeRegisterAntidependencies(Block *b) {
       // This can add edges to 'n' and obscure whether or not it was a def,
       // hence the is_def flag.
       fat_proj_seen = true;
-      RegMask rm = n->out_RegMask();// Make local copy
-      while( rm.is_NotEmpty() ) {
-        OptoReg::Name kill = rm.find_first_elem();
-        rm.Remove(kill);
-        anti_do_def( b, n, kill, is_def );
+      RegMaskIterator rmi(n->out_RegMask());
+      while (rmi.has_next()) {
+        OptoReg::Name kill = rmi.next();
+        anti_do_def(b, n, kill, is_def);
       }
     } else {
       // Get DEF'd registers the normal way
@@ -3065,11 +3063,10 @@ void Scheduling::ComputeRegisterAntidependencies(Block *b) {
       for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
         Node* use = n->fast_out(i);
         if (use->is_Proj()) {
-          RegMask rm = use->out_RegMask();// Make local copy
-          while( rm.is_NotEmpty() ) {
-            OptoReg::Name kill = rm.find_first_elem();
-            rm.Remove(kill);
-            anti_do_def( b, n, kill, false );
+          RegMaskIterator rmi(use->out_RegMask());
+          while (rmi.has_next()) {
+            OptoReg::Name kill = rmi.next();
+            anti_do_def(b, n, kill, false);
           }
         }
       }

--- a/src/hotspot/share/opto/postaloc.cpp
+++ b/src/hotspot/share/opto/postaloc.cpp
@@ -784,15 +784,12 @@ void PhaseChaitin::post_allocate_copy_removal() {
       }
 
       // Fat projections kill many registers
-      if( n_ideal_reg == MachProjNode::fat_proj ) {
-        RegMask rm = n->out_RegMask();
-        // wow, what an expensive iterator...
-        nreg = rm.find_first_elem();
-        while( OptoReg::is_valid(nreg)) {
-          rm.Remove(nreg);
-          value.map(nreg,n);
-          regnd.map(nreg,n);
-          nreg = rm.find_first_elem();
+      if (n_ideal_reg == MachProjNode::fat_proj) {
+        RegMaskIterator rmi(n->out_RegMask());
+        while (rmi.has_next()) {
+          nreg = rmi.next();
+          value.map(nreg, n);
+          regnd.map(nreg, n);
         }
       }
 

--- a/src/hotspot/share/opto/regmask.cpp
+++ b/src/hotspot/share/opto/regmask.cpp
@@ -355,24 +355,21 @@ uint RegMask::Size() const {
 #ifndef PRODUCT
 void RegMask::dump(outputStream *st) const {
   st->print("[");
-  RegMask rm = *this;           // Structure copy into local temp
 
-  OptoReg::Name start = rm.find_first_elem(); // Get a register
-  if (OptoReg::is_valid(start)) { // Check for empty mask
-    rm.Remove(start);           // Yank from mask
+  RegMaskIterator rmi(*this);
+  if (rmi.has_next()) {
+    OptoReg::Name start = rmi.next();
+
     OptoReg::dump(start, st);   // Print register
     OptoReg::Name last = start;
 
     // Now I have printed an initial register.
     // Print adjacent registers as "rX-rZ" instead of "rX,rY,rZ".
     // Begin looping over the remaining registers.
-    while (1) {                 //
-      OptoReg::Name reg = rm.find_first_elem(); // Get a register
-      if (!OptoReg::is_valid(reg))
-        break;                  // Empty mask, end loop
-      rm.Remove(reg);           // Yank from mask
+    while (rmi.has_next()) {
+      OptoReg::Name reg = rmi.next(); // Get a register
 
-      if (last+1 == reg) {      // See if they are adjacent
+      if (last + 1 == reg) {      // See if they are adjacent
         // Adjacent registers just collect into long runs, no printing.
         last = reg;
       } else {                  // Ending some kind of run
@@ -398,7 +395,7 @@ void RegMask::dump(outputStream *st) const {
       st->print("-");
       OptoReg::dump(last, st);
     }
-    if (rm.is_AllStack()) st->print("...");
+    if (is_AllStack()) st->print("...");
   }
   st->print("]");
 }

--- a/src/hotspot/share/opto/regmask.hpp
+++ b/src/hotspot/share/opto/regmask.hpp
@@ -386,7 +386,6 @@ class RegMaskIterator {
     if (_current_word != 0) {
       unsigned int next_bit = find_lowest_bit(_current_word);
       assert(next_bit > 0, "must be");
-      assert((int)_reg >> RegMask::_LogWordBits == _next_index - 1, "new _reg not within same word");
       assert(((_current_word >> next_bit) & 0x1) == 1, "sanity");
       _current_word = (_current_word >> next_bit) - 1;
       _reg = OptoReg::add(_reg, next_bit);

--- a/src/hotspot/share/opto/regmask.hpp
+++ b/src/hotspot/share/opto/regmask.hpp
@@ -56,6 +56,8 @@ static unsigned int find_highest_bit(uintptr_t mask) {
 
 class RegMask {
 
+  friend class RegMaskIterator;
+
   enum {
     _WordBits    = BitsPerWord,
     _LogWordBits = LogBitsPerWord,
@@ -359,6 +361,54 @@ class RegMask {
     // NOTE: -SlotsPerVecZ in computation reflects the need
     //       to keep mask aligned for largest value (VecZ).
     return (int)reg < (int)(CHUNK_SIZE-SlotsPerVecZ);
+  }
+};
+
+class RegMaskIterator {
+ private:
+  uintptr_t _current_word;
+  unsigned int _current_bit;
+  unsigned int _next_index;
+  OptoReg::Name _reg;
+  const RegMask&  _rm;
+ public:
+  RegMaskIterator(const RegMask& rm) : _current_word(0), _current_bit(0), _next_index(rm._lwm), _reg(OptoReg::Special), _rm(rm) {
+    // Calculate the first element
+    next();
+    assert(_reg == rm.find_first_elem(), "should be the same: %d == %d [%lu %u %u]", (int)_reg, (int)rm.find_first_elem(), _current_word, _current_bit, _next_index);
+  }
+
+  bool has_next() {
+    return _reg != OptoReg::Bad;
+  }
+
+  // Get the current element and calculate the next
+  OptoReg::Name next() {
+    OptoReg::Name r = _reg;
+    if (_current_word != 0) {
+      unsigned int next_bit = find_lowest_bit(_current_word);
+      assert(((_current_word >> next_bit) & 0x1) == 1, "sanity");
+      _current_word = (_current_word >> next_bit) - 1;
+      _current_bit += next_bit;
+      assert(_current_bit < RegMask::_WordBits, "sanity");
+      _reg = OptoReg::Name(((_next_index - 1) << RegMask::_LogWordBits) + _current_bit);
+      return r;
+    }
+
+    while (_next_index <= _rm._hwm) {
+      _current_word = _rm._RM_UP[_next_index++];
+      if (_current_word != 0) {
+        _current_bit = find_lowest_bit(_current_word);
+        assert(_current_bit < RegMask::_WordBits, "sanity");
+        assert(((_current_word >> _current_bit) & 0x1) == 1, "sanity");
+        _current_word = (_current_word >> _current_bit) - 1;
+        _reg = OptoReg::Name(((_next_index - 1) << RegMask::_LogWordBits) + _current_bit);
+        return r;
+      }
+    }
+
+    _reg = OptoReg::Name(OptoReg::Bad);
+    return r;
   }
 };
 


### PR DESCRIPTION
By implementing a simple RegMaskIterator we can speed this up and possibly make the code a bit clearer by doing so.

As a data point, this reduce the `C2Compiler::initialize` overhead from 8.82M instructions to 8.58M instructions, from the improvement in `PhaseChaitin::post_allocate_copy_removal` (~16k insns/compilation). The gain varies with type of compilation, so on the naive tests in `SimpleRepeatCompilation` it's in the noise (~2k insns/compilation on `trivialMath, for example).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256883](https://bugs.openjdk.java.net/browse/JDK-8256883): C2: Add a RegMask iterator


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to b928fcc19b1bc5ad278316f83ca5ef33922f4941
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1397/head:pull/1397`
`$ git checkout pull/1397`
