### PR TITLE
8256474: Migrate Mutex _owner accesses to use Atomic operations

### DIFF
--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -84,7 +84,7 @@ class Mutex : public CHeapObj<mtSynchronizer> {
 
  private:
   // The _owner field is only set by the current thread, either to itself after it has acquired
-  // the low-level _lock, or to NULL after it has released the _lock. Accesses by any thread other
+  // the low-level _lock, or to NULL before it has released the _lock. Accesses by any thread other
   // than the lock owner are inherently racy.
   Thread* _owner;
   void raw_set_owner(Thread* new_owner) { Atomic::store(&_owner, new_owner); }

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -86,7 +86,7 @@ class Mutex : public CHeapObj<mtSynchronizer> {
   // The _owner field is only set by the current thread, either to itself after it has acquired
   // the low-level _lock, or to NULL before it has released the _lock. Accesses by any thread other
   // than the lock owner are inherently racy.
-  Thread* _owner;
+  Thread* volatile _owner;
   void raw_set_owner(Thread* new_owner) { Atomic::store(&_owner, new_owner); }
 
  protected:                              // Monitor-Mutex metadata

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -26,6 +26,7 @@
 #define SHARE_RUNTIME_MUTEX_HPP
 
 #include "memory/allocation.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/os.hpp"
 
 // A Mutex/Monitor is a simple wrapper around a native lock plus condition
@@ -81,8 +82,14 @@ class Mutex : public CHeapObj<mtSynchronizer> {
        native         = max_nonleaf    +   1
   };
 
+ private:
+  // The _owner field is only set by the current thread, either to itself after it has acquired
+  // the low-level _lock, or to NULL after it has released the _lock. Accesses by any thread other
+  // than the lock owner are inherently racy.
+  Thread* _owner;
+  void raw_set_owner(Thread* new_owner) { Atomic::store(&_owner, new_owner); }
+
  protected:                              // Monitor-Mutex metadata
-  Thread * volatile _owner;              // The owner of the lock
   os::PlatformMonitor _lock;             // Native monitor implementation
   char _name[MUTEX_NAME_LEN];            // Name of mutex/monitor
 
@@ -111,7 +118,7 @@ class Mutex : public CHeapObj<mtSynchronizer> {
 #endif // ASSERT
 
  protected:
-  void set_owner_implementation(Thread* owner)                        NOT_DEBUG({ _owner = owner;});
+  void set_owner_implementation(Thread* owner)                        NOT_DEBUG({ raw_set_owner(owner);});
   void check_block_state       (Thread* thread)                       NOT_DEBUG_RETURN;
   void check_safepoint_state   (Thread* thread)                       NOT_DEBUG_RETURN;
   void check_no_safepoint_state(Thread* thread)                       NOT_DEBUG_RETURN;
@@ -180,7 +187,7 @@ class Mutex : public CHeapObj<mtSynchronizer> {
   void lock(); // prints out warning if VM thread blocks
   void lock(Thread *thread); // overloaded with current thread
   void unlock();
-  bool is_locked() const                     { return _owner != NULL; }
+  bool is_locked() const                     { return owner() != NULL; }
 
   bool try_lock(); // Like lock(), but unblocking. It returns false instead
  private:
@@ -197,9 +204,9 @@ class Mutex : public CHeapObj<mtSynchronizer> {
   // A thread should not call this if failure to acquire ownership will blocks its progress
   bool try_lock_without_rank_check();
 
-  // Current owner - not not MT-safe. Can only be used to guarantee that
+  // Current owner - note not MT-safe. Can only be used to guarantee that
   // the current running thread owns the lock
-  Thread* owner() const         { return _owner; }
+  Thread* owner() const         { return Atomic::load(&_owner); }
   void set_owner(Thread* owner) { set_owner_implementation(owner); }
   bool owned_by_self() const;
 


### PR DESCRIPTION
Simple update to move away from volatile fields and use Atomic::load/store on racy accesses.

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256474](https://bugs.openjdk.java.net/browse/JDK-8256474): Migrate Mutex _owner accesses to use Atomic operations


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1402/head:pull/1402`
`$ git checkout pull/1402`
