### PR TITLE
8257438: Avoid adding duplicate values into extendedKeyCodesSet

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/ExtendedKeyCodes.java
+++ b/src/java.desktop/share/classes/sun/awt/ExtendedKeyCodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class ExtendedKeyCodes {
      // known keyboard layout. For instance, sterling sign is on the primary layer
      // of the Mac Italian layout.
      private static final HashSet<Integer> extendedKeyCodesSet =
-                                                  new HashSet<Integer>(501, 1.0f);
+                                                  new HashSet<Integer>(496, 1.0f);
      public static final int getExtendedKeyCodeForChar( int c ) {
          int uc = Character.toUpperCase( c );
          int lc = Character.toLowerCase( c );
@@ -394,7 +394,6 @@ public class ExtendedKeyCodes {
          extendedKeyCodesSet.add(0x01000000+0x06AF);
          extendedKeyCodesSet.add(0x01000000+0x06BE);
          extendedKeyCodesSet.add(0x01000000+0x06CC);
-         extendedKeyCodesSet.add(0x01000000+0x06CC);
          extendedKeyCodesSet.add(0x01000000+0x06D2);
          extendedKeyCodesSet.add(0x01000000+0x0493);
          extendedKeyCodesSet.add(0x01000000+0x0497);
@@ -577,12 +576,8 @@ public class ExtendedKeyCodes {
          extendedKeyCodesSet.add(0x01000000+0x0E59);
          extendedKeyCodesSet.add(0x01000000+0x0587);
          extendedKeyCodesSet.add(0x01000000+0x0589);
-         extendedKeyCodesSet.add(0x01000000+0x0589);
-         extendedKeyCodesSet.add(0x01000000+0x055D);
          extendedKeyCodesSet.add(0x01000000+0x055D);
          extendedKeyCodesSet.add(0x01000000+0x055B);
-         extendedKeyCodesSet.add(0x01000000+0x055B);
-         extendedKeyCodesSet.add(0x01000000+0x055E);
          extendedKeyCodesSet.add(0x01000000+0x055E);
          extendedKeyCodesSet.add(0x01000000+0x0561);
          extendedKeyCodesSet.add(0x01000000+0x0562);


### PR DESCRIPTION
Looks like extended key codes set was filled with _synonyms_
https://wiki.linuxquestions.org/wiki/List_of_Keysyms_Recognised_by_Xmodmap
`0x10006cc` is a _Farsi_yeh_ and also deprecated synonym _Arabic_farsi_yeh_
`0x1000589` is an _Armenian_full_stop_ and also deprecated synonym _Armenian_verjaket_
`0x100055d` is an _Armenian_separation_mark_ and also deprecated synonym _Armenian_but_
`0x100055b` is an _Armenian_accent_ and also deprecated synonym _Armenian_shesht_
`0x100055e` is an _Armenian_question_ and also deprecated synonym _Armenian_paruyk_

Found by IntelliJ IDEA inspection `Java | Probable bugs | Overwritten Map key or Set element`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257438](https://bugs.openjdk.java.net/browse/JDK-8257438): Avoid adding duplicate values into extendedKeyCodesSet


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1496/head:pull/1496`
`$ git checkout pull/1496`
