### PR TITLE
8256995: [vector] Improve broadcast operations

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -3864,11 +3864,17 @@ instruct ReplI_reg(vec dst, rRegI src) %{
       int vlen_enc = vector_length_encoding(this);
       __ evpbroadcastd($dst$$XMMRegister, $src$$Register, vlen_enc);
     } else {
-      __ movdl($dst$$XMMRegister, $src$$Register);
-      __ pshufd($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
-      if (vlen >= 8) {
-        assert(vlen == 8, "sanity");
-        __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+      if (UseAVX >= 2) {
+        int vlen_enc = vector_length_encoding(this);
+        __ movdl($dst$$XMMRegister, $src$$Register);
+        __ vbroadcastss($dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
+      } else {
+        __ movdl($dst$$XMMRegister, $src$$Register);
+        __ pshufd($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
+        if (vlen >= 8) {
+          assert(vlen == 8, "sanity");
+          __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+        }
       }
     }
   %}

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -3709,6 +3709,10 @@ instruct ReplB_reg(vec dst, rRegI src) %{
       assert(VM_Version::supports_avx512bw(), "required"); // 512-bit byte vectors assume AVX512BW
       int vlen_enc = vector_length_encoding(this);
       __ evpbroadcastb($dst$$XMMRegister, $src$$Register, vlen_enc);
+    } else if (VM_Version::supports_avx2()) {
+      int vlen_enc = vector_length_encoding(this);
+      __ movdl($dst$$XMMRegister, $src$$Register);
+      __ vpbroadcastb($dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
     } else {
       __ movdl($dst$$XMMRegister, $src$$Register);
       __ punpcklbw($dst$$XMMRegister, $dst$$XMMRegister);
@@ -3788,6 +3792,10 @@ instruct ReplS_reg(vec dst, rRegI src) %{
       assert(VM_Version::supports_avx512bw(), "required"); // 512-bit short vectors assume AVX512BW
       int vlen_enc = vector_length_encoding(this);
       __ evpbroadcastw($dst$$XMMRegister, $src$$Register, vlen_enc);
+    } else if (VM_Version::supports_avx2()) {
+      int vlen_enc = vector_length_encoding(this);
+      __ movdl($dst$$XMMRegister, $src$$Register);
+      __ vpbroadcastw($dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
     } else {
       __ movdl($dst$$XMMRegister, $src$$Register);
       __ pshuflw($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
@@ -3863,18 +3871,16 @@ instruct ReplI_reg(vec dst, rRegI src) %{
     if (vlen == 16 || VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
       int vlen_enc = vector_length_encoding(this);
       __ evpbroadcastd($dst$$XMMRegister, $src$$Register, vlen_enc);
+    } else if (VM_Version::supports_avx2()) {
+      int vlen_enc = vector_length_encoding(this);
+      __ movdl($dst$$XMMRegister, $src$$Register);
+      __ vpbroadcastd($dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
     } else {
-      if (UseAVX >= 2) {
-        int vlen_enc = vector_length_encoding(this);
-        __ movdl($dst$$XMMRegister, $src$$Register);
-        __ vbroadcastss($dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
-      } else {
-        __ movdl($dst$$XMMRegister, $src$$Register);
-        __ pshufd($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
-        if (vlen >= 8) {
-          assert(vlen == 8, "sanity");
-          __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-        }
+      __ movdl($dst$$XMMRegister, $src$$Register);
+      __ pshufd($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
+      if (vlen >= 8) {
+        assert(vlen == 8, "sanity");
+        __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
       }
     }
   %}
@@ -3964,6 +3970,11 @@ instruct ReplL_reg(vec dst, rRegL src) %{
     } else if (vlen == 8 || VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
       int vlen_enc = vector_length_encoding(this);
       __ evpbroadcastq($dst$$XMMRegister, $src$$Register, vlen_enc);
+    } else if (VM_Version::supports_avx2()) {
+      assert(vlen == 4, "sanity");
+      int vlen_enc = vector_length_encoding(this);
+      __ movdq($dst$$XMMRegister, $src$$Register);
+      __ vpbroadcastq($dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
     } else {
       assert(vlen == 4, "sanity");
       __ movdq($dst$$XMMRegister, $src$$Register);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -400,7 +400,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     /*package-private*/
     @ForceInline
     static long toBits(double e) {
-        return  Double.doubleToLongBits(e);
+        return  Double.doubleToRawLongBits(e);
     }
 
     /*package-private*/

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -400,7 +400,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     /*package-private*/
     @ForceInline
     static long toBits(float e) {
-        return  Float.floatToIntBits(e);
+        return  Float.floatToRawIntBits(e);
     }
 
     /*package-private*/

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -404,7 +404,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     /*package-private*/
     @ForceInline
     static long toBits($type$ e) {
-        return {#if[FP]? $Type$.$type$To$Bitstype$Bits(e): e};
+        return {#if[FP]? $Type$.$type$ToRaw$Bitstype$Bits(e): e};
     }
 
     /*package-private*/


### PR DESCRIPTION
Use the raw FP to bits conversion methods (to avoid NaN checks). Improve the x64 code generation when broadcasting a value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256995](https://bugs.openjdk.java.net/browse/JDK-8256995): [vector] Improve broadcast operations


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Contributors
 * Paul Sandoz `<psandoz@openjdk.org>`
 * Sandhya Viswanathan `<sviswanathan@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1445/head:pull/1445`
`$ git checkout pull/1445`
