### PR TITLE
JDK-8257235: [PATCH] InetAddress.isReachable: Try to use an IPPROTO_ICMP socket type before attempting RAW_SOCK

### DIFF
--- a/src/java.base/unix/native/libnet/Inet4AddressImpl.c
+++ b/src/java.base/unix/native/libnet/Inet4AddressImpl.c
@@ -343,7 +343,7 @@ ping4(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
     struct sockaddr_in sa_recv;
     pid_t pid;
     struct timeval tv;
-    size_t plen = ICMP_ADVLENMIN + sizeof(tv) +sizeof(pid_t);
+    size_t plen = ICMP_ADVLENMIN + sizeof(tv) + sizeof(pid_t);
 
     setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size));
 

--- a/src/java.base/unix/native/libnet/Inet4AddressImpl.c
+++ b/src/java.base/unix/native/libnet/Inet4AddressImpl.c
@@ -424,7 +424,7 @@ ping4(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
                 // I.E.: An ICMP_ECHO_REPLY packet with the proper PID and
                 //       from the host that we are trying to determine is reachable.
                 if (icmp->icmp_type == ICMP_ECHOREPLY &&
-                (memcmp(icmp->icmp_data, &tv, sizeof(tv) == 0)) &&
+                (memcmp(icmp->icmp_data, &tv, sizeof(tv)) == 0) &&
                 (*(pid_t *)(icmp->icmp_data + sizeof(tv)) == pid))
                 {
                     if (sa->sa4.sin_addr.s_addr == sa_recv.sin_addr.s_addr) {

--- a/src/java.base/unix/native/libnet/Inet4AddressImpl.c
+++ b/src/java.base/unix/native/libnet/Inet4AddressImpl.c
@@ -423,8 +423,8 @@ ping4(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
                 // We did receive something, but is it what we were expecting?
                 // I.E.: An ICMP_ECHO_REPLY packet with the proper PID and
                 //       from the host that we are trying to determine is reachable.
-                if (icmp->icmp_type == ICMP_ECHOREPLY &&  
-                (memcmp(icmp->icmp_data, &tv, sizeof(tv) == 0)) && 
+                if (icmp->icmp_type == ICMP_ECHOREPLY &&
+                (memcmp(icmp->icmp_data, &tv, sizeof(tv) == 0)) &&
                 (*(pid_t *)(icmp->icmp_data + sizeof(tv)) == pid))
                 {
                     if (sa->sa4.sin_addr.s_addr == sa_recv.sin_addr.s_addr) {

--- a/src/java.base/unix/native/libnet/Inet4AddressImpl.c
+++ b/src/java.base/unix/native/libnet/Inet4AddressImpl.c
@@ -343,7 +343,7 @@ ping4(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
     struct sockaddr_in sa_recv;
     pid_t pid;
     struct timeval tv;
-    size_t plen = ICMP_ADVLENMIN + sizeof(tv);
+    size_t plen = ICMP_ADVLENMIN + sizeof(tv) +sizeof(pid_t);
 
     setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size));
 

--- a/src/java.base/unix/native/libnet/Inet4AddressImpl.c
+++ b/src/java.base/unix/native/libnet/Inet4AddressImpl.c
@@ -341,7 +341,7 @@ ping4(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
     struct icmp *icmp;
     struct ip *ip;
     struct sockaddr_in sa_recv;
-    jchar pid;
+    pid_t pid;
     struct timeval tv;
     size_t plen = ICMP_ADVLENMIN + sizeof(tv);
 
@@ -361,9 +361,8 @@ ping4(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
             return JNI_FALSE;
         }
     }
-
-    // icmp_id is a 16 bit data type, therefore down cast the pid
-    pid = (jchar)getpid();
+    //we don't need to cast this down, as it will be put into the icmp_data member
+    pid = htonl(getpid());
 
     // Make the socket non blocking so we can use select
     SET_NONBLOCKING(fd);
@@ -378,6 +377,8 @@ ping4(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
         seq++;
         gettimeofday(&tv, NULL);
         memcpy(icmp->icmp_data, &tv, sizeof(tv));
+        //copy our pid into icmp_data so we can uniquely identify the echo response
+        memcpy(icmp->icmp_data + sizeof(tv), &pid, sizeof(pid_t));
         icmp->icmp_cksum = 0;
         // manually calculate checksum
         icmp->icmp_cksum = in_cksum((u_short *)icmp, plen);
@@ -422,8 +423,9 @@ ping4(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
                 // We did receive something, but is it what we were expecting?
                 // I.E.: An ICMP_ECHO_REPLY packet with the proper PID and
                 //       from the host that we are trying to determine is reachable.
-                if (icmp->icmp_type == ICMP_ECHOREPLY &&
-                    (ntohs(icmp->icmp_id) == pid))
+                if (icmp->icmp_type == ICMP_ECHOREPLY &&  
+                (memcmp(icmp->icmp_data, &tv, sizeof(tv) == 0)) && 
+                (*(pid_t *)(icmp->icmp_data + sizeof(tv)) == pid))
                 {
                     if (sa->sa4.sin_addr.s_addr == sa_recv.sin_addr.s_addr) {
                         close(fd);
@@ -486,13 +488,21 @@ Java_java_net_Inet4AddressImpl_isReachable0(JNIEnv *env, jobject this,
         netif = &inf;
     }
 
-    // Let's try to create a RAW socket to send ICMP packets.
-    // This usually requires "root" privileges, so it's likely to fail.
-    fd = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
-    if (fd == -1) {
+/*
+    First we see if the OS supports ICMP as a protocol.
+    In the event that this is an older kernel without IPPROTO_ICMP
+    or that the net.ipv4.ping_group_range kernel parameter is not
+    set, then we fall back to trying to create a RAW socket to
+    send ICMP packets.
+    This usually requires "root" privileges, so it's likely to fail.
+    If all else fails, fall back to TCP and implement tcp echo
+*/
+    fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
+    if (fd == -1)
+        fd = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
+    if (fd == -1)
         return tcp_ping4(env, &sa, netif, timeout, ttl);
-    } else {
-        // It didn't fail, so we can use ICMP_ECHO requests.
+    else
         return ping4(env, fd, &sa, netif, timeout, ttl);
-    }
+
 }


### PR DESCRIPTION
Users have been able to send ICMP packets without the need for root privileges or the CAP_NET_RAW capability since at least kernel 3.11.

For some time now, if the kernel parameter net.ipv4.ping_group_range included the gid of a user sending an icmp packet with the IPPROTO_ICMP protocol, then the packet would>
It's important to note that the both the checksum and ident field are overwritten by the kernel when this is done.

Newer distributions are now setting the default value of net.ipv4.ping_group_range to be open to all possible group ids (Fedora 31 and Ubuntu 20.04 for example) so it can b>

Also of note is the that this is also implemented in MacOS.

This patch proposes attempting to use IPPROTO_ICMP first, and then fall back to attempting a raw socket and ultimately failing over to tcp echo.
This patch also alters the logic for identifying icmp reply packets, since the kernel overwrites id ident field when using the IPPROTO_ICMP protocol.
The method is similar to that used by the ping(8) utility in the iputils package, where we compare data in the icmp_data member of the icmp struct
to identify the packet as our response. The ping utility compares the timeval, whereas this patch proposes to compare both the timeval and the user's pid.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8257235](https://bugs.openjdk.java.net/browse/JDK-8257235)

### Issue
 * [JDK-8257235](https://bugs.openjdk.java.net/browse/JDK-8257235): InetAddress.isReachable should use non-privileged ICMP sockets when available ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/1502/head:pull/1502` \
`$ git checkout pull/1502`

Update a local copy of the PR: \
`$ git checkout pull/1502` \
`$ git pull https://git.openjdk.java.net/jdk pull/1502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1502`

View PR using the GUI difftool: \
`$ git pr show -t 1502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/1502.diff">https://git.openjdk.java.net/jdk/pull/1502.diff</a>

</details>
