### PR TITLE
8207329: Add NIL Constant to UUID

### DIFF
--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -71,6 +71,14 @@ import jdk.internal.access.SharedSecrets;
  * @since   1.5
  */
 public final class UUID implements java.io.Serializable, Comparable<UUID> {
+    /**
+     * Special NIL UUID where all bits are set to zero, as specified in
+     * <a href="https://tools.ietf.org/html/rfc4122#section-4.1.7">RFC&nbsp;4122
+     * Section 4.1.7</a>.
+     *
+     * @since 16
+     */
+    public static final UUID NIL = new UUID(0, 0);
 
     /**
      * Explicit serialVersionUID for interoperability.

--- a/test/jdk/java/util/UUID/UUIDTest.java
+++ b/test/jdk/java/util/UUID/UUIDTest.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4173528 5068772 8148936 8196334
+ * @bug 4173528 5068772 8148936 8196334 8207329
  * @summary Unit tests for java.util.UUID
  * @key randomness
  * @run main/othervm -XX:+CompactStrings UUIDTest
@@ -36,6 +36,7 @@ public class UUIDTest {
     static Random generator = new Random();
 
     public static void main(String[] args) throws Exception {
+        nilTest();
         containsTest();
         randomUUIDTest();
         nameUUIDFromBytesTest();
@@ -47,6 +48,14 @@ public class UUIDTest {
         nodeTest();
         hashCodeEqualsTest();
         compareTo();
+    }
+
+    private static void nilTest() throws Exception {
+        final long msb = UUID.NIL.getMostSignificantBits();
+        final long lsb = UUID.NIL.getLeastSignificantBits();
+
+        if (msb != 0) throw new Exception("MSB of NIL UUID must be zero, got: " + msb);
+        if (lsb != 0) throw new Exception("LSB of NIL UUID must be zero, got: " + lsb);
     }
 
     // Verify that list.contains detects UUID collisons


### PR DESCRIPTION
Adds a constant for the special NIL UUID where all bits are zero to `java.util.UUID`. The [8207329](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8207329) mentions the usage of it to avoid `null`, it for sure is also very handy in testing where a UUID is required and we do not care about its actual value. Using a random UUID stresses the PRNG for no good reason.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blockers
&nbsp;⚠️ The change requires a CSR request to be approved.
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8207329](https://bugs.openjdk.java.net/browse/JDK-8207329)

### Issue
 * [JDK-8207329](https://bugs.openjdk.java.net/browse/JDK-8207329): Add a constant for a nil UUID value of all zeros: `java.util.UUID.NIL` ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1460/head:pull/1460`
`$ git checkout pull/1460`
