### PR TITLE
5023614: UUID needs methods to get most/leastSigBits and write to DataOutput

### DIFF
--- a/test/jdk/java/util/UUID/UUIDTest.java
+++ b/test/jdk/java/util/UUID/UUIDTest.java
@@ -39,6 +39,7 @@ public class UUIDTest {
         containsTest();
         randomUUIDTest();
         nameUUIDFromBytesTest();
+        bytesTest();
         stringTest();
         versionTest();
         variantTest();
@@ -116,6 +117,25 @@ public class UUIDTest {
             throw new RuntimeException("Should have thrown IAE");
         } catch (IllegalArgumentException iae) {
             // pass
+        }
+    }
+
+    private static void bytesTest() throws Exception {
+        final UUID a = UUID.randomUUID();
+        final UUID b = new UUID(a.getBytes());
+        if (!a.equals(b)) {
+            throw new Exception("UUID -> byte[] -> UUID failed");
+        }
+
+        final byte[] dnsBytes = {
+                (byte) 0x6B, (byte) 0xA7, (byte) 0xB8, (byte) 0x10, (byte) 0x9D,
+                (byte) 0xAD, (byte) 0x11, (byte) 0xD1, (byte) 0x80, (byte) 0xB4,
+                (byte) 0x00, (byte) 0xC0, (byte) 0x4F, (byte) 0xD4, (byte) 0x30,
+                (byte) 0xC8
+        };
+        final String dnsUuid = new UUID(dnsBytes).toString();
+        if (!"6ba7b810-9dad-11d1-80b4-00c04fd430c8".equals(dnsUuid)) {
+            throw new Exception("DNS UUID was not correctly reconstructed from raw bytes, got: " + dnsUuid);
         }
     }
 


### PR DESCRIPTION
Made byte constructor public and changed the length assertion to an `IllegalArgumentException`, added a `getBytes` method that allows users to retrieve the raw bytes of the UUID, and created a new private constructor with an optimized construction for byte arrays that can set the version as desired and the variant to RFC 4122. Also changed the existing static factory methods to use the new constructor and removed the duplicate code from them where the variant and version is being set.

Report [5023614](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=5023614) asks for more than what I provided and with different names. However, I believe that there is no value in providing methods to deal with `DataInput` and `DataOutput` because they would only encapsulate single method calls that the caller can directly write as well (e.g. `output.write(uuid.getBytes())` vs `uuid.write(output)`). Hence, I consider this change to satisfy the feature request.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ❌ (2/9 failed) | ❌ (2/9 failed) | ❌ (1/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Linux x64 (hs/tier1 runtime)](https://github.com/Fleshgrinder/jdk/runs/1467058330)
- [Linux x64 (jdk/tier1 part 2)](https://github.com/Fleshgrinder/jdk/runs/1467058282)
- [Linux x86 (hs/tier1 compiler)](https://github.com/Fleshgrinder/jdk/runs/1467055807)
- [Linux x86 (jdk/tier1 part 2)](https://github.com/Fleshgrinder/jdk/runs/1467055786)
- [Windows x64 (jdk/tier1 part 2)](https://github.com/Fleshgrinder/jdk/runs/1467116018)
- [macOS x64 (jdk/tier1 part 2)](https://github.com/Fleshgrinder/jdk/runs/1467042534)

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-5023614](https://bugs.openjdk.java.net/browse/JDK-5023614): UUID needs methods to get most/leastSigBits and write to DataOutput


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1465/head:pull/1465`
`$ git checkout pull/1465`
