### PR TITLE
8257424: RecordingStream does not specify the recording name

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
@@ -69,6 +69,7 @@ import jdk.jfr.internal.consumer.JdkJfrConsumer;
 public final class RecordingStream implements AutoCloseable, EventStream {
 
     private final Recording recording;
+    private final Instant creationTime;
     private final EventDirectoryStream directoryStream;
 
     /**
@@ -86,6 +87,8 @@ public final class RecordingStream implements AutoCloseable, EventStream {
         Utils.checkAccessFlightRecorder();
         AccessControlContext acc = AccessController.getContext();
         this.recording = new Recording();
+        this.creationTime = Instant.now();
+        this.recording.setName("Recording Stream: " + creationTime);
         try {
             PlatformRecording pr = PrivateAccess.getInstance().getPlatformRecording(recording);
             this.directoryStream = new EventDirectoryStream(acc, null, SecuritySupport.PRIVILEGED, pr, configurations());
@@ -268,17 +271,6 @@ public final class RecordingStream implements AutoCloseable, EventStream {
      */
     public void setMaxSize(long maxSize) {
         recording.setMaxSize(maxSize);
-    }
-
-    /**
-     * Sets a human-readable name (for example, {@code "My Recording"}).
-     *
-     * @param name the recording name, not {@code null}
-     *
-     * @throws IllegalStateException if the recording is in {@code CLOSED} state
-     */
-    public void setName(String name) {
-        recording.setName(name);
     }
 
     @Override

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
@@ -270,6 +270,17 @@ public final class RecordingStream implements AutoCloseable, EventStream {
         recording.setMaxSize(maxSize);
     }
 
+    /**
+     * Sets a human-readable name (for example, {@code "My Recording"}).
+     *
+     * @param name the recording name, not {@code null}
+     *
+     * @throws IllegalStateException if the recording is in {@code CLOSED} state
+     */
+    public void setName(String name) {
+        recording.setName(name);
+    }
+
     @Override
     public void setReuse(boolean reuse) {
         directoryStream.setReuse(reuse);

--- a/test/jdk/jdk/jfr/api/consumer/recordingstream/TestRecordingName.java
+++ b/test/jdk/jdk/jfr/api/consumer/recordingstream/TestRecordingName.java
@@ -32,27 +32,25 @@ import jdk.test.lib.jfr.EventNames;
 /**
 * @test
 * @bug 8257424
-* @summary Tests RecordingStrream::setName
+* @summary Tests recording name for RecordingStrream
 * @key jfr
 * @requires vm.hasJFR
 * @library /test/lib
-* @run main/othervm jdk.jfr.api.consumer.recordingstream.TestSetName
+* @run main/othervm jdk.jfr.api.consumer.recordingstream.TestRecordingName
 */
-public class TestSetName {
+public class TestRecordingName {
 
    public static void main(String... args) throws Exception {
-       String testName = "Test Recording";
        try (RecordingStream r = new RecordingStream()) {
-           r.setName(testName);
            r.enable(EventNames.ActiveRecording);
            r.onEvent(e -> {
                System.out.println(e);
                String name = e.getString("name");
-               if (name.equals(testName)) {
+               if (name.startsWith("Recording Stream: ")) {
                    r.close();
                    return;
                }
-               System.err.println("Recording name not set, was " + name + ", but expected " + testName);
+               System.err.println("Recording name not set, was " + name + ", but expected \"Recording Stream: <Instant>\"");
            });
            r.start();
        }

--- a/test/jdk/jdk/jfr/api/consumer/recordingstream/TestSetName.java
+++ b/test/jdk/jdk/jfr/api/consumer/recordingstream/TestSetName.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, NTT DATA.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.api.consumer.recordingstream;
+
+import jdk.jfr.consumer.RecordingStream;
+import jdk.test.lib.jfr.EventNames;
+
+/**
+* @test
+* @bug 8257424
+* @summary Tests RecordingStrream::setName
+* @key jfr
+* @requires vm.hasJFR
+* @library /test/lib
+* @run main/othervm jdk.jfr.api.consumer.recordingstream.TestSetName
+*/
+public class TestSetName {
+
+   public static void main(String... args) throws Exception {
+       String testName = "Test Recording";
+       try (RecordingStream r = new RecordingStream()) {
+           r.setName(testName);
+           r.enable(EventNames.ActiveRecording);
+           r.onEvent(e -> {
+               System.out.println(e);
+               String name = e.getString("name");
+               if (name.equals(testName)) {
+                   r.close();
+                   return;
+               }
+               System.err.println("Recording name not set, was " + name + ", but expected " + testName);
+           });
+           r.start();
+       }
+   }
+}


### PR DESCRIPTION
`RecordingStream` will start new flight recording to gather events. It has some of methods which are equivalent to `Recording`, but we cannot set recording name.

If we can specify the name for `RecordingStream`, it is useful to distinguish recordings by JFR.check dcmd.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257424](https://bugs.openjdk.java.net/browse/JDK-8257424): RecordingStream does not specify the recording name


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1520/head:pull/1520`
`$ git checkout pull/1520`
