### PR TITLE
JDK-8257448: Clean duplicated non-null check in the SunJSSE provider implementation

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/Alert.java
+++ b/src/java.base/share/classes/sun/security/ssl/Alert.java
@@ -123,7 +123,7 @@ enum Alert {
         }
 
         SSLException ssle;
-        if ((cause != null) && (cause instanceof IOException)) {
+        if (cause instanceof IOException) {
             ssle = new SSLException(reason);
         } else if ((this == UNEXPECTED_MESSAGE)) {
             ssle = new SSLProtocolException(reason);

--- a/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
@@ -370,7 +370,7 @@ final class X509TrustManagerImpl extends X509ExtendedTrustManager
 
     private static List<SNIServerName> getRequestedServerNames(
             SSLSession session) {
-        if (session != null && (session instanceof ExtendedSSLSession)) {
+        if (session instanceof ExtendedSSLSession) {
             return ((ExtendedSSLSession)session).getRequestedServerNames();
         }
 


### PR DESCRIPTION
In the SunJSSE provider implementation, there are a few non-null check, used together with "instanceof" check.  For such cases, the non-null check is redundant as it could be covered by the "instanceof" check.  This update will remove the non-null check, like:
-   if ((cause != null) && (cause instanceof IOException)) { 
+  if (cause instanceof IOException) {

Code cleanup, no new regression text.

Bug: https://bugs.openjdk.java.net/browse/JDK-8257448

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ❌ (1/9 failed) | ✔️ (9/9 passed) | ⏳ (3/9 running) | ✔️ (9/9 passed) |

**Failed test task**
- [Linux x64 (hs/tier1 runtime)](https://github.com/XueleiFan/jdk/runs/1476279041)

### Issue
 * [JDK-8257448](https://bugs.openjdk.java.net/browse/JDK-8257448): Clean duplicated non-null check in the SunJSSE provider implementation


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1524/head:pull/1524`
`$ git checkout pull/1524`
