### PR TITLE
8256359: AArch64: runtime/ReservedStack/ReservedStackTestCompiler.java fails

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -681,14 +681,16 @@ void InterpreterMacroAssembler::remove_activation(
 
   // remove activation
   // get sender esp
-  ldr(esp,
+  ldr(rscratch2,
       Address(rfp, frame::interpreter_frame_sender_sp_offset * wordSize));
   if (StackReservedPages > 0) {
     // testing if reserved zone needs to be re-enabled
     Label no_reserved_zone_enabling;
 
+    // look for an overflow into the stack reserved zone, i.e.
+    // interpreter_frame_sender_sp <= JavaThread::reserved_stack_activation
     ldr(rscratch1, Address(rthread, JavaThread::reserved_stack_activation_offset()));
-    cmp(esp, rscratch1);
+    cmp(rscratch2, rscratch1);
     br(Assembler::LS, no_reserved_zone_enabling);
 
     call_VM_leaf(
@@ -699,6 +701,9 @@ void InterpreterMacroAssembler::remove_activation(
 
     bind(no_reserved_zone_enabling);
   }
+
+  // restore sender esp
+  mov(esp, rscratch2);
   // remove frame anchor
   leave();
   // If we're returning to interpreted code we will shortly be

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -87,7 +87,6 @@ gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
 runtime/cds/DeterministicDump.java 8253495 generic-all
 runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
 runtime/ReservedStack/ReservedStackTest.java 8231031 generic-all
-runtime/ReservedStack/ReservedStackTestCompiler.java 8256359 linux-aarch64
 
 #############################################################################
 


### PR DESCRIPTION
The problem is that the caller's expression SP is restored before throw_delayed_StackOverflowError() gets called. This is wrong: it leaves ESP pointing into the caller's frame, and this triggers an assert failure. The fix here delays updating ESP until we know we're not going to call throw_delayed_StackOverflowError(). This makes the logic the same as x86.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Linux x86 (build debug)](https://github.com/theRealAph/jdk/runs/1459045905)
- [Linux x86 (build release)](https://github.com/theRealAph/jdk/runs/1459045883)
- [macOS x64 (hs/tier1 compiler)](https://github.com/theRealAph/jdk/runs/1459218217)

### Issue
 * [JDK-8256359](https://bugs.openjdk.java.net/browse/JDK-8256359): AArch64: runtime/ReservedStack/ReservedStackTestCompiler.java fails


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1435/head:pull/1435`
`$ git checkout pull/1435`
