### PR TITLE
8255277: randomDelay in DrainDeadlockT and LoggingDeadlock do not randomly delay

### DIFF
--- a/test/jdk/java/util/logging/DrainFindDeadlockTest.java
+++ b/test/jdk/java/util/logging/DrainFindDeadlockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,11 @@ import java.lang.management.ThreadMXBean;
 import java.lang.Thread.State;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.util.Random;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import java.util.Map;
+import jdk.test.lib.RandomFactory;
 
 /**
  * @test
@@ -36,6 +38,7 @@ import java.util.Map;
  * @author jim.gish@oracle.com
  * @modules java.logging
  *          java.management
+ * @library /test/lib
  * @build DrainFindDeadlockTest
  * @run main/othervm DrainFindDeadlockTest
  * @key randomness
@@ -50,6 +53,8 @@ import java.util.Map;
 public class DrainFindDeadlockTest {
     private LogManager mgr = LogManager.getLogManager();
     private static final int MAX_ITERATIONS = 100;
+    private static final Random random = RandomFactory.getRandom();
+    private static int preventLoopElision;
 
     // Get a ThreadMXBean so we can check for deadlock.  N.B. this may
     // not be supported on all platforms, which means we will have to
@@ -66,12 +71,13 @@ public class DrainFindDeadlockTest {
     }
 
     public static void randomDelay() {
-        int runs = (int) Math.random() * 1000000;
+        int runs = random.nextInt(1000000);
         int c = 0;
 
         for (int i=0; i<runs; ++i) {
             c=c+i;
         }
+        preventLoopElision = c;
     }
 
     public void testForDeadlock() throws IOException, Exception {

--- a/test/jdk/java/util/logging/LoggingDeadlock.java
+++ b/test/jdk/java/util/logging/LoggingDeadlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
  * @summary deadlock in LogManager
  * @author  Serguei Spitsyn / SAP
  *
+ * @library  /test/lib
  * @build    LoggingDeadlock
  * @run  main/timeout=15 LoggingDeadlock
  * @key randomness
@@ -53,18 +54,24 @@
  */
 
 
+import java.util.Random;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
+import jdk.test.lib.RandomFactory;
 
 public class LoggingDeadlock {
 
+    private static int preventLoopElision;
+    private static final Random random = RandomFactory.getRandom();
+
     public static void randomDelay() {
-        int runs = (int) Math.random() * 1000000;
+        int runs = random.nextInt(1000000);
         int c = 0;
 
         for (int i = 0; i < runs; ++i) {
             c = c + i;
         }
+        preventLoopElision = c;
     }
 
     public static void main(String[] args) throws InterruptedException{


### PR DESCRIPTION
Hi,

Please find here an almost trivial fix for:
8255277: randomDelay in DrainDeadlockT and LoggingDeadlock do not randomly delay

The two tests are changed from using Math.random() to using the jdk test lib RandomFactory, which prints its seed in the log file and allows for better reproducibility in case of failures.

best regards,

-- daniel

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x86 (build debug)](https://github.com/dfuch/jdk/runs/1455554239)
- [Linux x86 (build release)](https://github.com/dfuch/jdk/runs/1455554232)

### Issue
 * [JDK-8255277](https://bugs.openjdk.java.net/browse/JDK-8255277): randomDelay in DrainDeadlockT and LoggingDeadlock do not randomly delay


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1441/head:pull/1441`
`$ git checkout pull/1441`
