### PR TITLE
8257020: [JVMCI] enable a JVMCICompiler to specify which GCs it supports

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -453,10 +453,6 @@ void CompilerConfig::ergo_initialize() {
 #endif
 
 #if INCLUDE_JVMCI
-  // Check that JVMCI compiler supports selested GC.
-  // Should be done after GCConfig::initialize() was called.
-  JVMCIGlobals::check_jvmci_supported_gc();
-
   // Do JVMCI specific settings
   set_jvmci_specific_flags();
 #endif

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -453,6 +453,10 @@ void CompilerConfig::ergo_initialize() {
 #endif
 
 #if INCLUDE_JVMCI
+  // Check that JVMCI supports selected GC.
+  // Should be done after GCConfig::initialize() was called.
+  JVMCIGlobals::check_jvmci_supported_gc();
+
   // Do JVMCI specific settings
   set_jvmci_specific_flags();
 #endif

--- a/src/hotspot/share/gc/shared/gcConfig.cpp
+++ b/src/hotspot/share/gc/shared/gcConfig.cpp
@@ -28,10 +28,6 @@
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
 #include "utilities/macros.hpp"
-#if INCLUDE_JVMCI
-#include "jvmci/jvmciEnv.hpp"
-#include "jvmci/jvmciRuntime.hpp"
-#endif
 #if INCLUDE_EPSILONGC
 #include "gc/epsilon/epsilonArguments.hpp"
 #endif
@@ -186,15 +182,6 @@ void GCConfig::initialize() {
 bool GCConfig::is_gc_supported(CollectedHeap::Name name) {
   FOR_EACH_INCLUDED_GC(gc) {
     if (gc->_name == name && gc->_arguments.is_supported()) {
-#if INCLUDE_JVMCI
-      if (EnableJVMCI) {
-        JavaThread *thread = JavaThread::current();
-        JVMCIEnv jvmciEnv(thread, thread->jni_environment(), __FILE__, __LINE__);
-        if (!jvmciEnv.runtime()->is_gc_supported(&jvmciEnv, (CollectedHeap::Name)name)) {
-          return false;
-        }
-      }
-#endif
       // Supported
       return true;
     }

--- a/src/hotspot/share/gc/shared/gcConfig.cpp
+++ b/src/hotspot/share/gc/shared/gcConfig.cpp
@@ -28,6 +28,10 @@
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
 #include "utilities/macros.hpp"
+#if INCLUDE_JVMCI
+#include "jvmci/jvmciEnv.hpp"
+#include "jvmci/jvmciRuntime.hpp"
+#endif
 #if INCLUDE_EPSILONGC
 #include "gc/epsilon/epsilonArguments.hpp"
 #endif
@@ -182,6 +186,15 @@ void GCConfig::initialize() {
 bool GCConfig::is_gc_supported(CollectedHeap::Name name) {
   FOR_EACH_INCLUDED_GC(gc) {
     if (gc->_name == name && gc->_arguments.is_supported()) {
+#if INCLUDE_JVMCI
+      if (EnableJVMCI) {
+        JavaThread *thread = JavaThread::current();
+        JVMCIEnv jvmciEnv(thread, thread->jni_environment(), __FILE__, __LINE__);
+        if (!jvmciEnv.runtime()->is_gc_supported(&jvmciEnv, (CollectedHeap::Name)name)) {
+          return false;
+        }
+      }
+#endif
       // Supported
       return true;
     }

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -645,7 +645,7 @@ jboolean JVMCIEnv::call_HotSpotJVMCIRuntime_isGCSupported (JVMCIObject runtime, 
     JavaCalls::call_special(&result,
                             HotSpotJVMCI::HotSpotJVMCIRuntime::klass(),
                             vmSymbols::isGCSupported_name(),
-                            vmSymbols::isGCSupported_signature(), &jargs, CHECK_0);
+                            vmSymbols::int_bool_signature(), &jargs, CHECK_0);
     return result.get_jboolean();
   } else {
     JNIAccessMark jni(this, THREAD);

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -635,6 +635,31 @@ void JVMCIEnv::fthrow_error(const char* file, int line, const char* format, ...)
   }
 }
 
+jboolean JVMCIEnv::call_HotSpotJVMCIRuntime_isGCSupported (JVMCIObject runtime, jint gcIdentifier) {
+  JavaThread* THREAD = JavaThread::current();
+  if (is_hotspot()) {
+    JavaCallArguments jargs;
+    jargs.push_oop(Handle(THREAD, HotSpotJVMCI::resolve(runtime)));
+    jargs.push_int(gcIdentifier);
+    JavaValue result(T_BOOLEAN);
+    JavaCalls::call_special(&result,
+                            HotSpotJVMCI::HotSpotJVMCIRuntime::klass(),
+                            vmSymbols::isGCSupported_name(),
+                            vmSymbols::isGCSupported_signature(), &jargs, CHECK_0);
+    return result.get_jboolean();
+  } else {
+    JNIAccessMark jni(this, THREAD);
+    jboolean result = jni()->CallNonvirtualBooleanMethod(runtime.as_jobject(),
+                                                     JNIJVMCI::HotSpotJVMCIRuntime::clazz(),
+                                                     JNIJVMCI::HotSpotJVMCIRuntime::isGCSupported_method(),
+                                                     gcIdentifier);
+    if (jni()->ExceptionCheck()) {
+      return false;
+    }
+    return result;
+  }
+}
+
 JVMCIObject JVMCIEnv::call_HotSpotJVMCIRuntime_compileMethod (JVMCIObject runtime, JVMCIObject method, int entry_bci,
                                                               jlong compile_state, int id) {
   JavaThread* THREAD = JVMCI::compilation_tick(JavaThread::current());

--- a/src/hotspot/share/jvmci/jvmciEnv.hpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.hpp
@@ -310,6 +310,8 @@ public:
   JVMCIObject call_JavaConstant_forFloat(float value, JVMCI_TRAPS);
   JVMCIObject call_JavaConstant_forDouble(double value, JVMCI_TRAPS);
 
+  jboolean call_HotSpotJVMCIRuntime_isGCSupported(JVMCIObject runtime, jint gcIdentifier);
+
   BasicType kindToBasicType(JVMCIObject kind, JVMCI_TRAPS);
 
 #define DO_THROW(name) \

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
@@ -348,7 +348,7 @@
   start_class(HotSpotJVMCIRuntime, jdk_vm_ci_hotspot_HotSpotJVMCIRuntime)                                     \
     objectarray_field(HotSpotJVMCIRuntime, excludeFromJVMCICompilation, "[Ljava/lang/Module;")                \
     jvmci_method(CallNonvirtualObjectMethod, GetMethodID, call_special, JVMCIObject, HotSpotJVMCIRuntime, compileMethod, compileMethod_signature, (JVMCIObject runtime, JVMCIObject method, int entry_bci, jlong env, int id)) \
-    jvmci_method(CallNonvirtualObjectMethod, GetMethodID, call_special, JVMCIObject, HotSpotJVMCIRuntime, isGCSupported, isGCSupported_signature, (JVMCIObject runtime, int gcIdentifier)) \
+    jvmci_method(CallNonvirtualObjectMethod, GetMethodID, call_special, JVMCIObject, HotSpotJVMCIRuntime, isGCSupported, int_bool_signature, (JVMCIObject runtime, int gcIdentifier)) \
     jvmci_method(CallStaticObjectMethod, GetStaticMethodID, call_static, JVMCIObject, HotSpotJVMCIRuntime, encodeThrowable, encodeThrowable_signature, (JVMCIObject throwable)) \
     jvmci_method(CallStaticObjectMethod, GetStaticMethodID, call_static, JVMCIObject, HotSpotJVMCIRuntime, decodeThrowable, decodeThrowable_signature, (JVMCIObject encodedThrowable)) \
     jvmci_method(CallNonvirtualVoidMethod, GetMethodID, call_special, void, HotSpotJVMCIRuntime, bootstrapFinished, void_method_signature, (JVMCIObject runtime, JVMCI_TRAPS)) \

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.hpp
@@ -348,6 +348,7 @@
   start_class(HotSpotJVMCIRuntime, jdk_vm_ci_hotspot_HotSpotJVMCIRuntime)                                     \
     objectarray_field(HotSpotJVMCIRuntime, excludeFromJVMCICompilation, "[Ljava/lang/Module;")                \
     jvmci_method(CallNonvirtualObjectMethod, GetMethodID, call_special, JVMCIObject, HotSpotJVMCIRuntime, compileMethod, compileMethod_signature, (JVMCIObject runtime, JVMCIObject method, int entry_bci, jlong env, int id)) \
+    jvmci_method(CallNonvirtualObjectMethod, GetMethodID, call_special, JVMCIObject, HotSpotJVMCIRuntime, isGCSupported, isGCSupported_signature, (JVMCIObject runtime, int gcIdentifier)) \
     jvmci_method(CallStaticObjectMethod, GetStaticMethodID, call_static, JVMCIObject, HotSpotJVMCIRuntime, encodeThrowable, encodeThrowable_signature, (JVMCIObject throwable)) \
     jvmci_method(CallStaticObjectMethod, GetStaticMethodID, call_static, JVMCIObject, HotSpotJVMCIRuntime, decodeThrowable, decodeThrowable_signature, (JVMCIObject encodedThrowable)) \
     jvmci_method(CallNonvirtualVoidMethod, GetMethodID, call_special, void, HotSpotJVMCIRuntime, bootstrapFinished, void_method_signature, (JVMCIObject runtime, JVMCI_TRAPS)) \

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1515,6 +1515,15 @@ void JVMCIRuntime::compile_method(JVMCIEnv* JVMCIENV, JVMCICompiler* compiler, c
   }
 }
 
+bool JVMCIRuntime::is_gc_supported(JVMCIEnv* JVMCIENV, CollectedHeap::Name name) {
+  JVMCI_EXCEPTION_CONTEXT
+
+  JVMCIObject receiver = get_HotSpotJVMCIRuntime(JVMCIENV);
+  if (JVMCIENV->has_pending_exception()) {
+    fatal_exception(JVMCIENV, "Exception during HotSpotJVMCIRuntime initialization");
+  }
+  return JVMCIENV->call_HotSpotJVMCIRuntime_isGCSupported(receiver, (int) name);
+}
 
 // ------------------------------------------------------------------
 JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -25,6 +25,7 @@
 #define SHARE_JVMCI_JVMCIRUNTIME_HPP
 
 #include "code/nmethod.hpp"
+#include "gc/shared/collectedHeap.hpp"
 #include "jvmci/jvmci.hpp"
 #include "jvmci/jvmciExceptions.hpp"
 #include "jvmci/jvmciObject.hpp"
@@ -278,6 +279,9 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
 
   // Compiles `target` with the JVMCI compiler.
   void compile_method(JVMCIEnv* JVMCIENV, JVMCICompiler* compiler, const methodHandle& target, int entry_bci);
+
+  // Determines if the GC identified by `name` is supported by the JVMCI compiler.
+  bool is_gc_supported(JVMCIEnv* JVMCIENV, CollectedHeap::Name name);
 
   // Register the result of a compilation.
   JVMCI::CodeInstallResult register_method(JVMCIEnv* JVMCIENV,

--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -199,14 +199,3 @@ bool JVMCIGlobals::enable_jvmci_product_mode(JVMFlagOrigin origin) {
 
   return true;
 }
-
-void JVMCIGlobals::check_jvmci_supported_gc() {
-  if (EnableJVMCI) {
-    // Check if selected GC is supported by JVMCI and Java compiler
-    if (!(UseSerialGC || UseParallelGC || UseG1GC)) {
-      vm_exit_during_initialization("JVMCI Compiler does not support selected GC", GCConfig::hs_err_name());
-      FLAG_SET_DEFAULT(EnableJVMCI, false);
-      FLAG_SET_DEFAULT(UseJVMCICompiler, false);
-    }
-  }
-}

--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -200,10 +200,14 @@ bool JVMCIGlobals::enable_jvmci_product_mode(JVMFlagOrigin origin) {
   return true;
 }
 
+bool JVMCIGlobals::gc_supports_jvmci() {
+  return UseSerialGC || UseParallelGC || UseG1GC;
+}
+
 void JVMCIGlobals::check_jvmci_supported_gc() {
   if (EnableJVMCI) {
     // Check if selected GC is supported by JVMCI and Java compiler
-    if (!(UseSerialGC || UseParallelGC || UseG1GC)) {
+    if (!gc_supports_jvmci()) {
       log_warning(gc, jvmci)("Setting EnableJVMCI to false as selected GC does not support JVMCI: %s", GCConfig::hs_err_name());
       FLAG_SET_DEFAULT(EnableJVMCI, false);
       FLAG_SET_DEFAULT(UseJVMCICompiler, false);

--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -204,7 +204,7 @@ void JVMCIGlobals::check_jvmci_supported_gc() {
   if (EnableJVMCI) {
     // Check if selected GC is supported by JVMCI and Java compiler
     if (!(UseSerialGC || UseParallelGC || UseG1GC)) {
-      log_warning(gc)("Selected GC does not support JVMCI: %s", GCConfig::hs_err_name());
+      log_warning(gc, jvmci)("Setting EnableJVMCI to false as selected GC does not support JVMCI: %s", GCConfig::hs_err_name());
       FLAG_SET_DEFAULT(EnableJVMCI, false);
       FLAG_SET_DEFAULT(UseJVMCICompiler, false);
     }

--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -199,3 +199,14 @@ bool JVMCIGlobals::enable_jvmci_product_mode(JVMFlagOrigin origin) {
 
   return true;
 }
+
+void JVMCIGlobals::check_jvmci_supported_gc() {
+  if (EnableJVMCI) {
+    // Check if selected GC is supported by JVMCI and Java compiler
+    if (!(UseSerialGC || UseParallelGC || UseG1GC)) {
+      log_warning(gc)("Selected GC does not support JVMCI: %s", GCConfig::hs_err_name());
+      FLAG_SET_DEFAULT(EnableJVMCI, false);
+      FLAG_SET_DEFAULT(UseJVMCICompiler, false);
+    }
+  }
+}

--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -155,6 +155,9 @@ class JVMCIGlobals {
   // Convert JVMCI experimental flags to product
   static bool enable_jvmci_product_mode(JVMFlagOrigin);
 
+  // Check and turn off EnableJVMCI if selected GC does not support JVMCI.
+  static void check_jvmci_supported_gc();
+
   static fileStream* get_jni_config_file() { return _jni_config_file; }
 };
 #endif // SHARE_JVMCI_JVMCI_GLOBALS_HPP

--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -155,6 +155,9 @@ class JVMCIGlobals {
   // Convert JVMCI experimental flags to product
   static bool enable_jvmci_product_mode(JVMFlagOrigin);
 
+  // Returns true iff the GC fully supports JVMCI.
+  static bool gc_supports_jvmci();
+
   // Check and turn off EnableJVMCI if selected GC does not support JVMCI.
   static void check_jvmci_supported_gc();
 

--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -155,9 +155,6 @@ class JVMCIGlobals {
   // Convert JVMCI experimental flags to product
   static bool enable_jvmci_product_mode(JVMFlagOrigin);
 
-  // Check and exit VM with error if selected GC is not supported by JVMCI.
-  static void check_jvmci_supported_gc();
-
   static fileStream* get_jni_config_file() { return _jni_config_file; }
 };
 #endif // SHARE_JVMCI_JVMCI_GLOBALS_HPP

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -482,6 +482,14 @@
   declare_constant(CodeInstaller::VERIFY_OOP_MASK)                        \
   declare_constant(CodeInstaller::INVOKE_INVALID)                         \
                                                                           \
+  declare_constant(CollectedHeap::None)                                   \
+  declare_constant(CollectedHeap::Serial)                                 \
+  declare_constant(CollectedHeap::Parallel)                               \
+  declare_constant(CollectedHeap::G1)                                     \
+  declare_constant(CollectedHeap::Epsilon)                                \
+  declare_constant(CollectedHeap::Z)                                      \
+  declare_constant(CollectedHeap::Shenandoah)                             \
+                                                                          \
   declare_constant(vmIntrinsics::FIRST_MH_SIG_POLY)                       \
   declare_constant(vmIntrinsics::LAST_MH_SIG_POLY)                        \
   declare_constant(vmIntrinsics::_invokeGeneric)                          \

--- a/src/hotspot/share/jvmci/vmSymbols_jvmci.hpp
+++ b/src/hotspot/share/jvmci/vmSymbols_jvmci.hpp
@@ -103,6 +103,8 @@
   template(visitFrame_signature,                                  "(Ljdk/vm/ci/code/stack/InspectedFrame;)Ljava/lang/Object;")            \
   template(compileMethod_name,                                    "compileMethod")                                                        \
   template(compileMethod_signature,                               "(Ljdk/vm/ci/hotspot/HotSpotResolvedJavaMethod;IJI)Ljdk/vm/ci/hotspot/HotSpotCompilationRequestResult;") \
+  template(isGCSupported_name,                                    "isGCSupported")                                                        \
+  template(isGCSupported_signature,                               "(I)Z")                                                                 \
   template(encodeThrowable_name,                                  "encodeThrowable")                                                      \
   template(encodeThrowable_signature,                             "(Ljava/lang/Throwable;)Ljava/lang/String;")                            \
   template(decodeThrowable_name,                                  "decodeThrowable")                                                      \

--- a/src/hotspot/share/jvmci/vmSymbols_jvmci.hpp
+++ b/src/hotspot/share/jvmci/vmSymbols_jvmci.hpp
@@ -104,7 +104,6 @@
   template(compileMethod_name,                                    "compileMethod")                                                        \
   template(compileMethod_signature,                               "(Ljdk/vm/ci/hotspot/HotSpotResolvedJavaMethod;IJI)Ljdk/vm/ci/hotspot/HotSpotCompilationRequestResult;") \
   template(isGCSupported_name,                                    "isGCSupported")                                                        \
-  template(isGCSupported_signature,                               "(I)Z")                                                                 \
   template(encodeThrowable_name,                                  "encodeThrowable")                                                      \
   template(encodeThrowable_signature,                             "(Ljava/lang/Throwable;)Ljava/lang/String;")                            \
   template(decodeThrowable_name,                                  "decodeThrowable")                                                      \

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -94,6 +94,7 @@
   LOG_TAG(jfr) \
   LOG_TAG(jit) \
   LOG_TAG(jni) \
+  LOG_TAG(jvmci) \
   LOG_TAG(jvmti) \
   LOG_TAG(lambda) \
   LOG_TAG(library) \

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -358,7 +358,7 @@ WB_ENTRY(jboolean, WB_IsGCSupported(JNIEnv* env, jobject o, jint name))
   return GCConfig::is_gc_supported((CollectedHeap::Name)name);
 WB_END
 
-WB_ENTRY(jboolean, WB_IsGCSupportedByJVMCI(JNIEnv* env, jobject o, jint name))
+WB_ENTRY(jboolean, WB_IsGCSupportedByJVMCICompiler(JNIEnv* env, jobject o, jint name))
 #if INCLUDE_JVMCI
   if (EnableJVMCI) {
     JVMCIEnv jvmciEnv(thread, env, __FILE__, __LINE__);
@@ -1953,6 +1953,14 @@ WB_ENTRY(jboolean, WB_isC2OrJVMCIIncludedInVmBuild(JNIEnv* env))
 #endif
 WB_END
 
+WB_ENTRY(jboolean, WB_IsJVMCISupportedByGC(JNIEnv* env))
+#if INCLUDE_JVMCI
+  return JVMCIGlobals::gc_supports_jvmci();
+#else
+  return false;
+#endif
+WB_END
+
 WB_ENTRY(jboolean, WB_IsJavaHeapArchiveSupported(JNIEnv* env))
   return HeapShared::is_heap_object_archiving_allowed();
 WB_END
@@ -2516,6 +2524,7 @@ static JNINativeMethod methods[] = {
   {CC"isCDSIncludedInVmBuild",            CC"()Z",    (void*)&WB_IsCDSIncludedInVmBuild },
   {CC"isJFRIncludedInVmBuild",            CC"()Z",    (void*)&WB_IsJFRIncludedInVmBuild },
   {CC"isC2OrJVMCIIncludedInVmBuild",      CC"()Z",    (void*)&WB_isC2OrJVMCIIncludedInVmBuild },
+  {CC"isJVMCISupportedByGC",              CC"()Z",    (void*)&WB_IsJVMCISupportedByGC},
   {CC"isJavaHeapArchiveSupported",        CC"()Z",    (void*)&WB_IsJavaHeapArchiveSupported },
   {CC"cdsMemoryMappingFailed",            CC"()Z",    (void*)&WB_CDSMemoryMappingFailed },
 
@@ -2528,7 +2537,7 @@ static JNINativeMethod methods[] = {
                                                       (void*)&WB_AddCompilerDirective },
   {CC"removeCompilerDirective",   CC"(I)V",           (void*)&WB_RemoveCompilerDirective },
   {CC"isGCSupported",             CC"(I)Z",           (void*)&WB_IsGCSupported},
-  {CC"isGCSupportedByJVMCI",      CC"(I)Z",           (void*)&WB_IsGCSupportedByJVMCI},
+  {CC"isGCSupportedByJVMCICompiler", CC"(I)Z",        (void*)&WB_IsGCSupportedByJVMCICompiler},
   {CC"isGCSelected",              CC"(I)Z",           (void*)&WB_IsGCSelected},
   {CC"isGCSelectedErgonomically", CC"()Z",            (void*)&WB_IsGCSelectedErgonomically},
   {CC"supportsConcurrentGCBreakpoints", CC"()Z",      (void*)&WB_SupportsConcurrentGCBreakpoints},

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -365,7 +365,7 @@ WB_ENTRY(jboolean, WB_IsGCSupportedByJVMCI(JNIEnv* env, jobject o, jint name))
     return jvmciEnv.runtime()->is_gc_supported(&jvmciEnv, (CollectedHeap::Name)name);
   }
 #endif
-  THROW_MSG_0(vmSymbols::java_lang_UnsupportedOperationException(), "WB_IsGCSupportedByJVMCI: JVMCI must be included and EnableJVMCI must be true");
+  return false;
 WB_END
 
 WB_ENTRY(jboolean, WB_IsGCSelected(JNIEnv* env, jobject o, jint name))

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -107,10 +107,6 @@
 #include "services/memTracker.hpp"
 #include "utilities/nativeCallStack.hpp"
 #endif // INCLUDE_NMT
-#if INCLUDE_JVMCI
-#include "jvmci/jvmciEnv.hpp"
-#include "jvmci/jvmciRuntime.hpp"
-#endif
 #if INCLUDE_AOT
 #include "aot/aotLoader.hpp"
 #endif // INCLUDE_AOT
@@ -355,14 +351,7 @@ WB_ENTRY(jint, WB_StressVirtualSpaceResize(JNIEnv* env, jobject o,
 WB_END
 
 WB_ENTRY(jboolean, WB_IsGCSupported(JNIEnv* env, jobject o, jint name))
-  jboolean res = GCConfig::is_gc_supported((CollectedHeap::Name)name);
-#if INCLUDE_JVMCI
-  if (EnableJVMCI && res) {
-    JVMCIEnv jvmciEnv(thread, env, __FILE__, __LINE__);
-    res = jvmciEnv.runtime()->is_gc_supported(&jvmciEnv, (CollectedHeap::Name)name);
-  }
-#endif
-  return res;
+  return GCConfig::is_gc_supported((CollectedHeap::Name)name);
 WB_END
 
 WB_ENTRY(jboolean, WB_IsGCSelected(JNIEnv* env, jobject o, jint name))

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCICompilerConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCICompilerConfig.java
@@ -67,6 +67,11 @@ final class HotSpotJVMCICompilerConfig {
         public JVMCICompiler createCompiler(JVMCIRuntime runtime) {
             return this;
         }
+
+        @Override
+        public boolean isGCSupported(int gcIdentifier) {
+            return false;
+        }
     }
 
     /**

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -710,6 +710,11 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
         public CompilationRequestResult compileMethod(CompilationRequest request) {
             throw t;
         }
+
+        @Override
+        public boolean isGCSupported(int gcIdentifier) {
+            return false;
+        }
     }
 
     @Override
@@ -810,6 +815,12 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
             }
         }
         return hsResult;
+    }
+
+    @SuppressWarnings("try")
+    @VMEntryPoint
+    private boolean isGCSupported(int gcIdentifier) {
+        return getCompiler().isGCSupported(gcIdentifier);
     }
 
     /**

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.runtime/src/jdk/vm/ci/runtime/JVMCICompiler.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.runtime/src/jdk/vm/ci/runtime/JVMCICompiler.java
@@ -33,4 +33,15 @@ public interface JVMCICompiler {
      * install it in the code cache if the compilation is successful.
      */
     CompilationRequestResult compileMethod(CompilationRequest request);
+
+    /**
+     * Determines if this compiler supports the {@code gcIdentifier} garbage collector. The default
+     * implementation of this method returns true as that is the effective answer given by a
+     * {@link JVMCICompiler} before this method was added.
+     *
+     * @param gcIdentifier a VM dependent GC identifier
+     */
+    default boolean isGCSupported(int gcIdentifier) {
+        return true;
+    }
 }

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/HotSpotGraalCompiler.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/HotSpotGraalCompiler.java
@@ -43,6 +43,7 @@ import org.graalvm.compiler.debug.DebugContext.Activation;
 import org.graalvm.compiler.debug.DebugHandlersFactory;
 import org.graalvm.compiler.debug.DebugOptions;
 import org.graalvm.compiler.hotspot.CompilationCounters.Options;
+import org.graalvm.compiler.hotspot.HotSpotGraalRuntime.HotSpotGC;
 import org.graalvm.compiler.hotspot.meta.HotSpotProviders;
 import org.graalvm.compiler.hotspot.phases.OnStackReplacementPhase;
 import org.graalvm.compiler.java.GraphBuilderPhase;
@@ -322,5 +323,14 @@ public class HotSpotGraalCompiler implements GraalJVMCICompiler, Cancellable {
                 }
             }
         };
+    }
+
+    @Override
+    public boolean isGCSupported(int gcIdentifier) {
+        HotSpotGC gc = HotSpotGC.forName(gcIdentifier, graalRuntime.getVMConfig());
+        if (gc != null) {
+            return gc.supported;
+        }
+        return false;
     }
 }

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/HotSpotGraalRuntime.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/HotSpotGraalRuntime.java
@@ -247,37 +247,58 @@ public final class HotSpotGraalRuntime implements HotSpotGraalRuntimeProvider {
     }
 
     /**
-     * Constants denoting the GC algorithms available in HotSpot.
+     * Constants denoting the GC algorithms available in HotSpot. The names of the constants match
+     * the constants in the {@code CollectedHeap::Name} C++ enum.
      */
     public enum HotSpotGC {
         // Supported GCs
-        Serial(true, "UseSerialGC", true),
-        Parallel(true, "UseParallelGC", true, "UseParallelOldGC", JDK < 15, "UseParNewGC", JDK < 10),
-        CMS(true, "UseConcMarkSweepGC", JDK < 14),
-        G1(true, "UseG1GC", true),
+        Serial(true, JDK >= 11, "UseSerialGC", true),
+        Parallel(true, JDK >= 11, "UseParallelGC", true, "UseParallelOldGC", JDK < 15, "UseParNewGC", JDK < 10),
+        CMS(true, JDK >= 11 && JDK <= 14, "UseConcMarkSweepGC", JDK < 14),
+        G1(true, JDK >= 11, "UseG1GC", true),
 
         // Unsupported GCs
-        Epsilon(false, "UseEpsilonGC", JDK >= 11),
-        Z(false, "UseZGC", JDK >= 11);
+        Epsilon(false, JDK >= 11, "UseEpsilonGC", JDK >= 11),
+        Z(false, JDK >= 11, "UseZGC", JDK >= 11),
+        Shenandoah(false, JDK >= 12, "UseShenandoahGC", JDK >= 12);
 
-        HotSpotGC(boolean supported,
+        HotSpotGC(boolean supported, boolean expectNamePresent,
                         String flag1, boolean expectFlagPresent1,
                         String flag2, boolean expectFlagPresent2,
                         String flag3, boolean expectFlagPresent3) {
             this.supported = supported;
+            this.expectNamePresent = expectNamePresent;
             this.expectFlagsPresent = new boolean[]{expectFlagPresent1, expectFlagPresent2, expectFlagPresent3};
             this.flags = new String[]{flag1, flag2, flag3};
         }
 
-        HotSpotGC(boolean supported, String flag, boolean expectFlagPresent) {
+        HotSpotGC(boolean supported, boolean expectNamePresent, String flag, boolean expectFlagPresent) {
             this.supported = supported;
+            this.expectNamePresent = expectNamePresent;
             this.expectFlagsPresent = new boolean[]{expectFlagPresent};
             this.flags = new String[]{flag};
         }
 
+        /**
+         * Specifies if this GC supported by Graal.
+         */
         final boolean supported;
-        final boolean[] expectFlagsPresent;
+
+        /**
+         * Specifies if {@link #name()} is expected to be present in the {@code CollectedHeap::Name}
+         * C++ enum.
+         */
+        final boolean expectNamePresent;
+
+        /**
+         * The VM flags that will select this GC.
+         */
         private final String[] flags;
+
+        /**
+         * Specifies which {@link #flags} are expected to be present in the VM.
+         */
+        final boolean[] expectFlagsPresent;
 
         public boolean isSelected(GraalHotSpotVMConfig config) {
             boolean selected = false;
@@ -292,6 +313,20 @@ public final class HotSpotGraalRuntime implements HotSpotGraalRuntimeProvider {
                 }
             }
             return selected;
+        }
+
+        /**
+         * Gets the GC matching {@code name}.
+         *
+         * @param name the ordinal of a {@code CollectedHeap::Name} value
+         */
+        static HotSpotGC forName(int name, GraalHotSpotVMConfig config) {
+            for (HotSpotGC gc : HotSpotGC.values()) {
+                if (config.getConstant("CollectedHeap::" + gc.name(), Integer.class, -1, gc.expectNamePresent) == name) {
+                    return gc;
+                }
+            }
+            return null;
         }
     }
 

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -235,22 +235,7 @@ public class VMProps implements Callable<Map<String, String>> {
      */
     protected String vmJvmci() {
         // builds with jvmci have this flag
-        if (WB.getBooleanVMFlag("EnableJVMCI") == null) {
-            return "false";
-        }
-
-        switch (GC.selected()) {
-            case Serial:
-            case Parallel:
-            case G1:
-                // These GCs are supported with JVMCI
-                return "true";
-            default:
-                break;
-        }
-
-        // Every other GC is not supported
-        return "false";
+        return WB.getBooleanVMFlag("EnableJVMCI") != null ? "true" : "false";
     }
 
     /**

--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -232,6 +232,7 @@ public class WhiteBox {
 
   // Compiler
   public native boolean isC2OrJVMCIIncludedInVmBuild();
+  public native boolean isJVMCISupportedByGC();
 
   public native int     matchesMethod(Executable method, String pattern);
   public native int     matchesInline(Executable method, String pattern);
@@ -415,7 +416,7 @@ public class WhiteBox {
   // Don't use these methods directly
   // Use sun.hotspot.gc.GC class instead.
   public native boolean isGCSupported(int name);
-  public native boolean isGCSupportedByJVMCI(int name);
+  public native boolean isGCSupportedByJVMCICompiler(int name);
   public native boolean isGCSelected(int name);
   public native boolean isGCSelectedErgonomically();
 

--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -415,6 +415,7 @@ public class WhiteBox {
   // Don't use these methods directly
   // Use sun.hotspot.gc.GC class instead.
   public native boolean isGCSupported(int name);
+  public native boolean isGCSupportedByJVMCI(int name);
   public native boolean isGCSelected(int name);
   public native boolean isGCSelectedErgonomically();
 

--- a/test/lib/sun/hotspot/code/Compiler.java
+++ b/test/lib/sun/hotspot/code/Compiler.java
@@ -44,6 +44,20 @@ public class Compiler {
     }
 
     /**
+     * Check if JVMCI is enabled.
+     *
+     * @return true if JVMCI is enabled
+     */
+    public static boolean isJVMCIEnabled() {
+        Boolean enableJvmci = WB.getBooleanVMFlag("EnableJVMCI");
+        if (enableJvmci == null || !enableJvmci) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Check if Graal is used as JIT compiler.
      *
      * Graal is enabled if following conditions are true:

--- a/test/lib/sun/hotspot/gc/GC.java
+++ b/test/lib/sun/hotspot/gc/GC.java
@@ -56,6 +56,14 @@ public enum GC {
     }
 
     /**
+     * @return true if this GC is supported by JVMCI.
+     * @throws UnsupportedOperationException if JVMCI is not built into the VM or EnableJVMCI is false
+     */
+    public boolean isSupportedByJVMCI() {
+        return WB.isGCSupportedByJVMCI(name);
+    }
+
+    /**
      * @return true if this GC is currently selected/used
      */
     public boolean isSelected() {

--- a/test/lib/sun/hotspot/gc/GC.java
+++ b/test/lib/sun/hotspot/gc/GC.java
@@ -56,11 +56,10 @@ public enum GC {
     }
 
     /**
-     * @return true if this GC is supported by JVMCI.
-     * @throws UnsupportedOperationException if JVMCI is not built into the VM or EnableJVMCI is false
+     * @return true if this GC is supported by the JVMCI compiler
      */
-    public boolean isSupportedByJVMCI() {
-        return WB.isGCSupportedByJVMCI(name);
+    public boolean isSupportedByJVMCICompiler() {
+        return WB.isGCSupportedByJVMCICompiler(name);
     }
 
     /**


### PR DESCRIPTION
A number of jtreg tests require a specific GC. These tests should be ignored when EnableJVMCI is true and the JVMCI compiler does not support the required GC.

This PR adds `JVMCICompiler.isGCSupported` and makes use of it in `WhiteBox.isGCSupported`.

Prior to this PR, a test requiring a GC not yet supported by a JVMCI compiler fail as follows:
```
Error occurred during initialization of VM
JVMCI Compiler does not support selected GC: epsilon gc
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257020](https://bugs.openjdk.java.net/browse/JDK-8257020): [JVMCI] enable a JVMCICompiler to specify which GCs it supports


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 2aa5be517355176c5417145789d70ad067415bd0


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1423/head:pull/1423`
`$ git checkout pull/1423`
