### PR TITLE
8254042: gtest/GTestWrapper.java failed os.test_random

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -2464,8 +2464,6 @@ void os::init(void) {
 
   clock_tics_per_sec = sysconf(_SC_CLK_TCK);
 
-  init_random(1234567);
-
   // _main_thread points to the thread that created/loaded the JVM.
   Aix::_main_thread = pthread_self();
 

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2089,8 +2089,6 @@ void os::init(void) {
 
   clock_tics_per_sec = CLK_TCK;
 
-  init_random(1234567);
-
   Bsd::set_page_size(getpagesize());
   if (Bsd::page_size() == -1) {
     fatal("os_bsd.cpp: os::init: sysconf failed (%s)", os::strerror(errno));

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4394,8 +4394,6 @@ void os::init(void) {
 
   clock_tics_per_sec = sysconf(_SC_CLK_TCK);
 
-  init_random(1234567);
-
   Linux::set_page_size(sysconf(_SC_PAGESIZE));
   if (Linux::page_size() == -1) {
     fatal("os_linux.cpp: os::init: sysconf failed (%s)",

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4164,8 +4164,6 @@ void nx_check_protection() {
 void os::init(void) {
   _initial_pid = _getpid();
 
-  init_random(1234567);
-
   win32::initialize_system_info();
   win32::setmode_streams();
   init_page_sizes((size_t) win32::vm_page_size());

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -297,7 +297,6 @@ static jint wb_stress_virtual_space_resize(size_t reserved_space_size,
     return 3;
   }
 
-  // Random sets the seed to the value returned.
   int seed = os::random();
   tty->print_cr("Random seed is %d", seed);
 

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -297,9 +297,9 @@ static jint wb_stress_virtual_space_resize(size_t reserved_space_size,
     return 3;
   }
 
+  // Random sets the seed to the value returned.
   int seed = os::random();
   tty->print_cr("Random seed is %d", seed);
-  os::init_random(seed);
 
   for (size_t i = 0; i < iterations; i++) {
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -72,7 +72,7 @@
 
 OSThread*         os::_starting_thread    = NULL;
 address           os::_polling_page       = NULL;
-volatile unsigned int os::_rand_seed      = 1;
+volatile unsigned int os::_rand_seed      = 1234567;
 int               os::_processor_count    = 0;
 int               os::_initial_active_processor_count = 0;
 size_t            os::_page_sizes[os::page_sizes_max];
@@ -805,6 +805,7 @@ void  os::free(void *memblock) {
 }
 
 void os::init_random(unsigned int initval) {
+  assert(SafepointSynchronize::is_at_safepoint(), "only safe at a safepoint");
   _rand_seed = initval;
 }
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -805,7 +805,6 @@ void  os::free(void *memblock) {
 }
 
 void os::init_random(unsigned int initval) {
-  assert(SafepointSynchronize::is_at_safepoint(), "only safe at a safepoint");
   _rand_seed = initval;
 }
 

--- a/test/hotspot/gtest/logging/test_logOutputList.cpp
+++ b/test/hotspot/gtest/logging/test_logOutputList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/logging/test_logOutputList.cpp
+++ b/test/hotspot/gtest/logging/test_logOutputList.cpp
@@ -66,6 +66,7 @@ TEST(LogOutputList, set_output_level_update) {
   size_t outputs_on_level[LogLevel::Count];
   LogLevelType expected_level_for_output[TestOutputCount];
 
+  os::init_random(0x4711);
   for (size_t i = 0; i < LogLevel::Count; i++) {
     outputs_on_level[i] = 0;
   }

--- a/test/hotspot/gtest/logging/test_logOutputList.cpp
+++ b/test/hotspot/gtest/logging/test_logOutputList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,6 @@ TEST(LogOutputList, set_output_level_update) {
   size_t outputs_on_level[LogLevel::Count];
   LogLevelType expected_level_for_output[TestOutputCount];
 
-  os::init_random(0x4711);
   for (size_t i = 0; i < LogLevel::Count; i++) {
     outputs_on_level[i] = 0;
   }

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -122,6 +122,7 @@ TEST(os, test_random) {
   // tty->print_cr("seed %ld for %ld repeats...", seed, reps);
   int num;
   for (int k = 0; k < reps; k++) {
+    // Use next_random so the calculation is stateless.
     num = seed = os::next_random(seed);
     double u = (double)num / m;
     ASSERT_TRUE(u >= 0.0 && u <= 1.0) << "bad random number!";

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,9 @@
 #include "precompiled.hpp"
 #include "memory/resourceArea.hpp"
 #include "runtime/os.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/vmOperations.hpp"
+#include "runtime/vmThread.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
@@ -113,39 +116,50 @@ TEST_VM(os, page_size_for_region_unaligned) {
   }
 }
 
-TEST(os, test_random) {
-  const double m = 2147483647;
-  double mean = 0.0, variance = 0.0, t;
-  const int reps = 10000;
-  unsigned int seed = 1;
+class VM_TestRandom : public VM_GTestExecuteAtSafepoint {
+public:
+  void doit() {
+    const double m = 2147483647;
+    double mean = 0.0, variance = 0.0, t;
+    const int reps = 10000;
+    unsigned int seed = 1;
 
-  // tty->print_cr("seed %ld for %ld repeats...", seed, reps);
-  os::init_random(seed);
-  int num;
-  for (int k = 0; k < reps; k++) {
-    num = os::random();
-    double u = (double)num / m;
-    ASSERT_TRUE(u >= 0.0 && u <= 1.0) << "bad random number!";
+    // tty->print_cr("seed %ld for %ld repeats...", seed, reps);
+    os::init_random(seed);
+    int num;
+    for (int k = 0; k < reps; k++) {
+      num = os::random();
+      double u = (double)num / m;
+      ASSERT_TRUE(u >= 0.0 && u <= 1.0) << "bad random number!";
 
-    // calculate mean and variance of the random sequence
-    mean += u;
-    variance += (u*u);
+      // calculate mean and variance of the random sequence
+      mean += u;
+      variance += (u*u);
+    }
+    mean /= reps;
+    variance /= (reps - 1);
+
+    ASSERT_EQ(num, 1043618065) << "bad seed";
+    // tty->print_cr("mean of the 1st 10000 numbers: %f", mean);
+    int intmean = mean*100;
+    ASSERT_EQ(intmean, 50);
+    // tty->print_cr("variance of the 1st 10000 numbers: %f", variance);
+    int intvariance = variance*100;
+    ASSERT_EQ(intvariance, 33);
+    const double eps = 0.0001;
+    t = fabsd(mean - 0.5018);
+    ASSERT_LT(t, eps) << "bad mean";
+    t = (variance - 0.3355) < 0.0 ? -(variance - 0.3355) : variance - 0.3355;
+    ASSERT_LT(t, eps) << "bad variance";
   }
-  mean /= reps;
-  variance /= (reps - 1);
+};
 
-  ASSERT_EQ(num, 1043618065) << "bad seed";
-  // tty->print_cr("mean of the 1st 10000 numbers: %f", mean);
-  int intmean = mean*100;
-  ASSERT_EQ(intmean, 50);
-  // tty->print_cr("variance of the 1st 10000 numbers: %f", variance);
-  int intvariance = variance*100;
-  ASSERT_EQ(intvariance, 33);
-  const double eps = 0.0001;
-  t = fabsd(mean - 0.5018);
-  ASSERT_LT(t, eps) << "bad mean";
-  t = (variance - 0.3355) < 0.0 ? -(variance - 0.3355) : variance - 0.3355;
-  ASSERT_LT(t, eps) << "bad variance";
+TEST_VM(os, random) {
+  // Can only change the random seed inside a safepoint and expect the
+  // threads to not change it by other os::random() calls.
+  ThreadInVMfromNative invm(JavaThread::current());
+  VM_TestRandom op;
+  VMThread::execute(&op);
 }
 
 


### PR DESCRIPTION
The function os::init_random() and os::random() both set the _rand_seed. This test thinks nothing can change the seed while it is computing its expected value.
I changed the test to run in a VM operation safepoint.  Alternately, I can change the test to not verify the random value computed in the loop, or remove the test.
Ran tier1 tests on linux-x64 and windows-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254042](https://bugs.openjdk.java.net/browse/JDK-8254042): gtest/GTestWrapper.java failed os.test_random


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 3292c2f84f57791702f833b67fd3890dd2870c17
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 3292c2f84f57791702f833b67fd3890dd2870c17
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 3292c2f84f57791702f833b67fd3890dd2870c17


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1422/head:pull/1422`
`$ git checkout pull/1422`
