### PR TITLE
8244847: Linux/PPC: runtime/CompressedOops/CompressedClassPointers: smallHeapTest fails

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -98,7 +98,12 @@ public class CompressedClassPointers {
             "-Xshare:off",
             "-XX:+VerifyBeforeGC", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        if (testNarrowKlassBase()) {
+        if (testNarrowKlassBase() && !Platform.isAix()) {
+            // AIX: the heap cannot be placed below 32g. The first attempt to
+            // place the CCS after the heap fails (luckily). Finally CCS is
+            // successfully placed below 32g. So we get 0x0 as narrow klass
+            // base.  As an enhancement the first attempt mapping the CCS should
+            // be made below 32g if oops are compressed but the heap is above 32g.
             output.shouldNotContain("Narrow klass base: 0x0000000000000000");
             output.shouldContain("Narrow klass shift: 0");
         }

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -44,7 +44,7 @@ public class CompressedClassPointers {
     // Returns true if we are to test the narrow klass base; we only do this on
     // platforms where we can be reasonably shure that we get reproducable placement).
     static boolean testNarrowKlassBase() {
-        if (Platform.isWindows() || Platform.isPPC()) {
+        if (Platform.isWindows()) {
             return false;
         }
         return true;

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -100,10 +100,9 @@ public class CompressedClassPointers {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         if (testNarrowKlassBase() && !Platform.isAix()) {
             // AIX: the heap cannot be placed below 32g. The first attempt to
-            // place the CCS after the heap fails (luckily). Finally CCS is
-            // successfully placed below 32g. So we get 0x0 as narrow klass
-            // base.  As an enhancement the first attempt mapping the CCS should
-            // be made below 32g if oops are compressed but the heap is above 32g.
+            // place the CCS behind the heap fails (luckily). Subsequently CCS
+            // is successfully placed below 32g. So we get 0x0 as narrow klass
+            // base.
             output.shouldNotContain("Narrow klass base: 0x0000000000000000");
             output.shouldContain("Narrow klass shift: 0");
         }


### PR DESCRIPTION
This is an XS sized patch to get a zerobased compressed class space on
Linux/PPC64 if a heap up to 2g size is configured and CDS is disabled.

On Linux 4.1.42 and higher we fail to get a zerobased CCS because just one
attempt is made to place the CCS right after the heap which will be at 4g
(ELF_ET_DYN_BASE) but there the java launcher is already mapped.

This change reuses the search already implemented for AARCH64.

```
                  Master without Fix                               Master with Fix

-Xmx   Narrow klass base     Compressed Class Space    Narrow klass base     Compressed Class Space
----------------------------------------------------------------------------------------------------
512m   0x00007fff00000000 !  0x00007fff00000000        0x0000000000000000    0x0000000200000000
  1g   0x00007fff14000000 !  0x00007fff14000000        0x0000000000000000    0x0000000200000000
  2g   0x00007fff30000000 !  0x00007fff30000000        0x0000000000000000    0x0000000200000000
  3g   0x0000000000000000    0x00000007c0000000        0x0000000000000000    0x00000007c0000000
  4g   0x0000000000000000    0x00000007c0000000        0x0000000000000000    0x00000007c0000000
  8g   0x0000000000000000    0x00000007c0000000        0x0000000000000000    0x00000007c0000000
 12g   0x0000000000000000    0x00000007c0000000        0x0000000000000000    0x00000007c0000000
 16g   0x0000000000000000    0x00000007c0000000        0x0000000000000000    0x00000007c0000000
 20g   0x0000000000000000    0x00000007c0000000        0x0000000000000000    0x00000007c0000000
 24g   0x0000000000000000    0x00000007c0000000        0x0000000000000000    0x00000007c0000000
 28g   0x0000001702000000    0x0000001702000000        0x0000001702000000    0x0000001702000000
 32g   0x0000000000000000    0x0000000080000000        0x0000000000000000    0x0000000080000000
 40g   0x0000000000000000    0x0000000080000000        0x0000000000000000    0x0000000080000000
 48g   0x0000000000000000    0x0000000080000000        0x0000000000000000    0x0000000080000000
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244847](https://bugs.openjdk.java.net/browse/JDK-8244847): Linux/PPC: runtime/CompressedOops/CompressedClassPointers: smallHeapTest fails


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to c78783cc3925ae59ec28f9fef74ce7f021a63973
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1512/head:pull/1512`
`$ git checkout pull/1512`
