### PR TITLE
8256359: AArch64: runtime/ReservedStack/ReservedStackTestCompiler.java fails with "assert(sp() <= (intptr_t*) result) failed: monitor end should be above the stack pointer"

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -681,14 +681,16 @@ void InterpreterMacroAssembler::remove_activation(
 
   // remove activation
   // get sender esp
-  ldr(esp,
+  ldr(rscratch2,
       Address(rfp, frame::interpreter_frame_sender_sp_offset * wordSize));
   if (StackReservedPages > 0) {
     // testing if reserved zone needs to be re-enabled
     Label no_reserved_zone_enabling;
 
+    // look for an overflow into the stack reserved zone, i.e.
+    // interpreter_frame_sender_sp <= JavaThread::reserved_stack_activation
     ldr(rscratch1, Address(rthread, JavaThread::reserved_stack_activation_offset()));
-    cmp(esp, rscratch1);
+    cmp(rscratch2, rscratch1);
     br(Assembler::LS, no_reserved_zone_enabling);
 
     call_VM_leaf(
@@ -699,6 +701,9 @@ void InterpreterMacroAssembler::remove_activation(
 
     bind(no_reserved_zone_enabling);
   }
+
+  // restore sender esp
+  mov(esp, rscratch2);
   // remove frame anchor
   leave();
   // If we're returning to interpreted code we will shortly be


### PR DESCRIPTION
The problem is that the caller's expression SP is restored before throw_delayed_StackOverflowError(). This is wrong: it leaves ESP pointing into the caller's frame, and this triggers an assert failure. The fix here delays updating ESP until we know we're not going to call throw_delayed_StackOverflowError(). This makes the logic the same as x86.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ 8256359 is used in problem lists: [test/hotspot/jtreg/ProblemList.txt]

### Issue
 * [JDK-8256359](https://bugs.openjdk.java.net/browse/JDK-8256359): AArch64: runtime/ReservedStack/ReservedStackTestCompiler.java fails with "assert(sp() <= (intptr_t*) result) failed: monitor end should be above the stack pointer"


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1417/head:pull/1417`
`$ git checkout pull/1417`
