### PR TITLE
8257225: UUID#fromString Accepts Invalid Input

### DIFF
--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinMsiBundler.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WinMsiBundler.java
@@ -237,7 +237,7 @@ public class WinMsiBundler  extends AbstractBundler {
     private static UUID getUpgradeCode(Map<String, ? super Object> params) {
         String upgradeCode = UPGRADE_UUID.fetchFrom(params);
         if (upgradeCode != null) {
-            return UUID.fromString(upgradeCode);
+            return UUID.parse(upgradeCode);
         }
         return createNameUUID("UpgradeCode", params, List.of(VENDOR, APP_NAME));
     }

--- a/src/jdk.management.agent/share/classes/sun/management/jdp/JdpJmxPacket.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jdp/JdpJmxPacket.java
@@ -111,7 +111,7 @@ public final class JdpJmxPacket
         Map<String, String> p = reader.getDiscoveryDataAsMap();
 
         String sId = p.get(UUID_KEY);
-        this.id = (sId == null) ? null : UUID.fromString(sId);
+        this.id = (sId == null) ? null : UUID.parse(sId);
         this.jmxServiceUrl = p.get(JMX_SERVICE_URL_KEY);
         this.mainClass = p.get(MAIN_CLASS_KEY);
         this.instanceName = p.get(INSTANCE_NAME_KEY);

--- a/test/jdk/tools/jpackage/windows/WinUpgradeUUIDTest.java
+++ b/test/jdk/tools/jpackage/windows/WinUpgradeUUIDTest.java
@@ -76,7 +76,7 @@ public class WinUpgradeUUIDTest {
     @Test
     public static void test() {
         Supplier<PackageTest> init = () -> {
-            final UUID upgradeCode = UUID.fromString(
+            final UUID upgradeCode = UUID.parse(
                     "F0B18E75-52AD-41A2-BC86-6BE4FCD50BEB");
             return new PackageTest()
                 .forTypes(PackageType.WIN_MSI)
@@ -87,7 +87,7 @@ public class WinUpgradeUUIDTest {
                     if (value.endsWith("}")) {
                         value = value.substring(0, value.length() - 1);
                     }
-                    return UUID.fromString(value).equals(upgradeCode);
+                    return UUID.parse(value).equals(upgradeCode);
                 }, "is a match with")
                 .forTypes(PackageType.WINDOWS)
                 .configureHelloApp()

--- a/test/micro/org/openjdk/bench/java/util/UUIDBench.java
+++ b/test/micro/org/openjdk/bench/java/util/UUIDBench.java
@@ -65,7 +65,7 @@ public class UUIDBench {
 
     @Benchmark
     public UUID fromString() {
-        return UUID.fromString(uuidStrings[index]);
+        return UUID.parse(uuidStrings[index]);
     }
 
     @Benchmark


### PR DESCRIPTION
The referenced report is still in review and I only sent out my OCA today so this will fail too. Anyways, this is about all of the following reports:

- [8159339](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8159339)
- [8165199](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8165199)
- [8182452](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8182452)
- [8188902](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8188902)
- [8202760](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8202760)
- [8216407](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8216407)
- [8219815](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8219815)
- [8257225](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8257225)

There have been discussions surrounding a fix for `UUID#fromString` but the result of those usually was that it cannot be changed due to breaking change concerns in regards to client code that relies on the bugs. Main argument here was that the bug has been there for such a long time and that it must be assumed that many clients knowingly or unknowingly rely on the present behavior.

I propose with this PR to deprecate `UUID#fromString` while keeping its functionality as is and to supersede it with `UUID#parse` that is 100% RFC compliant and uses the super fast implementation that was just recently implemented in `UUID#fromString` for valid inputs. I have chosen `UUID#parse` because it aligns well with other APIs in the JDK and should feel familiar to everyone.

I am not sure if this PR requires a CSR but I would of course be willing to provide one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ The commit message contains trailing whitespace on line 2

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issues
 * [JDK-8257225](https://bugs.openjdk.java.net/browse/JDK-8257225): UUID#fromString Accepts Invalid Input
 * [JDK-8159339](https://bugs.openjdk.java.net/browse/JDK-8159339): UUID:fromString() parses incorrect strings without error  ⚠️ Issue is not open. * [JDK-8165199](https://bugs.openjdk.java.net/browse/JDK-8165199): UUID.fromString accepts wrong placements of the dashes
 * [JDK-8182452](https://bugs.openjdk.java.net/browse/JDK-8182452): UUID.fromString accepts invalid UUIDs or throws wrong exception ⚠️ Issue is not open. * [JDK-8188902](https://bugs.openjdk.java.net/browse/JDK-8188902): UUID.fromString does not work as expected ⚠️ Issue is not open. * [JDK-8202760](https://bugs.openjdk.java.net/browse/JDK-8202760): UUID.fromString() accepts invalid (short) strings ⚠️ Issue is not open. * [JDK-8216407](https://bugs.openjdk.java.net/browse/JDK-8216407): java.util.UUID.fromString accepts input that does not match expected format
 * [JDK-8219815](https://bugs.openjdk.java.net/browse/JDK-8219815): UUID.fromString() is too lax ⚠️ Issue is not open. * [JDK-7092050](https://bugs.openjdk.java.net/browse/JDK-7092050): Add method UUID.valueOf(String)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1444/head:pull/1444`
`$ git checkout pull/1444`
