### PR TITLE
8257396: AArch64 Zero build is broken after JDK-8252684

### DIFF
--- a/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
+++ b/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
@@ -24,7 +24,7 @@
 
 #include "precompiled.hpp"
 
-#ifdef AARCH64
+#if defined(AARCH64) && !defined(ZERO)
 
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"


### PR DESCRIPTION
Zero does not have AArch64 assembler, so attempt to use it from the test fails to build. The fix is trivial: sense if we are building Zero.

Testing:
 - [x] Linux aarch64 zero build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8257396](https://bugs.openjdk.java.net/browse/JDK-8257396): AArch64 Zero build is broken after JDK-8252684


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1511/head:pull/1511`
`$ git checkout pull/1511`
