### PR TITLE
8257220: [JVMCI] option validation should not result in a heavy-weight VM crash

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -407,7 +407,7 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
                         msg.format("%nError: A fatal exception has occurred. Program will exit.%n");
                         byte[] msgBytes = msg.toString().getBytes();
                         compilerToVm.writeDebugOutput(msgBytes, 0, msgBytes.length, true, true);
-                        compilerToVm.callSystemExit(-1);
+                        compilerToVm.callSystemExit(1);
                     } else if (value instanceof Option) {
                         Option option = (Option) value;
                         option.init(e.getValue());

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -379,8 +379,10 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
         /**
          * Parses all system properties starting with {@value #JVMCI_OPTION_PROPERTY_PREFIX} and
          * initializes the options based on their values.
+         *
+         * @param compilerToVm
          */
-        static void parse() {
+        static void parse(CompilerToVM compilerToVm) {
             Map<String, String> savedProps = jdk.vm.ci.services.Services.getSavedProperties();
             for (Map.Entry<String, String> e : savedProps.entrySet()) {
                 String name = e.getKey();
@@ -395,14 +397,17 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
                             }
                         }
                         Formatter msg = new Formatter();
-                        msg.format("Could not find option %s", name);
+                        msg.format("Error parsing JVMCI options: Could not find option %s", name);
                         if (!matches.isEmpty()) {
                             msg.format("%nDid you mean one of the following?");
                             for (String match : matches) {
                                 msg.format("%n    %s=<value>", match);
                             }
                         }
-                        throw new IllegalArgumentException(msg.toString());
+                        msg.format("%nError: A fatal exception has occurred. Program will exit.%n");
+                        byte[] msgBytes = msg.toString().getBytes();
+                        compilerToVm.writeDebugOutput(msgBytes, 0, msgBytes.length, true, true);
+                        compilerToVm.callSystemExit(-1);
                     } else if (value instanceof Option) {
                         Option option = (Option) value;
                         option.init(e.getValue());
@@ -531,7 +536,7 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
         }
 
         // Initialize the Option values.
-        Option.parse();
+        Option.parse(compilerToVm);
 
         String hostArchitecture = config.getHostArchitectureName();
 

--- a/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
@@ -42,8 +42,16 @@ public class TestInvalidJVMCIOption {
             "-XX:+UseJVMCICompiler",
             "-Djvmci.XXXXXXXXX=true");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldMatch("Error parsing JVMCI options: Could not find option jvmci.XXXXXXXXX" + System.lineSeparator() +
-                           "Error: A fatal exception has occurred. Program will exit." + System.lineSeparator());
-        output.shouldHaveExitValue(255);
+        String expectStdout = String.format(
+            "Error parsing JVMCI options: Could not find option jvmci.XXXXXXXXX%n" +
+            "Error: A fatal exception has occurred. Program will exit.%n");
+        String actualStdout = output.getStdout();
+        if (!actualStdout.equals(expectStdout)) {
+            throw new RuntimeException(String.format("Invalid STDOUT:%nExpect:%n%s%nActual:%n%s", expectStdout, actualStdout));
+        }
+        if (!output.getStderr().isEmpty()) {
+            throw new RuntimeException("STDERR was not empty: " + output.getStderr());
+        }
+        output.shouldHaveExitValue(1);
     }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestInvalidJVMCIOption
+ * @bug 8257220
+ * @summary Ensures invalid JVMCI options do not crash the VM with a hs-err log.
+ * @requires vm.jvmci & vm.compMode == "Xmixed"
+ * @library /test/lib
+ * @run driver TestInvalidJVMCIOption
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestInvalidJVMCIOption {
+
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EagerJVMCI",
+            "-XX:+UseJVMCICompiler",
+            "-Djvmci.XXXXXXXXX=true");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldMatch("Error parsing JVMCI options: Could not find option jvmci.XXXXXXXXX" + System.lineSeparator() +
+                           "Error: A fatal exception has occurred. Program will exit." + System.lineSeparator());
+        output.shouldHaveExitValue(255);
+    }
+}


### PR DESCRIPTION
As a result of [JDK-8253228](https://bugs.openjdk.java.net/browse/JDK-8253228), a heavy-weight VM crash occurs for incorrectly specified JVMCI options. For example:
```
> java -XX:+UnlockExperimentalVMOptions -XX:+EagerJVMCI -XX:+UseJVMCICompiler -Djvmci.InitTiimer=true
Uncaught exception exiting JVMCIEnv scope entered at src/hotspot/share/jvmci/jvmciRuntime.cpp:626
java.lang.IllegalArgumentException: Could not find option jvmci.InitTiimer
Did you mean one of the following?
    jvmci.InitTimer=<value>
at jdk.vm.ci.hotspot.HotSpotJVMCIRuntime$Option.parse(jdk.internal.vm.ci/HotSpotJVMCIRuntime.java:405)
at jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.<init>(jdk.internal.vm.ci/HotSpotJVMCIRuntime.java:534)
at jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.runtime(jdk.internal.vm.ci/HotSpotJVMCIRuntime.java:174)
at jdk.vm.ci.runtime.JVMCI.initializeRuntime(jdk.internal.vm.ci/Native Method)
at jdk.vm.ci.runtime.JVMCI.getRuntime(jdk.internal.vm.ci/JVMCI.java:65)
#
# A fatal error has been detected by the Java Runtime Environment:
#
# Internal Error (jvmciRuntime.cpp:1102), pid=55794, tid=7939
# fatal error: Fatal exception in JVMCI: Uncaught exception exiting JVMCIEnv scope entered at src/hotspot/share/jvmci/jvmciRuntime.cpp:626
#
# JRE version: OpenJDK Runtime Environment (16.0) (build 16-internal+0-adhoc.dnsimon.open)
# Java VM: OpenJDK 64-Bit Server VM (16-internal+0-adhoc.dnsimon.open, mixed mode, tiered, jvmci, jvmci compiler, compressed oops, g1 gc, bsd-amd64)
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /Users/dnsimon/jdk-jdk/open/hs_err_pid55794.log
#
# If you would like to submit a bug report, please visit:
# https://bugreport.java.com/bugreport/crash.jsp
#
fish: 'build/macosx-x86_64-server-rele…' terminated by signal SIGABRT (Abort)
```

This is too heavy-weight. This PR makes it similar to how incorrectly specified -XX options are reported:

```
>  java -XX:+UnlockExperimentalVMOptions -XX:+EagerJVMCI -XX:+UseJVMCICompiler -Djvmci.InitTiimer=true
Error parsing JVMCI options: Could not find option jvmci.InitTiimer
Did you mean one of the following?
    jvmci.InitTimer=<value>
Error: A fatal exception has occurred. Program will exit.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8257220](https://bugs.openjdk.java.net/browse/JDK-8257220): [JVMCI] option validation should not result in a heavy-weight VM crash


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1487/head:pull/1487`
`$ git checkout pull/1487`
