### PR TITLE
8257418: C2: Rename barrier data member in MemNode and LoadStoreNode

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2956,7 +2956,7 @@ LoadStoreNode::LoadStoreNode( Node *c, Node *mem, Node *adr, Node *val, const Ty
   : Node(required),
     _type(rt),
     _adr_type(at),
-    _barrier(0)
+    _barrier_data(0)
 {
   init_req(MemNode::Control, c  );
   init_req(MemNode::Memory , mem);

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -43,7 +43,7 @@ private:
   bool _unaligned_access; // Unaligned access from unsafe
   bool _mismatched_access; // Mismatched access from unsafe: byte read in integer array for instance
   bool _unsafe_access;     // Access of unsafe origin.
-  uint8_t _barrier; // Bit field with barrier information
+  uint8_t _barrier_data;   // Bit field with barrier information
 
 protected:
 #ifdef ASSERT
@@ -69,7 +69,7 @@ protected:
       _unaligned_access(false),
       _mismatched_access(false),
       _unsafe_access(false),
-      _barrier(0) {
+      _barrier_data(0) {
     init_class_id(Class_Mem);
     debug_only(_adr_type=at; adr_type();)
   }
@@ -78,7 +78,7 @@ protected:
       _unaligned_access(false),
       _mismatched_access(false),
       _unsafe_access(false),
-      _barrier(0) {
+      _barrier_data(0) {
     init_class_id(Class_Mem);
     debug_only(_adr_type=at; adr_type();)
   }
@@ -87,7 +87,7 @@ protected:
       _unaligned_access(false),
       _mismatched_access(false),
       _unsafe_access(false),
-      _barrier(0) {
+      _barrier_data(0) {
     init_class_id(Class_Mem);
     debug_only(_adr_type=at; adr_type();)
   }
@@ -140,8 +140,8 @@ public:
 #endif
   }
 
-  uint8_t barrier_data() { return _barrier; }
-  void set_barrier_data(uint8_t barrier_data) { _barrier = barrier_data; }
+  uint8_t barrier_data() { return _barrier_data; }
+  void set_barrier_data(uint8_t barrier_data) { _barrier_data = barrier_data; }
 
   // Search through memory states which precede this node (load or store).
   // Look for an exact match for the address, with no intervening
@@ -839,7 +839,7 @@ class LoadStoreNode : public Node {
 private:
   const Type* const _type;      // What kind of value is loaded?
   const TypePtr* _adr_type;     // What kind of memory is being addressed?
-  uint8_t _barrier; // Bit field with barrier information
+  uint8_t _barrier_data;        // Bit field with barrier information
   virtual uint size_of() const; // Size is bigger
 public:
   LoadStoreNode( Node *c, Node *mem, Node *adr, Node *val, const TypePtr* at, const Type* rt, uint required );
@@ -853,8 +853,8 @@ public:
   bool result_not_used() const;
   MemBarNode* trailing_membar() const;
 
-  uint8_t barrier_data() { return _barrier; }
-  void set_barrier_data(uint8_t barrier_data) { _barrier = barrier_data; }
+  uint8_t barrier_data() { return _barrier_data; }
+  void set_barrier_data(uint8_t barrier_data) { _barrier_data = barrier_data; }
 };
 
 class LoadStoreConditionalNode : public LoadStoreNode {


### PR DESCRIPTION
Please review this trivial cleanup, which renames the "barrier data" member in `MemNode` and `LoadStoreNode` from `_barrier` to `_barrier_data`, to better match the names of the setters and getters (`barrier_data()` and `set_barrier_data()`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (1/2 running) | ⏳ (1/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8257418](https://bugs.openjdk.java.net/browse/JDK-8257418): C2: Rename barrier data member in MemNode and LoadStoreNode


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1516/head:pull/1516`
`$ git checkout pull/1516`
