### PR TITLE
8257077: ZGC: Remove ZWorkers::run_serial()

### DIFF
--- a/src/hotspot/share/gc/z/zWorkers.cpp
+++ b/src/hotspot/share/gc/z/zWorkers.cpp
@@ -100,10 +100,6 @@ void ZWorkers::run(ZTask* task, uint nworkers) {
   _workers.run_task(task->gang_task());
 }
 
-void ZWorkers::run_serial(ZTask* task) {
-  run(task, 1  /* nworkers */);
-}
-
 void ZWorkers::run_parallel(ZTask* task) {
   run(task, nparallel());
 }

--- a/src/hotspot/share/gc/z/zWorkers.hpp
+++ b/src/hotspot/share/gc/z/zWorkers.hpp
@@ -47,7 +47,6 @@ public:
 
   void set_boost(bool boost);
 
-  void run_serial(ZTask* task);
   void run_parallel(ZTask* task);
   void run_concurrent(ZTask* task);
 


### PR DESCRIPTION
`ZWorkers::run_serial()` is no longer used and can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ❌ (6/6 failed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build debug)](https://github.com/pliden/jdk/runs/1453557008)
- [Linux x64 (build hotspot minimal)](https://github.com/pliden/jdk/runs/1453557094)
- [Linux x64 (build hotspot no-pch)](https://github.com/pliden/jdk/runs/1453557037)
- [Linux x64 (build hotspot optimized)](https://github.com/pliden/jdk/runs/1453557116)
- [Linux x64 (build hotspot zero)](https://github.com/pliden/jdk/runs/1453557066)
- [Linux x64 (build release)](https://github.com/pliden/jdk/runs/1453556744)
- [Linux x86 (build debug)](https://github.com/pliden/jdk/runs/1453556460)
- [Linux x86 (build release)](https://github.com/pliden/jdk/runs/1453556433)

### Issue
 * [JDK-8257077](https://bugs.openjdk.java.net/browse/JDK-8257077): ZGC: Remove ZWorkers::run_serial()


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1432/head:pull/1432`
`$ git checkout pull/1432`
