### PR TITLE
8248736: [aarch64] runtime/signal/TestSigpoll.java failed "fatal error: not an ldr (literal) instruction."

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
@@ -254,7 +254,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
   __ cmpw(rscratch1, rscratch2);
   __ br(Assembler::EQ, skip);
 
-  __ mov(rscratch1, StubRoutines::aarch64::method_entry_barrier());
+  __ movptr(rscratch1, (uintptr_t) StubRoutines::aarch64::method_entry_barrier());
   __ blr(rscratch1);
   __ b(skip);
 


### PR DESCRIPTION
Change mov to movptr in the nmethod entry barrier. movptr will generate a consistent number of mov/movk instructions that are necessary to consistently calculate the size of the nmethod barrier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248736](https://bugs.openjdk.java.net/browse/JDK-8248736): [aarch64] runtime/signal/TestSigpoll.java failed "fatal error: not an ldr (literal) instruction."


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1481/head:pull/1481`
`$ git checkout pull/1481`
