### PR TITLE
8257079: ZGC: Fold ZMark::prepare_mark() into ZMark::start()

### DIFF
--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -94,7 +94,12 @@ size_t ZMark::calculate_nstripes(uint nworkers) const {
   return MIN2(nstripes, ZMarkStripesMax);
 }
 
-void ZMark::prepare_mark() {
+void ZMark::start() {
+  // Verification
+  if (ZVerifyMarking) {
+    verify_all_stacks_empty();
+  }
+
   // Increment global sequence number to invalidate
   // marking information for all pages.
   ZGlobalSeqNum++;
@@ -127,16 +132,6 @@ void ZMark::prepare_mark() {
                 worker_id, _nworkers, stripe_id, nstripes);
     }
   }
-}
-
-void ZMark::start() {
-  // Verification
-  if (ZVerifyMarking) {
-    verify_all_stacks_empty();
-  }
-
-  // Prepare for concurrent mark
-  prepare_mark();
 }
 
 void ZMark::prepare_work() {

--- a/src/hotspot/share/gc/z/zMark.hpp
+++ b/src/hotspot/share/gc/z/zMark.hpp
@@ -55,7 +55,6 @@ private:
   uint                _nworkers;
 
   size_t calculate_nstripes(uint nworkers) const;
-  void prepare_mark();
 
   bool is_array(uintptr_t addr) const;
   void push_partial_array(uintptr_t addr, size_t size, bool finalizable);


### PR DESCRIPTION
Since we no longer have STW roots, ZMark::start() is now just calls perpare_mark() (and does verification), so we can just as well fold perpare_mark() into start().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ❌ (6/6 failed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build debug)](https://github.com/pliden/jdk/runs/1453597585)
- [Linux x64 (build hotspot minimal)](https://github.com/pliden/jdk/runs/1453597672)
- [Linux x64 (build hotspot no-pch)](https://github.com/pliden/jdk/runs/1453597619)
- [Linux x64 (build hotspot optimized)](https://github.com/pliden/jdk/runs/1453597709)
- [Linux x64 (build hotspot zero)](https://github.com/pliden/jdk/runs/1453597651)
- [Linux x64 (build release)](https://github.com/pliden/jdk/runs/1453597560)
- [Linux x86 (build debug)](https://github.com/pliden/jdk/runs/1453597979)
- [Linux x86 (build release)](https://github.com/pliden/jdk/runs/1453597961)

### Issue
 * [JDK-8257079](https://bugs.openjdk.java.net/browse/JDK-8257079): ZGC: Fold ZMark::prepare_mark() into ZMark::start()


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1433/head:pull/1433`
`$ git checkout pull/1433`
