### PR TITLE
8256993: Clarify Package::isSealed javadoc about package sealing vs sealed class or interface

### DIFF
--- a/src/java.base/share/classes/java/lang/Package.java
+++ b/src/java.base/share/classes/java/lang/Package.java
@@ -53,7 +53,7 @@ import jdk.internal.reflect.Reflection;
  * {@code Package} is compatible with a particular specification version
  * by using the {@link #isCompatibleWith Package.isCompatibleWith(String)}
  * method. In addition, information about the actual classes that make up the
- * run-time package can be provided when the Package is defined.
+ * run-time package can be provided when the {@code Package} is defined.
  * This information consists of an implementation title, version, and vendor
  * (indicating the supplier of the classes).
  * <p>
@@ -221,7 +221,18 @@ public class Package extends NamedPackage implements java.lang.reflect.Annotated
     /**
      * Returns true if this package is sealed.
      *
+     * <p>
+     * <a href="{@docRoot}/../specs/jar/jar.html#package-sealing">Package sealing</a>
+     * is specific to JAR files defined for classes in unnamed module.
+     * See the {@link Package Package class specification} for details
+     * how a {@code Package} is defined as sealed package.
+     *
+     * @apiNote
+     * Package sealing has no relationship with {@linkplain Class#isSealed()
+     * sealed classes or interfaces}.
+     *
      * @return true if the package is sealed, false otherwise
+     *
      */
     public boolean isSealed() {
         return module().isNamed() || versionInfo.sealBase != null;
@@ -230,6 +241,16 @@ public class Package extends NamedPackage implements java.lang.reflect.Annotated
     /**
      * Returns true if this package is sealed with respect to the specified
      * code source {@code url}.
+     *
+     * <p>
+     * <a href="{@docRoot}/../specs/jar/jar.html#package-sealing">Package sealing</a>
+     * is specific to JAR files defined for classes in unnamed module.
+     * See the {@link Package Package class specification} for details
+     * how a {@code Package} is defined as sealed package.
+     *
+     * @apiNote
+     * Package sealing has no relationship with {@linkplain Class#isSealed()
+     * sealed classes or interfaces}.
      *
      * @param  url the code source URL
      * @return true if this package is sealed with respect to the given {@code url}

--- a/src/java.base/share/classes/java/lang/Package.java
+++ b/src/java.base/share/classes/java/lang/Package.java
@@ -221,15 +221,12 @@ public class Package extends NamedPackage implements java.lang.reflect.Annotated
     /**
      * Returns true if this package is sealed.
      *
-     * <p>
-     * <a href="{@docRoot}/../specs/jar/jar.html#package-sealing">Package sealing</a>
-     * is specific to JAR files defined for classes in unnamed module.
-     * See the {@link Package Package class specification} for details
-     * how a {@code Package} is defined as sealed package.
-     *
      * @apiNote
-     * Package sealing has no relationship with {@linkplain Class#isSealed()
-     * sealed classes or interfaces}.
+     * <a href="{@docRoot}/../specs/jar/jar.html#package-sealing">Package sealing</a>
+     * has no relationship with {@linkplain Class#isSealed() sealed classes or interfaces}.
+     * Package sealing is specific to JAR files defined for classes in an unnamed module.
+     * See the {@link Package Package} class specification for details
+     * how a {@code Package} is defined as sealed package.
      *
      * @return true if the package is sealed, false otherwise
      *
@@ -242,15 +239,12 @@ public class Package extends NamedPackage implements java.lang.reflect.Annotated
      * Returns true if this package is sealed with respect to the specified
      * code source {@code url}.
      *
-     * <p>
-     * <a href="{@docRoot}/../specs/jar/jar.html#package-sealing">Package sealing</a>
-     * is specific to JAR files defined for classes in unnamed module.
-     * See the {@link Package Package class specification} for details
-     * how a {@code Package} is defined as sealed package.
-     *
      * @apiNote
-     * Package sealing has no relationship with {@linkplain Class#isSealed()
-     * sealed classes or interfaces}.
+     * <a href="{@docRoot}/../specs/jar/jar.html#package-sealing">Package sealing</a>
+     * has no relationship with {@linkplain Class#isSealed() sealed classes or interfaces}.
+     * Package sealing is specific to JAR files defined for classes in an unnamed module.
+     * See the {@link Package Package} class specification for details
+     * how a {@code Package} is defined as sealed package.
      *
      * @param  url the code source URL
      * @return true if this package is sealed with respect to the given {@code url}


### PR DESCRIPTION
This adds API note in `Package::isSealed` javadoc to clarify package sealing vs sealed class or interface.   Since it's spec clarification, CSR is not strictly needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ❌ (1/6 failed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |  ⏳ (3/9 running) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build debug)](https://github.com/mlchung/jdk/runs/1449492843)
- [Linux x86 (build debug)](https://github.com/mlchung/jdk/runs/1449493111)
- [Linux x86 (build release)](https://github.com/mlchung/jdk/runs/1449493091)

### Issue
 * [JDK-8256993](https://bugs.openjdk.java.net/browse/JDK-8256993): Clarify Package::isSealed javadoc about package sealing vs sealed class or interface


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1419/head:pull/1419`
`$ git checkout pull/1419`
