### PR TITLE
8256912: Zero builds fail after JDK-8255984

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -27,6 +27,8 @@
 #include "gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp"
 #include "gc/shenandoah/shenandoahCollectionSet.hpp"
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
+#include "gc/shenandoah/shenandoahHeap.inline.hpp"
+#include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
 #include "logging/log.hpp"
 #include "logging/logTag.hpp"
 #include "utilities/quickSort.hpp"


### PR DESCRIPTION
This went through testing cracks, as JDK-8256497 was integrated at the same time. Zero x86_64 fails with:

```
In file included from /home/runner/work/jdk/jdk/jdk/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp:30,
                 from /home/runner/work/jdk/jdk/jdk/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp:28:
/home/runner/work/jdk/jdk/jdk/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp:348:17: error: inline function 'size_t ShenandoahHeapRegion::get_live_data_bytes() const' used but never defined [-Werror]
  348 | inline size_t get_live_data_bytes() const;
      | ^~~~~~~~~~~~~~~~~~~
/home/runner/work/jdk/jdk/jdk/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp:351:17: error: inline function 'size_t ShenandoahHeapRegion::garbage() const' used but never defined [-Werror]
  351 | inline size_t garbage() const;
      | ^~~~~~~
```

The fix is trivial: reinstating the `#include`-s.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (3/6 running) | ❌ (2/2 failed) | ⏳ (2/2 running) | ⏳ (2/2 running) |

**Failed test tasks**
- [Linux x86 (build debug)](https://github.com/shipilev/jdk/runs/1444634856)
- [Linux x86 (build release)](https://github.com/shipilev/jdk/runs/1444634839)

### Issue
 * [JDK-8256912](https://bugs.openjdk.java.net/browse/JDK-8256912): Zero builds fail after JDK-8255984


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1401/head:pull/1401`
`$ git checkout pull/1401`
