### PR TITLE
[PATCH] Remove unnecessary array allocation in WindowsPath

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
@@ -689,9 +689,7 @@ class WindowsPath implements Path {
             throw new IllegalArgumentException();
 
         StringBuilder sb = new StringBuilder();
-        Integer[] nelems = new Integer[endIndex - beginIndex];
         for (int i = beginIndex; i < endIndex; i++) {
-            nelems[i-beginIndex] = sb.length();
             sb.append(elementAsString(i));
             if (i != (endIndex-1))
                 sb.append("\\");


### PR DESCRIPTION
Unused array `nelems` was here since initial implementation of NIO [JDK-4313887](https://bugs.openjdk.java.net/browse/JDK-4313887)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1493/head:pull/1493`
`$ git checkout pull/1493`
