### PR TITLE
8257708: Remove redundant unmodifiableSet wrapper from already immutable set returned by Collections.singleton

### DIFF
--- a/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
+++ b/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
@@ -56,8 +56,7 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<ClassLoadingMXBean>() {
             private final Set<String> classLoadingInterfaceNames =
-                    Collections.singleton(
-                            "java.lang.management.ClassLoadingMXBean");
+                    Collections.singleton("java.lang.management.ClassLoadingMXBean");
 
             @Override
             public Set<Class<? extends ClassLoadingMXBean>> mbeanInterfaces() {
@@ -87,8 +86,7 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<CompilationMXBean>() {
             private final Set<String> compilationMXBeanInterfaceNames
-                    = Collections.singleton(
-                            "java.lang.management.CompilationMXBean");
+                    = Collections.singleton("java.lang.management.CompilationMXBean");
 
             @Override
             public Set<Class<? extends CompilationMXBean>> mbeanInterfaces() {
@@ -123,8 +121,7 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<MemoryMXBean>() {
             private final Set<String> memoryMXBeanInterfaceNames
-                    = Collections.singleton(
-                            "java.lang.management.MemoryMXBean");
+                    = Collections.singleton("java.lang.management.MemoryMXBean");
 
             @Override
             public Set<Class<? extends MemoryMXBean>> mbeanInterfaces() {
@@ -203,8 +200,7 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<MemoryManagerMXBean>() {
             private final Set<String> memoryManagerMXBeanInterfaceNames
-                    = Collections.singleton(
-                            "java.lang.management.MemoryManagerMXBean");
+                    = Collections.singleton("java.lang.management.MemoryManagerMXBean");
 
             @Override
             public Set<Class<? extends MemoryManagerMXBean>> mbeanInterfaces() {
@@ -252,8 +248,7 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<MemoryPoolMXBean>() {
             private final Set<String> memoryPoolMXBeanInterfaceNames
-                    = Collections.singleton(
-                            "java.lang.management.MemoryPoolMXBean");
+                    = Collections.singleton("java.lang.management.MemoryPoolMXBean");
 
             @Override
             public Set<Class<? extends MemoryPoolMXBean>> mbeanInterfaces() {
@@ -298,8 +293,7 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<RuntimeMXBean>() {
             private final Set<String> runtimeMXBeanInterfaceNames
-                    = Collections.singleton(
-                            "java.lang.management.RuntimeMXBean");
+                    = Collections.singleton("java.lang.management.RuntimeMXBean");
 
             @Override
             public Set<Class<? extends RuntimeMXBean>> mbeanInterfaces() {
@@ -329,8 +323,7 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<ThreadMXBean>() {
             private final Set<String> threadMXBeanInterfaceNames
-                    = Collections.singleton(
-                            "java.lang.management.ThreadMXBean");
+                    = Collections.singleton("java.lang.management.ThreadMXBean");
 
             @Override
             public Set<Class<? extends ThreadMXBean>> mbeanInterfaces() {
@@ -361,8 +354,7 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
              */
             initMBeanList.add(new PlatformComponent<PlatformLoggingMXBean>() {
                 private final Set<String> platformLoggingMXBeanInterfaceNames
-                    = Collections.singleton(
-                            "java.lang.management.PlatformLoggingMXBean");
+                    = Collections.singleton("java.lang.management.PlatformLoggingMXBean");
 
                 @Override
                 public Set<Class<? extends PlatformLoggingMXBean>> mbeanInterfaces() {
@@ -393,8 +385,7 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<BufferPoolMXBean>() {
             private final Set<String> bufferPoolMXBeanInterfaceNames
-                    = Collections.singleton(
-                            "java.lang.management.BufferPoolMXBean");
+                    = Collections.singleton("java.lang.management.BufferPoolMXBean");
 
             @Override
             public Set<Class<? extends BufferPoolMXBean>> mbeanInterfaces() {
@@ -437,8 +428,7 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<OperatingSystemMXBean>() {
             private final Set<String> operatingSystemMXBeanInterfaceNames
-                    = Collections.singleton(
-                            "java.lang.management.OperatingSystemMXBean");
+                    = Collections.singleton("java.lang.management.OperatingSystemMXBean");
 
             @Override
             public Set<Class<? extends OperatingSystemMXBean>> mbeanInterfaces() {

--- a/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
+++ b/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,8 +56,8 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<ClassLoadingMXBean>() {
             private final Set<String> classLoadingInterfaceNames =
-                    Collections.unmodifiableSet(Collections.singleton(
-                            "java.lang.management.ClassLoadingMXBean"));
+                    Collections.singleton(
+                            "java.lang.management.ClassLoadingMXBean");
 
             @Override
             public Set<Class<? extends ClassLoadingMXBean>> mbeanInterfaces() {
@@ -87,8 +87,8 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<CompilationMXBean>() {
             private final Set<String> compilationMXBeanInterfaceNames
-                    = Collections.unmodifiableSet(Collections.singleton(
-                            "java.lang.management.CompilationMXBean"));
+                    = Collections.singleton(
+                            "java.lang.management.CompilationMXBean");
 
             @Override
             public Set<Class<? extends CompilationMXBean>> mbeanInterfaces() {
@@ -123,8 +123,8 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<MemoryMXBean>() {
             private final Set<String> memoryMXBeanInterfaceNames
-                    = Collections.unmodifiableSet(Collections.singleton(
-                            "java.lang.management.MemoryMXBean"));
+                    = Collections.singleton(
+                            "java.lang.management.MemoryMXBean");
 
             @Override
             public Set<Class<? extends MemoryMXBean>> mbeanInterfaces() {
@@ -203,8 +203,8 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<MemoryManagerMXBean>() {
             private final Set<String> memoryManagerMXBeanInterfaceNames
-                    = Collections.unmodifiableSet(Collections.singleton(
-                            "java.lang.management.MemoryManagerMXBean"));
+                    = Collections.singleton(
+                            "java.lang.management.MemoryManagerMXBean");
 
             @Override
             public Set<Class<? extends MemoryManagerMXBean>> mbeanInterfaces() {
@@ -252,8 +252,8 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<MemoryPoolMXBean>() {
             private final Set<String> memoryPoolMXBeanInterfaceNames
-                    = Collections.unmodifiableSet(Collections.singleton(
-                            "java.lang.management.MemoryPoolMXBean"));
+                    = Collections.singleton(
+                            "java.lang.management.MemoryPoolMXBean");
 
             @Override
             public Set<Class<? extends MemoryPoolMXBean>> mbeanInterfaces() {
@@ -298,8 +298,8 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<RuntimeMXBean>() {
             private final Set<String> runtimeMXBeanInterfaceNames
-                    = Collections.unmodifiableSet(Collections.singleton(
-                            "java.lang.management.RuntimeMXBean"));
+                    = Collections.singleton(
+                            "java.lang.management.RuntimeMXBean");
 
             @Override
             public Set<Class<? extends RuntimeMXBean>> mbeanInterfaces() {
@@ -329,8 +329,8 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<ThreadMXBean>() {
             private final Set<String> threadMXBeanInterfaceNames
-                    = Collections.unmodifiableSet(Collections.singleton(
-                            "java.lang.management.ThreadMXBean"));
+                    = Collections.singleton(
+                            "java.lang.management.ThreadMXBean");
 
             @Override
             public Set<Class<? extends ThreadMXBean>> mbeanInterfaces() {
@@ -361,8 +361,8 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
              */
             initMBeanList.add(new PlatformComponent<PlatformLoggingMXBean>() {
                 private final Set<String> platformLoggingMXBeanInterfaceNames
-                    = Collections.unmodifiableSet(Collections.singleton(
-                            "java.lang.management.PlatformLoggingMXBean"));
+                    = Collections.singleton(
+                            "java.lang.management.PlatformLoggingMXBean");
 
                 @Override
                 public Set<Class<? extends PlatformLoggingMXBean>> mbeanInterfaces() {
@@ -393,8 +393,8 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<BufferPoolMXBean>() {
             private final Set<String> bufferPoolMXBeanInterfaceNames
-                    = Collections.unmodifiableSet(Collections.singleton(
-                            "java.lang.management.BufferPoolMXBean"));
+                    = Collections.singleton(
+                            "java.lang.management.BufferPoolMXBean");
 
             @Override
             public Set<Class<? extends BufferPoolMXBean>> mbeanInterfaces() {
@@ -437,8 +437,8 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<OperatingSystemMXBean>() {
             private final Set<String> operatingSystemMXBeanInterfaceNames
-                    = Collections.unmodifiableSet(Collections.singleton(
-                            "java.lang.management.OperatingSystemMXBean"));
+                    = Collections.singleton(
+                            "java.lang.management.OperatingSystemMXBean");
 
             @Override
             public Set<Class<? extends OperatingSystemMXBean>> mbeanInterfaces() {

--- a/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
@@ -204,8 +204,7 @@ public final class PlatformMBeanProviderImpl extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<com.sun.management.HotSpotDiagnosticMXBean>() {
             private final Set<String> hotSpotDiagnosticMXBeanInterfaceNames =
-                    Collections.singleton(
-                            "com.sun.management.HotSpotDiagnosticMXBean");
+                    Collections.singleton("com.sun.management.HotSpotDiagnosticMXBean");
 
             @Override
             public Set<Class<? extends com.sun.management.HotSpotDiagnosticMXBean>> mbeanInterfaces() {
@@ -237,8 +236,7 @@ public final class PlatformMBeanProviderImpl extends PlatformMBeanProvider {
         if (diagMBean != null) {
             initMBeanList.add(new PlatformComponent<DynamicMBean>() {
                 final Set<String> dynamicMBeanInterfaceNames
-                        = Collections.singleton(
-                                "javax.management.DynamicMBean");
+                        = Collections.singleton("javax.management.DynamicMBean");
 
                 @Override
                 public Set<String> mbeanInterfaceNames() {

--- a/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -204,8 +204,8 @@ public final class PlatformMBeanProviderImpl extends PlatformMBeanProvider {
          */
         initMBeanList.add(new PlatformComponent<com.sun.management.HotSpotDiagnosticMXBean>() {
             private final Set<String> hotSpotDiagnosticMXBeanInterfaceNames =
-                    Collections.unmodifiableSet(Collections.<String>singleton(
-                            "com.sun.management.HotSpotDiagnosticMXBean"));
+                    Collections.singleton(
+                            "com.sun.management.HotSpotDiagnosticMXBean");
 
             @Override
             public Set<Class<? extends com.sun.management.HotSpotDiagnosticMXBean>> mbeanInterfaces() {
@@ -237,8 +237,8 @@ public final class PlatformMBeanProviderImpl extends PlatformMBeanProvider {
         if (diagMBean != null) {
             initMBeanList.add(new PlatformComponent<DynamicMBean>() {
                 final Set<String> dynamicMBeanInterfaceNames
-                        = Collections.unmodifiableSet(Collections.<String>singleton(
-                                "javax.management.DynamicMBean"));
+                        = Collections.singleton(
+                                "javax.management.DynamicMBean");
 
                 @Override
                 public Set<String> mbeanInterfaceNames() {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257708](https://bugs.openjdk.java.net/browse/JDK-8257708): Remove redundant unmodifiableSet wrapper from already immutable set returned by Collections.singleton


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1505/head:pull/1505`
`$ git checkout pull/1505`
