### PR TITLE
8257146: C2: extend the scope of StressGCM

### DIFF
--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -1174,8 +1174,8 @@ Block* PhaseCFG::hoist_to_cheaper_block(Block* LCA, Block* early, Node* self) {
     }
 #endif
     cand_cnt++;
-    if (LCA_freq < least_freq              || // Better Frequency
-        (StressGCM && C->randomized_select(cand_cnt)) || // Should be randomly accepted in stress mode
+    if ((StressGCM && C->randomized_select(cand_cnt)) || // Should be randomly accepted in stress mode
+        (!StressGCM && LCA_freq < least_freq) || // Better Frequency
          (!StressGCM                    &&    // Otherwise, choose with latency
           !in_latency                   &&    // No block containing latency
           LCA_freq < least_freq * delta &&    // No worse frequency


### PR DESCRIPTION
Extend the scope of StressGCM by allowing it to move instructions into basic blocks with worse frequency. This should improve StressGCM's ability to expose bugs where C2 relies on GCM heuristics for correctness.

Tested with StressGCM enabled on `hs-tier1-3` and a single repetition, the following test cases fail on `linux-aarch64-debug` and require further investigation:
- `serviceability/sa/ClhsdbJstackXcompStress.java`
- `compiler/c2/cr6663848/Tester.java`

Also tested with StressGCM disabled (default)  on `hs-tier1-3`, all tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8257146](https://bugs.openjdk.java.net/browse/JDK-8257146): C2: extend the scope of StressGCM


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1469/head:pull/1469`
`$ git checkout pull/1469`
