### PR TITLE
8255001: Move G1PeriodicGCTask to its own file

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -52,6 +52,7 @@
 #include "gc/g1/g1OopClosures.inline.hpp"
 #include "gc/g1/g1ParallelCleaning.hpp"
 #include "gc/g1/g1ParScanThreadState.inline.hpp"
+#include "gc/g1/g1PeriodicGCTask.hpp"
 #include "gc/g1/g1Policy.hpp"
 #include "gc/g1/g1RedirtyCardsQueue.hpp"
 #include "gc/g1/g1RegionToSpaceMapper.hpp"
@@ -1390,6 +1391,7 @@ public:
 G1CollectedHeap::G1CollectedHeap() :
   CollectedHeap(),
   _service_thread(NULL),
+  _periodic_gc_task(NULL),
   _workers(NULL),
   _card_table(NULL),
   _collection_pause_end(Ticks::now()),
@@ -1688,6 +1690,10 @@ jint G1CollectedHeap::initialize() {
 
   // Initialize and schedule sampling task on service thread.
   _rem_set->initialize_sampling_task(service_thread());
+
+  // Create and schedule the periodic gc task on the service thread.
+  _periodic_gc_task = new G1PeriodicGCTask("Periodic GC Task");
+  _service_thread->register_task(_periodic_gc_task);
 
   {
     G1DirtyCardQueueSet& dcqs = G1BarrierSet::dirty_card_queue_set();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -79,6 +79,7 @@ class G1CollectionSet;
 class G1Policy;
 class G1HotCardCache;
 class G1RemSet;
+class G1ServiceTask;
 class G1ServiceThread;
 class G1ConcurrentMark;
 class G1ConcurrentMarkThread;
@@ -154,6 +155,7 @@ class G1CollectedHeap : public CollectedHeap {
 
 private:
   G1ServiceThread* _service_thread;
+  G1ServiceTask* _periodic_gc_task;
 
   WorkGang* _workers;
   G1CardTable* _card_table;

--- a/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
+++ b/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
@@ -30,6 +30,7 @@
 #include "logging/log.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 bool G1PeriodicGCTask::should_start_periodic_gc() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();

--- a/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
+++ b/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "gc/g1/g1CollectedHeap.inline.hpp"
+#include "gc/g1/g1ConcurrentMark.inline.hpp"
+#include "gc/g1/g1ConcurrentMarkThread.inline.hpp"
+#include "gc/g1/g1PeriodicGCTask.hpp"
+#include "logging/log.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/os.hpp"
+
+bool G1PeriodicGCTask::should_start_periodic_gc() {
+  G1CollectedHeap* g1h = G1CollectedHeap::heap();
+  // If we are currently in a concurrent mark we are going to uncommit memory soon.
+  if (g1h->concurrent_mark()->cm_thread()->in_progress()) {
+    log_debug(gc, periodic)("Concurrent cycle in progress. Skipping.");
+    return false;
+  }
+
+  // Check if enough time has passed since the last GC.
+  uintx time_since_last_gc = (uintx)g1h->time_since_last_collection().milliseconds();
+  if ((time_since_last_gc < G1PeriodicGCInterval)) {
+    log_debug(gc, periodic)("Last GC occurred " UINTX_FORMAT "ms before which is below threshold " UINTX_FORMAT "ms. Skipping.",
+                            time_since_last_gc, G1PeriodicGCInterval);
+    return false;
+  }
+
+  // Check if load is lower than max.
+  double recent_load;
+  if ((G1PeriodicGCSystemLoadThreshold > 0.0f) &&
+      (os::loadavg(&recent_load, 1) == -1 || recent_load > G1PeriodicGCSystemLoadThreshold)) {
+    log_debug(gc, periodic)("Load %1.2f is higher than threshold %1.2f. Skipping.",
+                            recent_load, G1PeriodicGCSystemLoadThreshold);
+    return false;
+  }
+  return true;
+}
+
+void G1PeriodicGCTask::check_for_periodic_gc() {
+  // If disabled, just return.
+  if (G1PeriodicGCInterval == 0) {
+    return;
+  }
+
+  log_debug(gc, periodic)("Checking for periodic GC.");
+  if (should_start_periodic_gc()) {
+    if (!G1CollectedHeap::heap()->try_collect(GCCause::_g1_periodic_collection)) {
+      log_debug(gc, periodic)("GC request denied. Skipping.");
+    }
+  }
+}
+
+G1PeriodicGCTask::G1PeriodicGCTask(const char* name) :
+  G1ServiceTask(name) { }
+
+void G1PeriodicGCTask::execute() {
+  check_for_periodic_gc();
+  // G1PeriodicGCInterval is a manageable flag and can be updated
+  // during runtime. If no value is set, wait a second and run it
+  // again to see if the value has been updated. Otherwise use the
+  // real value provided.
+  schedule(G1PeriodicGCInterval == 0 ? 1000 : G1PeriodicGCInterval);
+}

--- a/src/hotspot/share/gc/g1/g1PeriodicGCTask.hpp
+++ b/src/hotspot/share/gc/g1/g1PeriodicGCTask.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_G1_G1PERIODICGCTASK_HPP
+#define SHARE_GC_G1_G1PERIODICGCTASK_HPP
+
+#include "gc/g1/g1ServiceThread.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/ticks.hpp"
+
+// Task handling periodic GCs
+class G1PeriodicGCTask : public G1ServiceTask {
+  bool should_start_periodic_gc();
+  void check_for_periodic_gc();
+
+public:
+  G1PeriodicGCTask(const char* name);
+  virtual void execute();
+};
+
+#endif // SHARE_GC_G1_G1PERIODICGCTASK_HPP

--- a/src/hotspot/share/gc/g1/g1PeriodicGCTask.hpp
+++ b/src/hotspot/share/gc/g1/g1PeriodicGCTask.hpp
@@ -26,8 +26,6 @@
 #define SHARE_GC_G1_G1PERIODICGCTASK_HPP
 
 #include "gc/g1/g1ServiceThread.hpp"
-#include "utilities/globalDefinitions.hpp"
-#include "utilities/ticks.hpp"
 
 // Task handling periodic GCs
 class G1PeriodicGCTask : public G1ServiceTask {

--- a/src/hotspot/share/gc/g1/g1ServiceThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ServiceThread.cpp
@@ -23,12 +23,10 @@
  */
 
 #include "precompiled.hpp"
-#include "gc/g1/g1CollectedHeap.inline.hpp"
-#include "gc/g1/g1ConcurrentMark.inline.hpp"
-#include "gc/g1/g1ConcurrentMarkThread.inline.hpp"
 #include "gc/g1/g1ServiceThread.hpp"
-#include "memory/universe.hpp"
+#include "logging/log.hpp"
 #include "runtime/mutexLocker.hpp"
+#include "runtime/timer.hpp"
 #include "runtime/os.hpp"
 
 G1SentinelTask::G1SentinelTask() : G1ServiceTask("Sentinel Task") {
@@ -40,61 +38,6 @@ void G1SentinelTask::execute() {
   guarantee(false, "Sentinel service task should never be executed.");
 }
 
-// Task handling periodic GCs
-class G1PeriodicGCTask : public G1ServiceTask {
-  bool should_start_periodic_gc() {
-    G1CollectedHeap* g1h = G1CollectedHeap::heap();
-    // If we are currently in a concurrent mark we are going to uncommit memory soon.
-    if (g1h->concurrent_mark()->cm_thread()->in_progress()) {
-      log_debug(gc, periodic)("Concurrent cycle in progress. Skipping.");
-      return false;
-    }
-
-    // Check if enough time has passed since the last GC.
-    uintx time_since_last_gc = (uintx)g1h->time_since_last_collection().milliseconds();
-    if ((time_since_last_gc < G1PeriodicGCInterval)) {
-      log_debug(gc, periodic)("Last GC occurred " UINTX_FORMAT "ms before which is below threshold " UINTX_FORMAT "ms. Skipping.",
-                              time_since_last_gc, G1PeriodicGCInterval);
-      return false;
-    }
-
-    // Check if load is lower than max.
-    double recent_load;
-    if ((G1PeriodicGCSystemLoadThreshold > 0.0f) &&
-        (os::loadavg(&recent_load, 1) == -1 || recent_load > G1PeriodicGCSystemLoadThreshold)) {
-      log_debug(gc, periodic)("Load %1.2f is higher than threshold %1.2f. Skipping.",
-                              recent_load, G1PeriodicGCSystemLoadThreshold);
-      return false;
-    }
-    return true;
-  }
-
-  void check_for_periodic_gc(){
-    // If disabled, just return.
-    if (G1PeriodicGCInterval == 0) {
-      return;
-    }
-
-    log_debug(gc, periodic)("Checking for periodic GC.");
-    if (should_start_periodic_gc()) {
-      if (!G1CollectedHeap::heap()->try_collect(GCCause::_g1_periodic_collection)) {
-        log_debug(gc, periodic)("GC request denied. Skipping.");
-      }
-    }
-  }
-public:
-  G1PeriodicGCTask(const char* name) : G1ServiceTask(name) { }
-
-  virtual void execute() {
-    check_for_periodic_gc();
-    // G1PeriodicGCInterval is a manageable flag and can be updated
-    // during runtime. If no value is set, wait a second and run it
-    // again to see if the value has been updated. Otherwise use the
-    // real value provided.
-    schedule(G1PeriodicGCInterval == 0 ? 1000 : G1PeriodicGCInterval);
-  }
-};
-
 G1ServiceThread::G1ServiceThread() :
     ConcurrentGCThread(),
     _monitor(Mutex::nonleaf,
@@ -102,14 +45,9 @@ G1ServiceThread::G1ServiceThread() :
              true,
              Monitor::_safepoint_check_never),
     _task_queue(),
-    _periodic_gc_task(new G1PeriodicGCTask("Periodic GC Task")),
     _vtime_accum(0) {
   set_name("G1 Service");
   create_and_start();
-}
-
-G1ServiceThread::~G1ServiceThread() {
-  delete _periodic_gc_task;
 }
 
 void G1ServiceThread::register_task(G1ServiceTask* task, jlong delay) {
@@ -216,9 +154,6 @@ void G1ServiceThread::run_task(G1ServiceTask* task) {
 
 void G1ServiceThread::run_service() {
   double vtime_start = os::elapsedVTime();
-
-  // Register the tasks handled by the service thread.
-  register_task(_periodic_gc_task);
 
   while (!should_terminate()) {
     G1ServiceTask* task = pop_due_task();

--- a/src/hotspot/share/gc/g1/g1ServiceThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ServiceThread.hpp
@@ -28,7 +28,6 @@
 #include "gc/shared/concurrentGCThread.hpp"
 #include "runtime/mutex.hpp"
 
-class G1PeriodicGCTask;
 class G1ServiceTaskQueue;
 class G1ServiceThread;
 
@@ -105,8 +104,6 @@ class G1ServiceThread: public ConcurrentGCThread {
   Monitor _monitor;
   G1ServiceTaskQueue _task_queue;
 
-  G1PeriodicGCTask* _periodic_gc_task;
-
   double _vtime_accum;  // Accumulated virtual time.
 
   void run_service();
@@ -131,7 +128,6 @@ class G1ServiceThread: public ConcurrentGCThread {
 
 public:
   G1ServiceThread();
-  ~G1ServiceThread();
 
   double vtime_accum() { return _vtime_accum; }
   // Register a task with the service thread and schedule it. If


### PR DESCRIPTION
After making the service thread task based it is now possible to move the tasks out of `g1ServiceThread.cpp`. The periodic task is moved to its own files and the initialization and registration with the service thread is done while initializing `G1CollectedHeap`.

No functionality is changed for the task, but it has been split up into a header and a source file. 

**Testing**
tier 1-2 + manual testing setting `G1PeriodicGCInterval` through `jcmd`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ❌ (1/2 failed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (build debug)](https://github.com/kstefanj/jdk/runs/1463585491)

### Issue
 * [JDK-8255001](https://bugs.openjdk.java.net/browse/JDK-8255001): Move G1PeriodicGCTask to its own file


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Leo Korinth](https://openjdk.java.net/census#lkorinth) (@lkorinth - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1471/head:pull/1471`
`$ git checkout pull/1471`
