### PR TITLE
8257238: Cleanup include directives for precompiled.hpp

### DIFF
--- a/src/hotspot/os/bsd/semaphore_bsd.cpp
+++ b/src/hotspot/os/bsd/semaphore_bsd.cpp
@@ -22,7 +22,7 @@
  *
  */
 
-#include "precompiled/precompiled.hpp"
+#include "precompiled.hpp"
 #include "semaphore_bsd.hpp"
 #include "runtime/os.hpp"
 #include "utilities/debug.hpp"

--- a/src/hotspot/os/linux/waitBarrier_linux.cpp
+++ b/src/hotspot/os/linux/waitBarrier_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  *
  */
 
-#include "precompiled/precompiled.hpp"
+#include "precompiled.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/os.hpp"
 #include "waitBarrier_linux.hpp"

--- a/src/hotspot/os/posix/semaphore_posix.cpp
+++ b/src/hotspot/os/posix/semaphore_posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  *
  */
 
-#include "precompiled/precompiled.hpp"
+#include "precompiled.hpp"
 #ifndef __APPLE__
 #include "runtime/os.hpp"
 // POSIX unamed semaphores are not supported on OS X.

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -22,7 +22,7 @@
  *
  */
 
-#include "precompiled/precompiled.hpp"
+#include "precompiled.hpp"
 
 #include "jvm.h"
 #include "logging/log.hpp"


### PR DESCRIPTION
The precompiled header file is:

src/hotspot/share/precompiled/precompiled.hpp

The normal way to include precompiled headers is to just have:

#include "precompiled.hpp"

as the first directive in a file. This works because the makefiles set:

 -I$(TOPDIR)/src/hotspot/share/precompiled

 Some files instead have:

#include "precompiled/precompiled.hpp"

./os/bsd/semaphore_bsd.cpp
./os/linux/waitBarrier_linux.cpp
./os/posix/semaphore_posix.cpp
./os/posix/signals_posix.cpp

This should be trivially cleaned up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ❌ (1/2 failed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ⏳ (1/9 running) |    | 

**Failed test task**
- [macOS x64 (build debug)](https://github.com/dholmes-ora/jdk/runs/1471444715)

### Issue
 * [JDK-8257238](https://bugs.openjdk.java.net/browse/JDK-8257238): Cleanup include directives for precompiled.hpp


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1510/head:pull/1510`
`$ git checkout pull/1510`
