### PR TITLE
6594730: UUID.getVersion() is only meaningful for Leach-Salz variant

### DIFF
--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -325,8 +325,14 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
      * </ul>
      *
      * @return  The version number of this {@code UUID}
+     * @throws UnsupportedOperationException
+     *         If this {@code UUID} is not an RFC&nbsp;4122 {@link #variant()}.
      */
     public int version() {
+        if (variant() != 2) {
+            throw new UnsupportedOperationException("Not a variant 2 (RFC 4122) UUID");
+        }
+
         // Version is bits masked by 0x000000000000F000 in MS long
         return (int)((mostSigBits >> 12) & 0x0f);
     }

--- a/test/jdk/java/util/UUID/UUIDTest.java
+++ b/test/jdk/java/util/UUID/UUIDTest.java
@@ -171,12 +171,20 @@ public class UUIDTest {
         test = new UUID(55L, 0x8000000000001000L);
         if (test.variant() != 2)
             throw new Exception("wrong variant from bit set to 2");
-       test = new UUID(55L, 0xc000000000001000L);
+        test = new UUID(55L, 0xc000000000001000L);
         if (test.variant() != 6)
             throw new Exception("wrong variant from bit set to 6");
-       test = new UUID(55L, 0xe000000000001000L);
+        test = new UUID(55L, 0xe000000000001000L);
         if (test.variant() != 7)
             throw new Exception("wrong variant from bit set to 7");
+
+        test = new UUID(0, 0);
+        try {
+            int ignored = test.variant();
+            throw new Exception("Expected exception not thrown");
+        } catch (UnsupportedOperationException uoe) {
+            // pass
+        }
     }
 
     private static void timestampTest() throws Exception {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ❌ (1/9 failed) | ❌ (2/9 failed) | ❌ (1/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Linux x64 (jdk/tier1 part 2)](https://github.com/Fleshgrinder/jdk/runs/1460924680)
- [Linux x86 (hs/tier1 compiler)](https://github.com/Fleshgrinder/jdk/runs/1460910376)
- [Linux x86 (jdk/tier1 part 2)](https://github.com/Fleshgrinder/jdk/runs/1460910341)
- [Windows x64 (jdk/tier1 part 2)](https://github.com/Fleshgrinder/jdk/runs/1461025513)
- [macOS x64 (jdk/tier1 part 2)](https://github.com/Fleshgrinder/jdk/runs/1461025155)

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-6594730](https://bugs.openjdk.java.net/browse/JDK-6594730): UUID.getVersion() is only meaningful for Leach-Salz variant


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1467/head:pull/1467`
`$ git checkout pull/1467`
