### PR TITLE
[PATCH] Replaces usages of StringBuffer with StringBuilder where appropriate

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1957,7 +1957,7 @@ abstract class MethodHandleImpl {
         }
         @Override
         public String toString() {
-            StringBuffer sb = new StringBuffer("LoopClauses -- ");
+            StringBuilder sb = new StringBuilder("LoopClauses -- ");
             for (int i = 0; i < 4; ++i) {
                 if (i > 0) {
                     sb.append("       ");

--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotatedTypeFactory.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotatedTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -230,7 +230,7 @@ public final class AnnotatedTypeFactory {
 
         protected String annotationsToString(Annotation[] annotations, boolean leadingSpace) {
             if (annotations != null && annotations.length > 0) {
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
 
                 sb.append(Stream.of(annotations).
                           map(Annotation::toString).

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
@@ -320,7 +320,7 @@ class WindowsSelectorImpl extends SelectorImpl {
         private void checkForException() throws IOException {
             if (exception == null)
                 return;
-            StringBuffer message =  new StringBuffer("An exception occurred" +
+            StringBuilder message =  new StringBuilder("An exception occurred" +
                                        " during the execution of select(): \n");
             message.append(exception);
             message.append('\n');

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFFieldNode.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFFieldNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,7 +122,7 @@ public class TIFFFieldNode extends IIOMetadataNode {
                 child = new IIOMetadataNode("TIFFUndefined");
 
                 byte[] data = field.getAsBytes();
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 for (int i = 0; i < count; i++) {
                     sb.append(Integer.toString(data[i] & 0xff));
                     if (i < count - 1) {

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageMetadata.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -327,7 +327,7 @@ public class TIFFImageMetadata extends IIOMetadata {
         if (times == 1) {
             return s;
         }
-        StringBuffer sb = new StringBuffer((s.length() + 1)*times - 1);
+        StringBuilder sb = new StringBuilder((s.length() + 1)*times - 1);
         sb.append(s);
         for (int i = 1; i < times; i++) {
             sb.append(" ");
@@ -1229,7 +1229,7 @@ public class TIFFImageMetadata extends IIOMetadata {
                         String minute = getAttribute(child, "minute");
                         String second = getAttribute(child, "second");
 
-                        StringBuffer sb = new StringBuffer();
+                        StringBuilder sb = new StringBuilder();
                         sb.append(year);
                         sb.append(":");
                         if(month.length() == 1) {

--- a/src/java.desktop/windows/classes/sun/awt/windows/WDataTransferer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WDataTransferer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -575,7 +575,7 @@ class HTMLCodec extends InputStream {
         if (n >= 0 && len < width) {
             char[] array = new char[width - len];
             Arrays.fill(array, '0');
-            StringBuffer buffer = new StringBuffer(width);
+            StringBuilder buffer = new StringBuilder(width);
             buffer.append(array);
             buffer.append(string);
             string = buffer.toString();

--- a/src/java.desktop/windows/classes/sun/java2d/d3d/D3DContext.java
+++ b/src/java.desktop/windows/classes/sun/java2d/d3d/D3DContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,7 +136,7 @@ final class D3DContext extends BufferedContext {
 
         @Override
         public String toString() {
-            StringBuffer buf = new StringBuffer(super.toString());
+            StringBuilder buf = new StringBuilder(super.toString());
             if ((caps & CAPS_LCD_SHADER) != 0) {
                 buf.append("CAPS_LCD_SHADER|");
             }

--- a/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
+++ b/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
@@ -2191,7 +2191,7 @@ final public class AccessBridge {
                         if (end >= at.getCharCount()) {
                             return null;
                         }
-                        StringBuffer buf = new StringBuffer(end - start + 1);
+                        StringBuilder buf = new StringBuilder(end - start + 1);
                         for (int i = start; i <= end; i++) {
                             buf.append(at.getAtIndex(AccessibleText.CHARACTER, i));
                         }

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ public abstract class CPublicKey extends CKey implements PublicKey {
         }
 
         public String toString() {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             sb.append(algorithm + "PublicKey [size=").append(keyLength)
                     .append("]\n  ECPoint: ").append(getW())
                     .append("\n  params: ").append(getParams());
@@ -126,7 +126,7 @@ public abstract class CPublicKey extends CKey implements PublicKey {
         }
 
         public String toString() {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             sb.append(algorithm + "PublicKey [size=").append(keyLength)
                     .append(" bits, type=");
             if (handles.hCryptKey != 0) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CLHSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CLHSDB.java
@@ -246,7 +246,7 @@ public class CLHSDB {
         exceed the given number of characters per line. Strips
         extraneous whitespace. */
     private String formatMessage(String message, int charsPerLine) {
-        StringBuffer buf = new StringBuffer(message.length());
+        StringBuilder buf = new StringBuilder(message.length());
         StringTokenizer tokenizer = new StringTokenizer(message);
         int curLineLength = 0;
         while (tokenizer.hasMoreTokens()) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -225,7 +225,7 @@ public class CommandProcessor {
             }
         }
         String join(String sep) {
-            StringBuffer result = new StringBuffer();
+            StringBuilder result = new StringBuilder();
             for (int w = i; w < length; w++) {
                 result.append(tokens[w]);
                 if (w + 1 < length) {
@@ -370,7 +370,7 @@ public class CommandProcessor {
     Address lookup(String symbol) {
         if (symbol.indexOf("::") != -1) {
             String[] parts = symbol.split("::");
-            StringBuffer mangled = new StringBuffer("__1c");
+            StringBuilder mangled = new StringBuilder("__1c");
             for (int i = 0; i < parts.length; i++) {
                 int len = parts[i].length();
                 if (len >= 26) {
@@ -1734,7 +1734,7 @@ public class CommandProcessor {
                 }
 
                 /* Compute filename for class. */
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 if (tokenCount > 1) {
                     buf.append(t.nextToken());
                 } else {
@@ -1911,7 +1911,7 @@ public class CommandProcessor {
                 ln = "";
                 err.println("History is empty");
             } else {
-                StringBuffer result = new StringBuffer();
+                StringBuilder result = new StringBuilder();
                 Matcher m = historyPattern.matcher(ln);
                 int start = 0;
                 while (m.find()) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
@@ -1812,7 +1812,7 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
       exceed the given number of characters per line. Strips
       extraneous whitespace. */
   private String formatMessage(String message, int charsPerLine) {
-    StringBuffer buf = new StringBuffer(message.length());
+    StringBuilder buf = new StringBuilder(message.length());
     StringTokenizer tokenizer = new StringTokenizer(message);
     int curLineLength = 0;
     while (tokenizer.hasMoreTokens()) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/RMIHelper.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/RMIHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,7 @@ public class RMIHelper {
         // we have to transform this as //host[:port]/<serverNamePrefix>['_'<unique_id>]
 
         int index = debugServerID.indexOf('@');
-        StringBuffer nameBuf = new StringBuffer("//");
+        StringBuilder nameBuf = new StringBuilder("//");
         String uniqueID = null;
         if (index != -1) {
             nameBuf.append(debugServerID.substring(index + 1));

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/DebuggerUtilities.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/DebuggerUtilities.java
@@ -36,7 +36,7 @@ public class DebuggerUtilities {
   }
 
   public String addressValueToString(long address) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("0x");
     String val;
     // Make negative addresses have the correct size

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicFunctionSym.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicFunctionSym.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class BasicFunctionSym extends BasicBlockSym implements FunctionSym {
       return null;
     }
 
-    StringBuffer res = new StringBuffer();
+    StringBuilder res = new StringBuilder();
     res.append(getName());
     res.append("(");
     FunctionType type = (FunctionType) getType();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/dummy/DummyDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/dummy/DummyDebugger.java
@@ -136,7 +136,7 @@ public class DummyDebugger extends DebuggerBase {
   //
 
   String addressToString(DummyAddress addr) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("0x");
     String val;
     if (addr == null) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/Bytecode.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/Bytecode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,7 @@ public class Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer(getJavaBytecodeName());
+    StringBuilder buf = new StringBuilder(getJavaBytecodeName());
     if (code() != javaCode()) {
        buf.append(spaces);
        buf.append('[');

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeBipush.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeBipush.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class BytecodeBipush extends Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("bipush");
     buf.append(spaces);
     buf.append(Byte.toString(getValue()));

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeGetPut.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeGetPut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public abstract class BytecodeGetPut extends BytecodeWithCPIndex {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(getJavaBytecodeName());
     buf.append(spaces);
     buf.append('#');

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeIinc.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeIinc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public class BytecodeIinc extends BytecodeWideable {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("iinc");
     buf.append(spaces);
     buf.append('#');

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeInvoke.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeInvoke.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,7 @@ public class BytecodeInvoke extends BytecodeWithCPIndex {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(getJavaBytecodeName());
     buf.append(spaces);
     buf.append('#');

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeJmp.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeJmp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ public abstract class BytecodeJmp extends Bytecode {
   public abstract int getTargetBCI();
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(getJavaBytecodeName());
     buf.append(spaces);
     buf.append(Integer.toString(getTargetBCI()));

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeLoadConstant.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeLoadConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,7 +195,7 @@ public class BytecodeLoadConstant extends Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(getJavaBytecodeName());
     buf.append(spaces);
     buf.append('#');

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeLoadStore.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeLoadStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ public abstract class BytecodeLoadStore extends BytecodeWideable {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(getJavaBytecodeName());
     buf.append(spaces);
     buf.append('#');

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeLookupswitch.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeLookupswitch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ public class BytecodeLookupswitch extends Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("lookupswitch");
     buf.append(spaces);
     buf.append("default: ");

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeMultiANewArray.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeMultiANewArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public class BytecodeMultiANewArray extends BytecodeWithKlass {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(super.toString());
     buf.append(spaces);
     buf.append(Integer.toString(getDimension()));

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeNewArray.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeNewArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,7 +124,7 @@ public class BytecodeNewArray extends Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("newarray");
     buf.append(spaces);
     buf.append(getTypeName());

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeRet.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeRet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class BytecodeRet extends BytecodeWideable {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("ret");
     buf.append(spaces);
     buf.append('#');

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeSipush.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeSipush.java
@@ -65,7 +65,7 @@ public class BytecodeSipush extends Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("sipush");
     buf.append(spaces);
     buf.append(Short.toString(getValue()));

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeTableswitch.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeTableswitch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ public class BytecodeTableswitch extends Bytecode {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("tableswitch");
     buf.append(spaces);
     buf.append("default: ");

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeWithKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeWithKlass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class BytecodeWithKlass extends BytecodeWithCPIndex {
   }
 
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append(getJavaBytecodeName());
     buf.append(spaces);
     buf.append('#');

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogramElement.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogramElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ public class ObjectHistogramElement {
           ObjArrayKlass oak = (ObjArrayKlass) ak;
           Klass bottom = oak.getBottomKlass();
           int dim = (int) oak.getDimension();
-          StringBuffer buf = new StringBuffer();
+          StringBuilder buf = new StringBuilder();
           if (bottom instanceof TypeArrayKlass) {
             buf.append(((TypeArrayKlass) bottom).getElementTypeName());
           } else if (bottom instanceof InstanceKlass) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/OopUtilities.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/OopUtilities.java
@@ -99,7 +99,7 @@ public class OopUtilities {
       return null;
     }
     int length = (int)charArray.getLength();
-    StringBuffer buf = new StringBuffer(length);
+    StringBuilder buf = new StringBuilder(length);
     for (int i = 0; i < length; i++) {
       buf.append(charArray.getCharAt(i));
     }
@@ -111,7 +111,7 @@ public class OopUtilities {
       return null;
     }
     int length = (int)byteArray.getLength() >> coder;
-    StringBuffer buf = new StringBuffer(length);
+    StringBuilder buf = new StringBuilder(length);
     if (coder == 0) {
       // Latin1 encoded
       for (int i = 0; i < length; i++) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/PerfDataEntry.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/PerfDataEntry.java
@@ -352,7 +352,7 @@ public class PerfDataEntry extends VMObject {
         } else { // vector
             if (dataType == BasicType.getTBoolean()) {
                 boolean[] res = booleanArrayValue();
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 buf.append('[');
                 for (int i = 0; i < res.length; i++) {
                     buf.append(Boolean.toString(res[i]));
@@ -369,7 +369,7 @@ public class PerfDataEntry extends VMObject {
                                                  StandardCharsets.US_ASCII);
             } else if (dataType == BasicType.getTShort()) {
                 short[] res = shortArrayValue();
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 buf.append('[');
                 for (int i = 0; i < res.length; i++) {
                     buf.append(Short.toString(res[i]));
@@ -379,7 +379,7 @@ public class PerfDataEntry extends VMObject {
                 str = buf.toString();
             } else if (dataType ==  BasicType.getTInt()) {
                 int[] res = intArrayValue();
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 buf.append('[');
                 for (int i = 0; i < res.length; i++) {
                     buf.append(Integer.toString(res[i]));
@@ -389,7 +389,7 @@ public class PerfDataEntry extends VMObject {
                 str = buf.toString();
             } else if (dataType == BasicType.getTLong()) {
                 long[] res = longArrayValue();
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 buf.append('[');
                 for (int i = 0; i < res.length; i++) {
                     buf.append(Long.toString(res[i]));
@@ -399,7 +399,7 @@ public class PerfDataEntry extends VMObject {
                 str = buf.toString();
             } else if (dataType == BasicType.getTFloat()) {
                 float[] res = floatArrayValue();
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 buf.append('[');
                 for (int i = 0; i < res.length; i++) {
                     buf.append(Float.toString(res[i]));
@@ -409,7 +409,7 @@ public class PerfDataEntry extends VMObject {
                 str = buf.toString();
             } else if (dataType == BasicType.getTDouble()) {
                 double[] res = doubleArrayValue();
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 buf.append('[');
                 for (int i = 0; i < res.length; i++) {
                     buf.append(Double.toString(res[i]));

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMVersionMismatchException.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMVersionMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ public class VMVersionMismatchException extends RuntimeException {
     }
 
     public String getMessage() {
-        StringBuffer msg = new StringBuffer();
+        StringBuilder msg = new StringBuilder();
         msg.append("Supported versions are ");
         msg.append(supportedVersions);
         msg.append(". Target VM is ");

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
@@ -245,7 +245,7 @@ public class PStack extends Tool {
          JavaVFrame vf = jvframes[fCount];
          Frame f = vf.getFrame();
          if (fp.equals(f.getFP())) {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             Method method = vf.getMethod();
             // a special char to identify java frames in output
             sb.append("* ");

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/AnnotatedMemoryPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/AnnotatedMemoryPanel.java
@@ -402,7 +402,7 @@ public class AnnotatedMemoryPanel extends JPanel {
   }
 
   private String bigIntToHexString(BigInteger bi) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("0x");
     String val = bi.toString(16);
     for (int i = 0; i < ((2 * addressSize) - val.length()); i++) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,7 +146,7 @@ public class MemoryPanel extends JPanel {
         protected Transferable createTransferable(JComponent c) {
           JTable table = (JTable)c;
           if (haveSelection()) {
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             int iDir = (getRowAnchor() < getRowLead() ? 1 : -1);
             int jDir = (getColAnchor() < getColLead() ? 1 : -1);
 
@@ -553,7 +553,7 @@ public class MemoryPanel extends JPanel {
   }
 
   private String bigIntToHexString(BigInteger bi) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("0x");
     String val = bi.toString(16);
     for (int i = 0; i < ((2 * addressSize) - val.length()); i++) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/SAEditorPane.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/SAEditorPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class SAEditorPane extends JEditorPane {
    */
 
   public String getSelectedText() {
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     Document doc = getDocument();
 
     int start = getSelectionStart();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/SourceCodePanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/SourceCodePanel.java
@@ -219,7 +219,7 @@ public class SourceCodePanel extends JPanel {
       this.filename = filename;
       File file = new File(filename);
       int len = (int) file.length();
-      StringBuffer buf = new StringBuffer(len); // Approximation
+      StringBuilder buf = new StringBuilder(len); // Approximation
       char[] tmp = new char[4096];
       FileReader in = new FileReader(file);
       int res = 0;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/SysPropsPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/SysPropsPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class SysPropsPanel extends JPanel {
     }
 
     private String getFlags() {
-       final StringBuffer buf = new StringBuffer();
+       final StringBuilder buf = new StringBuilder();
        buf.append("<html><head><title>System Properties</title></head><body>");
        buf.append("<table border='1'>");
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/VMFlagsPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/VMFlagsPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class VMFlagsPanel extends JPanel {
 
     private String getFlags() {
        VM.Flag[] flags = VM.getVM().getCommandLineFlags();
-       StringBuffer buf = new StringBuffer();
+       StringBuilder buf = new StringBuilder();
        buf.append("<html><head><title>VM Command Line Flags</title></head><body>");
        if (flags == null) {
           buf.append("<b>Command Flag info not available (use 1.4.1_03 or later)!</b>");

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/VMVersionInfoPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/VMVersionInfoPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class VMVersionInfoPanel extends JPanel {
 
     private String getVersionInfo() {
        VM vm = VM.getVM();
-       StringBuffer buf = new StringBuffer();
+       StringBuilder buf = new StringBuilder();
        buf.append("<html><head><title>VM Version Info</title></head>");
        buf.append("<body><table border='1'>");
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
@@ -883,7 +883,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
    }
 
    protected String genMultPCHref(String pcs) {
-      StringBuffer buf = new StringBuffer(genBaseHref());
+      StringBuilder buf = new StringBuilder(genBaseHref());
       buf.append("pc_multiple=");
       buf.append(pcs);
       return buf.toString();
@@ -1542,7 +1542,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
    }
 
    protected String genDumpKlassesHref(InstanceKlass[] klasses) {
-      StringBuffer buf = new StringBuffer(genBaseHref());
+      StringBuilder buf = new StringBuilder(genBaseHref());
       buf.append("jcore_multiple=");
       for (int k = 0; k < klasses.length; k++) {
          buf.append(klasses[k].getAddress().toString());

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/ObjectReader.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/ObjectReader.java
@@ -774,7 +774,7 @@ public class ObjectReader {
       }
 
       protected String getClassName(int begin, int end) {
-         StringBuffer buf = new StringBuffer();
+         StringBuilder buf = new StringBuilder();
          for (int i = begin; i < end; i++) {
             char c = (char) (_signature.getByteAt(i) & 0xFF);
             if (c == '/') {


### PR DESCRIPTION
Found by IntelliJ IDEA inspection `Java | Java language level migration aids | Java 5 | 'StringBuffer' may be 'StringBuilder'`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (1/9 failed) |

**Failed test task**
- [macOS x64 (hs/tier1 runtime)](https://github.com/turbanoff/jdk/runs/1470827694)

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1507/head:pull/1507`
`$ git checkout pull/1507`
