### PR TITLE
8257460: Further CompilerOracle cleanup

### DIFF
--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -359,7 +359,7 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
     }
 
     // inline and dontinline (including exclude) are implemented in the directiveset accessors
-#define init_default_cc(name, type, dvalue, cc_flag) { type v; if (!_modified[name##Index] && CompilerOracle::has_option_value(method, CompileCommand::cc_flag, v) && v != this->name##Option) { set.cloned()->name##Option = v; } }
+#define init_default_cc(name, type, dvalue, cc_flag) { type v; if (!_modified[name##Index] && CompileCommand::cc_flag != CompileCommand::Unknown && CompilerOracle::has_option_value(method, CompileCommand::cc_flag, v) && v != this->name##Option) { set.cloned()->name##Option = v; } }
     compilerdirectives_common_flags(init_default_cc)
     compilerdirectives_c2_flags(init_default_cc)
     compilerdirectives_c1_flags(init_default_cc)

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -104,7 +104,6 @@ class TypedMethodOptionMatcher : public MethodMatcher {
  private:
   TypedMethodOptionMatcher* _next;
   enum CompileCommand _option;
-  OptionType    _type;
  public:
 
   union {
@@ -117,18 +116,16 @@ class TypedMethodOptionMatcher : public MethodMatcher {
 
   TypedMethodOptionMatcher() : MethodMatcher(),
     _next(NULL),
-    _option(CompileCommand::Unknown),
-    _type(OptionType::Unknown) {
+    _option(CompileCommand::Unknown) {
       memset(&_u, 0, sizeof(_u));
   }
 
   ~TypedMethodOptionMatcher();
   static TypedMethodOptionMatcher* parse_method_pattern(char*& line, char* errorbuf, const int buf_size);
-  TypedMethodOptionMatcher* match(const methodHandle &method, enum CompileCommand option, OptionType type);
+  TypedMethodOptionMatcher* match(const methodHandle &method, enum CompileCommand option);
 
-  void init(enum CompileCommand option, OptionType type, TypedMethodOptionMatcher* next) {
+  void init(enum CompileCommand option, TypedMethodOptionMatcher* next) {
     _next = next;
-    _type = type;
     _option = option;
   }
 
@@ -140,7 +137,6 @@ class TypedMethodOptionMatcher : public MethodMatcher {
 
   void set_next(TypedMethodOptionMatcher* next) {_next = next; }
   TypedMethodOptionMatcher* next() { return _next; }
-  OptionType type() { return _type; }
   enum CompileCommand option() { return _option; }
   template<typename T> T value();
   template<typename T> void set_value(T value);
@@ -194,8 +190,9 @@ void TypedMethodOptionMatcher::print() {
   ttyLocker ttyl;
   print_base(tty);
   const char* name = option2name(_option);
-  switch (_type) {
-  case OptionType::Intx:
+  enum OptionType type = option2type(_option);
+  switch (type) {
+    case OptionType::Intx:
     tty->print_cr(" intx %s = " INTX_FORMAT, name, value<intx>());
     break;
     case OptionType::Uintx:
@@ -208,6 +205,7 @@ void TypedMethodOptionMatcher::print() {
     tty->print_cr(" double %s = %f", name, value<double>());
     break;
     case OptionType::Ccstr:
+    case OptionType::Ccstrlist:
     tty->print_cr(" const char* %s = '%s'", name, value<ccstr>());
     break;
   default:
@@ -244,7 +242,8 @@ TypedMethodOptionMatcher* TypedMethodOptionMatcher::clone() {
 }
 
 TypedMethodOptionMatcher::~TypedMethodOptionMatcher() {
-  if (type() == OptionType::Ccstr) {
+  enum OptionType type = option2type(_option);
+  if (type == OptionType::Ccstr || type == OptionType::Ccstrlist) {
     ccstr v = value<ccstr>();
     os::free((void*)v);
   }
@@ -263,7 +262,7 @@ TypedMethodOptionMatcher* TypedMethodOptionMatcher::parse_method_pattern(char*& 
   return tom;
 }
 
-TypedMethodOptionMatcher* TypedMethodOptionMatcher::match(const methodHandle& method, enum CompileCommand option, OptionType type) {
+TypedMethodOptionMatcher* TypedMethodOptionMatcher::match(const methodHandle& method, enum CompileCommand option) {
   TypedMethodOptionMatcher* current = this;
   while (current != NULL) {
     if (current->_option == option) {
@@ -285,12 +284,9 @@ static void register_command(TypedMethodOptionMatcher* matcher,
     tty->print_cr("Warning:  +LogCompilation must be enabled in order for individual methods to be logged with ");
     tty->print_cr("          CompileCommand=log,<method pattern>");
   }
-  enum OptionType type = option2type(option);
-  if (type == OptionType::Ccstrlist) {
-    type = OptionType::Ccstr; // ccstrlists are stores as ccstr
-  }
-  assert(type == get_type_for<T>(), "sanity");
-  matcher->init(option, type, option_list);
+  assert(CompilerOracle::option_matches_type(option, value), "Value must match option type");
+
+  matcher->init(option, option_list);
   matcher->set_value<T>(value);
   option_list = matcher;
   if ((option != CompileCommand::DontInline) &&
@@ -308,26 +304,15 @@ static void register_command(TypedMethodOptionMatcher* matcher,
 }
 
 template<typename T>
-bool CompilerOracle::has_option_value(const methodHandle& method, enum CompileCommand option, T& value, bool verify_type) {
+bool CompilerOracle::has_option_value(const methodHandle& method, enum CompileCommand option, T& value) {
   enum OptionType type = option2type(option);
   if (type == OptionType::Unknown) {
     return false; // Can't query options with type Unknown.
   }
-  if (type == OptionType::Ccstrlist) {
-    type = OptionType::Ccstr; // CCstrList type options are stored as Ccstr
-  }
-  if (verify_type) {
-    if (type != get_type_for<T>()) {
-      // Whitebox API expects false if option and type doesn't match
-      return false;
-    }
-  } else {
-    assert(type == get_type_for<T>(), "Value type (%s) must match option %s (%s)",
-            optiontype2name(get_type_for<T>()),
-           option2name(option), optiontype2name(option2type(option)));
-  }
+  assert(option_matches_type(option, value), "Value must match option type");
+
   if (option_list != NULL) {
-    TypedMethodOptionMatcher* m = option_list->match(method, option, type);
+    TypedMethodOptionMatcher* m = option_list->match(method, option);
     if (m != NULL) {
       value = m->value<T>();
       return true;
@@ -361,11 +346,26 @@ bool CompilerOracle::has_any_command_set() {
 }
 
 // Explicit instantiation for all OptionTypes supported.
-template bool CompilerOracle::has_option_value<intx>(const methodHandle& method, enum CompileCommand option, intx& value, bool verify_type);
-template bool CompilerOracle::has_option_value<uintx>(const methodHandle& method, enum CompileCommand option, uintx& value, bool verify_type);
-template bool CompilerOracle::has_option_value<bool>(const methodHandle& method, enum CompileCommand option, bool& value, bool verify_type);
-template bool CompilerOracle::has_option_value<ccstr>(const methodHandle& method, enum CompileCommand option, ccstr& value, bool verify_type);
-template bool CompilerOracle::has_option_value<double>(const methodHandle& method, enum CompileCommand option, double& value, bool verify_type);
+template bool CompilerOracle::has_option_value<intx>(const methodHandle& method, enum CompileCommand option, intx& value);
+template bool CompilerOracle::has_option_value<uintx>(const methodHandle& method, enum CompileCommand option, uintx& value);
+template bool CompilerOracle::has_option_value<bool>(const methodHandle& method, enum CompileCommand option, bool& value);
+template bool CompilerOracle::has_option_value<ccstr>(const methodHandle& method, enum CompileCommand option, ccstr& value);
+template bool CompilerOracle::has_option_value<double>(const methodHandle& method, enum CompileCommand option, double& value);
+
+template<typename T>
+bool CompilerOracle::option_matches_type(enum CompileCommand option, T& value) {
+  enum OptionType option_type = option2type(option);
+  if (option_type == OptionType::Ccstrlist) {
+    option_type = OptionType::Ccstr; // CCstrList type options are stored as Ccstr
+  }
+  return (get_type_for<T>() == option_type);
+}
+
+template bool CompilerOracle::option_matches_type<intx>(enum CompileCommand option, intx& value);
+template bool CompilerOracle::option_matches_type<uintx>(enum CompileCommand option, uintx& value);
+template bool CompilerOracle::option_matches_type<bool>(enum CompileCommand option, bool& value);
+template bool CompilerOracle::option_matches_type<ccstr>(enum CompileCommand option, ccstr& value);
+template bool CompilerOracle::option_matches_type<double>(enum CompileCommand option, double& value);
 
 bool CompilerOracle::has_option(const methodHandle& method, enum CompileCommand option) {
   bool value = false;

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -305,12 +305,7 @@ static void register_command(TypedMethodOptionMatcher* matcher,
 
 template<typename T>
 bool CompilerOracle::has_option_value(const methodHandle& method, enum CompileCommand option, T& value) {
-  enum OptionType type = option2type(option);
-  if (type == OptionType::Unknown) {
-    return false; // Can't query options with type Unknown.
-  }
   assert(option_matches_type(option, value), "Value must match option type");
-
   if (option_list != NULL) {
     TypedMethodOptionMatcher* m = option_list->match(method, option);
     if (m != NULL) {
@@ -355,6 +350,9 @@ template bool CompilerOracle::has_option_value<double>(const methodHandle& metho
 template<typename T>
 bool CompilerOracle::option_matches_type(enum CompileCommand option, T& value) {
   enum OptionType option_type = option2type(option);
+  if (option_type == OptionType::Unknown) {
+    return false; // Can't query options with type Unknown.
+  }
   if (option_type == OptionType::Ccstrlist) {
     option_type = OptionType::Ccstr; // CCstrList type options are stored as Ccstr
   }

--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -149,9 +149,13 @@ class CompilerOracle : AllStatic {
   // Check if method has option and value set. If yes, overwrite value and return true,
   // otherwise leave value unchanged and return false.
   template<typename T>
-  static bool has_option_value(const methodHandle& method, enum CompileCommand option, T& value, bool verfiy_type = false);
+  static bool has_option_value(const methodHandle& method, enum CompileCommand option, T& value);
 
-  // Reads from string instead of file
+  // This check is currently only needed by whitebox API
+  template<typename T>
+  static bool option_matches_type(enum CompileCommand option, T& value);
+
+    // Reads from string instead of file
   static void parse_from_string(const char* option_string, void (*parser)(char*));
   static void parse_from_line(char* line);
   static void parse_compile_only(char* line);

--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -155,7 +155,7 @@ class CompilerOracle : AllStatic {
   template<typename T>
   static bool option_matches_type(enum CompileCommand option, T& value);
 
-    // Reads from string instead of file
+  // Reads from string instead of file
   static void parse_from_string(const char* option_string, void (*parser)(char*));
   static void parse_from_line(char* line);
   static void parse_compile_only(char* line);

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1814,7 +1814,10 @@ static bool GetMethodOption(JavaThread* thread, JNIEnv* env, jobject method, jst
   if (option == CompileCommand::Unknown) {
     return false;
   }
-  return CompilerOracle::has_option_value(mh, option, *value, true /* verify type*/);
+  if (!CompilerOracle::option_matches_type(option, *value)) {
+    return false;
+  }
+  return CompilerOracle::has_option_value(mh, option, *value);
 }
 
 WB_ENTRY(jobject, WB_GetMethodBooleaneOption(JNIEnv* env, jobject wb, jobject method, jstring name))


### PR DESCRIPTION
I got some additional feedback on 8256508: "Improve CompileCommand flag" from Claes.

1. The _type field in TypedMethodMatcher is not used any more. It is derived from the option.

2. The verify_type argument is only used from whitebox API and the check should be pushed out to that code. The check is needed because the option is passed from java as a String and we need to verify that the value type matches the option type.
 
3. The type parameter to TypedMethodMatcher::match isn't used.
 
4. Some code only used for asserts was moved into assert

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257460](https://bugs.openjdk.java.net/browse/JDK-8257460): Further CompilerOracle cleanup


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 0a08c8283e3bcd256a513832fb8262425e3bcc39


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1528/head:pull/1528`
`$ git checkout pull/1528`
