### PR TITLE
8254699: Suboptimal PreTouchParallelChunkSize defaults and limits

### DIFF
--- a/src/hotspot/os/aix/globals_aix.hpp
+++ b/src/hotspot/os/aix/globals_aix.hpp
@@ -86,6 +86,7 @@
 
 // UseLargePages means nothing, for now, on AIX.
 // Use Use64KPages or Use16MPages instead.
+define_pd_global(size_t, PreTouchParallelChunkSize, 1 * G);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, false);
 define_pd_global(bool, UseThreadPriorities, true) ;

--- a/src/hotspot/os/bsd/globals_bsd.hpp
+++ b/src/hotspot/os/bsd/globals_bsd.hpp
@@ -42,6 +42,7 @@
 // Defines Bsd-specific default values. The flags are available on all
 // platforms, but they may have different default values on other platforms.
 //
+define_pd_global(size_t, PreTouchParallelChunkSize, 1 * G);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, false);
 define_pd_global(bool, UseThreadPriorities, true) ;

--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -90,6 +90,7 @@
 // Defines Linux-specific default values. The flags are available on all
 // platforms, but they may have different default values on other platforms.
 //
+define_pd_global(size_t, PreTouchParallelChunkSize, 4 * M);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, false);
 define_pd_global(bool, UseThreadPriorities, true) ;

--- a/src/hotspot/os/windows/globals_windows.hpp
+++ b/src/hotspot/os/windows/globals_windows.hpp
@@ -45,6 +45,7 @@ product(bool, UseOSErrorReporting, false,                                 \
 // Defines Windows-specific default values. The flags are available on all
 // platforms, but they may have different default values on other platforms.
 //
+define_pd_global(size_t, PreTouchParallelChunkSize, 1 * G);
 define_pd_global(bool, UseLargePages, false);
 define_pd_global(bool, UseLargePagesIndividualAllocation, true);
 define_pd_global(bool, UseThreadPriorities, true) ;

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -200,7 +200,7 @@
   product(bool, AlwaysPreTouch, false,                                      \
           "Force all freshly committed pages to be pre-touched")            \
                                                                             \
-  product(size_t, PreTouchParallelChunkSize, 4 * M,                         \
+  product_pd(size_t, PreTouchParallelChunkSize,                             \
           "Per-thread chunk size for parallel memory pre-touch.")           \
           range(4*K, SIZE_MAX / 2)                                          \
                                                                             \

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -200,9 +200,9 @@
   product(bool, AlwaysPreTouch, false,                                      \
           "Force all freshly committed pages to be pre-touched")            \
                                                                             \
-  product(size_t, PreTouchParallelChunkSize, 1 * G,                         \
+  product(size_t, PreTouchParallelChunkSize, 4 * M,                         \
           "Per-thread chunk size for parallel memory pre-touch.")           \
-          range(1, SIZE_MAX / 2)                                            \
+          range(4*K, SIZE_MAX / 2)                                          \
                                                                             \
   /* where does the range max value of (max_jint - 1) come from? */         \
   product(size_t, MarkStackSizeMax, NOT_LP64(4*M) LP64_ONLY(512*M),         \

--- a/src/hotspot/share/gc/shared/pretouchTask.cpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.cpp
@@ -27,7 +27,6 @@
 #include "runtime/atomic.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
-#include "utilities/ticks.hpp"
 
 PretouchTask::PretouchTask(const char* task_name,
                            char* start_address,
@@ -63,8 +62,6 @@ void PretouchTask::work(uint worker_id) {
   }
 }
 
-#define TIME_FORMAT "%.3lfms"
-
 void PretouchTask::pretouch(const char* task_name, char* start_address, char* end_address,
                             size_t page_size, WorkGang* pretouch_gang) {
 
@@ -86,20 +83,14 @@ void PretouchTask::pretouch(const char* task_name, char* start_address, char* en
     size_t num_chunks = (total_bytes + chunk_size - 1) / chunk_size;
 
     uint num_workers = (uint)MIN2(num_chunks, (size_t)pretouch_gang->total_workers());
+    log_debug(gc, heap)("Running %s with %u workers for " SIZE_FORMAT " work units pre-touching " SIZE_FORMAT "B.",
+                        task.name(), num_workers, num_chunks, total_bytes);
 
-    Ticks start = Ticks::now();
     pretouch_gang->run_task(&task, num_workers);
-    Ticks end = Ticks::now();
-
-    log_debug(gc, heap)("%s with %u workers for " SIZE_FORMAT " work units pre-touching " SIZE_FORMAT "B " TIME_FORMAT,
-                        task.name(), num_workers, num_chunks, total_bytes, (end-start).seconds());
-
   } else {
-    Ticks start = Ticks::now();
+    log_debug(gc, heap)("Running %s pre-touching " SIZE_FORMAT "B.",
+                        task.name(), total_bytes);
     task.work(0);
-    Ticks end = Ticks::now();
-    log_debug(gc, heap)("%s pre-touching " SIZE_FORMAT "B " TIME_FORMAT ,
-                        task.name(), total_bytes, (end-start).seconds());
   }
 }
 


### PR DESCRIPTION
This PR fixes lower and default value of JVM flag PreTouchParallelChunkSize. Its default value is 1GB and is used by both G1GC and ParallelGC to pretouch the pages. Following test showed that reducing the chunk size improves JVM startup time and GC pause time.

Tests are: (Test machine 2P 64C/128T with 1TB memory)
1. JVM startup time test with AdaptiveSizePolicy disabled: Pretouch 1TB of memory with/without transparent large page support and used time command to measure the time taken.
Command: time ./jdk/bin/java -XX:+AlwaysPreTouch -XX:+<UseParallelGC or UseG1GC>-Xmx900g -Xms900g -Xmn800g -XX:SurvivorRatio=400 -Xlog:gc*=debug:file=gc.log -XX:ParallelGCThreads=128 -XX:PreTouchParallelChunkSize=<chunk size> -version
2. JVM startup and GC pause time test with AdaptiveSizePolicy enabled: SPECjbb composite run with 1TB heap and transparent large page support was enabled.

Test results are recorded in XL file. [PreTouchParallelChunkSize_TestResults.xlsx](https://github.com/openjdk/jdk/files/5612448/PreTouchParallelChunkSize_TestResults.xlsx)

Test results shows:
1. With AdaptiveSizePolicy disabled.
    1. G1GC improved upto ~14% on large page disabled and ~5% on enabled.
    2. ParallelGC improved upto ~15% on large page disabled and ~5% on enabled.
    3. Tests showed improvement from 64KB for default page size and 2MB for lage page size.
    4. Please check "JVM_Startup_Summary" sheet in XL file for more detail.

2. SPECjbb composite test with UseAdaptiveSizePolicy + UseLargePages enabled.
   1. Pretouch takes up-to 30-90% less time for memory range 32MB-4GB. This happens because memory less than 1GB also pretouched with multiple threads.
   2. Same also helps to bring down GC pause time and this is dependent on memory size. Effect is larger when expansion size is smaller.
   3. Please check SPECjbb_Summary sheet in XL file for more detail.

Default value of PreTouchParallelChunkSize is changed to 4MB and based your suggestion it can be changed to right value. Please check and review this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254699](https://bugs.openjdk.java.net/browse/JDK-8254699): Suboptimal PreTouchParallelChunkSize defaults and limits


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to ef6fa419273e3af3b0be15127de42b6fc8aeb141
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1503/head:pull/1503`
`$ git checkout pull/1503`
