### PR TITLE
8257151: ZGC: Simplify ZVerify

### DIFF
--- a/src/hotspot/share/gc/z/zVerify.hpp
+++ b/src/hotspot/share/gc/z/zVerify.hpp
@@ -34,9 +34,7 @@ private:
   static void roots_strong(bool verify_fixed);
   static void roots_weak();
 
-  static void roots(bool verify_strong, bool verify_weaks);
   static void objects(bool verify_weaks);
-  static void roots_and_objects(bool verify_strong, bool verify_weaks);
 
 public:
   static void before_zoperation();


### PR DESCRIPTION
ZVerify has a few oddities:

1) The comment and the parameter name don't match. 
```
void ZVerify::before_zoperation() {
  // Verify strong roots
  ZStatTimerDisable disable;
  roots(false /* verify_strong */, false /* verify_weaks */);
}
```
This is caused by a name clash between the layers:
```

roots_strong(bool verify_fixed
roots(bool verify_strong
roots_and_objects(bool verify_strong
```

2) Both usages of roots_and_objects pass true as the verify_strong argument:

```
void ZVerify::after_mark() {
  // Verify all strong roots and strong references
  ZStatTimerDisable disable;
  roots_and_objects(true /* verify_strong */, false /* verify_weaks */);
}

void ZVerify::after_weak_processing() {
  // Verify all roots and all references
  ZStatTimerDisable disable;
  roots_and_objects(true /* verify_strong */, true /* verify_weaks */);
}
```

The proposal is to remove the middle layers and be more explicit at the call sites.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8257151](https://bugs.openjdk.java.net/browse/JDK-8257151): ZGC: Simplify ZVerify


### Reviewers
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1449/head:pull/1449`
`$ git checkout pull/1449`
