### PR TITLE
Make unix platforms respect the XDG base spec

### DIFF
--- a/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
@@ -352,7 +352,11 @@ public class FcFontConfiguration extends FontConfiguration {
             String userDir = System.getProperty("user.home");
             String version = System.getProperty("java.version");
             String fs = File.separator;
-            String dir = userDir+fs+".java"+fs+"fonts"+fs+version;
+            String baseDir = System.getenv("XDG_DATA_HOME");
+            if (baseDir == null) {
+                baseDir = userDir + "/.local/share";
+            }
+            String dir = userDir+fs+"java"+fs+"fonts"+fs+version;
             Locale locale = SunToolkit.getStartupLocale();
             String lang = locale.getLanguage();
             String country = locale.getCountry();

--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -113,9 +113,13 @@ class FileSystemPreferences extends AbstractPreferences {
     private static void setupUserRoot() {
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
             public Void run() {
+                String baseDir = System.getenv("XDG_CONFIG_HOME");
+                if (baseDir == null) {
+                    baseDir = System.getProperty("user.home") + "/.config/";
+                }
                 userRootDir =
                       new File(System.getProperty("java.util.prefs.userRoot",
-                      System.getProperty("user.home")), ".java/.userPrefs");
+                      baseDir), "java/.userPrefs");
                 // Attempt to create root dir if it does not yet exist.
                 if (!userRootDir.exists()) {
                     if (userRootDir.mkdirs()) {


### PR DESCRIPTION
Hello JDK!

First time contributor here, sorry if this is the wrong place to send my patch, I've read through your contribution guide but it tells me to use both mercurial and your ML. Your ML jdk-changes though only seems to have git notification so I assumed you would prefer having the patch sent there, feel free to tell me to send it on the ML if you prefer!

This patch ensures jdk complies with the XDG base specification ( https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html ) on UNIX based systems.

While we could _technically_ modify userRoot, it would modify the "home folder" and not the preferences folder themselves, making them redundant. 

Also userRoot isn't used everywhere, eg on fonts. I did not modify the "hardcodedness" of userDir in the font files but feel free to tell me if you want the fonts to also comply with the userRoot preferences!

Fonts now use XDG_DATA_HOME and preferences XDG_CONFIG_HOME, along with their default value if not set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1494/head:pull/1494`
`$ git checkout pull/1494`
