### PR TITLE
8220730: sun.security.provider.SecureRandom default constructor has wrong documentation

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/SecureRandom.java
+++ b/src/java.base/share/classes/sun/security/provider/SecureRandom.java
@@ -65,20 +65,21 @@ implements java.io.Serializable {
     private int remCount;
 
     /**
-     * This empty constructor.
+     * An empty constructor that creates an unseeded SecureRandom object.
      * <p>
-     * If the initial state has not been provided by the user via a setSeed()
-     * call, on the first call to engineGetBytes this object will call the
-     * SeedGenerator to provide sufficient seed bytes to completely randomize
-     * the internal state of the generator (20 bytes).  Note that the old
-     * threaded seed generation algorithm is provided only as a fallback, and
-     * has not been thoroughly studied or widely deployed.
-     *
-     * <p>The first time this constructor is called in a given Virtual Machine,
-     * it may take several seconds of CPU time to seed the generator, depending
-     * on the underlying hardware.  Successive calls run quickly because they
-     * rely on the same (internal) pseudo-random number generator for their
-     * seed bits.
+     * Unless the user calls setSeed(), the first call to engineGetBytes()
+     * will have the SeedGenerator provide sufficient seed bytes to
+     * completely randomize the internal state of the generator (20 bytes).
+     * Note that the old threaded seed generation algorithm is provided
+     * only as a fallback, and has not been thoroughly studied or widely
+     * deployed.
+     * <p>
+     * The SeedGenerator relies on a VM-wide entropy pool to generate
+     * seed bytes for these objects.  The first time the SeedGenerator is
+     * called, it may take several seconds of CPU time to initialize,
+     * depending on the underlying hardware.  Successive calls run
+     * quickly because they rely on the same (internal) pseudo-random
+     * number generator for their seed bits.
      */
     public SecureRandom() {
         init(null);

--- a/src/java.base/share/classes/sun/security/provider/SecureRandom.java
+++ b/src/java.base/share/classes/sun/security/provider/SecureRandom.java
@@ -68,7 +68,7 @@ implements java.io.Serializable {
      * This empty constructor.
      * <p>
      * If the initial state has not been provided by the user via a setSeed()
-     * call, on the first call to engineGetBytes, this object will call the
+     * call, on the first call to engineGetBytes this object will call the
      * SeedGenerator to provide sufficient seed bytes to completely randomize
      * the internal state of the generator (20 bytes).  Note that the old
      * threaded seed generation algorithm is provided only as a fallback, and

--- a/src/java.base/share/classes/sun/security/provider/SecureRandom.java
+++ b/src/java.base/share/classes/sun/security/provider/SecureRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,10 +65,14 @@ implements java.io.Serializable {
     private int remCount;
 
     /**
-     * This empty constructor automatically seeds the generator.  We attempt
-     * to provide sufficient seed bytes to completely randomize the internal
-     * state of the generator (20 bytes).  Note, however, that our seed
-     * generation algorithm has not been thoroughly studied or widely deployed.
+     * This empty constructor.
+     * <p>
+     * If the initial state has not been provided by the user via a setSeed()
+     * call, on the first call to engineGetBytes, this object will call the
+     * SeedGenerator to provide sufficient seed bytes to completely randomize
+     * the internal state of the generator (20 bytes).  Note that the old
+     * threaded seed generation algorithm is provided only as a fallback, and
+     * has not been thoroughly studied or widely deployed.
      *
      * <p>The first time this constructor is called in a given Virtual Machine,
      * it may take several seconds of CPU time to seed the generator, depending


### PR DESCRIPTION
This is to fix some out-of-date information in the javadoc for the SHA1PRNG that has generated a customer bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8220730](https://bugs.openjdk.java.net/browse/JDK-8220730): sun.security.provider.SecureRandom default constructor has wrong documentation


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1461/head:pull/1461`
`$ git checkout pull/1461`
