### PR TITLE
8256757: Incorrect MachCallRuntimeNode::ret_addr_offset() for CallLeafNoFP on x86_32

### DIFF
--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -308,7 +308,7 @@ static int sizeof_FFree_Float_Stack_All = -1;
 
 int MachCallRuntimeNode::ret_addr_offset() {
   assert(sizeof_FFree_Float_Stack_All != -1, "must have been emitted already");
-  return sizeof_FFree_Float_Stack_All + 5 + pre_call_resets_size();
+  return 5 + pre_call_resets_size() + (_leaf_no_fp ? 0 : sizeof_FFree_Float_Stack_All);
 }
 
 int MachCallNativeNode::ret_addr_offset() {

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -854,6 +854,7 @@ public:
                    const TypePtr* adr_type)
     : CallLeafNode(tf, addr, name, adr_type)
   {
+    init_class_id(Class_CallLeafNoFP);
   }
   virtual int   Opcode() const;
 };

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -994,7 +994,7 @@ class MachCallRuntimeNode : public MachCallNode {
   virtual uint size_of() const; // Size is bigger
 public:
   const char *_name;            // Printable name, if _method is NULL
-  bool _leaf_no_fp;
+  bool _leaf_no_fp;             // Is this CallLeafNoFP?
   MachCallRuntimeNode() : MachCallNode() {
     init_class_id(Class_MachCallRuntime);
   }

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -994,6 +994,7 @@ class MachCallRuntimeNode : public MachCallNode {
   virtual uint size_of() const; // Size is bigger
 public:
   const char *_name;            // Printable name, if _method is NULL
+  bool _leaf_no_fp;
   MachCallRuntimeNode() : MachCallNode() {
     init_class_id(Class_MachCallRuntime);
   }

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -1264,7 +1264,9 @@ MachNode *Matcher::match_sfpt( SafePointNode *sfpt ) {
          call_java->as_CallDynamicJava()->_vtable_index;
     }
     else if( mcall->is_MachCallRuntime() ) {
-      mcall->as_MachCallRuntime()->_name = call->as_CallRuntime()->_name;
+      MachCallRuntimeNode* mach_call_rt = mcall->as_MachCallRuntime();
+      mach_call_rt->_name = call->as_CallRuntime()->_name;
+      mach_call_rt->_leaf_no_fp = call->is_CallLeafNoFP();
     }
     else if( mcall->is_MachCallNative() ) {
       MachCallNativeNode* mach_call_native = mcall->as_MachCallNative();

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -49,6 +49,7 @@ class CMoveNode;
 class CallDynamicJavaNode;
 class CallJavaNode;
 class CallLeafNode;
+class CallLeafNoFPNode;
 class CallNode;
 class CallRuntimeNode;
 class CallNativeNode;
@@ -627,6 +628,7 @@ public:
             DEFINE_CLASS_ID(CallDynamicJava,  CallJava, 1)
           DEFINE_CLASS_ID(CallRuntime,      Call, 1)
             DEFINE_CLASS_ID(CallLeaf,         CallRuntime, 0)
+              DEFINE_CLASS_ID(CallLeafNoFP,   CallLeaf, 0)
           DEFINE_CLASS_ID(Allocate,         Call, 2)
             DEFINE_CLASS_ID(AllocateArray,    Allocate, 0)
           DEFINE_CLASS_ID(AbstractLock,     Call, 3)
@@ -821,6 +823,7 @@ public:
   DEFINE_CLASS_QUERY(CallDynamicJava)
   DEFINE_CLASS_QUERY(CallJava)
   DEFINE_CLASS_QUERY(CallLeaf)
+  DEFINE_CLASS_QUERY(CallLeafNoFP)
   DEFINE_CLASS_QUERY(CallRuntime)
   DEFINE_CLASS_QUERY(CallStaticJava)
   DEFINE_CLASS_QUERY(Catch)

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -628,7 +628,7 @@ public:
             DEFINE_CLASS_ID(CallDynamicJava,  CallJava, 1)
           DEFINE_CLASS_ID(CallRuntime,      Call, 1)
             DEFINE_CLASS_ID(CallLeaf,         CallRuntime, 0)
-              DEFINE_CLASS_ID(CallLeafNoFP,   CallLeaf, 0)
+              DEFINE_CLASS_ID(CallLeafNoFP,     CallLeaf, 0)
           DEFINE_CLASS_ID(Allocate,         Call, 2)
             DEFINE_CLASS_ID(AllocateArray,    Allocate, 0)
           DEFINE_CLASS_ID(AbstractLock,     Call, 3)


### PR DESCRIPTION
Importance: fixes one of `tier1` tests, including the runs in GH Actions.

JDK-8254231 added new assert in `output.cpp`:

```
    assert(!is_mcall || (call_returns[block->_pre_order] <= (uint) current_offset))
```

Which verifies that the offset returned by MachCallNode::ret_addr_offset() (and sub-types) at matches the emitted code, to avoid potential conflicts between oop maps of different calls.

It caught the failure running `compiler/intrinsics/string/TestStringLatin1IndexOfChar.java` on Linux x86_32. I think that happened because the test forced lower SSE settings. But more tests fail if you force with lower SSE settings with e.g. `TEST_VM_OPTS=-XX:UseSSE=1`. The real issue is `MachCallRuntimeNode::ret_addr_offset()` computing the offset incorrectly for `CallLeafNoFP`: the match rule for it does not include `FFree_Float_Stack_All`. With `UseSSE < 2`, `FFree_Float_Stack_All` becomes non-zero.

See the definitions in `x86_32.ad`:

```
  enc_class FFree_Float_Stack_All %{    // Free_Float_Stack_All
    MacroAssembler masm(&cbuf);
    int start = masm.offset();
    if (UseSSE >= 2) {
      if (VerifyFPU) {
        masm.verify_FPU(0, "must be empty in SSE2+ mode");
      }
    } else { // <---- taking this with UseSSE < 2
      // External c_calling_convention expects the FPU stack to be 'clean'.
      // Compiled code leaves it dirty.  Do cleanup now.
      masm.empty_FPU_stack();  
    }
    if (sizeof_FFree_Float_Stack_All == -1) {
      sizeof_FFree_Float_Stack_All = masm.offset() - start;
    } else {
      assert(masm.offset() - start == sizeof_FFree_Float_Stack_All, "wrong size");
    }
  %}

// Call runtime without safepoint
instruct CallLeafDirect(method meth) %{
  match(CallLeaf);
  effect(USE meth);

  ins_cost(300);
  format %{ "CALL_LEAF,runtime " %}
  opcode(0xE8); /* E8 cd */
  ins_encode( pre_call_resets,
              FFree_Float_Stack_All,
              Java_To_Runtime( meth ),
              Verify_FPU_For_Leaf, post_call_FPU );
  ins_pipe( pipe_slow );
%}

instruct CallLeafNoFPDirect(method meth) %{
  match(CallLeafNoFP);
  effect(USE meth);

  ins_cost(300);
  format %{ "CALL_LEAF_NOFP,runtime " %}
  opcode(0xE8); /* E8 cd */
  ins_encode(pre_call_resets, Java_To_Runtime(meth));
  ins_pipe( pipe_slow );
%}
```

This does not affect `x86_64`, AFAICS.

Additional testing:
 - [x] A few known failing tests on Linux x86_32
 - [x] Linux x86_32 `tier1`
 - [x] Linux x86_32 `tier1` with `-XX:UseSSE=1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256757](https://bugs.openjdk.java.net/browse/JDK-8256757): Incorrect MachCallRuntimeNode::ret_addr_offset() for CallLeafNoFP on x86_32


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1452/head:pull/1452`
`$ git checkout pull/1452`
