### PR TITLE
8257186: Size of heap segments is not computed correctlyFix overflow in size computation for heap segments

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -98,7 +98,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
 
         public static MemorySegment fromArray(byte[] arr) {
             Objects.requireNonNull(arr);
-            int byteSize = arr.length * Unsafe.ARRAY_BYTE_INDEX_SCALE;
+            long byteSize = (long)arr.length * Unsafe.ARRAY_BYTE_INDEX_SCALE;
             MemoryScope scope = MemoryScope.createConfined(null, MemoryScope.DUMMY_CLEANUP_ACTION, null);
             return new OfByte(Unsafe.ARRAY_BYTE_BASE_OFFSET, arr, byteSize, defaultAccessModes(byteSize), scope);
         }
@@ -122,7 +122,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
 
         public static MemorySegment fromArray(char[] arr) {
             Objects.requireNonNull(arr);
-            int byteSize = arr.length * Unsafe.ARRAY_CHAR_INDEX_SCALE;
+            long byteSize = (long)arr.length * Unsafe.ARRAY_CHAR_INDEX_SCALE;
             MemoryScope scope = MemoryScope.createConfined(null, MemoryScope.DUMMY_CLEANUP_ACTION, null);
             return new OfChar(Unsafe.ARRAY_CHAR_BASE_OFFSET, arr, byteSize, defaultAccessModes(byteSize), scope);
         }
@@ -146,7 +146,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
 
         public static MemorySegment fromArray(short[] arr) {
             Objects.requireNonNull(arr);
-            int byteSize = arr.length * Unsafe.ARRAY_SHORT_INDEX_SCALE;
+            long byteSize = (long)arr.length * Unsafe.ARRAY_SHORT_INDEX_SCALE;
             MemoryScope scope = MemoryScope.createConfined(null, MemoryScope.DUMMY_CLEANUP_ACTION, null);
             return new OfShort(Unsafe.ARRAY_SHORT_BASE_OFFSET, arr, byteSize, defaultAccessModes(byteSize), scope);
         }
@@ -170,7 +170,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
 
         public static MemorySegment fromArray(int[] arr) {
             Objects.requireNonNull(arr);
-            int byteSize = arr.length * Unsafe.ARRAY_INT_INDEX_SCALE;
+            long byteSize = (long)arr.length * Unsafe.ARRAY_INT_INDEX_SCALE;
             MemoryScope scope = MemoryScope.createConfined(null, MemoryScope.DUMMY_CLEANUP_ACTION, null);
             return new OfInt(Unsafe.ARRAY_INT_BASE_OFFSET, arr, byteSize, defaultAccessModes(byteSize), scope);
         }
@@ -194,7 +194,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
 
         public static MemorySegment fromArray(long[] arr) {
             Objects.requireNonNull(arr);
-            int byteSize = arr.length * Unsafe.ARRAY_LONG_INDEX_SCALE;
+            long byteSize = (long)arr.length * Unsafe.ARRAY_LONG_INDEX_SCALE;
             MemoryScope scope = MemoryScope.createConfined(null, MemoryScope.DUMMY_CLEANUP_ACTION, null);
             return new OfLong(Unsafe.ARRAY_LONG_BASE_OFFSET, arr, byteSize, defaultAccessModes(byteSize), scope);
         }
@@ -218,7 +218,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
 
         public static MemorySegment fromArray(float[] arr) {
             Objects.requireNonNull(arr);
-            int byteSize = arr.length * Unsafe.ARRAY_FLOAT_INDEX_SCALE;
+            long byteSize = (long)arr.length * Unsafe.ARRAY_FLOAT_INDEX_SCALE;
             MemoryScope scope = MemoryScope.createConfined(null, MemoryScope.DUMMY_CLEANUP_ACTION, null);
             return new OfFloat(Unsafe.ARRAY_FLOAT_BASE_OFFSET, arr, byteSize, defaultAccessModes(byteSize), scope);
         }
@@ -242,7 +242,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
 
         public static MemorySegment fromArray(double[] arr) {
             Objects.requireNonNull(arr);
-            int byteSize = arr.length * Unsafe.ARRAY_DOUBLE_INDEX_SCALE;
+            long byteSize = (long)arr.length * Unsafe.ARRAY_DOUBLE_INDEX_SCALE;
             MemoryScope scope = MemoryScope.createConfined(null, MemoryScope.DUMMY_CLEANUP_ACTION, null);
             return new OfDouble(Unsafe.ARRAY_DOUBLE_BASE_OFFSET, arr, byteSize, defaultAccessModes(byteSize), scope);
         }

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @run testng/othervm -XX:MaxDirectMemorySize=1M TestSegments
+ * @run testng/othervm -Xmx4G -XX:MaxDirectMemorySize=1M TestSegments
  */
 
 import jdk.incubator.foreign.MappedMemorySegments;
@@ -47,6 +47,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -277,6 +279,13 @@ public class TestSegments {
         segment.hasAccessModes((1 << AccessActions.values().length) + 1);
     }
 
+    @Test(dataProvider = "heapFactories")
+    public void testBigHeapSegments(IntFunction<MemorySegment> heapSegmentFactory, int factor) {
+        int bigSize = (Integer.MAX_VALUE / factor) + 1;
+        MemorySegment segment = heapSegmentFactory.apply(bigSize);
+        assertTrue(segment.byteSize() > 0);
+    }
+
     @DataProvider(name = "badSizeAndAlignments")
     public Object[][] sizesAndAlignments() {
         return new Object[][] {
@@ -444,5 +453,17 @@ public class TestSegments {
         }
 
         abstract void run(MemorySegment segment);
+    }
+
+    @DataProvider(name = "heapFactories")
+    public Object[][] heapFactories() {
+        return new Object[][] {
+                { (IntFunction<MemorySegment>) size -> MemorySegment.ofArray(new char[size]), 2 },
+                { (IntFunction<MemorySegment>) size -> MemorySegment.ofArray(new short[size]), 2 },
+                { (IntFunction<MemorySegment>) size -> MemorySegment.ofArray(new int[size]), 4 },
+                { (IntFunction<MemorySegment>) size -> MemorySegment.ofArray(new float[size]), 4 },
+                { (IntFunction<MemorySegment>) size -> MemorySegment.ofArray(new long[size]), 8 },
+                { (IntFunction<MemorySegment>) size -> MemorySegment.ofArray(new double[size]), 8 }
+        };
     }
 }


### PR DESCRIPTION
There is a subtle bug in the heap segment factories: the byte size is computed using an int multiplication instead of a long multiplication. Because of that, it is possible to observe overflow when creating segments out of arrays whose carrier has a byte size greater than one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * ⚠️ Temporary failure when trying to retrieve information on issue `8257186`.


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1466/head:pull/1466`
`$ git checkout pull/1466`
