### PR TITLE
JDK-8257588: Make os::_page_sizes a bitmask

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -2441,7 +2441,7 @@ void os::init(void) {
 
   // For now UseLargePages is just ignored.
   FLAG_SET_ERGO(UseLargePages, false);
-  _page_sizes[0] = 0;
+  _page_sizes.add(Aix::_page_size);
 
   // debug trace
   trcVerbose("os::vm_page_size %s", describe_pagesize(os::vm_page_size()));

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2093,7 +2093,7 @@ void os::init(void) {
   if (Bsd::page_size() == -1) {
     fatal("os_bsd.cpp: os::init: sysconf failed (%s)", os::strerror(errno));
   }
-  init_page_sizes((size_t) Bsd::page_size());
+  _page_sizes.add(Bsd::page_size());
 
   Bsd::initialize_system_info();
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3769,9 +3769,7 @@ size_t os::Linux::setup_large_page_size() {
 
   const size_t default_page_size = (size_t)Linux::page_size();
   if (_large_page_size > default_page_size) {
-    _page_sizes[0] = _large_page_size;
-    _page_sizes[1] = default_page_size;
-    _page_sizes[2] = 0;
+    _page_sizes.add(_large_page_size);
   }
 
   return _large_page_size;
@@ -4399,7 +4397,7 @@ void os::init(void) {
     fatal("os_linux.cpp: os::init: sysconf failed (%s)",
           os::strerror(errno));
   }
-  init_page_sizes((size_t) Linux::page_size());
+  _page_sizes.add(Linux::page_size());
 
   Linux::initialize_system_info();
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3118,12 +3118,9 @@ void os::large_page_init() {
   }
 
   _large_page_size = large_page_init_decide_size();
-
   const size_t default_page_size = (size_t) vm_page_size();
   if (_large_page_size > default_page_size) {
-    _page_sizes[0] = _large_page_size;
-    _page_sizes[1] = default_page_size;
-    _page_sizes[2] = 0;
+    _page_sizes.add(_large_page_size);
   }
 
   UseLargePages = _large_page_size != 0;
@@ -4166,7 +4163,7 @@ void os::init(void) {
 
   win32::initialize_system_info();
   win32::setmode_streams();
-  init_page_sizes((size_t) win32::vm_page_size());
+  _page_sizes.add(win32::vm_page_size());
 
   // This may be overridden later when argument processing is done.
   FLAG_SET_ERGO(UseLargePagesIndividualAllocation, false);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1876,6 +1876,9 @@ size_t os::PagesizeSet::next_smaller(size_t pagesize) const {
 
 size_t os::PagesizeSet::next_larger(size_t pagesize) const {
   assert(is_power_of_2(pagesize), "pagesize must be a power of 2: " INTPTR_FORMAT, pagesize);
+  if (pagesize == max_power_of_2<uintx>()) { // Shift by 32/64 would be UB
+    return 0;
+  }
   int l = exact_log2(pagesize) + 1;
   uintx v2 = _v >> l;
   if (v2 == 0) {
@@ -1889,11 +1892,15 @@ size_t os::PagesizeSet::next_larger(size_t pagesize) const {
 }
 
 size_t os::PagesizeSet::largest() const {
-  return next_smaller(max_power_of_2<uintx>());
+  const size_t max = max_power_of_2<uintx>();
+  if (is_set(max)) {
+    return max;
+  }
+  return next_smaller(max);
 }
 
 size_t os::PagesizeSet::smallest() const {
-  assert(min_page_size() <= 4 * K, "must be");
+  assert(min_page_size() > 0, "Sanity");
   return next_larger(min_page_size() / 2);
 }
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -64,6 +64,7 @@
 #include "services/nmtCommon.hpp"
 #include "services/threadService.hpp"
 #include "utilities/align.hpp"
+#include "utilities/count_trailing_zeros.hpp"
 #include "utilities/defaultStream.hpp"
 #include "utilities/events.hpp"
 #include "utilities/powerOfTwo.hpp"

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -102,12 +102,12 @@ class os: AllStatic {
  public:
 
   // A simple value class holding a set of page sizes (similar to sigset_t)
-  class PagesizeSet {
-    uintx _v;
+  class PageSizes {
+    size_t _v; // actually a bitmap.
   public:
-    PagesizeSet() : _v(0) {}
+    PageSizes() : _v(0) {}
     void add(size_t pagesize);
-    bool is_set(size_t pagesize) const;
+    bool contains(size_t pagesize) const;
     // Given a page size, return the next smaller page size in this set, or 0.
     size_t next_smaller(size_t pagesize) const;
     // Given a page size, return the next larger page size in this set, or 0.
@@ -123,7 +123,7 @@ class os: AllStatic {
  private:
   static OSThread*          _starting_thread;
   static address            _polling_page;
-  static PagesizeSet        _page_sizes;
+  static PageSizes        _page_sizes;
 
   static char*  pd_reserve_memory(size_t bytes);
 
@@ -287,7 +287,7 @@ class os: AllStatic {
 
   // The set of page sizes which the VM is allowed to use (may be a subset of
   //  the page sizes actually available on the platform).
-  static const PagesizeSet& page_sizes() { return _page_sizes; }
+  static const PageSizes& page_sizes() { return _page_sizes; }
 
   // Returns the page size to use for a region of memory.
   // region_size / min_pages will always be greater than or equal to the

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -100,19 +100,30 @@ class os: AllStatic {
 #endif
 
  public:
-  enum { page_sizes_max = 9 }; // Size of _page_sizes array (8 plus a sentinel)
+
+  // A simple value class holding a set of page sizes (similar to sigset_t)
+  class PagesizeSet {
+    uintx _v;
+  public:
+    PagesizeSet() : _v(0) {}
+    void add(size_t pagesize);
+    bool is_set(size_t pagesize) const;
+    // given a page size, return the next smaller page size in this set, or 0.
+    size_t next_smaller(size_t pagesize) const;
+    // given a page size, return the next larger page size in this set, or 0.
+    size_t next_larger(size_t pagesize) const;
+    // returns the largest page size in this set, or 0 if set is empty.
+    size_t largest() const;
+    // returns the smallest page size in this set, or 0 if set is empty.
+    size_t smallest() const;
+    // prints one line of comma separated, human readable page sizes, "empty" if empty.
+    void print_on(outputStream* st) const;
+  };
 
  private:
   static OSThread*          _starting_thread;
   static address            _polling_page;
- public:
-  static size_t             _page_sizes[page_sizes_max];
-
- private:
-  static void init_page_sizes(size_t default_page_size) {
-    _page_sizes[0] = default_page_size;
-    _page_sizes[1] = 0; // sentinel
-  }
+  static PagesizeSet        _page_sizes;
 
   static char*  pd_reserve_memory(size_t bytes);
 
@@ -274,6 +285,10 @@ class os: AllStatic {
   // Return the default page size.
   static int    vm_page_size();
 
+  // The set of page sizes which the VM is allowed to use (may be a subset of
+  //  the page sizes actually available on the platform).
+  static const PagesizeSet& page_sizes() { return _page_sizes; }
+
   // Returns the page size to use for a region of memory.
   // region_size / min_pages will always be greater than or equal to the
   // returned value. The returned value will divide region_size.
@@ -285,10 +300,7 @@ class os: AllStatic {
   static size_t page_size_for_region_unaligned(size_t region_size, size_t min_pages);
 
   // Return the largest page size that can be used
-  static size_t max_page_size() {
-    // The _page_sizes array is sorted in descending order.
-    return _page_sizes[0];
-  }
+  static size_t max_page_size() { return page_sizes().largest(); }
 
   // Return a lower bound for page sizes. Also works before os::init completed.
   static size_t min_page_size() { return 4 * K; }

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -123,7 +123,7 @@ class os: AllStatic {
  private:
   static OSThread*          _starting_thread;
   static address            _polling_page;
-  static PageSizes        _page_sizes;
+  static PageSizes          _page_sizes;
 
   static char*  pd_reserve_memory(size_t bytes);
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -108,15 +108,15 @@ class os: AllStatic {
     PagesizeSet() : _v(0) {}
     void add(size_t pagesize);
     bool is_set(size_t pagesize) const;
-    // given a page size, return the next smaller page size in this set, or 0.
+    // Given a page size, return the next smaller page size in this set, or 0.
     size_t next_smaller(size_t pagesize) const;
-    // given a page size, return the next larger page size in this set, or 0.
+    // Given a page size, return the next larger page size in this set, or 0.
     size_t next_larger(size_t pagesize) const;
-    // returns the largest page size in this set, or 0 if set is empty.
+    // Returns the largest page size in this set, or 0 if set is empty.
     size_t largest() const;
-    // returns the smallest page size in this set, or 0 if set is empty.
+    // Returns the smallest page size in this set, or 0 if set is empty.
     size_t smallest() const;
-    // prints one line of comma separated, human readable page sizes, "empty" if empty.
+    // Prints one line of comma separated, human readable page sizes, "empty" if empty.
     void print_on(outputStream* st) const;
   };
 

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -363,7 +363,7 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
   // .. release it...
   EXPECT_TRUE(os::release_memory((char*)p, total_range_len));
   // ... re-reserve in the same spot multiple areas...
-  for (int stripe = 0; stripe < num_stripes; stripe ++) {
+  for (int stripe = 0; stripe < num_stripes; stripe++) {
     address q = p + (stripe * stripe_len);
     q = (address)os::attempt_reserve_memory_at((char*)q, stripe_len);
     EXPECT_NE(q, (address)NULL);
@@ -383,7 +383,7 @@ static address reserve_one_commit_multiple(int num_stripes, size_t stripe_len) {
   size_t total_range_len = num_stripes * stripe_len;
   address p = (address)os::reserve_memory(total_range_len);
   EXPECT_NE(p, (address)NULL);
-  for (int stripe = 0; stripe < num_stripes; stripe ++) {
+  for (int stripe = 0; stripe < num_stripes; stripe++) {
     address q = p + (stripe * stripe_len);
     if (stripe % 2 == 0) {
       EXPECT_TRUE(os::commit_memory((char*)q, stripe_len, false));
@@ -396,7 +396,7 @@ static address reserve_one_commit_multiple(int num_stripes, size_t stripe_len) {
 // Release a range allocated with reserve_multiple carefully, to not trip mapping
 // asserts on Windows in os::release_memory()
 static void carefully_release_multiple(address start, int num_stripes, size_t stripe_len) {
-  for (int stripe = 0; stripe < num_stripes; stripe ++) {
+  for (int stripe = 0; stripe < num_stripes; stripe++) {
     address q = start + (stripe * stripe_len);
     EXPECT_TRUE(os::release_memory((char*)q, stripe_len));
   }
@@ -574,7 +574,7 @@ TEST_VM(os, find_mapping_3) {
     address p = reserve_multiple(4, stripe_len);
     ASSERT_NE(p, (address)NULL);
     PRINT_MAPPINGS("E");
-    for (int stripe = 0; stripe < 4; stripe ++) {
+    for (int stripe = 0; stripe < 4; stripe++) {
       ASSERT_TRUE(os::win32::find_mapping(p + (stripe * stripe_len), &mapping_info));
       ASSERT_EQ(mapping_info.base, p + (stripe * stripe_len));
       ASSERT_EQ(mapping_info.regions, 1);
@@ -588,7 +588,7 @@ TEST_VM(os, find_mapping_3) {
 }
 #endif // _WIN32
 
-TEST_VM(os, pagesizes) {
+TEST_VM(os, os_pagesizes) {
   ASSERT_EQ(os::min_page_size(), 4 * K);
   ASSERT_LE(os::min_page_size(), (size_t)os::vm_page_size());
   // The vm_page_size should be the smallest in the set of allowed page sizes
@@ -607,20 +607,14 @@ TEST_VM(os, pagesizes) {
 }
 
 static const int min_page_size_log2 = exact_log2(os::min_page_size());
-static const int max_page_size_log2 = (int)(sizeof(size_t) * 8);
+static const int max_page_size_log2 = (int)BitsPerWord;
 
-TEST_VM(os, pagesizeset_test_range) {
-  for (int bit = min_page_size_log2; bit < max_page_size_log2; bit ++) {
-    for (int bit2 = min_page_size_log2; bit2 < max_page_size_log2; bit2 ++) {
+TEST_VM(os, pagesizes_test_range) {
+  for (int bit = min_page_size_log2; bit < max_page_size_log2; bit++) {
+    for (int bit2 = min_page_size_log2; bit2 < max_page_size_log2; bit2++) {
       const size_t s =  (size_t)1 << bit;
       const size_t s2 = (size_t)1 << bit2;
-      //tty->print_cr(SIZE_FORMAT " - " SIZE_FORMAT, s, s2);
       os::PageSizes pss;
-      // Empty set
-      for (int bit3 = min_page_size_log2; bit3 < max_page_size_log2; bit3 ++) {
-        const size_t s3 = (size_t)1 << bit3;
-        ASSERT_FALSE(pss.contains(s3));
-      }
       ASSERT_EQ((size_t)0, pss.smallest());
       ASSERT_EQ((size_t)0, pss.largest());
       // one size set
@@ -648,7 +642,7 @@ TEST_VM(os, pagesizeset_test_range) {
         ASSERT_EQ(pss.next_larger(s2), (size_t)0);
         ASSERT_EQ(pss.next_smaller(s2), (size_t)s);
       }
-      for (int bit3 = min_page_size_log2; bit3 < max_page_size_log2; bit3 ++) {
+      for (int bit3 = min_page_size_log2; bit3 < max_page_size_log2; bit3++) {
         const size_t s3 = (size_t)1 << bit3;
         ASSERT_EQ(s3 == s || s3 == s2, pss.contains(s3));
       }
@@ -656,16 +650,15 @@ TEST_VM(os, pagesizeset_test_range) {
   }
 }
 
-TEST_VM(os, pagesizeset_print) {
+TEST_VM(os, pagesizes_test_print) {
   os::PageSizes pss;
   const size_t sizes[] = { 16 * K, 64 * K, 128 * K, 1 * M, 4 * M, 1 * G, 2 * G, 0 };
   static const char* const expected = "16k, 64k, 128k, 1M, 4M, 1G, 2G";
-  for (int i = 0; sizes[i] != 0; i ++) {
+  for (int i = 0; sizes[i] != 0; i++) {
     pss.add(sizes[i]);
   }
   char buffer[256];
   stringStream ss(buffer, sizeof(buffer));
   pss.print_on(&ss);
-  // tty->print_cr("%s", buffer);
   ASSERT_EQ(strcmp(expected, buffer), 0);
 }

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -659,11 +659,13 @@ TEST_VM(os, pagesizeset_test_range) {
 TEST_VM(os, pagesizeset_print) {
   os::PagesizeSet pss;
   const size_t sizes[] = { 16 * K, 64 * K, 128 * K, 1 * M, 4 * M, 1 * G, 2 * G, 0 };
+  static const char* const expected = "16k, 64k, 128k, 1M, 4M, 1G, 2G";
   for (int i = 0; sizes[i] != 0; i ++) {
     pss.add(sizes[i]);
   }
   char buffer[256];
   stringStream ss(buffer, sizeof(buffer));
   pss.print_on(&ss);
-  ASSERT_EQ(strcmp("16k, 64k, 128k, 1m, 4m, 1g, 2g", buffer), 0);
+  // tty->print_cr("%s", buffer);
+  ASSERT_EQ(strcmp(expected, buffer), 0);
 }

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -85,29 +85,29 @@ TEST_VM(os, page_size_for_region_alignment) {
 TEST_VM(os, page_size_for_region_unaligned) {
   if (UseLargePages) {
     // Given exact page size, should return that page size.
-    for (size_t i = 0; os::_page_sizes[i] != 0; i++) {
-      size_t expected = os::_page_sizes[i];
-      size_t actual = os::page_size_for_region_unaligned(expected, 1);
-      ASSERT_EQ(expected, actual);
+    for (size_t s = os::page_sizes().largest(); s != 0; s = os::page_sizes().next_smaller(s)) {
+      size_t actual = os::page_size_for_region_unaligned(s, 1);
+      ASSERT_EQ(s, actual);
     }
 
     // Given slightly larger size than a page size, return the page size.
-    for (size_t i = 0; os::_page_sizes[i] != 0; i++) {
-      size_t expected = os::_page_sizes[i];
-      size_t actual = os::page_size_for_region_unaligned(expected + 17, 1);
-      ASSERT_EQ(expected, actual);
+    for (size_t s = os::page_sizes().largest(); s != 0; s = os::page_sizes().next_smaller(s)) {
+      size_t actual = os::page_size_for_region_unaligned(s + 17, 1);
+      ASSERT_EQ(s, actual);
     }
 
     // Given a slightly smaller size than a page size,
     // return the next smaller page size.
-    if (os::_page_sizes[1] > os::_page_sizes[0]) {
-      size_t expected = os::_page_sizes[0];
-      size_t actual = os::page_size_for_region_unaligned(os::_page_sizes[1] - 17, 1);
-      ASSERT_EQ(actual, expected);
+    for (size_t s = os::page_sizes().largest(); s != 0; s = os::page_sizes().next_smaller(s)) {
+      const size_t expected = os::page_sizes().next_smaller(s);
+      if (expected != 0) {
+        size_t actual = os::page_size_for_region_unaligned(expected - 17, 1);
+        ASSERT_EQ(actual, expected);
+      }
     }
 
     // Return small page size for values less than a small page.
-    size_t small_page = small_page_size();
+    size_t small_page = os::page_sizes().smallest();
     size_t actual = os::page_size_for_region_unaligned(small_page - 17, 1);
     ASSERT_EQ(small_page, actual);
   }
@@ -587,3 +587,80 @@ TEST_VM(os, find_mapping_3) {
   }
 }
 #endif // _WIN32
+
+TEST_VM(os, pagesizes) {
+  // The vm_page_size should be the smallest in the set of allowed page sizes
+  // (contract says "default" page size but a lot of code actually assumes
+  //  this to be the smallest page size; notable, deliberate exception is
+  //  AIX which can have smaller page sizes but those are not part of the
+  //  page_sizes() set).
+  ASSERT_EQ(os::page_sizes().smallest(), (size_t)os::vm_page_size());
+  // The large page size, if it exists, shall be part of the set
+  if (UseLargePages) {
+    ASSERT_GT(os::large_page_size(), (size_t)os::vm_page_size());
+    ASSERT_TRUE(os::page_sizes().is_set(os::large_page_size()));
+  }
+  os::page_sizes().print_on(tty);
+  tty->cr();
+}
+
+TEST_VM(os, pagesizeset) {
+  const size_t largest_page_size = LP64_ONLY(1024 * G) NOT_LP64(1 * G);
+  // Test a set with just one page size set
+  for (size_t s = os::min_page_size(); s <= largest_page_size; s *= 2) {
+    os::PagesizeSet pss;
+    // Empty set
+    ASSERT_FALSE(pss.is_set(s));
+    ASSERT_FALSE(pss.is_set(s / 2));
+    ASSERT_FALSE(pss.is_set(s * 2));
+    ASSERT_EQ((size_t)0, pss.smallest());
+    ASSERT_EQ((size_t)0, pss.largest());
+    pss.add(s);
+    // one size set
+    ASSERT_TRUE(pss.is_set(s));
+    ASSERT_FALSE(pss.is_set(s / 2));
+    ASSERT_FALSE(pss.is_set(s * 2));
+    ASSERT_EQ(s, pss.smallest());
+    ASSERT_EQ(s, pss.largest());
+    ASSERT_EQ(pss.next_larger(s), (size_t)0);
+    ASSERT_EQ(pss.next_smaller(s), (size_t)0);
+  }
+  // Test a random set
+  {
+    os::PagesizeSet pss;
+    const uintx master = LP64_ONLY(((uintx)os::random() << 32) + )
+                                    (uintx)os::random();
+    for (size_t s = os::min_page_size(); s < largest_page_size; s *= 2) {
+      if (master & s) {
+        pss.add(s);
+      }
+    }
+    // query all sizes
+    for (size_t s = os::min_page_size(); s < largest_page_size; s *= 2) {
+      ASSERT_EQ(((master & s) > 0), pss.is_set(s));
+    }
+    // iterate both ways
+    for (size_t s = pss.smallest(); s != 0; s = pss.next_larger(s)) {
+      ASSERT_TRUE(master & s);
+      ASSERT_TRUE(pss.is_set(s));
+    }
+    for (size_t s = pss.largest(); s != 0; s = pss.next_smaller(s)) {
+      ASSERT_TRUE(master & s);
+      ASSERT_TRUE(pss.is_set(s));
+    }
+  }
+  // Test printing
+  {
+    os::PagesizeSet pss;
+    const size_t sizes[] = { 16 * K, 64 * K, 128 * K, 1 * M, 4 * M, 1 * G, 2 * G, 0 };
+    // init set
+    for (int i = 0; sizes[i] != 0; i ++) {
+      pss.add(sizes[i]);
+    }
+    // test printing
+    char buffer[256];
+    stringStream ss(buffer, sizeof(buffer));
+    pss.print_on(&ss);
+    ASSERT_EQ(strcmp("16k, 64k, 128k, 1m, 4m, 1g, 2g", buffer), 0);
+  }
+}

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -600,7 +600,7 @@ TEST_VM(os, pagesizes) {
   // The large page size, if it exists, shall be part of the set
   if (UseLargePages) {
     ASSERT_GT(os::large_page_size(), (size_t)os::vm_page_size());
-    ASSERT_TRUE(os::page_sizes().is_set(os::large_page_size()));
+    ASSERT_TRUE(os::page_sizes().contains(os::large_page_size()));
   }
   os::page_sizes().print_on(tty);
   tty->cr();
@@ -615,24 +615,24 @@ TEST_VM(os, pagesizeset_test_range) {
       const size_t s =  (size_t)1 << bit;
       const size_t s2 = (size_t)1 << bit2;
       //tty->print_cr(SIZE_FORMAT " - " SIZE_FORMAT, s, s2);
-      os::PagesizeSet pss;
+      os::PageSizes pss;
       // Empty set
       for (int bit3 = min_page_size_log2; bit3 < max_page_size_log2; bit3 ++) {
         const size_t s3 = (size_t)1 << bit3;
-        ASSERT_FALSE(pss.is_set(s3));
+        ASSERT_FALSE(pss.contains(s3));
       }
       ASSERT_EQ((size_t)0, pss.smallest());
       ASSERT_EQ((size_t)0, pss.largest());
       // one size set
       pss.add(s);
-      ASSERT_TRUE(pss.is_set(s));
+      ASSERT_TRUE(pss.contains(s));
       ASSERT_EQ(s, pss.smallest());
       ASSERT_EQ(s, pss.largest());
       ASSERT_EQ(pss.next_larger(s), (size_t)0);
       ASSERT_EQ(pss.next_smaller(s), (size_t)0);
       // two set
       pss.add(s2);
-      ASSERT_TRUE(pss.is_set(s2));
+      ASSERT_TRUE(pss.contains(s2));
       if (s2 < s) {
         ASSERT_EQ(s2, pss.smallest());
         ASSERT_EQ(s, pss.largest());
@@ -650,14 +650,14 @@ TEST_VM(os, pagesizeset_test_range) {
       }
       for (int bit3 = min_page_size_log2; bit3 < max_page_size_log2; bit3 ++) {
         const size_t s3 = (size_t)1 << bit3;
-        ASSERT_EQ(s3 == s || s3 == s2, pss.is_set(s3));
+        ASSERT_EQ(s3 == s || s3 == s2, pss.contains(s3));
       }
     }
   }
 }
 
 TEST_VM(os, pagesizeset_print) {
-  os::PagesizeSet pss;
+  os::PageSizes pss;
   const size_t sizes[] = { 16 * K, 64 * K, 128 * K, 1 * M, 4 * M, 1 * G, 2 * G, 0 };
   static const char* const expected = "16k, 64k, 128k, 1M, 4M, 1G, 2G";
   for (int i = 0; sizes[i] != 0; i ++) {


### PR DESCRIPTION
Hi,

may I please have reviews for the following very small improvement:

While discussing JDK-8243315 [1], and aiming to make planned changes like JDK-8256155 [2] easier:

```
size_t os::_page_sizes[os::page_sizes_max];
```

is an array used to keep all page sizes the hotspot can use. It is sorted by size and filled in at initialization time.

Coding dealing with this can be simplified by making this a set (which is very easy since all page sizes are power-2-values so they lend themselves nicely to a bitmap).

That has the following advantages:
- makes adding new sizes simple since we do not have to re-sort the array. Coding is easier to read too.
- it makes it possible to encode a set of page sizes in one number, so we can hand a set-of-page-sizes around as a value.

-----

The patch adds a new class, os::PagesizeSet, which is a bitmap containing page sizes. It adds gtests for this class. It replaces the old os::_page_sizes with an object of that class. It also removes an unused function.


Testing:
- nightlies at SAP
- manual tests with UseLargePages
- the new gtests
- gh actions (with x86 still failing because of unrelated issues)

Thank you,

Thomas

[1] https://bugs.openjdk.java.net/browse/JDK-8243315
[2] https://bugs.openjdk.java.net/browse/JDK-8256155

/label hotspot-dev

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257588](https://bugs.openjdk.java.net/browse/JDK-8257588): Make os::_page_sizes a bitmask


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to 919d90bb274e7bd55f5443d3943adaf5ef4926a2


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1522/head:pull/1522`
`$ git checkout pull/1522`
