### PR TITLE
8257181: s390x builds are very noisy with gc-sections messages

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -70,7 +70,7 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
     # Linux : remove unused code+data in link step
     if test "x$ENABLE_LINKTIME_GC" = xtrue; then
       if test "x$OPENJDK_TARGET_CPU" = xs390x; then
-        BASIC_LDFLAGS="$BASIC_LDFLAGS -Wl,--gc-sections -Wl,--print-gc-sections"
+        BASIC_LDFLAGS="$BASIC_LDFLAGS -Wl,--gc-sections"
       else
         BASIC_LDFLAGS_JDK_ONLY="$BASIC_LDFLAGS_JDK_ONLY -Wl,--gc-sections"
       fi


### PR DESCRIPTION
Sample build log sizes:

PPC64 fastdebug, 200 kilobytes:
   https://builds.shipilev.net/openjdk-jdk/build-logs/build-linux-ppc64le-fastdebug.log

S390X fastdebug, 20 megabytes!
   https://builds.shipilev.net/openjdk-jdk/build-logs/build-linux-s390x-server-fastdebug.log

S390X slowdebug, 200 megabytes!
   https://builds.shipilev.net/openjdk-jdk/build-logs/build-linux-s390x-server-slowdebug.log

JDK-8234525 enabled `gc-sections`. We can and should disable `print-gc-sections` to get sane build logs back.

Additional testing:
 - [x] Linux s390x fastdebug cross-compilation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x86 (hs/tier1 compiler)](https://github.com/shipilev/jdk/runs/1459875126)

### Issue
 * [JDK-8257181](https://bugs.openjdk.java.net/browse/JDK-8257181): s390x builds are very noisy with gc-sections messages


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1459/head:pull/1459`
`$ git checkout pull/1459`
