### PR TITLE
JDK-8256801: tools/jpackage/share/FileAssociationsTest.java#id0 failed unpack.bat with "Exit code: 1603"

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -65,7 +65,11 @@ public class WindowsHelper {
         Executor.Result result = null;
         for (int attempt = 0; attempt != 3; ++attempt) {
             result = misexec.executeWithoutExitCodeCheck();
-            if (result.exitCode == 1618) {
+
+            // The given Executor may either be of an msiexe command or an
+            // unpack.bat script containing the msiexec command. In the later
+            // case, when misexec returns 1618, the unpack.bat may return 1603
+            if ((result.exitCode == 1618) || (result.exitCode == 1603)) {
                 // Another installation is already in progress.
                 // Wait a little and try again.
                 ThrowingRunnable.toRunnable(() -> Thread.sleep(3000)).run();


### PR DESCRIPTION
When executing msiexec (possibly from batch script) retry on exitCode 1603 as well as 1618

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256801](https://bugs.openjdk.java.net/browse/JDK-8256801): tools/jpackage/share/FileAssociationsTest.java#id0 failed unpack.bat with "Exit code: 1603"


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1400/head:pull/1400`
`$ git checkout pull/1400`
