### PR TITLE
8255264: Support for identifying the full range of IPv4 localhost addresses on Windows

### DIFF
--- a/src/java.base/windows/native/libnet/net_util_md.h
+++ b/src/java.base/windows/native/libnet/net_util_md.h
@@ -90,24 +90,30 @@ struct ipv6bind {
 /**
  * With dual socket implementation the
  * IPv4 addresseses might be mapped as IPv6.
- * The IPv4 loopback adapter address will
- * be mapped as the following IPv6 ::ffff:127.0.0.1.
+ * The IPv4 loopback adapter address ranges (127.0.0.0 through 127.255.255.255) will
+ * be mapped as the following IPv6 ::ffff:127.0.0.0 through ::ffff:127.255.255.255.
  * For example, this is done by NET_InetAddressToSockaddr.
  */
 #define IN6_IS_ADDR_V4MAPPED_LOOPBACK(x) ( \
-    (((x)->s6_words[0] == 0)      &&  \
-     ((x)->s6_words[1] == 0)      &&  \
-     ((x)->s6_words[2] == 0)      &&  \
-     ((x)->s6_words[3] == 0)      &&  \
-     ((x)->s6_words[4] == 0)      &&  \
-     ((x)->s6_words[5] == 0xFFFF) &&  \
-     ((x)->s6_words[6] == 0x007F) &&  \
-     ((x)->s6_words[7] == 0x0100))    \
+    (((x)->s6_words[0] == 0)               &&  \
+     ((x)->s6_words[1] == 0)               &&  \
+     ((x)->s6_words[2] == 0)               &&  \
+     ((x)->s6_words[3] == 0)               &&  \
+     ((x)->s6_words[4] == 0)               &&  \
+     ((x)->s6_words[5] == 0xFFFF)          &&  \
+     (((x)->s6_words[6] & 0x00FF) == 0x007F)) \
+)
+
+/**
+ * Check for IPv4 loopback adapter address ranges (127.0.0.0 through 127.255.255.255)
+ */
+#define IN4_IS_ADDR_NETLONG_LOOPBACK(l) ( \
+    ((l & 0xFF000000) == 0x7F000000) \
 )
 
 #define IS_LOOPBACK_ADDRESS(x) ( \
     ((x)->sa.sa_family == AF_INET) ? \
-        (ntohl((x)->sa4.sin_addr.s_addr) == INADDR_LOOPBACK) : \
+        (IN4_IS_ADDR_NETLONG_LOOPBACK(ntohl((x)->sa4.sin_addr.s_addr))) : \
         ((IN6_IS_ADDR_LOOPBACK(&(x)->sa6.sin6_addr)) || \
          (IN6_IS_ADDR_V4MAPPED_LOOPBACK(&(x)->sa6.sin6_addr))) \
 )


### PR DESCRIPTION
Modified Windows specific loopback macros to support full range of loopback addresses, commit message includes unit test data as there's no gtest's for java libraries (only hotspot compiler)

This is an expansion on the original fix for 8250521: Configure initial RTO to use minimal retry for loopback connections on Windows

IPV4 loopback addresses are defined as 127.0.0.0/8 the CIDR translates to a range of 127.0.0.0 to
127.255.255.255 inclusive.

The previous macro implementation only identified 127.0.0.1 and ::1 as loopback addresses, this is corrected in this change

Note that as IPV6 is defined as ::1/128 only ::1 is a valid loopback address

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255264](https://bugs.openjdk.java.net/browse/JDK-8255264): Support for identifying the full range of IPv4 localhost addresses on Windows


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1523/head:pull/1523`
`$ git checkout pull/1523`
