### PR TITLE
8257460: Further CompilerOracle cleanup

### DIFF
--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -149,9 +149,13 @@ class CompilerOracle : AllStatic {
   // Check if method has option and value set. If yes, overwrite value and return true,
   // otherwise leave value unchanged and return false.
   template<typename T>
-  static bool has_option_value(const methodHandle& method, enum CompileCommand option, T& value, bool verfiy_type = false);
+  static bool has_option_value(const methodHandle& method, enum CompileCommand option, T& value);
 
-  // Reads from string instead of file
+  // This check is currently only needed by whitebox API
+  template<typename T>
+  static bool option_matches_type(enum CompileCommand option, T& value);
+
+    // Reads from string instead of file
   static void parse_from_string(const char* option_string, void (*parser)(char*));
   static void parse_from_line(char* line);
   static void parse_compile_only(char* line);

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1814,7 +1814,10 @@ static bool GetMethodOption(JavaThread* thread, JNIEnv* env, jobject method, jst
   if (option == CompileCommand::Unknown) {
     return false;
   }
-  return CompilerOracle::has_option_value(mh, option, *value, true /* verify type*/);
+  if (!CompilerOracle::option_matches_type(option, *value)) {
+    return false;
+  }
+  return CompilerOracle::has_option_value(mh, option, *value);
 }
 
 WB_ENTRY(jobject, WB_GetMethodBooleaneOption(JNIEnv* env, jobject wb, jobject method, jstring name))


### PR DESCRIPTION
I got some additional feedback on 8256508: "Improve CompileCommand flag" from Claes.

1) The _type field in TypedMethodMatcher is not used any more. It is derived from the option.

2) The verify_type  argument is only used from whitebox API and the check should be pushed out to that code. The check is needed because the option is passed from java as a String and we need to verify that the value type matches the option type.

3) The type parameter to TypedMethodMatcher::match isn't used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ⏳ (8/8 running) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ⏳ (8/9 running) | ❌ (1/9 failed) |    |  ❌ (3/9 failed) |

**Failed test tasks**
- [Linux x86 (hs/tier1 serviceability)](https://github.com/neliasso/jdk/runs/1476678624)
- [macOS x64 (hs/tier1 gc)](https://github.com/neliasso/jdk/runs/1476597087)
- [macOS x64 (hs/tier1 runtime)](https://github.com/neliasso/jdk/runs/1476597104)
- [macOS x64 (hs/tier1 serviceability)](https://github.com/neliasso/jdk/runs/1476597123)

### Issue
 * [JDK-8257460](https://bugs.openjdk.java.net/browse/JDK-8257460): Further CompilerOracle cleanup


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1526/head:pull/1526`
`$ git checkout pull/1526`
