### PR TITLE
8257162: Initialize ThreadLocalAllocBuffer members

### DIFF
--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
@@ -55,7 +55,7 @@ ThreadLocalAllocBuffer::ThreadLocalAllocBuffer() :
   _allocated_size(0),
   _allocation_fraction(TLABAllocationWeight) {
 
-  // do nothing.  tlabs must be inited by initialize() calls
+  // do nothing. TLABs must be inited by initialize() calls
 }
 
 size_t ThreadLocalAllocBuffer::remaining() {

--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
@@ -37,6 +37,27 @@ size_t       ThreadLocalAllocBuffer::_max_size = 0;
 int          ThreadLocalAllocBuffer::_reserve_for_allocation_prefetch = 0;
 unsigned int ThreadLocalAllocBuffer::_target_refills = 0;
 
+ThreadLocalAllocBuffer::ThreadLocalAllocBuffer() :
+  _start(NULL),
+  _top(NULL),
+  _pf_top(NULL),
+  _end(NULL),
+  _allocation_end(NULL),
+  _desired_size(0),
+  _refill_waste_limit(0),
+  _allocated_before_last_gc(0),
+  _bytes_since_last_sample_point(0),
+  _number_of_refills(0),
+  _fast_refill_waste(0),
+  _slow_refill_waste(0),
+  _gc_waste(0),
+  _slow_allocations(0),
+  _allocated_size(0),
+  _allocation_fraction(TLABAllocationWeight) {
+
+  // do nothing.  tlabs must be inited by initialize() calls
+}
+
 size_t ThreadLocalAllocBuffer::remaining() {
   if (end() == NULL) {
     return 0;

--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.hpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.hpp
@@ -111,10 +111,7 @@ private:
   int slow_allocations() const  { return _slow_allocations; }
 
 public:
-  ThreadLocalAllocBuffer() : _allocated_before_last_gc(0), _bytes_since_last_sample_point(0),
-    _allocation_fraction(TLABAllocationWeight) {
-    // do nothing.  tlabs must be inited by initialize() calls
-  }
+  ThreadLocalAllocBuffer();
 
   static size_t min_size()                       { return align_object_size(MinTLABSize / HeapWordSize) + alignment_reserve(); }
   static size_t max_size()                       { assert(_max_size != 0, "max_size not set up"); return _max_size; }


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that adds initialization for all ThreadLocalAllocBuffer members so that when inspecting threads' TLABs the values are not random too?

Testing: tier1,tier2

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257162](https://bugs.openjdk.java.net/browse/JDK-8257162): Initialize ThreadLocalAllocBuffer members


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 9b7c212742f5cd1b291d57bd15d2f888bc1fca4e
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1458/head:pull/1458`
`$ git checkout pull/1458`
