### PR TITLE
8257072: ZGC: Rename roots iterators

### DIFF
--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -302,8 +302,8 @@ void ZHeap::process_non_strong_references() {
   // Process Soft/Weak/Final/PhantomReferences
   _reference_processor.process_references();
 
-  // Process concurrent weak roots
-  _weak_roots_processor.process_concurrent_weak_roots();
+  // Process weak roots
+  _weak_roots_processor.process_weak_roots();
 
   // Unlink stale metadata and nmethods
   _unload.unlink();

--- a/src/hotspot/share/gc/z/zHeapIterator.cpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.cpp
@@ -162,8 +162,8 @@ ZHeapIterator::ZHeapIterator(uint nworkers, bool visit_weaks) :
     _bitmaps_lock(),
     _queues(nworkers),
     _array_queues(nworkers),
-    _concurrent_roots(ClassLoaderData::_claim_other),
-    _concurrent_weak_roots(),
+    _roots(ClassLoaderData::_claim_other),
+    _weak_roots(),
     _terminator(nworkers, &_queues) {
 
   // Create queues
@@ -280,15 +280,12 @@ void ZHeapIterator::push_strong_roots(const ZHeapIteratorContext& context) {
   ZHeapIteratorNMethodClosure nm_cl(&cl);
   ZHeapIteratorThreadClosure thread_cl(&cl, &nm_cl);
 
-  _concurrent_roots.apply(&cl,
-                          &cld_cl,
-                          &thread_cl,
-                          &nm_cl);
+  _roots.apply(&cl, &cld_cl, &thread_cl, &nm_cl);
 }
 
 void ZHeapIterator::push_weak_roots(const ZHeapIteratorContext& context) {
   ZHeapIteratorRootOopClosure<true  /* Weak */> cl(context);
-  _concurrent_weak_roots.apply(&cl);
+  _weak_roots.apply(&cl);
 }
 
 template <bool VisitWeaks>

--- a/src/hotspot/share/gc/z/zHeapIterator.cpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.cpp
@@ -280,7 +280,10 @@ void ZHeapIterator::push_strong_roots(const ZHeapIteratorContext& context) {
   ZHeapIteratorNMethodClosure nm_cl(&cl);
   ZHeapIteratorThreadClosure thread_cl(&cl, &nm_cl);
 
-  _roots.apply(&cl, &cld_cl, &thread_cl, &nm_cl);
+  _roots.apply(&cl,
+               &cld_cl,
+               &thread_cl,
+               &nm_cl);
 }
 
 void ZHeapIterator::push_weak_roots(const ZHeapIteratorContext& context) {

--- a/src/hotspot/share/gc/z/zHeapIterator.hpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.hpp
@@ -46,15 +46,15 @@ class ZHeapIterator : public ParallelObjectIterator {
   friend class ZHeapIteratorContext;
 
 private:
-  const bool                   _visit_weaks;
-  ZStatTimerDisable            _timer_disable;
-  ZHeapIteratorBitMaps         _bitmaps;
-  ZLock                        _bitmaps_lock;
-  ZHeapIteratorQueues          _queues;
-  ZHeapIteratorArrayQueues     _array_queues;
-  ZConcurrentRootsIterator     _concurrent_roots;
-  ZConcurrentWeakRootsIterator _concurrent_weak_roots;
-  TaskTerminator               _terminator;
+  const bool               _visit_weaks;
+  ZStatTimerDisable        _timer_disable;
+  ZHeapIteratorBitMaps     _bitmaps;
+  ZLock                    _bitmaps_lock;
+  ZHeapIteratorQueues      _queues;
+  ZHeapIteratorArrayQueues _array_queues;
+  ZRootsIterator           _roots;
+  ZWeakRootsIterator       _weak_roots;
+  TaskTerminator           _terminator;
 
   ZHeapIteratorBitMap* object_bitmap(oop obj);
 

--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -649,7 +649,7 @@ public:
 
 typedef ClaimingCLDToOopClosure<ClassLoaderData::_claim_strong> ZMarkCLDClosure;
 
-class ZMarkConcurrentRootsTask : public ZTask {
+class ZMarkRootsTask : public ZTask {
 private:
   ZMark* const               _mark;
   SuspendibleThreadSetJoiner _sts_joiner;
@@ -661,8 +661,8 @@ private:
   ZMarkNMethodClosure        _nm_cl;
 
 public:
-  ZMarkConcurrentRootsTask(ZMark* mark) :
-      ZTask("ZMarkConcurrentRootsTask"),
+  ZMarkRootsTask(ZMark* mark) :
+      ZTask("ZMarkRootsTask"),
       _mark(mark),
       _sts_joiner(),
       _roots(ClassLoaderData::_claim_strong),
@@ -673,7 +673,7 @@ public:
     ClassLoaderDataGraph_lock->lock();
   }
 
-  ~ZMarkConcurrentRootsTask() {
+  ~ZMarkRootsTask() {
     ClassLoaderDataGraph_lock->unlock();
   }
 
@@ -715,7 +715,7 @@ public:
 
 void ZMark::mark(bool initial) {
   if (initial) {
-    ZMarkConcurrentRootsTask task(this);
+    ZMarkRootsTask task(this);
     _workers->run_concurrent(&task);
   }
 

--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -653,7 +653,7 @@ class ZMarkConcurrentRootsTask : public ZTask {
 private:
   ZMark* const               _mark;
   SuspendibleThreadSetJoiner _sts_joiner;
-  ZConcurrentRootsIterator   _roots;
+  ZRootsIterator             _roots;
 
   ZMarkOopClosure            _cl;
   ZMarkCLDClosure            _cld_cl;

--- a/src/hotspot/share/gc/z/zRootsIterator.cpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.cpp
@@ -52,7 +52,6 @@ void ZParallelApply<Iterator>::apply(ClosureType* cl) {
   }
 }
 
-
 ZStrongOopStorageSetIterator::ZStrongOopStorageSetIterator() :
     _iter() {}
 
@@ -104,16 +103,13 @@ void ZNMethodsIterator::apply(NMethodClosure* cl) {
   ZNMethod::nmethods_do(cl);
 }
 
-ZConcurrentRootsIterator::ZConcurrentRootsIterator(int cld_claim) {
+ZRootsIterator::ZRootsIterator(int cld_claim) {
   if (cld_claim != ClassLoaderData::_claim_none) {
     ClassLoaderDataGraph::clear_claimed_marks(cld_claim);
   }
 }
 
-void ZConcurrentRootsIterator::apply(OopClosure* cl,
-                                     CLDClosure* cld_cl,
-                                     ThreadClosure* thread_cl,
-                                     NMethodClosure* nm_cl) {
+void ZRootsIterator::apply(OopClosure* cl, CLDClosure* cld_cl, ThreadClosure* thread_cl, NMethodClosure* nm_cl) {
   _oop_storage_set.apply(cl);
   _class_loader_data_graph.apply(cld_cl);
   _java_threads.apply(thread_cl);
@@ -134,10 +130,10 @@ void ZWeakOopStorageSetIterator::report_num_dead() {
   _iter.report_num_dead();
 }
 
-void ZConcurrentWeakRootsIterator::report_num_dead() {
+void ZWeakRootsIterator::report_num_dead() {
   _oop_storage_set.iter().report_num_dead();
 }
 
-void ZConcurrentWeakRootsIterator::apply(OopClosure* cl) {
+void ZWeakRootsIterator::apply(OopClosure* cl) {
   _oop_storage_set.apply(cl);
 }

--- a/src/hotspot/share/gc/z/zRootsIterator.cpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.cpp
@@ -109,7 +109,10 @@ ZRootsIterator::ZRootsIterator(int cld_claim) {
   }
 }
 
-void ZRootsIterator::apply(OopClosure* cl, CLDClosure* cld_cl, ThreadClosure* thread_cl, NMethodClosure* nm_cl) {
+void ZRootsIterator::apply(OopClosure* cl,
+                           CLDClosure* cld_cl,
+                           ThreadClosure* thread_cl,
+                           NMethodClosure* nm_cl) {
   _oop_storage_set.apply(cl);
   _class_loader_data_graph.apply(cld_cl);
   _java_threads.apply(thread_cl);

--- a/src/hotspot/share/gc/z/zRootsIterator.hpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.hpp
@@ -83,7 +83,7 @@ public:
   void apply(NMethodClosure* cl);
 };
 
-class ZConcurrentRootsIterator {
+class ZRootsIterator {
 private:
   ZParallelApply<ZStrongOopStorageSetIterator> _oop_storage_set;
   ZParallelApply<ZStrongCLDsIterator>          _class_loader_data_graph;
@@ -91,12 +91,9 @@ private:
   ZParallelApply<ZNMethodsIterator>            _nmethods;
 
 public:
-  ZConcurrentRootsIterator(int cld_claim);
+  ZRootsIterator(int cld_claim);
 
-  void apply(OopClosure* cl,
-             CLDClosure* cld_cl,
-             ThreadClosure* thread_cl,
-             NMethodClosure* nm_cl);
+  void apply(OopClosure* cl, CLDClosure* cld_cl, ThreadClosure* thread_cl, NMethodClosure* nm_cl);
 };
 
 class ZWeakOopStorageSetIterator {
@@ -111,7 +108,7 @@ public:
   void report_num_dead();
 };
 
-class ZConcurrentWeakRootsIterator {
+class ZWeakRootsIterator {
 private:
   ZParallelApply<ZWeakOopStorageSetIterator> _oop_storage_set;
 

--- a/src/hotspot/share/gc/z/zRootsIterator.hpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.hpp
@@ -93,7 +93,10 @@ private:
 public:
   ZRootsIterator(int cld_claim);
 
-  void apply(OopClosure* cl, CLDClosure* cld_cl, ThreadClosure* thread_cl, NMethodClosure* nm_cl);
+  void apply(OopClosure* cl,
+             CLDClosure* cld_cl,
+             ThreadClosure* thread_cl,
+             NMethodClosure* nm_cl);
 };
 
 class ZWeakOopStorageSetIterator {

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -258,7 +258,10 @@ void ZVerify::roots_strong(bool verify_fixed) {
   ZVerifyNMethodClosure nm_cl(&cl, verify_fixed);
 
   ZRootsIterator iter(ClassLoaderData::_claim_none);
-  iter.apply(&cl, &cld_cl, &thread_cl, &nm_cl);
+  iter.apply(&cl,
+             &cld_cl,
+             &thread_cl,
+             &nm_cl);
 }
 
 void ZVerify::roots_weak() {

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -251,33 +251,30 @@ public:
   }
 };
 
-void ZVerify::roots_concurrent_strong(bool verify_fixed) {
+void ZVerify::roots_strong(bool verify_fixed) {
   ZVerifyRootClosure cl(verify_fixed);
   ZVerifyCLDClosure cld_cl(&cl);
   ZVerifyThreadClosure thread_cl(&cl);
   ZVerifyNMethodClosure nm_cl(&cl, verify_fixed);
 
-  ZConcurrentRootsIterator iter(ClassLoaderData::_claim_none);
-  iter.apply(&cl,
-             &cld_cl,
-             &thread_cl,
-             &nm_cl);
+  ZRootsIterator iter(ClassLoaderData::_claim_none);
+  iter.apply(&cl, &cld_cl, &thread_cl, &nm_cl);
 }
 
-void ZVerify::roots_concurrent_weak() {
+void ZVerify::roots_weak() {
   ZVerifyRootClosure cl(true /* verify_fixed */);
-  ZConcurrentWeakRootsIterator iter;
+  ZWeakRootsIterator iter;
   iter.apply(&cl);
 }
 
-void ZVerify::roots(bool verify_concurrent_strong, bool verify_weaks) {
+void ZVerify::roots(bool verify_strong, bool verify_weaks) {
   assert(SafepointSynchronize::is_at_safepoint(), "Must be at a safepoint");
   assert(!ZResurrection::is_blocked(), "Invalid phase");
 
   if (ZVerifyRoots) {
-    roots_concurrent_strong(verify_concurrent_strong);
+    roots_strong(verify_strong);
     if (verify_weaks) {
-      roots_concurrent_weak();
+      roots_weak();
     }
   }
 }
@@ -294,27 +291,27 @@ void ZVerify::objects(bool verify_weaks) {
   }
 }
 
-void ZVerify::roots_and_objects(bool verify_concurrent_strong, bool verify_weaks) {
-  roots(verify_concurrent_strong, verify_weaks);
+void ZVerify::roots_and_objects(bool verify_strong, bool verify_weaks) {
+  roots(verify_strong, verify_weaks);
   objects(verify_weaks);
 }
 
 void ZVerify::before_zoperation() {
   // Verify strong roots
   ZStatTimerDisable disable;
-  roots(false /* verify_concurrent_strong */, false /* verify_weaks */);
+  roots(false /* verify_strong */, false /* verify_weaks */);
 }
 
 void ZVerify::after_mark() {
   // Verify all strong roots and strong references
   ZStatTimerDisable disable;
-  roots_and_objects(true /* verify_concurrent_strong*/, false /* verify_weaks */);
+  roots_and_objects(true /* verify_strong */, false /* verify_weaks */);
 }
 
 void ZVerify::after_weak_processing() {
   // Verify all roots and all references
   ZStatTimerDisable disable;
-  roots_and_objects(true /* verify_concurrent_strong*/, true /* verify_weaks */);
+  roots_and_objects(true /* verify_strong */, true /* verify_weaks */);
 }
 
 template <bool Map>

--- a/src/hotspot/share/gc/z/zVerify.hpp
+++ b/src/hotspot/share/gc/z/zVerify.hpp
@@ -31,12 +31,12 @@ class ZPageAllocator;
 
 class ZVerify : public AllStatic {
 private:
-  static void roots_concurrent_strong(bool verify_fixed);
-  static void roots_concurrent_weak();
+  static void roots_strong(bool verify_fixed);
+  static void roots_weak();
 
-  static void roots(bool verify_concurrent_strong, bool verify_weaks);
+  static void roots(bool verify_strong, bool verify_weaks);
   static void objects(bool verify_weaks);
-  static void roots_and_objects(bool verify_concurrent_strong, bool verify_weaks);
+  static void roots_and_objects(bool verify_strong, bool verify_weaks);
 
 public:
   static void before_zoperation();

--- a/src/hotspot/share/gc/z/zWeakRootsProcessor.cpp
+++ b/src/hotspot/share/gc/z/zWeakRootsProcessor.cpp
@@ -54,16 +54,16 @@ public:
 ZWeakRootsProcessor::ZWeakRootsProcessor(ZWorkers* workers) :
     _workers(workers) {}
 
-class ZProcessConcurrentWeakRootsTask : public ZTask {
+class ZProcessWeakRootsTask : public ZTask {
 private:
   ZWeakRootsIterator _weak_roots;
 
 public:
-  ZProcessConcurrentWeakRootsTask() :
+  ZProcessWeakRootsTask() :
       ZTask("ZProcessConccurentWeakRootsTask"),
       _weak_roots() {}
 
-  ~ZProcessConcurrentWeakRootsTask() {
+  ~ZProcessWeakRootsTask() {
     _weak_roots.report_num_dead();
   }
 
@@ -73,7 +73,7 @@ public:
   }
 };
 
-void ZWeakRootsProcessor::process_concurrent_weak_roots() {
-  ZProcessConcurrentWeakRootsTask task;
+void ZWeakRootsProcessor::process_weak_roots() {
+  ZProcessWeakRootsTask task;
   _workers->run_concurrent(&task);
 }

--- a/src/hotspot/share/gc/z/zWeakRootsProcessor.cpp
+++ b/src/hotspot/share/gc/z/zWeakRootsProcessor.cpp
@@ -56,20 +56,20 @@ ZWeakRootsProcessor::ZWeakRootsProcessor(ZWorkers* workers) :
 
 class ZProcessConcurrentWeakRootsTask : public ZTask {
 private:
-  ZConcurrentWeakRootsIterator _concurrent_weak_roots;
+  ZWeakRootsIterator _weak_roots;
 
 public:
   ZProcessConcurrentWeakRootsTask() :
       ZTask("ZProcessConccurentWeakRootsTask"),
-      _concurrent_weak_roots() {}
+      _weak_roots() {}
 
   ~ZProcessConcurrentWeakRootsTask() {
-    _concurrent_weak_roots.report_num_dead();
+    _weak_roots.report_num_dead();
   }
 
   virtual void work() {
     ZPhantomCleanOopClosure cl;
-    _concurrent_weak_roots.apply(&cl);
+    _weak_roots.apply(&cl);
   }
 };
 

--- a/src/hotspot/share/gc/z/zWeakRootsProcessor.cpp
+++ b/src/hotspot/share/gc/z/zWeakRootsProcessor.cpp
@@ -60,7 +60,7 @@ private:
 
 public:
   ZProcessWeakRootsTask() :
-      ZTask("ZProcessConccurentWeakRootsTask"),
+      ZTask("ZProcessWeakRootsTask"),
       _weak_roots() {}
 
   ~ZProcessWeakRootsTask() {

--- a/src/hotspot/share/gc/z/zWeakRootsProcessor.hpp
+++ b/src/hotspot/share/gc/z/zWeakRootsProcessor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ private:
 public:
   ZWeakRootsProcessor(ZWorkers* workers);
 
-  void process_concurrent_weak_roots();
+  void process_weak_roots();
 };
 
 #endif // SHARE_GC_Z_ZWEAKROOTSPROCESSOR_HPP


### PR DESCRIPTION
Since we no longer have any STW roots (they are all concurrent now), we can shorten the names of the roots iterators to just ZRootsIterator and ZWeakRootsIterator.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ❌ (6/6 failed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build debug)](https://github.com/pliden/jdk/runs/1455223791)
- [Linux x64 (build hotspot minimal)](https://github.com/pliden/jdk/runs/1455223844)
- [Linux x64 (build hotspot no-pch)](https://github.com/pliden/jdk/runs/1455223808)
- [Linux x64 (build hotspot optimized)](https://github.com/pliden/jdk/runs/1455223863)
- [Linux x64 (build hotspot zero)](https://github.com/pliden/jdk/runs/1455223824)
- [Linux x64 (build release)](https://github.com/pliden/jdk/runs/1455223777)
- [Linux x86 (build debug)](https://github.com/pliden/jdk/runs/1455223900)
- [Linux x86 (build release)](https://github.com/pliden/jdk/runs/1455223886)

### Issue
 * [JDK-8257072](https://bugs.openjdk.java.net/browse/JDK-8257072): ZGC: Rename roots iterators


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author) ⚠️ Review applies to 230f6fe5c15646e69c17bebea2d51ec143a5f7a5
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1429/head:pull/1429`
`$ git checkout pull/1429`
