### PR TITLE
8257083: Security infra test failures caused by JDK-8202343

### DIFF
--- a/test/jdk/javax/net/ssl/TLSCommon/interop/JdkProcClient.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/JdkProcClient.java
@@ -24,10 +24,11 @@
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.Security;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-
-import jdk.test.lib.security.SecurityUtils;
 
 /*
  * A JDK client process.
@@ -161,7 +162,7 @@ public class JdkProcClient extends AbstractClient {
         String appProtocolsStr = System.getProperty(JdkProcUtils.PROP_APP_PROTOCOLS);
 
         // Re-enable TLSv1 and TLSv1.1 since client depends on them
-        SecurityUtils.removeFromDisabledTlsAlgs("TLSv1", "TLSv1.1");
+        removeFromDisabledTlsAlgs("TLSv1", "TLSv1.1");
 
         JdkClient.Builder builder = new JdkClient.Builder();
         builder.setCertTuple(JdkProcUtils.createCertTuple(
@@ -187,5 +188,23 @@ public class JdkProcClient extends AbstractClient {
         try(JdkClient client = builder.build()) {
             client.connect(host, port);
         }
+    }
+
+    /**
+     * Removes the specified protocols from the jdk.tls.disabledAlgorithms
+     * security property.
+     */
+    private static void removeFromDisabledTlsAlgs(String... algs) {
+        List<String> algList = Arrays.asList(algs);
+        String value = Security.getProperty("jdk.tls.disabledAlgorithms");
+        StringBuilder newValue = new StringBuilder();
+        for (String constraint : value.split(",")) {
+            String tmp = constraint.trim();
+            if (!algList.contains(tmp)) {
+                newValue.append(tmp);
+                newValue.append(",");
+            }
+        }
+        Security.setProperty("jdk.tls.disabledAlgorithms", newValue.toString());
     }
 }


### PR DESCRIPTION
There are several infra test failures that were caused by the fix for JDK-8202343 (Disable TLS 1.0 and 1.1).

The problem is that test/jdk/javax/net/ssl/TLSCommon/interop/JdkProcClient.java is designed to be run with different versions of the JDK such as JDK 8 but now calls SecurityUtils.removeFromDisabledTlsAlgs() which calls APIs such as List.of() that are not available in JDK 8.

The fix is to create a private method which does the same thing as SecurityUtils.removeFromDisabledTlsAlgs() but doesn't depend on newer APIs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x86 (build debug)](https://github.com/seanjmullan/jdk/runs/1455566365)
- [Linux x86 (build release)](https://github.com/seanjmullan/jdk/runs/1455566341)

### Issue
 * [JDK-8257083](https://bugs.openjdk.java.net/browse/JDK-8257083): Security infra test failures caused by JDK-8202343


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1442/head:pull/1442`
`$ git checkout pull/1442`
