### PR TITLE
8256830: misc tests failed with "assert(env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) failed: checking"

### DIFF
--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -456,14 +456,8 @@ JvmtiEventControllerPrivate::recompute_env_enabled(JvmtiEnvBase* env) {
     break;
   }
 
-  // will we really send these events to this env
-  if (((was_enabled & OBJECT_FREE_BIT) != 0) ||
-      ((now_enabled & OBJECT_FREE_BIT)) != 0) {
-    // Set/reset the event enabled under the tagmap lock.
-    set_enabled_events_with_lock(env, now_enabled);
-  } else {
-    env->env_event_enable()->_event_enabled.set_bits(now_enabled);
-  }
+  // Set/reset the event enabled under the tagmap lock.
+  set_enabled_events_with_lock(env, now_enabled);
 
   trace_changed(now_enabled, (now_enabled ^ was_enabled)  & ~THREAD_FILTERED_EVENT_BITS);
 

--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -307,6 +307,7 @@ public:
   static void trace_changed(jlong now_enabled, jlong changed);
 
   static void flush_object_free_events(JvmtiEnvBase *env);
+  static void set_enabled_events_with_lock(JvmtiEnvBase *env, jlong now_enabled);
 };
 
 bool JvmtiEventControllerPrivate::_initialized = false;
@@ -409,6 +410,19 @@ JvmtiEventControllerPrivate::flush_object_free_events(JvmtiEnvBase* env) {
   }
 }
 
+void
+JvmtiEventControllerPrivate::set_enabled_events_with_lock(JvmtiEnvBase* env, jlong now_enabled) {
+  // The state for ObjectFree events must be enabled or disabled
+  // under the TagMap lock, to allow pending object posting events to complete.
+  JvmtiTagMap* tag_map = env->tag_map_acquire();
+  if (tag_map != NULL) {
+    MutexLocker ml(tag_map->lock(), Mutex::_no_safepoint_check_flag);
+    env->env_event_enable()->_event_enabled.set_bits(now_enabled);
+  } else {
+    env->env_event_enable()->_event_enabled.set_bits(now_enabled);
+  }
+}
+
 // For the specified env: compute the currently truly enabled events
 // set external state accordingly.
 // Return value and set value must include all events.
@@ -443,7 +457,13 @@ JvmtiEventControllerPrivate::recompute_env_enabled(JvmtiEnvBase* env) {
   }
 
   // will we really send these events to this env
-  env->env_event_enable()->_event_enabled.set_bits(now_enabled);
+  if (((was_enabled & OBJECT_FREE_BIT) != 0) ||
+      ((now_enabled & OBJECT_FREE_BIT)) != 0) {
+    // Set/reset the event enabled under the tagmap lock.
+    set_enabled_events_with_lock(env, now_enabled);
+  } else {
+    env->env_event_enable()->_event_enabled.set_bits(now_enabled);
+  }
 
   trace_changed(now_enabled, (now_enabled ^ was_enabled)  & ~THREAD_FILTERED_EVENT_BITS);
 

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -1158,6 +1158,8 @@ void JvmtiTagMap::iterate_through_heap(jint heap_filter,
 void JvmtiTagMap::remove_dead_entries_locked(bool post_object_free) {
   assert(is_locked(), "precondition");
   if (_needs_cleaning) {
+    // Recheck whether to post object free events under the lock.
+    post_object_free = post_object_free && env()->is_enabled(JVMTI_EVENT_OBJECT_FREE);
     log_info(jvmti, table)("TagMap table needs cleaning%s",
                            (post_object_free ? " and posting" : ""));
     hashmap()->remove_dead_entries(env(), post_object_free);

--- a/src/hotspot/share/prims/jvmtiTagMap.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.hpp
@@ -49,7 +49,6 @@ class JvmtiTagMap :  public CHeapObj<mtInternal> {
   JvmtiTagMap(JvmtiEnv* env);
 
   // accessors
-  inline Mutex* lock()                      { return &_lock; }
   inline JvmtiEnv* env() const              { return _env; }
 
   void check_hashmap(bool post_events);
@@ -60,6 +59,7 @@ class JvmtiTagMap :  public CHeapObj<mtInternal> {
  public:
   // indicates if this tag map is locked
   bool is_locked()                          { return lock()->is_locked(); }
+  inline Mutex* lock()                      { return &_lock; }
 
   JvmtiTagMapTable* hashmap() { return _hashmap; }
 


### PR DESCRIPTION
The ServiceThread cleaning used a stale ObjectFree state when calling remove_dead_entries, because another thread had concurrently set is_enabled to false.  Add a lock around setting/resetting the lock event state and retest the state under a lock.  Ran the test 100s of time without failure, where otherwise it fails very quickly.
Tested with tier2,3 and running tiers 4,5,6 in progress.
Thanks to Kim for his previous feedback.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256830](https://bugs.openjdk.java.net/browse/JDK-8256830): misc tests failed with "assert(env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) failed: checking"


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 1d9e6bef598ff844c218b8c6ab887ce230660897
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1439/head:pull/1439`
`$ git checkout pull/1439`
