### PR TITLE
8257037: No javac warning when calling deprecated constructor with diamond

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4459,15 +4459,10 @@ public class Attr extends JCTree.Visitor {
             }
 
             // Emit a `deprecation' warning if symbol is deprecated.
-            // (for constructors (but not for constructor references), the error
-            // was given when the constructor was resolved)
-
-            if (sym.name != names.init || tree.hasTag(REFERENCE)) {
-                chk.checkDeprecated(tree.pos(), env.info.scope.owner, sym);
-                chk.checkSunAPI(tree.pos(), sym);
-                chk.checkProfile(tree.pos(), sym);
-                chk.checkPreview(tree.pos(), sym);
-            }
+            chk.checkDeprecated(tree.pos(), env.info.scope.owner, sym);
+            chk.checkSunAPI(tree.pos(), sym);
+            chk.checkProfile(tree.pos(), sym);
+            chk.checkPreview(tree.pos(), sym);
 
             // If symbol is a variable, check that its type and
             // kind are compatible with the prototype and protokind.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4459,10 +4459,15 @@ public class Attr extends JCTree.Visitor {
             }
 
             // Emit a `deprecation' warning if symbol is deprecated.
-            chk.checkDeprecated(tree.pos(), env.info.scope.owner, sym);
-            chk.checkSunAPI(tree.pos(), sym);
-            chk.checkProfile(tree.pos(), sym);
-            chk.checkPreview(tree.pos(), sym);
+            // (for constructors (but not for constructor references), the error
+            // was given when the constructor was resolved)
+
+            if (sym.name != names.init || tree.hasTag(REFERENCE)) {
+                chk.checkDeprecated(tree.pos(), env.info.scope.owner, sym);
+                chk.checkSunAPI(tree.pos(), sym);
+                chk.checkProfile(tree.pos(), sym);
+                chk.checkPreview(tree.pos(), sym);
+            }
 
             // If symbol is a variable, check that its type and
             // kind are compatible with the prototype and protokind.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -2855,13 +2855,8 @@ public class Resolve {
                               List<Type> typeargtypes,
                               boolean allowBoxing,
                               boolean useVarargs) {
-        Symbol sym = findMethod(env, site,
-                                    names.init, argtypes,
-                                    typeargtypes, allowBoxing,
-                                    useVarargs);
-        chk.checkDeprecated(pos, env.info.scope.owner, sym);
-        chk.checkPreview(pos, sym);
-        return sym;
+        return findMethod(env, site, names.init, argtypes,
+                            typeargtypes, allowBoxing, useVarargs);
     }
 
     /** Resolve constructor using diamond inference.
@@ -2883,7 +2878,7 @@ public class Resolve {
                 new BasicLookupHelper(names.init, site, argtypes, typeargtypes) {
                     @Override
                     Symbol doLookup(Env<AttrContext> env, MethodResolutionPhase phase) {
-                        return findDiamond(pos, env, site, argtypes, typeargtypes,
+                        return findDiamond(env, site, argtypes, typeargtypes,
                                 phase.isBoxingRequired(),
                                 phase.isVarargsRequired());
                     }
@@ -2904,29 +2899,6 @@ public class Resolve {
                         }
                         return sym;
                     }});
-    }
-
-    /** Find the constructor using diamond inference and do some checks(deprecated and preview).
-     *  @param pos          The position to use for error reporting.
-     *  @param env          The environment current at the constructor invocation.
-     *  @param site         The type of class for which a constructor is searched.
-     *                      The scope of this class has been touched in attribution.
-     *  @param argtypes     The types of the constructor invocation's value arguments.
-     *  @param typeargtypes The types of the constructor invocation's type arguments.
-     *  @param allowBoxing  Allow boxing conversions of arguments.
-     *  @param useVarargs   Box trailing arguments into an array for varargs.
-     */
-    private Symbol findDiamond(DiagnosticPosition pos,
-                               Env<AttrContext> env,
-                               Type site,
-                               List<Type> argtypes,
-                               List<Type> typeargtypes,
-                               boolean allowBoxing,
-                               boolean useVarargs) {
-        Symbol sym = findDiamond(env, site, argtypes, typeargtypes, allowBoxing, useVarargs);
-        chk.checkDeprecated(pos, env.info.scope.owner, sym);
-        chk.checkPreview(pos, sym);
-        return sym;
     }
 
     /** This method scans all the constructor symbol in a given class scope -

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -2896,28 +2896,25 @@ public class Resolve {
                             } else {
                                 final JCDiagnostic details = sym.kind == WRONG_MTH ?
                                                 ((InapplicableSymbolError)sym.baseSymbol()).errCandidate().snd :
-                                        null;
+                                                null;
                                 sym = new DiamondError(sym, currentResolutionContext);
                                 sym = accessMethod(sym, pos, site, names.init, true, argtypes, typeargtypes);
                                 env.info.pendingResolutionPhase = currentResolutionContext.step;
                             }
                         }
                         return sym;
-                    }
-                });
+                    }});
     }
 
-    /**
-     * Find the constructor using diamond inference and do some checks(deprecated and preview).
-     *
-     * @param pos          The position to use for error reporting.
-     * @param env          The environment current at the constructor invocation.
-     * @param site         The type of class for which a constructor is searched.
-     *                     The scope of this class has been touched in attribution.
-     * @param argtypes     The types of the constructor invocation's value arguments.
-     * @param typeargtypes The types of the constructor invocation's type arguments.
-     * @param allowBoxing  Allow boxing conversions of arguments.
-     * @param useVarargs   Box trailing arguments into an array for varargs.
+    /** Find the constructor using diamond inference and do some checks(deprecated and preview).
+     *  @param pos          The position to use for error reporting.
+     *  @param env          The environment current at the constructor invocation.
+     *  @param site         The type of class for which a constructor is searched.
+     *                      The scope of this class has been touched in attribution.
+     *  @param argtypes     The types of the constructor invocation's value arguments.
+     *  @param typeargtypes The types of the constructor invocation's type arguments.
+     *  @param allowBoxing  Allow boxing conversions of arguments.
+     *  @param useVarargs   Box trailing arguments into an array for varargs.
      */
     private Symbol findDiamond(DiagnosticPosition pos,
                                Env<AttrContext> env,
@@ -2932,14 +2929,13 @@ public class Resolve {
         return sym;
     }
 
-    /**
-     * This method scans all the constructor symbol in a given class scope -
-     * assuming that the original scope contains a constructor of the kind:
-     * {@code Foo(X x, Y y)}, where X,Y are class type-variables declared in Foo,
-     * a method check is executed against the modified constructor type:
-     * {@code <X,Y>Foo<X,Y>(X x, Y y)}. This is crucial in order to enable diamond
-     * inference. The inferred return type of the synthetic constructor IS
-     * the inferred type for the diamond operator.
+    /** This method scans all the constructor symbol in a given class scope -
+     *  assuming that the original scope contains a constructor of the kind:
+     *  {@code Foo(X x, Y y)}, where X,Y are class type-variables declared in Foo,
+     *  a method check is executed against the modified constructor type:
+     *  {@code <X,Y>Foo<X,Y>(X x, Y y)}. This is crucial in order to enable diamond
+     *  inference. The inferred return type of the synthetic constructor IS
+     *  the inferred type for the diamond operator.
      */
     private Symbol findDiamond(Env<AttrContext> env,
                               Type site,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -2883,7 +2883,7 @@ public class Resolve {
                 new BasicLookupHelper(names.init, site, argtypes, typeargtypes) {
                     @Override
                     Symbol doLookup(Env<AttrContext> env, MethodResolutionPhase phase) {
-                        return findDiamond(env, site, argtypes, typeargtypes,
+                        return findDiamond(pos, env, site, argtypes, typeargtypes,
                                 phase.isBoxingRequired(),
                                 phase.isVarargsRequired());
                     }
@@ -2896,23 +2896,50 @@ public class Resolve {
                             } else {
                                 final JCDiagnostic details = sym.kind == WRONG_MTH ?
                                                 ((InapplicableSymbolError)sym.baseSymbol()).errCandidate().snd :
-                                                null;
+                                        null;
                                 sym = new DiamondError(sym, currentResolutionContext);
                                 sym = accessMethod(sym, pos, site, names.init, true, argtypes, typeargtypes);
                                 env.info.pendingResolutionPhase = currentResolutionContext.step;
                             }
                         }
                         return sym;
-                    }});
+                    }
+                });
     }
 
-    /** This method scans all the constructor symbol in a given class scope -
-     *  assuming that the original scope contains a constructor of the kind:
-     *  {@code Foo(X x, Y y)}, where X,Y are class type-variables declared in Foo,
-     *  a method check is executed against the modified constructor type:
-     *  {@code <X,Y>Foo<X,Y>(X x, Y y)}. This is crucial in order to enable diamond
-     *  inference. The inferred return type of the synthetic constructor IS
-     *  the inferred type for the diamond operator.
+    /**
+     * Find the constructor using diamond inference and do some checks(deprecated and preview).
+     *
+     * @param pos          The position to use for error reporting.
+     * @param env          The environment current at the constructor invocation.
+     * @param site         The type of class for which a constructor is searched.
+     *                     The scope of this class has been touched in attribution.
+     * @param argtypes     The types of the constructor invocation's value arguments.
+     * @param typeargtypes The types of the constructor invocation's type arguments.
+     * @param allowBoxing  Allow boxing conversions of arguments.
+     * @param useVarargs   Box trailing arguments into an array for varargs.
+     */
+    private Symbol findDiamond(DiagnosticPosition pos,
+                               Env<AttrContext> env,
+                               Type site,
+                               List<Type> argtypes,
+                               List<Type> typeargtypes,
+                               boolean allowBoxing,
+                               boolean useVarargs) {
+        Symbol sym = findDiamond(env, site, argtypes, typeargtypes, allowBoxing, useVarargs);
+        chk.checkDeprecated(pos, env.info.scope.owner, sym);
+        chk.checkPreview(pos, sym);
+        return sym;
+    }
+
+    /**
+     * This method scans all the constructor symbol in a given class scope -
+     * assuming that the original scope contains a constructor of the kind:
+     * {@code Foo(X x, Y y)}, where X,Y are class type-variables declared in Foo,
+     * a method check is executed against the modified constructor type:
+     * {@code <X,Y>Foo<X,Y>(X x, Y y)}. This is crucial in order to enable diamond
+     * inference. The inferred return type of the synthetic constructor IS
+     * the inferred type for the diamond operator.
      */
     private Symbol findDiamond(Env<AttrContext> env,
                               Type site,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -2855,8 +2855,13 @@ public class Resolve {
                               List<Type> typeargtypes,
                               boolean allowBoxing,
                               boolean useVarargs) {
-        return findMethod(env, site, names.init, argtypes,
-                            typeargtypes, allowBoxing, useVarargs);
+        Symbol sym = findMethod(env, site,
+                                    names.init, argtypes,
+                                    typeargtypes, allowBoxing,
+                                    useVarargs);
+        chk.checkDeprecated(pos, env.info.scope.owner, sym);
+        chk.checkPreview(pos, sym);
+        return sym;
     }
 
     /** Resolve constructor using diamond inference.
@@ -2878,7 +2883,7 @@ public class Resolve {
                 new BasicLookupHelper(names.init, site, argtypes, typeargtypes) {
                     @Override
                     Symbol doLookup(Env<AttrContext> env, MethodResolutionPhase phase) {
-                        return findDiamond(env, site, argtypes, typeargtypes,
+                        return findDiamond(pos, env, site, argtypes, typeargtypes,
                                 phase.isBoxingRequired(),
                                 phase.isVarargsRequired());
                     }
@@ -2899,6 +2904,29 @@ public class Resolve {
                         }
                         return sym;
                     }});
+    }
+
+    /** Find the constructor using diamond inference and do some checks(deprecated and preview).
+     *  @param pos          The position to use for error reporting.
+     *  @param env          The environment current at the constructor invocation.
+     *  @param site         The type of class for which a constructor is searched.
+     *                      The scope of this class has been touched in attribution.
+     *  @param argtypes     The types of the constructor invocation's value arguments.
+     *  @param typeargtypes The types of the constructor invocation's type arguments.
+     *  @param allowBoxing  Allow boxing conversions of arguments.
+     *  @param useVarargs   Box trailing arguments into an array for varargs.
+     */
+    private Symbol findDiamond(DiagnosticPosition pos,
+                               Env<AttrContext> env,
+                               Type site,
+                               List<Type> argtypes,
+                               List<Type> typeargtypes,
+                               boolean allowBoxing,
+                               boolean useVarargs) {
+        Symbol sym = findDiamond(env, site, argtypes, typeargtypes, allowBoxing, useVarargs);
+        chk.checkDeprecated(pos, env.info.scope.owner, sym);
+        chk.checkPreview(pos, sym);
+        return sym;
     }
 
     /** This method scans all the constructor symbol in a given class scope -

--- a/test/langtools/tools/javac/T8257037/T8257037.java
+++ b/test/langtools/tools/javac/T8257037/T8257037.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8257307
+ * @summary No javac warning when calling deprecated constructor with diamond
+ * @run compile/ref=T8257037.out -Xlint -XDrawDiagnostics T8257037.java
+ */
+
+public class T8257037 {
+    T8257037_GenericClass<Object> test = new T8257037_GenericClass<>(); // use diamond
+}
+
+class T8257037_GenericClass<T> {
+    @Deprecated
+    public T8257037_GenericClass() {}
+}

--- a/test/langtools/tools/javac/T8257037/T8257037.java
+++ b/test/langtools/tools/javac/T8257037/T8257037.java
@@ -1,28 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
- *
- * This code is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
- *
- * This code is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * version 2 for more details (a copy is included in the LICENSE file that
- * accompanied this code).
- *
- * You should have received a copy of the GNU General Public License version
- * 2 along with this work; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
- * or visit www.oracle.com if you need additional information or have any
- * questions.
- */
-
-/*
- * @test
+ * @test /nodynamiccopyright/
  * @bug 8257307
  * @summary No javac warning when calling deprecated constructor with diamond
  * @run compile/ref=T8257037.out -Xlint -XDrawDiagnostics T8257037.java

--- a/test/langtools/tools/javac/T8257037/T8257037.out
+++ b/test/langtools/tools/javac/T8257037/T8257037.out
@@ -1,2 +1,2 @@
-T8257037.java:32:42: compiler.warn.has.been.deprecated: <T>T8257037_GenericClass(), T8257037_GenericClass
+T8257037.java:9:42: compiler.warn.has.been.deprecated: <T>T8257037_GenericClass(), T8257037_GenericClass
 1 warning

--- a/test/langtools/tools/javac/T8257037/T8257037.out
+++ b/test/langtools/tools/javac/T8257037/T8257037.out
@@ -1,0 +1,2 @@
+T8257037.java:32:42: compiler.warn.has.been.deprecated: <T>T8257037_GenericClass(), T8257037_GenericClass
+1 warning


### PR DESCRIPTION
Hi all,

When calling deprecated constructor with diamond, the compiler doesn't output warning.
The test case is shown below.

```
GenericClass<Object> o2 = new GenericClass<>();

public class GenericClass<T> {
    @Deprecated
    public GenericClass() {}
}
```

This patch solves the bug and adds corresponding test case.
Thank you for taking the time to review.

Best Regards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257037](https://bugs.openjdk.java.net/browse/JDK-8257037): No javac warning when calling deprecated constructor with diamond


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1490/head:pull/1490`
`$ git checkout pull/1490`
