### PR TITLE
8257073: ZGC: Try forward object before retaining page

### DIFF
--- a/src/hotspot/share/gc/z/zForwarding.inline.hpp
+++ b/src/hotspot/share/gc/z/zForwarding.inline.hpp
@@ -94,7 +94,9 @@ inline ZForwardingEntry* ZForwarding::entries() const {
 }
 
 inline ZForwardingEntry ZForwarding::at(ZForwardingCursor* cursor) const {
-  return Atomic::load(entries() + *cursor);
+  // Load acquire for correctness with regards to
+  // accesses to the contents of the forwarded object.
+  return Atomic::load_acquire(entries() + *cursor);
 }
 
 inline ZForwardingEntry ZForwarding::first(uintptr_t from_index, ZForwardingCursor* cursor) const {

--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -58,21 +58,12 @@ static uintptr_t forwarding_insert(ZForwarding* forwarding, uintptr_t from_addr,
   return ZAddress::good(to_offset_final);
 }
 
-uintptr_t ZRelocate::relocate_object_inner(ZForwarding* forwarding, uintptr_t from_addr) const {
-  ZForwardingCursor cursor;
-
-  // Lookup forwarding
-  uintptr_t to_addr = forwarding_find(forwarding, from_addr, &cursor);
-  if (to_addr != 0) {
-    // Already relocated
-    return to_addr;
-  }
-
+static uintptr_t relocate_object_inner(ZForwarding* forwarding, uintptr_t from_addr, ZForwardingCursor* cursor) {
   assert(ZHeap::heap()->is_object_live(from_addr), "Should be live");
 
   // Allocate object
   const size_t size = ZUtils::object_size(from_addr);
-  to_addr = ZHeap::heap()->alloc_object_non_blocking(size);
+  const uintptr_t to_addr = ZHeap::heap()->alloc_object_non_blocking(size);
   if (to_addr == 0) {
     // Allocation failed
     return 0;
@@ -82,7 +73,7 @@ uintptr_t ZRelocate::relocate_object_inner(ZForwarding* forwarding, uintptr_t fr
   ZUtils::object_copy_disjoint(from_addr, to_addr, size);
 
   // Insert forwarding
-  const uintptr_t to_addr_final = forwarding_insert(forwarding, from_addr, to_addr, &cursor);
+  const uintptr_t to_addr_final = forwarding_insert(forwarding, from_addr, to_addr, cursor);
   if (to_addr_final != to_addr) {
     // Already relocated, try undo allocation
     ZHeap::heap()->undo_alloc_object(to_addr, size);
@@ -92,9 +83,18 @@ uintptr_t ZRelocate::relocate_object_inner(ZForwarding* forwarding, uintptr_t fr
 }
 
 uintptr_t ZRelocate::relocate_object(ZForwarding* forwarding, uintptr_t from_addr) const {
+  ZForwardingCursor cursor;
+
+  // Lookup forwarding
+  uintptr_t to_addr = forwarding_find(forwarding, from_addr, &cursor);
+  if (to_addr != 0) {
+    // Already relocated
+    return to_addr;
+  }
+
   // Relocate object
   if (forwarding->retain_page()) {
-    const uintptr_t to_addr = relocate_object_inner(forwarding, from_addr);
+    to_addr = relocate_object_inner(forwarding, from_addr, &cursor);
     forwarding->release_page();
 
     if (to_addr != 0) {

--- a/src/hotspot/share/gc/z/zRelocate.hpp
+++ b/src/hotspot/share/gc/z/zRelocate.hpp
@@ -35,7 +35,6 @@ class ZRelocate {
 private:
   ZWorkers* const _workers;
 
-  uintptr_t relocate_object_inner(ZForwarding* forwarding, uintptr_t from_addr) const;
   void work(ZRelocationSetParallelIterator* iter);
 
 public:


### PR DESCRIPTION
This is a follow up to @albertnetymk's comment in the review of #1228, where he suggested that we could try to forward the object before we go ahead and retain the page. This could be an optimization in two cases:
1) A mutator would avoid a relocation stall in case the page is claimed, but the object the mutator is interested in has already been relocated.
2) The worker thread detaching the page would not have to wait for a mutator that is just forwarding an object.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ❌ (6/6 failed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build debug)](https://github.com/pliden/jdk/runs/1453466921)
- [Linux x64 (build hotspot minimal)](https://github.com/pliden/jdk/runs/1453466980)
- [Linux x64 (build hotspot no-pch)](https://github.com/pliden/jdk/runs/1453466939)
- [Linux x64 (build hotspot optimized)](https://github.com/pliden/jdk/runs/1453466995)
- [Linux x64 (build hotspot zero)](https://github.com/pliden/jdk/runs/1453466961)
- [Linux x64 (build release)](https://github.com/pliden/jdk/runs/1453466902)
- [Linux x86 (build debug)](https://github.com/pliden/jdk/runs/1453467147)
- [Linux x86 (build release)](https://github.com/pliden/jdk/runs/1453467133)

### Issue
 * [JDK-8257073](https://bugs.openjdk.java.net/browse/JDK-8257073): ZGC: Try forward object before retaining page


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1431/head:pull/1431`
`$ git checkout pull/1431`
