### PR TITLE
8257242: [macOS] Java app crashes while switching input methods

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.h
@@ -37,9 +37,6 @@
 
     // TODO: NSMenu *contextualMenu;
 
-    // Keyboard layout
-    NSString *kbdLayout;
-
     // dnd support (see AppKit/NSDragging.h, NSDraggingSource/Destination):
     CDragSource *_dragSource;
     CDropTarget *_dropTarget;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -37,6 +37,9 @@
 #import <Carbon/Carbon.h>
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 
+// keyboard layout
+static NSString *kbdLayout;
+
 @interface AWTView()
 @property (retain) CDropTarget *_dropTarget;
 @property (retain) CDragSource *_dragSource;
@@ -998,7 +1001,7 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
     [self abandonInput];
 }
 
-- (void)keyboardInputSourceChanged:(NSNotification *)notification
++ (void)keyboardInputSourceChanged:(NSNotification *)notification
 {
 #ifdef IM_DEBUG
     NSLog(@"keyboardInputSourceChangeNotification received");
@@ -1295,7 +1298,7 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
     jint index = JNFCallIntMethod(env, fInputMethodLOCKABLE, jm_characterIndexForPoint, (jint)flippedLocation.x, (jint)flippedLocation.y); // AWT_THREADING Safe (AWTRunLoopMode)
 
 #ifdef IM_DEBUG
-    fprintf(stderr, "characterIndexForPoint returning %ld\n", index);
+    fprintf(stderr, "characterIndexForPoint returning %d\n", index);
 #endif // IM_DEBUG
 
     if (index == -1) {


### PR DESCRIPTION
It seems the patch for https://bugs.openjdk.java.net/browse/JDK-8248532 causes a crash, as it attempts to call a method selector on a class for an instance method (- keyboardInputSourceChanged). It was not observed in 10.14 but seen in 10.15 or later.
It resulted in crash as we are passing [AWTView class] as an instance to the notification observer but notification function keyboardInputSourceChanged is not a member function.
Modified the code to make that function a class-level function so that it does not crash.
mucommander.app, JDK-8214578 testcase worked with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ❌ (2/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Windows x64 (hs/tier1 gc)](https://github.com/prsadhuk/jdk/runs/1474383393)
- [Windows x64 (hs/tier1 serviceability)](https://github.com/prsadhuk/jdk/runs/1474383440)
- [macOS x64 (hs/tier1 gc)](https://github.com/prsadhuk/jdk/runs/1474200351)

### Issue
 * [JDK-8257242](https://bugs.openjdk.java.net/browse/JDK-8257242): [macOS] Java app crashes while switching input methods


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1517/head:pull/1517`
`$ git checkout pull/1517`
