### PR TITLE
8257233: Windows x86 build is broken by JDK-8252684

### DIFF
--- a/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
+++ b/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
@@ -22,9 +22,10 @@
  * questions.
  */
 
+#include "precompiled.hpp"
+
 #ifdef AARCH64
 
-#include "precompiled.hpp"
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
 #include "compiler/disassembler.hpp"


### PR DESCRIPTION
Moved the ifdef after the include of precompiled.hpp.

Awaiting GHA results.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ⏳ (8/8 running) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ⏳ (2/2 running) | ⏳ (1/2 running) |
| Test (tier1) |    |  ⏳ (7/9 running) |    |     |     | 

### Issue
 * [JDK-8257233](https://bugs.openjdk.java.net/browse/JDK-8257233): Windows x86 build is broken by JDK-8252684


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1500/head:pull/1500`
`$ git checkout pull/1500`
