### PR TITLE
8257423: [PPC64] Support -XX:-UseInlineCaches

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -1100,8 +1100,7 @@ int MachCallStaticJavaNode::ret_addr_offset() {
 int MachCallDynamicJavaNode::ret_addr_offset() {
   // Offset is 4 with postalloc expanded calls (bl is one instruction). We use
   // postalloc expanded calls if we use inline caches and do not update method data.
-  if (UseInlineCaches)
-    return 4;
+  if (UseInlineCaches) return 4;
 
   int vtable_index = this->_vtable_index;
   if (vtable_index < 0) {
@@ -1109,8 +1108,7 @@ int MachCallDynamicJavaNode::ret_addr_offset() {
     assert(vtable_index == Method::invalid_vtable_index, "correct sentinel value");
     return 12;
   } else {
-    assert(!UseInlineCaches, "expect vtable calls only if not using ICs");
-    return 24;
+    return 24 + MacroAssembler::instr_size_for_decode_klass_not_null();
   }
 }
 
@@ -3635,7 +3633,7 @@ encode %{
     int start_offset = __ offset();
 
     Register Rtoc = (ra_) ? $constanttablebase : R2_TOC;
-#if 0
+
     int vtable_index = this->_vtable_index;
     if (_vtable_index < 0) {
       // Must be invalid_vtable_index, not nonvirtual_vtable_index.
@@ -3656,7 +3654,7 @@ encode %{
       __ relocate(virtual_call_Relocation::spec(virtual_call_meta_addr));
       emit_call_with_trampoline_stub(_masm, (address)$meth$$method, relocInfo::none);
       assert(((MachCallDynamicJavaNode*)this)->ret_addr_offset() == __ offset() - start_offset,
-             "Fix constant in ret_addr_offset()");
+             "Fix constant in ret_addr_offset(), expected %d", __ offset() - start_offset);
     } else {
       assert(!UseInlineCaches, "expect vtable calls only if not using ICs");
       // Go thru the vtable. Get receiver klass. Receiver already
@@ -3676,14 +3674,9 @@ encode %{
       // Call target. Either compiled code or C2I adapter.
       __ mtctr(R11_scratch1);
       __ bctrl();
-      if (((MachCallDynamicJavaNode*)this)->ret_addr_offset() != __ offset() - start_offset) {
-        tty->print(" %d, %d\n", ((MachCallDynamicJavaNode*)this)->ret_addr_offset(),__ offset() - start_offset);
-      }
       assert(((MachCallDynamicJavaNode*)this)->ret_addr_offset() == __ offset() - start_offset,
-             "Fix constant in ret_addr_offset()");
+             "Fix constant in ret_addr_offset(), expected %d", __ offset() - start_offset);
     }
-#endif
-    Unimplemented();  // ret_addr_offset not yet fixed. Depends on compressed oops (load klass!).
   %}
 
   // a runtime call


### PR DESCRIPTION
The JVM currently runs into Unimplemented() when using -XX:-UseInlineCaches in C2 code (postalloc_expand_java_dynamic_call_sched).
I'd like to enable the existing code in postalloc_expand_java_dynamic_call_sched and fix MachCallDynamicJavaNode::ret_addr_offset() and MacroAssembler::instr_size_for_decode_klass_not_null().
I suggest to use scratch emit to determine the size, because there are too many cases and emitting it once is fast.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257423](https://bugs.openjdk.java.net/browse/JDK-8257423): [PPC64] Support -XX:-UseInlineCaches


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1521/head:pull/1521`
`$ git checkout pull/1521`
