### PR TITLE
Reproducibility improvement: Remove the build user from the version string

### DIFF
--- a/make/autoconf/jdk-version.m4
+++ b/make/autoconf/jdk-version.m4
@@ -239,10 +239,10 @@ AC_DEFUN_ONCE([JDKVER_SETUP_JDK_VERSION_NUMBERS],
     fi
   else
     if test "x$NO_DEFAULT_VERSION_PARTS" != xtrue; then
-      # Default is to calculate a string like this 'adhoc.<username>.<base dir name>'
+      # Default is to calculate a string like this 'adhoc.<base dir name>'
       # Outer [ ] to quote m4.
       [ basedirname=`$BASENAME "$TOPDIR" | $TR -d -c '[a-z][A-Z][0-9].-'` ]
-      VERSION_OPT="adhoc.$USERNAME.$basedirname"
+      VERSION_OPT="adhoc.$basedirname"
     fi
   fi
 


### PR DESCRIPTION
Hi,

We've been working toward making OpenJDK reproducible in Debian (see https://reproducible-builds.org for why it matters) and one of the issues identified is the inclusion of the build user in the version string. Ideally two different users building the same sources should get the same binaries without tweaking the build settings. Therefore we'd like to suggest the removal of the user from the version string. If having the user in the version string is desirable in some cases, maybe the build could be modified to not include it by default but provide an option to add one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/1491/head:pull/1491` \
`$ git checkout pull/1491`

Update a local copy of the PR: \
`$ git checkout pull/1491` \
`$ git pull https://git.openjdk.java.net/jdk pull/1491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1491`

View PR using the GUI difftool: \
`$ git pr show -t 1491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/1491.diff">https://git.openjdk.java.net/jdk/pull/1491.diff</a>

</details>
