### PR TITLE
JDK-8257042: [aix] Disable os.release_one_mapping_multi_commits_vm gtest

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -352,6 +352,7 @@ TEST_VM(os, jio_snprintf) {
 #define PRINT_MAPPINGS(s) { tty->print_cr("%s", s); os::print_memory_mappings((char*)p, total_range_len, tty); }
 //#define PRINT_MAPPINGS
 
+#ifndef _AIX // JDK-8257041
 // Reserve an area consisting of multiple mappings
 //  (from multiple calls to os::reserve_memory)
 static address reserve_multiple(int num_stripes, size_t stripe_len) {
@@ -374,6 +375,7 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
   }
   return p;
 }
+#endif // !AIX
 
 // Reserve an area with a single call to os::reserve_memory,
 //  with multiple committed and uncommitted regions
@@ -407,6 +409,7 @@ struct NUMASwitcher {
 };
 #endif
 
+#ifndef _AIX // JDK-8257041
 TEST_VM(os, release_multi_mappings) {
   // Test that we can release an area created with multiple reservation calls
   const size_t stripe_len = 4 * M;
@@ -435,6 +438,7 @@ TEST_VM(os, release_multi_mappings) {
 
   ASSERT_TRUE(os::release_memory((char*)p, total_range_len));
 }
+#endif // !AIX
 
 #ifdef _WIN32
 // On Windows, test that we recognize bad ranges.


### PR DESCRIPTION
On AIX, os::release_memory() cannot release multi-mappings since os::reserve_memory() may return system V shared memory instead of the usual mmapped memory. This makes a new gtest fail.

This is very difficult to fix, therefore lets just disable this test for now.

For details about the underlying issue, see https://bugs.openjdk.java.net/browse/JDK-8257041.

--

patch disables the test for AIX, and also needs to disable the local reserve helper function to avoid an "unused symbol" warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ❌ (6/6 failed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build debug)](https://github.com/tstuefe/jdk/runs/1452221092)
- [Linux x64 (build hotspot minimal)](https://github.com/tstuefe/jdk/runs/1452221129)
- [Linux x64 (build hotspot no-pch)](https://github.com/tstuefe/jdk/runs/1452221108)
- [Linux x64 (build hotspot optimized)](https://github.com/tstuefe/jdk/runs/1452221146)
- [Linux x64 (build hotspot zero)](https://github.com/tstuefe/jdk/runs/1452221121)
- [Linux x64 (build release)](https://github.com/tstuefe/jdk/runs/1452221085)
- [Linux x86 (build debug)](https://github.com/tstuefe/jdk/runs/1452221020)
- [Linux x86 (build release)](https://github.com/tstuefe/jdk/runs/1452221014)

### Issue
 * [JDK-8257042](https://bugs.openjdk.java.net/browse/JDK-8257042): [aix] Disable os.release_one_mapping_multi_commits_vm gtest


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1426/head:pull/1426`
`$ git checkout pull/1426`
