### PR TITLE
JDK-8256725: Metaspace: better blocktree and binlist asserts

### DIFF
--- a/src/hotspot/share/memory/metaspace/freeBlocks.hpp
+++ b/src/hotspot/share/memory/metaspace/freeBlocks.hpp
@@ -69,6 +69,10 @@ class FreeBlocks : public CHeapObj<mtMetaspace> {
   // to fit into _smallblocks.
   BlockTree _tree;
 
+  // This verifies that blocks too large to go into the binlist can be
+  // kept in the blocktree.
+  STATIC_ASSERT(BinList32::MaxWordSize >= BlockTree::MinWordSize);
+
   // Cutoff point: blocks larger than this size are kept in the
   // tree, blocks smaller than or equal to this size in the bin list.
   const size_t MaxSmallBlocksWordSize = BinList32::MaxWordSize;


### PR DESCRIPTION
This is a re-post of https://github.com/openjdk/jdk/pull/1339. It was approved and I integrated, but apparently deleted the branch too soon and interrupted the integration.

May I have approvals again please? Patch is unchanged from the final version of https://github.com/openjdk/jdk/pull/1339.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (6/6 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8256725](https://bugs.openjdk.java.net/browse/JDK-8256725): Metaspace: better blocktree and binlist asserts


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1398/head:pull/1398`
`$ git checkout pull/1398`
