### PR TITLE
8255904: Remove superfluous use of reflection in Class::isRecord

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3661,16 +3661,6 @@ public final class Class<T> implements java.io.Serializable,
         this.getSuperclass() == java.lang.Enum.class;
     }
 
-    /** java.lang.Record.class */
-    private static final Class<?> JAVA_LANG_RECORD_CLASS = javaLangRecordClass();
-    private static Class<?> javaLangRecordClass() {
-        try {
-            return Class.forName0("java.lang.Record", false, null, null);
-        } catch (ClassNotFoundException e) {
-            throw new InternalError("should not reach here", e);
-        }
-    }
-
     /**
      * Returns {@code true} if and only if this class is a record class.
      *
@@ -3687,7 +3677,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since 16
      */
     public boolean isRecord() {
-        return getSuperclass() == JAVA_LANG_RECORD_CLASS && isRecord0();
+        return getSuperclass() == java.lang.Record.class && isRecord0();
     }
 
     // Fetches the factory for reflective objects


### PR DESCRIPTION
Minor cleanup - Reflective access to j.l.Record is no longer required since it became standard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (2/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Windows x64 (hs/tier1 gc)](https://github.com/ChrisHegarty/jdk/runs/1447368985)
- [Windows x64 (hs/tier1 serviceability)](https://github.com/ChrisHegarty/jdk/runs/1447369043)
- [macOS x64 (hs/tier1 gc)](https://github.com/ChrisHegarty/jdk/runs/1447200845)

### Issue
 * [JDK-8255904](https://bugs.openjdk.java.net/browse/JDK-8255904): Remove superfluous use of reflection in Class::isRecord


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1406/head:pull/1406`
`$ git checkout pull/1406`
