### PR TITLE
8257056: Submit workflow should apt-get update to avoid package installation errors

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -168,6 +168,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install gcc-10=10.2.0-5ubuntu1~20.04 g++-10=10.2.0-5ubuntu1~20.04 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
@@ -477,6 +478,9 @@ jobs:
         run: |
           build_jdk_root=`find ${HOME}/jdk-linux-x64/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin -name release -type f`
           echo "build_jdk_root=`dirname ${build_jdk_root}`" >> $GITHUB_ENV
+
+      - name: Update apt
+        run: sudo apt-get update
 
       - name: Install native host dependencies
         run: |


### PR DESCRIPTION
For example, current jobs fail with:

```
Get:13 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libxtst-dev amd64 2:1.2.3-1 [15.2 kB]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/a/alsa-lib/libasound2-dev_1.2.2-2.1ubuntu2.1_amd64.deb 404 Not Found [IP: 52.147.219.192 80]
Fetched 760 kB in 0s (3154 kB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x86 (build debug)](https://github.com/shipilev/jdk/runs/1452464004)
- [Linux x86 (build release)](https://github.com/shipilev/jdk/runs/1452463990)

### Issue
 * [JDK-8257056](https://bugs.openjdk.java.net/browse/JDK-8257056): Submit workflow should apt-get update to avoid package installation errors


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - Committer)
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1427/head:pull/1427`
`$ git checkout pull/1427`
