### PR TITLE
8257707: Fix incorrect format string in Http1HeaderParser

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1HeaderParser.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1HeaderParser.java
@@ -96,9 +96,9 @@ class Http1HeaderParser {
                 headerName = headerName.substring(0, headerName.indexOf(':')+1) + "...";
             msg = format("parsing HTTP/1.1 header, receiving [%s]", headerName);
         } else {
-            msg =format("HTTP/1.1 parser receiving [%s]", state, sb.toString());
+            msg = format("HTTP/1.1 parser receiving [%s]", sb.toString());
         }
-        return format("%s, parser state [%s]", msg , state);
+        return format("%s, parser state [%s]", msg, state);
     }
 
     /**


### PR DESCRIPTION
Incorrect format string was found by IntelliJ IDEA inspection `Java | Probable bugs | Malformed format string`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257707](https://bugs.openjdk.java.net/browse/JDK-8257707): Fix incorrect format string in Http1HeaderParser


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1495/head:pull/1495`
`$ git checkout pull/1495`
