### PR TITLE
8257082: ZGC: Clean up ZRuntimeWorkers and ZWorkers

### DIFF
--- a/src/hotspot/share/gc/z/zThread.cpp
+++ b/src/hotspot/share/gc/z/zThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ THREAD_LOCAL uintptr_t ZThread::_id;
 THREAD_LOCAL bool      ZThread::_is_vm;
 THREAD_LOCAL bool      ZThread::_is_java;
 THREAD_LOCAL bool      ZThread::_is_worker;
-THREAD_LOCAL bool      ZThread::_is_runtime_worker;
 THREAD_LOCAL uint      ZThread::_worker_id;
 
 void ZThread::initialize() {
@@ -42,7 +41,6 @@ void ZThread::initialize() {
   _is_vm = thread->is_VM_thread();
   _is_java = thread->is_Java_thread();
   _is_worker = false;
-  _is_runtime_worker = false;
   _worker_id = (uint)-1;
 }
 
@@ -61,11 +59,6 @@ const char* ZThread::name() {
 void ZThread::set_worker() {
   ensure_initialized();
   _is_worker = true;
-}
-
-void ZThread::set_runtime_worker() {
-  ensure_initialized();
-  _is_runtime_worker = true;
 }
 
 bool ZThread::has_worker_id() {

--- a/src/hotspot/share/gc/z/zThread.hpp
+++ b/src/hotspot/share/gc/z/zThread.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,14 +38,12 @@ private:
   static THREAD_LOCAL bool      _is_vm;
   static THREAD_LOCAL bool      _is_java;
   static THREAD_LOCAL bool      _is_worker;
-  static THREAD_LOCAL bool      _is_runtime_worker;
   static THREAD_LOCAL uint      _worker_id;
 
   static void initialize();
   static void ensure_initialized();
 
   static void set_worker();
-  static void set_runtime_worker();
 
   static bool has_worker_id();
   static void set_worker_id(uint worker_id);
@@ -57,7 +55,6 @@ public:
   static bool is_vm();
   static bool is_java();
   static bool is_worker();
-  static bool is_runtime_worker();
   static uint worker_id();
 };
 

--- a/src/hotspot/share/gc/z/zThread.inline.hpp
+++ b/src/hotspot/share/gc/z/zThread.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,11 +51,6 @@ inline bool ZThread::is_java() {
 inline bool ZThread::is_worker() {
   ensure_initialized();
   return _is_worker;
-}
-
-inline bool ZThread::is_runtime_worker() {
-  ensure_initialized();
-  return _is_runtime_worker;
 }
 
 inline uint ZThread::worker_id() {

--- a/src/hotspot/share/gc/z/zWorkers.cpp
+++ b/src/hotspot/share/gc/z/zWorkers.cpp
@@ -23,41 +23,37 @@
 
 #include "precompiled.hpp"
 #include "gc/shared/gcLogPrecious.hpp"
+#include "gc/z/zLock.inline.hpp"
 #include "gc/z/zTask.hpp"
 #include "gc/z/zThread.hpp"
 #include "gc/z/zWorkers.inline.hpp"
 #include "runtime/java.hpp"
-#include "runtime/mutex.hpp"
-#include "runtime/mutexLocker.hpp"
 
 class ZWorkersInitializeTask : public ZTask {
 private:
-  const uint _nworkers;
-  uint       _started;
-  Monitor    _monitor;
+  const uint     _nworkers;
+  uint           _started;
+  ZConditionLock _lock;
 
 public:
   ZWorkersInitializeTask(uint nworkers) :
       ZTask("ZWorkersInitializeTask"),
       _nworkers(nworkers),
       _started(0),
-      _monitor(Monitor::leaf,
-               "ZWorkersInitialize",
-               false /* allow_vm_block */,
-               Monitor::_safepoint_check_never) {}
+      _lock() {}
 
   virtual void work() {
     // Register as worker
     ZThread::set_worker();
 
     // Wait for all threads to start
-    MonitorLocker ml(&_monitor, Monitor::_no_safepoint_check_flag);
+    ZLocker<ZConditionLock> locker(&_lock);
     if (++_started == _nworkers) {
       // All threads started
-      ml.notify_all();
+      _lock.notify_all();
     } else {
       while (_started != _nworkers) {
-        ml.wait();
+        _lock.wait();
       }
     }
   }
@@ -79,9 +75,7 @@ ZWorkers::ZWorkers() :
     vm_exit_during_initialization("Failed to create ZWorkers");
   }
 
-  // Execute task to register threads as workers. This also helps
-  // reduce latency in early GC pauses, which otherwise would have
-  // to take on any warmup costs.
+  // Execute task to register threads as workers
   ZWorkersInitializeTask task(nworkers());
   run(&task, nworkers());
 }


### PR DESCRIPTION
Found some additional stuff in ZRuntimeWorkers and ZWorkers that could be cleaned up.
* `ZThread::set_runtime_worker()` and friends are no longer used, and can be remove
* Fixed obsolete comment
* Added a missing `zTask.hpp` include
* Replaced `Monitor` with `ZConditionLock`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ❌ (6/6 failed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build debug)](https://github.com/pliden/jdk/runs/1454335031)
- [Linux x64 (build hotspot minimal)](https://github.com/pliden/jdk/runs/1454335090)
- [Linux x64 (build hotspot no-pch)](https://github.com/pliden/jdk/runs/1454335059)
- [Linux x64 (build hotspot optimized)](https://github.com/pliden/jdk/runs/1454335119)
- [Linux x64 (build hotspot zero)](https://github.com/pliden/jdk/runs/1454335076)
- [Linux x64 (build release)](https://github.com/pliden/jdk/runs/1454335014)
- [Linux x86 (build debug)](https://github.com/pliden/jdk/runs/1454335262)
- [Linux x86 (build release)](https://github.com/pliden/jdk/runs/1454335239)

### Issue
 * [JDK-8257082](https://bugs.openjdk.java.net/browse/JDK-8257082): ZGC: Clean up ZRuntimeWorkers and ZWorkers


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1436/head:pull/1436`
`$ git checkout pull/1436`
