### PR TITLE
8256949: Shenandoah: ditch allocation spike and GC penalties handling

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -49,7 +49,6 @@ ShenandoahHeuristics::ShenandoahHeuristics() :
   _cycle_start(os::elapsedTime()),
   _last_cycle_end(0),
   _gc_times_learned(0),
-  _gc_time_penalties(0),
   _gc_time_history(new TruncatedSeq(10, ShenandoahAdaptiveDecayFactor)),
   _metaspace_oom()
 {
@@ -206,45 +205,22 @@ bool ShenandoahHeuristics::should_degenerate_cycle() {
   return _degenerated_cycles_in_a_row <= ShenandoahFullGCThreshold;
 }
 
-void ShenandoahHeuristics::adjust_penalty(intx step) {
-  assert(0 <= _gc_time_penalties && _gc_time_penalties <= 100,
-          "In range before adjustment: " INTX_FORMAT, _gc_time_penalties);
-
-  intx new_val = _gc_time_penalties + step;
-  if (new_val < 0) {
-    new_val = 0;
-  }
-  if (new_val > 100) {
-    new_val = 100;
-  }
-  _gc_time_penalties = new_val;
-
-  assert(0 <= _gc_time_penalties && _gc_time_penalties <= 100,
-          "In range after adjustment: " INTX_FORMAT, _gc_time_penalties);
-}
-
 void ShenandoahHeuristics::record_success_concurrent() {
   _degenerated_cycles_in_a_row = 0;
   _successful_cycles_in_a_row++;
 
   _gc_time_history->add(time_since_last_gc());
   _gc_times_learned++;
-
-  adjust_penalty(Concurrent_Adjust);
 }
 
 void ShenandoahHeuristics::record_success_degenerated() {
   _degenerated_cycles_in_a_row++;
   _successful_cycles_in_a_row = 0;
-
-  adjust_penalty(Degenerated_Penalty);
 }
 
 void ShenandoahHeuristics::record_success_full() {
   _degenerated_cycles_in_a_row = 0;
   _successful_cycles_in_a_row++;
-
-  adjust_penalty(Full_Penalty);
 }
 
 void ShenandoahHeuristics::record_allocation_failure_gc() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -59,10 +59,6 @@ class ShenandoahCollectionSet;
 class ShenandoahHeapRegion;
 
 class ShenandoahHeuristics : public CHeapObj<mtGC> {
-  static const intx Concurrent_Adjust   = -1; // recover from penalties
-  static const intx Degenerated_Penalty = 10; // how much to penalize average GC duration history on Degenerated GC
-  static const intx Full_Penalty        = 20; // how much to penalize average GC duration history on Full GC
-
 protected:
   typedef struct {
     ShenandoahHeapRegion* _region;
@@ -78,7 +74,6 @@ protected:
   double _last_cycle_end;
 
   size_t _gc_times_learned;
-  intx _gc_time_penalties;
   TruncatedSeq* _gc_time_history;
 
   // There may be many threads that contend to set this flag
@@ -89,8 +84,6 @@ protected:
   virtual void choose_collection_set_from_regiondata(ShenandoahCollectionSet* set,
                                                      RegionData* data, size_t data_size,
                                                      size_t free) = 0;
-
-  void adjust_penalty(intx step);
 
 public:
   ShenandoahHeuristics();

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -108,13 +108,6 @@
           "(soft) max heap size. Set to zero to effectively disable.")      \
           range(0,100)                                                      \
                                                                             \
-  product(uintx, ShenandoahAllocSpikeFactor, 5, EXPERIMENTAL,               \
-          "How much of heap should some heuristics reserve for absorbing "  \
-          "the allocation spikes. Larger value wastes more memory in "      \
-          "non-emergency cases, but provides more safety in emergency "     \
-          "cases. In percents of (soft) max heap size.")                    \
-          range(0,100)                                                      \
-                                                                            \
   product(uintx, ShenandoahLearningSteps, 5, EXPERIMENTAL,                  \
           "The number of cycles some heuristics take to collect in order "  \
           "to learn application and GC performance.")                       \


### PR DESCRIPTION
Following the improvements in JDK-8255984, I think we can dispense with old-style allocation spike and GC penalties handling. JDK-8255984 is supposed to accommodate both cases now. This issue is to have a base for performance evaluation.

Additional testing:
 - [x] Linux x86_64 `hotspot_gc_shenandoah`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux aarch64 | Linux arm | Linux ppc64le | Linux s390x | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (1/1 passed) | ❌ (1/1 failed) | ❌ (1/1 failed) | ✔️ (1/1 passed) | ✔️ (6/6 passed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |     |     |  ❌ (1/9 failed) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux arm (build hotspot no-pch)](https://github.com/shipilev/jdk/runs/1447886209)
- [Linux ppc64le (build hotspot no-pch)](https://github.com/shipilev/jdk/runs/1447886711)
- [Linux x64 (hs/tier1 runtime)](https://github.com/shipilev/jdk/runs/1447886496)
- [Linux x86 (build debug)](https://github.com/shipilev/jdk/runs/1447673088)
- [Linux x86 (build release)](https://github.com/shipilev/jdk/runs/1447673076)

### Issue
 * [JDK-8256949](https://bugs.openjdk.java.net/browse/JDK-8256949): Shenandoah: ditch allocation spike and GC penalties handling


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1409/head:pull/1409`
`$ git checkout pull/1409`
