### PR TITLE
8256808: com/sun/jdi/CatchAllTest.java failed with "NullPointerException: Cannot invoke "lib.jdb.Jdb.log(String)" because "this.jdb" is null"

### DIFF
--- a/test/jdk/com/sun/jdi/lib/jdb/Jdb.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/Jdb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/jdi/lib/jdb/Jdb.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/Jdb.java
@@ -260,7 +260,7 @@ public class Jdb implements AutoCloseable {
         command(JdbCommand.quit());
     }
 
-    static void log(String s) {
+    private void log(String s) {
         System.out.println(s);
     }
 

--- a/test/jdk/com/sun/jdi/lib/jdb/Jdb.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/Jdb.java
@@ -260,7 +260,7 @@ public class Jdb implements AutoCloseable {
         command(JdbCommand.quit());
     }
 
-    void log(String s) {
+    static void log(String s) {
         System.out.println(s);
     }
 

--- a/test/jdk/com/sun/jdi/lib/jdb/JdbTest.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/JdbTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/jdi/lib/jdb/JdbTest.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/JdbTest.java
@@ -94,9 +94,9 @@ public abstract class JdbTest {
             setup();
             runCases();
         } catch (Throwable e) {
-            Jdb.log("=======================================");
-            Jdb.log("Exception thrown during test execution: " + e.getMessage());
-            Jdb.log("=======================================");
+            System.out.println("=======================================");
+            System.out.println("Exception thrown during test execution: " + e.getMessage());
+            System.out.println("=======================================");
             throw e;
         } finally {
             shutdown();

--- a/test/jdk/com/sun/jdi/lib/jdb/JdbTest.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/JdbTest.java
@@ -94,9 +94,9 @@ public abstract class JdbTest {
             setup();
             runCases();
         } catch (Throwable e) {
-            jdb.log("=======================================");
-            jdb.log("Exception thrown during test execution: " + e.getMessage());
-            jdb.log("=======================================");
+            Jdb.log("=======================================");
+            Jdb.log("Exception thrown during test execution: " + e.getMessage());
+            Jdb.log("=======================================");
             throw e;
         } finally {
             shutdown();


### PR DESCRIPTION
JdbTest can get exception before jdb field is initialized.
As Jdb logging does not depend on the instance, made Jdb.log method static

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256808](https://bugs.openjdk.java.net/browse/JDK-8256808): com/sun/jdi/CatchAllTest.java failed with "NullPointerException: Cannot invoke "lib.jdb.Jdb.log(String)" because "this.jdb" is null"


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1443/head:pull/1443`
`$ git checkout pull/1443`
