### PR TITLE
8257232: CompileThresholdScaling fails to work on 32-bit platforms

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -119,13 +119,17 @@ intx CompilerConfig::scaled_freq_log(intx freq_log, double scale) {
   // max_freq_bits accordingly.
   intx max_freq_bits = InvocationCounter::number_of_count_bits + 1;
   intx scaled_freq = scaled_compile_threshold((intx)1 << freq_log, scale);
+
   if (scaled_freq == 0) {
     // Return 0 right away to avoid calculating log2 of 0.
     return 0;
-  } else if (scaled_freq > nth_bit(max_freq_bits)) {
-    return max_freq_bits;
   } else {
-    return log2_intptr(scaled_freq);
+    intx res = log2_intptr(scaled_freq);
+    if (res > max_freq_bits) {
+      return max_freq_bits;
+    } else {
+      return res;
+    }
   }
 }
 


### PR DESCRIPTION
Hi all,

CompileThresholdScaling is incorrect on 32-bit platforms.

If you run the following command on Linux-32:
```
java -XX:CompileThresholdScaling=0.75 -version
```
It gets the following unexpected warnings:
```
intx Tier0InvokeNotifyFreqLog=32 is outside the allowed range [ 0 ... 30 ]
intx Tier0BackedgeNotifyFreqLog=32 is outside the allowed range [ 0 ... 30 ]
intx Tier2InvokeNotifyFreqLog=32 is outside the allowed range [ 0 ... 30 ]
intx Tier2BackedgeNotifyFreqLog=32 is outside the allowed range [ 0 ... 30 ]
intx Tier3InvokeNotifyFreqLog=32 is outside the allowed range [ 0 ... 30 ]
intx Tier3BackedgeNotifyFreqLog=32 is outside the allowed range [ 0 ... 30 ]
intx Tier23InlineeNotifyFreqLog=32 is outside the allowed range [ 0 ... 30 ]
```

The failure is that nth_bit(max_freq_bits) [1] = nth_bit(32) [2] = 0 on 32-bit platforms.
So the scaling logic is wrong.
It would be better to fix it.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/compiler/compilerDefinitions.cpp#L125
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/globalDefinitions.hpp#L973

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257232](https://bugs.openjdk.java.net/browse/JDK-8257232): CompileThresholdScaling fails to work on 32-bit platforms


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1499/head:pull/1499`
`$ git checkout pull/1499`
