### PR TITLE
8256986: [PPC64] C2 crashes when accessing nonexisting jvms of CallLeafDirectNode

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -1115,11 +1115,15 @@ int MachCallDynamicJavaNode::ret_addr_offset() {
 }
 
 int MachCallRuntimeNode::ret_addr_offset() {
+  if (rule() == CallRuntimeDirect_rule) {
+    // CallRuntimeDirectNode uses call_c.
 #if defined(ABI_ELFv2)
-  return 28;
+    return 28;
 #else
-  return 40;
+    return 40;
 #endif
+  }
+  return 4;
 }
 
 int MachCallNativeNode::ret_addr_offset() {
@@ -3784,7 +3788,7 @@ encode %{
     call->_jvmadj      = _jvmadj;
     call->_in_rms      = _in_rms;
     call->_nesting     = _nesting;
-
+    call->set_guaranteed_safepoint(false);
 
     // New call needs all inputs of old call.
     // Req...

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -1123,6 +1123,8 @@ int MachCallRuntimeNode::ret_addr_offset() {
     return 40;
 #endif
   }
+  assert(rule() == CallLeafDirect_rule, "unexpected node with rule %u", rule());
+  // CallLeafDirectNode uses bl.
   return 4;
 }
 
@@ -3582,6 +3584,7 @@ encode %{
     call->_tf                = _tf;
     call->_entry_point       = _entry_point;
     call->_cnt               = _cnt;
+    call->_guaranteed_safepoint = true;
     call->_oop_map           = _oop_map;
     call->_jvms              = _jvms;
     call->_jvmadj            = _jvmadj;
@@ -3782,13 +3785,13 @@ encode %{
     call->_tf          = _tf;
     call->_entry_point = _entry_point;
     call->_cnt         = _cnt;
+    call->_guaranteed_safepoint = false;
     call->_oop_map     = _oop_map;
     guarantee(!_jvms, "You must clone the jvms and adapt the offsets by fix_jvms().");
     call->_jvms        = NULL;
     call->_jvmadj      = _jvmadj;
     call->_in_rms      = _in_rms;
     call->_nesting     = _nesting;
-    call->set_guaranteed_safepoint(false);
 
     // New call needs all inputs of old call.
     // Req...


### PR DESCRIPTION
observe_safepoint() is called with jvms == NULL from fill_buffer with mach = CallLeafDirectNode.
That node represents a leaf call and does not safepoint.
"_guaranteed_safepoint" needs to get set correctly for all MachCallNodes after JDK-8254231. 

In addition MachCallRuntimeNode::ret_addr_offset() need update for the new assertion in output.cpp.
This was already fixed on some other platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ❌ (6/6 failed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build debug)](https://github.com/TheRealMDoerr/jdk/runs/1463223645)
- [Linux x64 (build hotspot minimal)](https://github.com/TheRealMDoerr/jdk/runs/1463223757)
- [Linux x64 (build hotspot no-pch)](https://github.com/TheRealMDoerr/jdk/runs/1463223673)
- [Linux x64 (build hotspot optimized)](https://github.com/TheRealMDoerr/jdk/runs/1463223779)
- [Linux x64 (build hotspot zero)](https://github.com/TheRealMDoerr/jdk/runs/1463223718)
- [Linux x64 (build release)](https://github.com/TheRealMDoerr/jdk/runs/1463223604)
- [Linux x86 (build debug)](https://github.com/TheRealMDoerr/jdk/runs/1463223557)
- [Linux x86 (build release)](https://github.com/TheRealMDoerr/jdk/runs/1463223536)

### Issue
 * [JDK-8256986](https://bugs.openjdk.java.net/browse/JDK-8256986): [PPC64] C2 crashes when accessing nonexisting jvms of CallLeafDirectNode


### Reviewers
 * @jrziviani (no known github.com user name / role)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1418/head:pull/1418`
`$ git checkout pull/1418`
