### PR TITLE
8257445: (zipfs) Add DataProvider to TestLocOffsetFromZip64EF.java

### DIFF
--- a/test/jdk/jdk/nio/zipfs/TestLocOffsetFromZip64EF.java
+++ b/test/jdk/jdk/nio/zipfs/TestLocOffsetFromZip64EF.java
@@ -24,10 +24,12 @@
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
@@ -38,7 +40,7 @@ import static java.lang.String.format;
 
 /**
  * @test
- * @bug 8255380
+ * @bug 8255380 8257445
  * @summary Test that Zip FS can access the LOC offset from the Zip64 extra field
  * @modules jdk.zipfs
  * @requires (os.family == "linux") | (os.family == "mac")
@@ -91,14 +93,29 @@ public class TestLocOffsetFromZip64EF {
         rc.assertSuccess();
     }
 
+    /*
+     * DataProvider used to verify that a Zip file that will an Zip64 Extra
+     * (EXT) header can be traversed
+     */
+    @DataProvider(name = "zipInfoTimeMap")
+    protected Object[][] zipInfoTimeMap() {
+        return new Object[][]{
+                {Map.of()},
+                {Map.of("zipinfo-time", "False")},
+                {Map.of("zipinfo-time", "true")},
+                {Map.of("zipinfo-time", "false")}
+        };
+    }
+
     /**
      * Navigate through the Zip file entries using Zip FS
+     * @param env Zip FS properties to use when accessing the Zip file
      * @throws IOException if an error occurs
      */
-    @Test
-    public void walkZipFSTest() throws IOException {
+    @Test(dataProvider = "zipInfoTimeMap")
+    public void walkZipFSTest(final Map<String, String> env) throws IOException {
         try (FileSystem fs =
-                     FileSystems.newFileSystem(Paths.get(ZIP_FILE_NAME), Map.of("zipinfo-time", "False"))) {
+                     FileSystems.newFileSystem(Paths.get(ZIP_FILE_NAME), env)) {
             for (Path root : fs.getRootDirectories()) {
                 Files.walkFileTree(root, new SimpleFileVisitor<>() {
                     @Override

--- a/test/jdk/jdk/nio/zipfs/TestLocOffsetFromZip64EF.java
+++ b/test/jdk/jdk/nio/zipfs/TestLocOffsetFromZip64EF.java
@@ -94,7 +94,7 @@ public class TestLocOffsetFromZip64EF {
     }
 
     /*
-     * DataProvider used to verify that a Zip file that will an Zip64 Extra
+     * DataProvider used to verify that a Zip file that contains a Zip64 Extra
      * (EXT) header can be traversed
      */
     @DataProvider(name = "zipInfoTimeMap")


### PR DESCRIPTION
HI all,

Please review this trivial change which adds a DataProvider to the manual test TestLocOffsetFromZip64EF.java, added as part of the fix for https://bugs.openjdk.java.net/browse/JDK-8255380,  to specify additional values for the  Zip FS file System property zipinfo-time.

Best,
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux additional | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- | ----- |
| Build | ✔️ (8/8 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ✔️ (9/9 passed) | ⏳ (2/9 running) | ⏳ (3/9 running) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8257445](https://bugs.openjdk.java.net/browse/JDK-8257445): (zipfs) Add DataProvider to TestLocOffsetFromZip64EF.java


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1527/head:pull/1527`
`$ git checkout pull/1527`
