### PR TITLE
8254631: Better support ALPN byte wire values in SunJSSE

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -345,11 +345,12 @@ import java.util.function.BiFunction;
  *
  * <blockquote><pre>
  *     String networkString = sslEngine.getHandshakeApplicationProtocol();
- *     String unicodeString = new String(networkString.getBytes(
- *             StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+ *     String unicodeString = new String(
+ *             networkString.getBytes(StandardCharsets.ISO_8859_1),
+ *             StandardCharsets.UTF_8);
  *
  *     // MEETEI MAYEK LETTERS HUK UN I (Unicode 0xabcd->0xabcf)
- *     if (unicodeString.equals("\uabcd\uabce\uabcf") {
+ *     if (unicodeString.equals("\u005cuabcd\u005cuabce\u005cuabcf")) {
  *         ...
  *     }
  * </pre></blockquote>

--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -336,21 +336,43 @@ import java.util.function.BiFunction;
  * started, an {@code SSLEngine} can not switch between client and server
  * modes, even when performing renegotiations.
  * <P>
- * The ApplicationProtocol {@code String} values returned by the methods in
- * this class are in the network byte representation sent by the peer and
- * may need to be converted to its Unicode format before use.  For example,
- * if an ALPN value was encoded using {@code UTF-8}, the {@code String}
- * should be converted to its {@code byte[]} representation and then
- * {@code UTF-8}-decoded to a {@code String} before use.
+ * The ApplicationProtocol {@code String} values returned by the methods
+ * in this class are in the network byte representation sent by the peer.
+ * The bytes could be directly compared, or converted to its Unicode
+ * {code String} format for comparison.
  *
  * <blockquote><pre>
  *     String networkString = sslEngine.getHandshakeApplicationProtocol();
- *     String unicodeString = new String(
- *             networkString.getBytes(StandardCharsets.ISO_8859_1),
- *             StandardCharsets.UTF_8);
+ *     byte[] bytes = networkString.getBytes(StandardCharsets.ISO_8859_1);
  *
- *     // MEETEI MAYEK LETTERS HUK UN I (Unicode 0xabcd->0xabcf)
- *     if (unicodeString.equals("\u005cuabcd\u005cuabce\u005cuabcf")) {
+ *     //
+ *     // Match using bytes:
+ *     //
+ *     //   "http/1.1"                       (7-bit ASCII values same in UTF-8)
+ *     //   MEETEI MAYEK LETTERS "HUK UN I"  (Unicode 0xabcd->0xabcf)
+ *     //
+ *     String HTTP1_1 = "http/1.1";
+ *     byte[] HTTP1_1_BYTES = HTTP1_1.getBytes(StandardCharsets.UTF_8);
+ *
+ *     byte[] HUK_UN_I_BYTES = new byte[] {
+ *         (byte) 0xab, (byte) 0xcd,
+ *         (byte) 0xab, (byte) 0xce,
+ *         (byte) 0xab, (byte) 0xcf};
+ *
+ *     if ((Arrays.compare(bytes, HTTP1_1_BYTES) == 0 )
+ *             || Arrays.compare(bytes, HUK_UN_I_BYTES) == 0) {
+ *        ...
+ *     }
+ *
+ *     //
+ *     // Alternatively match using string.equals() if we know the ALPN value
+ *     // was encoded from a {@code String} using a certain character set,
+ *     // for example {@code UTF-8}.  The ALPN value must first be properly
+ *     // decoded to a Unicode {@code String} before use.
+ *     //
+ *     String unicodeString = new String(bytes, StandardCharsets.UTF_8);
+ *     if (unicodeString.equals(HTTP1_1)
+ *             || unicodeString.equals("\u005cuabcd\u005cuabce\u005cuabcf")) {
  *         ...
  *     }
  * </pre></blockquote>

--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -353,7 +353,7 @@ import java.util.function.BiFunction;
  *         ...
  *     }
  * </pre></blockquote>
- * 
+ *
  * <P>
  * Applications might choose to process delegated tasks in different
  * threads.  When an {@code SSLEngine}

--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -336,6 +336,25 @@ import java.util.function.BiFunction;
  * started, an {@code SSLEngine} can not switch between client and server
  * modes, even when performing renegotiations.
  * <P>
+ * The ApplicationProtocol {@code String} values returned by the methods in
+ * this class are in the network byte representation sent by the peer and
+ * may need to be converted to its Unicode format before use.  For example,
+ * if an ALPN value was encoded using {@code UTF-8}, the {@code String}
+ * should be converted to its {@code byte[]} representation and then
+ * {@code UTF-8}-decoded to a {@code String} before use.
+ *
+ * <blockquote><pre>
+ *     String networkString = sslEngine.getHandshakeApplicationProtocol();
+ *     String unicodeString = new String(networkString.getBytes(
+ *             StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+ *
+ *     // MEETEI MAYEK LETTERS HUK UN I (Unicode 0xabcd->0xabcf)
+ *     if (unicodeString.equals("\uabcd\uabce\uabcf") {
+ *         ...
+ *     }
+ * </pre></blockquote>
+ * 
+ * <P>
  * Applications might choose to process delegated tasks in different
  * threads.  When an {@code SSLEngine}
  * is created, the current {@link java.security.AccessControlContext}

--- a/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -654,11 +654,11 @@ public class SSLParameters {
      * and stored as a byte-oriented {@code String} before calling this method.
      *
      * <blockquote><pre>
-     *     // MEETEI MAYEK LETTERS HUK UN I (Unicode 0xabcd->0xabcf)
+     *     // MEETEI MAYEK LETTERS HUK UN I (Unicode 0xabcd->0xabcf) 2 bytes
      *     byte[] bytes = "\uabcd\uabce\uabcf".getBytes(StandardCharsets.UTF_8);
      *     String HUK_UN_I = new String(bytes, StandardCharsets.ISO_8859_1);
      *
-     *     String rfc7301Grease8F = "\u008F\u008F";   // 0x00-0xFF: 8-bit bytes
+     *     String rfc7301Grease8F = "\u008F\u008F";   // 0x00-0xFF:  1 byte
      *     SSLParameters p = sslSocket.getSSLParameters();
      *     p.setApplicationProtocols(new String[] {
      *         "h2", "http/1.1", rfc7301Grease8F, HUK_UN_I});

--- a/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
@@ -654,14 +654,17 @@ public class SSLParameters {
      * and stored as a byte-oriented {@code String} before calling this method.
      *
      * <blockquote><pre>
-     *     // MEETEI MAYEK LETTERS HUK UN I (Unicode 0xabcd->0xabcf) 2 bytes
-     *     byte[] bytes = "\uabcd\uabce\uabcf".getBytes(StandardCharsets.UTF_8);
+     *     // MEETEI MAYEK LETTERS HUK UN I (Unicode 0xabcd->0xabcf): 2 bytes
+     *     byte[] bytes = "\u005cuabcd\u005cuabce\u005cuabcf"
+     *             .getBytes(StandardCharsets.UTF_8);
      *     String HUK_UN_I = new String(bytes, StandardCharsets.ISO_8859_1);
      *
-     *     String rfc7301Grease8F = "\u008F\u008F";   // 0x00-0xFF:  1 byte
+     *     // 0x00-0xFF:  1 byte
+     *     String rfc7301Grease8F = "\u005c008F\u005c008F";
+     *
      *     SSLParameters p = sslSocket.getSSLParameters();
      *     p.setApplicationProtocols(new String[] {
-     *         "h2", "http/1.1", rfc7301Grease8F, HUK_UN_I});
+     *             "h2", "http/1.1", rfc7301Grease8F, HUK_UN_I});
      *     sslSocket.setSSLParameters(p);
      * </pre></blockquote>
      *

--- a/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
@@ -646,6 +646,24 @@ public class SSLParameters {
      * requested by the peer, the underlying protocol will determine what
      * action to take.  (For example, ALPN will send a
      * {@code "no_application_protocol"} alert and terminate the connection.)
+     * <p>
+     * The {@code String} values must be presented using the network
+     * byte representation expected by the peer.  For example, if an ALPN
+     * {@code String} should be exchanged using {@code UTF-8}, the
+     * {@code String} should be converted to its {@code byte[]} representation
+     * and stored as a byte-oriented {@code String} before calling this method.
+     *
+     * <blockquote><pre>
+     *     // MEETEI MAYEK LETTERS HUK UN I (Unicode 0xabcd->0xabcf)
+     *     byte[] bytes = "\uabcd\uabce\uabcf".getBytes(StandardCharsets.UTF_8);
+     *     String HUK_UN_I = new String(bytes, StandardCharsets.ISO_8859_1);
+     *
+     *     String rfc7301Grease8F = "\u008F\u008F";   // 0x00-0xFF: 8-bit bytes
+     *     SSLParameters p = sslSocket.getSSLParameters();
+     *     p.setApplicationProtocols(new String[] {
+     *         "h2", "http/1.1", rfc7301Grease8F, HUK_UN_I});
+     *     sslSocket.setSSLParameters(p);
+     * </pre></blockquote>
      *
      * @implSpec
      * This method will make a copy of the {@code protocols} array.

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -139,11 +139,12 @@ import java.util.function.BiFunction;
  *
  * <blockquote><pre>
  *     String networkString = sslSocket.getHandshakeApplicationProtocol();
- *     String unicodeString = new String(networkString.getBytes(
- *             StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+ *     String unicodeString = new String(
+ *             networkString.getBytes(StandardCharsets.ISO_8859_1),
+ *             StandardCharsets.UTF_8);
  *
  *     // MEETEI MAYEK LETTERS HUK UN I (Unicode 0xabcd->0xabcf)
- *     if (unicodeString.equals("\uabcd\uabce\uabcf") {
+ *     if (unicodeString.equals("\u005cuabcd\u005cuabce\u005cuabcf")) {
  *         ...
  *     }
  * </pre></blockquote>

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -130,21 +130,43 @@ import java.util.function.BiFunction;
  * socket can not switch between client and server modes, even when
  * performing renegotiations.
  *
- * <P> The ApplicationProtocol {@code String} values returned by the methods in
- * this class are in the network byte representation sent by the peer and
- * may need to be converted to its Unicode format before use.  For example,
- * if an ALPN value was encoded using {@code UTF-8}, the {@code String}
- * should be converted to its {@code byte[]} representation and then
- * {@code UTF-8}-decoded to a {@code String} before use.
+ * <P> The ApplicationProtocol {@code String} values returned by the methods
+ * in this class are in the network byte representation sent by the peer.
+ * The bytes could be directly compared, or converted to its Unicode
+ * {code String} format for comparison.
  *
  * <blockquote><pre>
  *     String networkString = sslSocket.getHandshakeApplicationProtocol();
- *     String unicodeString = new String(
- *             networkString.getBytes(StandardCharsets.ISO_8859_1),
- *             StandardCharsets.UTF_8);
+ *     byte[] bytes = networkString.getBytes(StandardCharsets.ISO_8859_1);
  *
- *     // MEETEI MAYEK LETTERS HUK UN I (Unicode 0xabcd->0xabcf)
- *     if (unicodeString.equals("\u005cuabcd\u005cuabce\u005cuabcf")) {
+ *     //
+ *     // Match using bytes:
+ *     //
+ *     //   "http/1.1"                       (7-bit ASCII values same in UTF-8)
+ *     //   MEETEI MAYEK LETTERS "HUK UN I"  (Unicode 0xabcd->0xabcf)
+ *     //
+ *     String HTTP1_1 = "http/1.1";
+ *     byte[] HTTP1_1_BYTES = HTTP1_1.getBytes(StandardCharsets.UTF_8);
+ *
+ *     byte[] HUK_UN_I_BYTES = new byte[] {
+ *         (byte) 0xab, (byte) 0xcd,
+ *         (byte) 0xab, (byte) 0xce,
+ *         (byte) 0xab, (byte) 0xcf};
+ *
+ *     if ((Arrays.compare(bytes, HTTP1_1_BYTES) == 0 )
+ *             || Arrays.compare(bytes, HUK_UN_I_BYTES) == 0) {
+ *        ...
+ *     }
+ *
+ *     //
+ *     // Alternatively match using string.equals() if we know the ALPN value
+ *     // was encoded from a {@code String} using a certain character set,
+ *     // for example {@code UTF-8}.  The ALPN value must first be properly
+ *     // decoded to a Unicode {@code String} before use.
+ *     //
+ *     String unicodeString = new String(bytes, StandardCharsets.UTF_8);
+ *     if (unicodeString.equals(HTTP1_1)
+ *             || unicodeString.equals("\u005cuabcd\u005cuabce\u005cuabcf")) {
  *         ...
  *     }
  * </pre></blockquote>

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -130,6 +130,24 @@ import java.util.function.BiFunction;
  * socket can not switch between client and server modes, even when
  * performing renegotiations.
  *
+ * <P> The ApplicationProtocol {@code String} values returned by the methods in
+ * this class are in the network byte representation sent by the peer and
+ * may need to be converted to its Unicode format before use.  For example,
+ * if an ALPN value was encoded using {@code UTF-8}, the {@code String}
+ * should be converted to its {@code byte[]} representation and then
+ * {@code UTF-8}-decoded to a {@code String} before use.
+ *
+ * <blockquote><pre>
+ *     String networkString = sslSocket.getHandshakeApplicationProtocol();
+ *     String unicodeString = new String(networkString.getBytes(
+ *             StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+ *
+ *     // MEETEI MAYEK LETTERS HUK UN I (Unicode 0xabcd->0xabcf)
+ *     if (unicodeString.equals("\uabcd\uabce\uabcf") {
+ *         ...
+ *     }
+ * </pre></blockquote>
+ *
  * @apiNote
  * When the connection is no longer needed, the client and server
  * applications should each close both sides of their respective connection.

--- a/src/java.base/share/classes/sun/security/ssl/AlpnExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/AlpnExtension.java
@@ -186,7 +186,7 @@ final class AlpnExtension {
                 return null;
             }
 
-            // Produce the extension.
+            // Produce the extension:  first find the overall length
             int listLength = 0;     // ProtocolNameList length
             for (String ap : laps) {
                 int length = ap.getBytes(alpnCharset).length;
@@ -241,6 +241,8 @@ final class AlpnExtension {
             byte[] extData = new byte[listLength + 2];
             ByteBuffer m = ByteBuffer.wrap(extData);
             Record.putInt16(m, listLength);
+
+            // opaque ProtocolName<1..2^8-1>;
             for (String ap : laps) {
                 Record.putBytes8(m, ap.getBytes(alpnCharset));
             }
@@ -432,14 +434,14 @@ final class AlpnExtension {
             }
 
             // opaque ProtocolName<1..2^8-1>, RFC 7301.
-            int listLen = shc.applicationProtocol.length() + 1;
-                                                        // 1: length byte
+            byte[] bytes = shc.applicationProtocol.getBytes(alpnCharset);
+            int listLen = bytes.length + 1;             // 1: length byte
+
             // ProtocolName protocol_name_list<2..2^16-1>, RFC 7301.
             byte[] extData = new byte[listLen + 2];     // 2: list length
             ByteBuffer m = ByteBuffer.wrap(extData);
             Record.putInt16(m, listLen);
-            Record.putBytes8(m,
-                    shc.applicationProtocol.getBytes(alpnCharset));
+            Record.putBytes8(m, bytes);
 
             // Update the context.
             shc.conContext.applicationProtocol = shc.applicationProtocol;

--- a/src/java.base/share/classes/sun/security/ssl/AlpnExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/AlpnExtension.java
@@ -28,7 +28,6 @@ package sun.security.ssl;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.Security;

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1309,3 +1309,10 @@ jdk.io.permissionsUseCanonicalPath=false
 # System value prevails. The default value of the property is "false".
 #
 #jdk.security.allowNonCaAnchor=true
+
+#
+# The default Character set for converting TLS ALPN values between byte
+# arrays and Strings. Older versions of JDK used UTF-8.
+#
+# jdk.jsse.alpnCharacterEncoder=UTF-8
+jdk.tls.alpnCharset=ISO_8859_1

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1314,5 +1314,5 @@ jdk.io.permissionsUseCanonicalPath=false
 # The default Character set for converting TLS ALPN values between byte
 # arrays and Strings. Older versions of JDK used UTF-8.
 #
-# jdk.jsse.alpnCharacterEncoder=UTF-8
+# jdk.tls.alpnCharset=UTF-8
 jdk.tls.alpnCharset=ISO_8859_1

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1311,8 +1311,9 @@ jdk.io.permissionsUseCanonicalPath=false
 #jdk.security.allowNonCaAnchor=true
 
 #
-# The default Character set for converting TLS ALPN values between byte
-# arrays and Strings. Older versions of JDK used UTF-8.
+# The default Character set name (java.nio.charset.Charset.forName()) for
+# converting TLS ALPN values between byte arrays and Strings. Older versions
+# of JDK used UTF-8.
 #
 # jdk.tls.alpnCharset=UTF-8
 jdk.tls.alpnCharset=ISO_8859_1

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1311,8 +1311,11 @@ jdk.io.permissionsUseCanonicalPath=false
 #jdk.security.allowNonCaAnchor=true
 
 #
-# The default Character set name (java.nio.charset.Charset.forName()) for
-# converting TLS ALPN values between byte arrays and Strings.
+# The default Character set name (java.nio.charset.Charset.forName())
+# for converting TLS ALPN values between byte arrays and Strings.
+# Prior versions of the JDK may use UTF-8 as the default charset. If
+# you experience interoperability issues, setting this property to UTF-8
+# may help.
 #
 # jdk.tls.alpnCharset=UTF-8
 jdk.tls.alpnCharset=ISO_8859_1

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1312,8 +1312,7 @@ jdk.io.permissionsUseCanonicalPath=false
 
 #
 # The default Character set name (java.nio.charset.Charset.forName()) for
-# converting TLS ALPN values between byte arrays and Strings. Older versions
-# of JDK used UTF-8.
+# converting TLS ALPN values between byte arrays and Strings.
 #
 # jdk.tls.alpnCharset=UTF-8
 jdk.tls.alpnCharset=ISO_8859_1

--- a/test/jdk/sun/security/ssl/ALPN/AlpnGreaseTest.java
+++ b/test/jdk/sun/security/ssl/ALPN/AlpnGreaseTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// SunJSSE does not support dynamic system properties, no way to re-use
+// system properties in samevm/agentvm mode.
+
+/*
+ * @test
+ * @bug 8254631
+ * @summary Better support ALPN byte wire values in SunJSSE
+ * @library /javax/net/ssl/templates
+ * @run main/othervm AlpnGreaseTest
+ */
+import javax.net.ssl.*;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * A SSLEngine usage example which simplifies the presentation
+ * by removing the I/O and multi-threading concerns.
+ *
+ * The test creates two SSLEngines, simulating a client and server.
+ * The "transport" layer consists two byte buffers:  think of them
+ * as directly connected pipes.
+ *
+ * Note, this is a *very* simple example: real code will be much more
+ * involved.  For example, different threading and I/O models could be
+ * used, transport mechanisms could close unexpectedly, and so on.
+ *
+ * When this application runs, notice that several messages
+ * (wrap/unwrap) pass before any application data is consumed or
+ * produced.
+ */
+public class AlpnGreaseTest implements SSLContextTemplate {
+
+    private final SSLEngine clientEngine;     // client Engine
+    private final ByteBuffer clientOut;       // write side of clientEngine
+    private final ByteBuffer clientIn;        // read side of clientEngine
+
+    private final SSLEngine serverEngine;     // server Engine
+    private final ByteBuffer serverOut;       // write side of serverEngine
+    private final ByteBuffer serverIn;        // read side of serverEngine
+
+    // For data transport, this example uses local ByteBuffers.  This
+    // isn't really useful, but the purpose of this example is to show
+    // SSLEngine concepts, not how to do network transport.
+    private final ByteBuffer cTOs;      // "reliable" transport client->server
+    private final ByteBuffer sTOc;      // "reliable" transport server->client
+
+    // These are the various 8-bit char values that could  be sent as GREASE
+    // values.  We'll just make one big String here to make it easy to check
+    // that the right values are being output.
+    private static final byte[] greaseBytes = new byte[] {
+        (byte) 0x0A, (byte) 0x1A, (byte) 0x2A, (byte) 0x3A,
+        (byte) 0x4A, (byte) 0x5A, (byte) 0x6A, (byte) 0x7A,
+        (byte) 0x8A, (byte) 0x9A, (byte) 0xAA, (byte) 0xBA,
+        (byte) 0xCA, (byte) 0xDA, (byte) 0xEA, (byte) 0xFA
+    };
+
+    private static final String greaseString =
+            new String(greaseBytes, StandardCharsets.ISO_8859_1);
+
+    private static void findGreaseInClientHello(byte[] bytes) throws Exception {
+        for (int i = 0; i < bytes.length - greaseBytes.length; i++) {
+            if (Arrays.equals(bytes, i, i + greaseBytes.length,
+                    greaseBytes, 0, greaseBytes.length)) {
+                System.out.println("Found greaseBytes in ClientHello at: " + i);
+                return;
+            }
+        }
+        //throw new Exception("Couldn't find greaseBytes");
+    }
+
+    private AlpnGreaseTest() throws Exception {
+        serverEngine = configureServerEngine(
+                createServerSSLContext().createSSLEngine());
+
+        clientEngine = configureClientEngine(
+                createClientSSLContext().createSSLEngine());
+
+        // We'll assume the buffer sizes are the same
+        // between client and server.
+        SSLSession session = clientEngine.getSession();
+        int appBufferMax = session.getApplicationBufferSize();
+        int netBufferMax = session.getPacketBufferSize();
+
+        // We'll make the input buffers a bit bigger than the max needed
+        // size, so that unwrap()s following a successful data transfer
+        // won't generate BUFFER_OVERFLOWS.
+        //
+        // We'll use a mix of direct and indirect ByteBuffers for
+        // tutorial purposes only.  In reality, only use direct
+        // ByteBuffers when they give a clear performance enhancement.
+        clientIn = ByteBuffer.allocate(appBufferMax + 50);
+        serverIn = ByteBuffer.allocate(appBufferMax + 50);
+
+        cTOs = ByteBuffer.allocateDirect(netBufferMax);
+        sTOc = ByteBuffer.allocateDirect(netBufferMax);
+
+        clientOut = ByteBuffer.wrap("Hi Server, I'm Client".getBytes());
+        serverOut = ByteBuffer.wrap("Hello Client, I'm Server".getBytes());
+    }
+
+    //
+    // Protected methods could be used to customize the test case.
+    //
+
+    /*
+     * Configure the client side engine.
+     */
+    protected SSLEngine configureClientEngine(SSLEngine clientEngine) {
+        clientEngine.setUseClientMode(true);
+
+        // Get/set parameters if needed
+        SSLParameters paramsClient = clientEngine.getSSLParameters();
+        paramsClient.setApplicationProtocols(new String[] { greaseString });
+
+        clientEngine.setSSLParameters(paramsClient);
+
+        return clientEngine;
+    }
+
+    /*
+     * Configure the server side engine.
+     */
+    protected SSLEngine configureServerEngine(SSLEngine serverEngine) {
+        serverEngine.setUseClientMode(false);
+        serverEngine.setNeedClientAuth(true);
+
+        // Get/set parameters if needed
+        //
+        SSLParameters paramsServer = serverEngine.getSSLParameters();
+        paramsServer.setApplicationProtocols(new String[] { greaseString });
+        serverEngine.setSSLParameters(paramsServer);
+
+        return serverEngine;
+    }
+
+    public static void main(String[] args) throws Exception {
+        new AlpnGreaseTest().runTest();
+    }
+
+    //
+    // Private methods that used to build the common part of the test.
+    //
+
+    private void runTest() throws Exception {
+        SSLEngineResult clientResult;
+        SSLEngineResult serverResult;
+
+        boolean dataDone = false;
+        boolean firstClientWrap = true;
+        while (isOpen(clientEngine) || isOpen(serverEngine)) {
+            log("=================");
+
+            // client wrap
+            log("---Client Wrap---");
+            clientResult = clientEngine.wrap(clientOut, cTOs);
+            logEngineStatus(clientEngine, clientResult);
+            runDelegatedTasks(clientEngine);
+
+            if (firstClientWrap) {
+                firstClientWrap = false;
+                byte[] bytes = new byte[cTOs.position()];
+                cTOs.duplicate().flip().get(bytes);
+                findGreaseInClientHello(bytes);
+            }
+
+            // server wrap
+            log("---Server Wrap---");
+            serverResult = serverEngine.wrap(serverOut, sTOc);
+            logEngineStatus(serverEngine, serverResult);
+            runDelegatedTasks(serverEngine);
+
+            cTOs.flip();
+            sTOc.flip();
+
+            // client unwrap
+            log("---Client Unwrap---");
+            clientResult = clientEngine.unwrap(sTOc, clientIn);
+            logEngineStatus(clientEngine, clientResult);
+            runDelegatedTasks(clientEngine);
+
+            // server unwrap
+            log("---Server Unwrap---");
+            serverResult = serverEngine.unwrap(cTOs, serverIn);
+            logEngineStatus(serverEngine, serverResult);
+            runDelegatedTasks(serverEngine);
+
+            cTOs.compact();
+            sTOc.compact();
+
+            // After we've transferred all application data between the client
+            // and server, we close the clientEngine's outbound stream.
+            // This generates a close_notify handshake message, which the
+            // server engine receives and responds by closing itself.
+            if (!dataDone && (clientOut.limit() == serverIn.position()) &&
+                    (serverOut.limit() == clientIn.position())) {
+
+                // Check ALPN Value
+                String alpnServerValue = serverEngine.getApplicationProtocol();
+                String alpnClientValue = clientEngine.getApplicationProtocol();
+
+                if (!alpnServerValue.equals(greaseString)
+                        || !alpnClientValue.equals(greaseString)) {
+                    throw new Exception("greaseString didn't match");
+                }
+
+                // A sanity check to ensure we got what was sent.
+                checkTransfer(serverOut, clientIn);
+                checkTransfer(clientOut, serverIn);
+
+                log("\tClosing clientEngine's *OUTBOUND*...");
+                clientEngine.closeOutbound();
+                logEngineStatus(clientEngine);
+
+                dataDone = true;
+                log("\tClosing serverEngine's *OUTBOUND*...");
+                serverEngine.closeOutbound();
+                logEngineStatus(serverEngine);
+            }
+        }
+    }
+
+    private static boolean isOpen(SSLEngine engine) {
+        return (!engine.isOutboundDone() || !engine.isInboundDone());
+    }
+
+    private static void logEngineStatus(SSLEngine engine) {
+        log("\tCurrent HS State: " + engine.getHandshakeStatus());
+        log("\tisInboundDone() : " + engine.isInboundDone());
+        log("\tisOutboundDone(): " + engine.isOutboundDone());
+    }
+
+    private static void logEngineStatus(
+            SSLEngine engine, SSLEngineResult result) {
+        log("\tResult Status    : " + result.getStatus());
+        log("\tResult HS Status : " + result.getHandshakeStatus());
+        log("\tEngine HS Status : " + engine.getHandshakeStatus());
+        log("\tisInboundDone()  : " + engine.isInboundDone());
+        log("\tisOutboundDone() : " + engine.isOutboundDone());
+        log("\tMore Result      : " + result);
+    }
+
+    private static void log(String message) {
+        System.err.println(message);
+    }
+
+    // If the result indicates that we have outstanding tasks to do,
+    // go ahead and run them in this thread.
+    private static void runDelegatedTasks(SSLEngine engine) throws Exception {
+        if (engine.getHandshakeStatus() == HandshakeStatus.NEED_TASK) {
+            Runnable runnable;
+            while ((runnable = engine.getDelegatedTask()) != null) {
+                log("    running delegated task...");
+                runnable.run();
+            }
+            HandshakeStatus hsStatus = engine.getHandshakeStatus();
+            if (hsStatus == HandshakeStatus.NEED_TASK) {
+                throw new Exception(
+                        "handshake shouldn't need additional tasks");
+            }
+            logEngineStatus(engine);
+        }
+    }
+
+    // Simple check to make sure everything came across as expected.
+    private static void checkTransfer(ByteBuffer a, ByteBuffer b)
+            throws Exception {
+        a.flip();
+        b.flip();
+
+        if (!a.equals(b)) {
+            throw new Exception("Data didn't transfer cleanly");
+        } else {
+            log("\tData transferred cleanly");
+        }
+
+        a.position(a.limit());
+        b.position(b.limit());
+        a.limit(a.capacity());
+        b.limit(b.capacity());
+    }
+}

--- a/test/jdk/sun/security/ssl/ALPN/AlpnGreaseTest.java
+++ b/test/jdk/sun/security/ssl/ALPN/AlpnGreaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public class AlpnGreaseTest implements SSLContextTemplate {
     private final ByteBuffer cTOs;      // "reliable" transport client->server
     private final ByteBuffer sTOc;      // "reliable" transport server->client
 
-    // These are the various 8-bit char values that could  be sent as GREASE
+    // These are the various 8-bit char values that could be sent as GREASE
     // values.  We'll just make one big String here to make it easy to check
     // that the right values are being output.
     private static final byte[] greaseBytes = new byte[] {

--- a/test/jdk/sun/security/ssl/ALPN/AlpnGreaseTest.java
+++ b/test/jdk/sun/security/ssl/ALPN/AlpnGreaseTest.java
@@ -90,7 +90,7 @@ public class AlpnGreaseTest implements SSLContextTemplate {
                 return;
             }
         }
-        //throw new Exception("Couldn't find greaseBytes");
+        throw new Exception("Couldn't find greaseBytes");
     }
 
     private AlpnGreaseTest() throws Exception {


### PR DESCRIPTION
Certain TLS ALPN values can't be properly read or written by the SunJSSE provider. This is due to the choice of Strings as the API interface and the undocumented internal use of the UTF-8 Character Set which converts characters larger than U+00007F into multi-byte arrays that may not be expected by a peer.

Full details are available in:

- Bug:  https://bugs.openjdk.java.net/browse/JDK-8254631
- CSR:  https://bugs.openjdk.java.net/browse/JDK-8256817

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254631](https://bugs.openjdk.java.net/browse/JDK-8254631): Better support ALPN byte wire values in SunJSSE


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * dfuchs - **Reviewer** ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1440/head:pull/1440`
`$ git checkout pull/1440`
