### PR TITLE
8257149: Improve G1 Service thread task scheduling to guarantee task delay

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -564,12 +564,6 @@ class G1RemSetSamplingTask : public G1ServiceTask {
     }
   }
 
-  // To avoid extensive rescheduling if the task is executed a bit early. The task is
-  // only rescheduled if the expected time is more than 1ms away.
-  bool should_reschedule() {
-    return reschedule_delay_ms() > 1;
-  }
-
   // There is no reason to do the sampling if a GC occurred recently. We use the
   // G1ConcRefinementServiceIntervalMillis as the metric for recently and calculate
   // the diff to the last GC. If the last GC occurred longer ago than the interval
@@ -586,9 +580,9 @@ public:
     SuspendibleThreadSetJoiner sts;
 
     // Reschedule if a GC happened too recently.
-    if (should_reschedule()) {
-      // Calculate the delay given the last GC and the interval.
-      schedule(reschedule_delay_ms());
+    auto delay_ms = reschedule_delay_ms();
+    if (delay_ms > 0) {
+      schedule(delay_ms);
       return;
     }
 

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -580,7 +580,7 @@ public:
     SuspendibleThreadSetJoiner sts;
 
     // Reschedule if a GC happened too recently.
-    auto delay_ms = reschedule_delay_ms();
+    jlong delay_ms = reschedule_delay_ms();
     if (delay_ms > 0) {
       schedule(delay_ms);
       return;

--- a/src/hotspot/share/gc/g1/g1ServiceThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ServiceThread.cpp
@@ -112,7 +112,7 @@ G1ServiceThread::~G1ServiceThread() {
   delete _periodic_gc_task;
 }
 
-void G1ServiceThread::register_task(G1ServiceTask* task, jlong delay) {
+void G1ServiceThread::register_task(G1ServiceTask* task, jlong delay_ms) {
   guarantee(!task->is_registered(), "Task already registered");
   guarantee(task->next() == NULL, "Task already in queue");
 
@@ -131,7 +131,7 @@ void G1ServiceThread::register_task(G1ServiceTask* task, jlong delay) {
 
   // Schedule the task to run after the given delay. The service will be
   // notified to check if this task is first in the queue.
-  schedule_task(task, delay);
+  schedule_task(task, delay_ms);
 }
 
 void G1ServiceThread::schedule(G1ServiceTask* task, jlong delay_ms) {
@@ -164,8 +164,9 @@ int64_t G1ServiceThread::time_to_next_task_ms() {
     return 0;
   }
 
-  // Return sleep time in milliseconds.
-  return (int64_t) TimeHelper::counter_to_millis(time_diff);
+  // Return sleep time in milliseconds. Using ceil to make sure we never
+  // schedule a task too early.
+  return (int64_t) ceil(TimeHelper::counter_to_millis(time_diff));
 }
 
 void G1ServiceThread::notify() {

--- a/src/hotspot/share/gc/g1/g1ServiceThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ServiceThread.hpp
@@ -134,13 +134,14 @@ public:
   ~G1ServiceThread();
 
   double vtime_accum() { return _vtime_accum; }
-  // Register a task with the service thread and schedule it. If
-  // no delay is specified the task is scheduled to run directly.
-  void register_task(G1ServiceTask* task, jlong delay = 0);
 
-  // Schedule the task and notify the service thread that a new
-  // task might be ready to run.
-  void schedule_task(G1ServiceTask* task, jlong delay);
+  // Register a task with the service thread. The task is guaranteed not to run
+  // until >= `delay_ms` has passed. If no delay is specified or the delay is
+  // 0, the task will run in the earliest time possible.
+  void register_task(G1ServiceTask* task, jlong delay_ms = 0);
+
+  // Schedule an already-registered task to run in >= `delay_ms` time.
+  void schedule_task(G1ServiceTask* task, jlong delay_ms);
 };
 
 #endif // SHARE_GC_G1_G1SERVICETHREAD_HPP

--- a/src/hotspot/share/gc/g1/g1ServiceThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ServiceThread.hpp
@@ -136,11 +136,12 @@ public:
   double vtime_accum() { return _vtime_accum; }
 
   // Register a task with the service thread. The task is guaranteed not to run
-  // until >= `delay_ms` has passed. If no delay is specified or the delay is
-  // 0, the task will run in the earliest time possible.
+  // until at least `delay_ms` has passed. If no delay is specified or the
+  // delay is 0, the task will run in the earliest time possible.
   void register_task(G1ServiceTask* task, jlong delay_ms = 0);
 
-  // Schedule an already-registered task to run in >= `delay_ms` time.
+  // Schedule an already-registered task to run in at least `delay_ms` time,
+  // and notify the service thread.
   void schedule_task(G1ServiceTask* task, jlong delay_ms);
 };
 


### PR DESCRIPTION
Adopt the "at-least" semantics for scheduling delays in G1 service thread scheduling API so that a task is never scheduled earlier than it asked for. IOW, `schedule_task(task, delay_ms)` means `task` will run after `>= delay_ms` has passed.

Inspecting the logs (`-Xlog:gc,gc+task*=trace`) and focusing lines containing `(Remembered Set Sampling Task) (schedule)`, we can see at what time the sampling task is scheduled.
 
Without `ceil`, sampling task could be scheduled more frequent than intended:
```
[0.321s][trace][gc,task      ] G1 Service Thread (Remembered Set Sampling Task) (schedule) @0.322s
[0.321s][debug][gc,task      ] G1 Service Thread (Remembered Set Sampling Task) (run) 0.042ms (cpu: 0.000ms)
[0.321s][debug][gc,task,start] G1 Service Thread (Remembered Set Sampling Task) (run)
[0.321s][trace][gc,task      ] G1 Service Thread (Remembered Set Sampling Task) (schedule) @0.322s
[0.321s][debug][gc,task      ] G1 Service Thread (Remembered Set Sampling Task) (run) 0.010ms (cpu: 0.000ms)
[0.321s][debug][gc,task,start] G1 Service Thread (Remembered Set Sampling Task) (run)
[0.321s][trace][gc,task      ] G1 Service Thread (Remembered Set Sampling Task) (schedule) @0.322s
[0.321s][debug][gc,task      ] G1 Service Thread (Remembered Set Sampling Task) (run) 0.008ms (cpu: 0.000ms)
[0.321s][debug][gc,task,start] G1 Service Thread (Remembered Set Sampling Task) (run)

```
With ceil; there's 300ms (`G1ConcRefinementServiceIntervalMillis`) interval btw each scheduling of the sampling task.
```
[0.093s][trace][gc,task      ] G1 Service Thread (Remembered Set Sampling Task) (schedule) @0.323s
[0.093s][debug][gc,task      ] G1 Service Thread (Remembered Set Sampling Task) (run) 0.006ms (cpu: 0.000ms)
[0.093s][debug][gc,task,start] G1 Service Thread (Periodic GC Task) (run)
[0.093s][trace][gc,task      ] G1 Service Thread (Periodic GC Task) (schedule) @1.093s
[0.093s][debug][gc,task      ] G1 Service Thread (Periodic GC Task) (run) 0.004ms (cpu: 0.000ms)
[0.093s][trace][gc,task      ] G1 Service Thread (wait) 0.230s
[0.323s][debug][gc,task,start] G1 Service Thread (Remembered Set Sampling Task) (run)
[0.323s][trace][gc,task      ] G1 Service Thread (Remembered Set Sampling Task) (schedule) @0.623s
[0.323s][debug][gc,task      ] G1 Service Thread (Remembered Set Sampling Task) (run) 0.024ms (cpu: 0.000ms)
[0.323s][trace][gc,task      ] G1 Service Thread (wait) 0.300s
[0.623s][debug][gc,task,start] G1 Service Thread (Remembered Set Sampling Task) (run)
[0.623s][trace][gc,task      ] G1 Service Thread (Remembered Set Sampling Task) (schedule) @0.923s
[0.623s][debug][gc,task      ] G1 Service Thread (Remembered Set Sampling Task) (run) 0.026ms (cpu: 0.000ms)
[0.623s][trace][gc,task      ] G1 Service Thread (wait) 0.300s
```

Tested: tier1 and manually checking the logs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ❌ (1/2 failed) | ✔️ (2/2 passed) | ❌ (1/2 failed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ⏳ (3/9 running) |    |  ⏳ (1/9 running) |

**Failed test tasks**
- [Linux x64 (build debug)](https://github.com/albertnetymk/jdk/runs/1463219867)
- [Windows x64 (build debug)](https://github.com/albertnetymk/jdk/runs/1463219690)

### Issue
 * [JDK-8257149](https://bugs.openjdk.java.net/browse/JDK-8257149): Improve G1 Service thread task scheduling to guarantee task delay


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to ff513b05909eac5bc05d37a55289bbf858e43206
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer) ⚠️ Review applies to ff513b05909eac5bc05d37a55289bbf858e43206


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1451/head:pull/1451`
`$ git checkout pull/1451`
