### PR TITLE
8257483: C2: Split immediate vector rotate from RotateLeftV and RotateRightV nodes

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2437,7 +2437,7 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return true;
 }
 
-bool Matcher::supports_vector_variable_rotates(VectorNode *n) {
+bool Matcher::supports_vector_variable_rotates(void) {
   return false; // not supported
 }
 

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2437,6 +2437,10 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return true;
 }
 
+bool Matcher::supports_vector_variable_rotates(VectorNode *n) {
+  return false; // not supported
+}
+
 const int Matcher::float_pressure(int default_pressure_threshold) {
   return default_pressure_threshold;
 }

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -997,7 +997,7 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return VM_Version::has_simd();
 }
 
-bool Matcher::supports_vector_variable_rotates(VectorNode *n) {
+bool Matcher::supports_vector_variable_rotates(void) {
   return false; // not supported
 }
 

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -997,6 +997,10 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return VM_Version::has_simd();
 }
 
+bool Matcher::supports_vector_variable_rotates(VectorNode *n) {
+  return false; // not supported
+}
+
 const int Matcher::float_pressure(int default_pressure_threshold) {
   return default_pressure_threshold;
 }

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2153,7 +2153,7 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return false; // not supported
 }
 
-bool Matcher::supports_vector_variable_rotates(VectorNode *n) {
+bool Matcher::supports_vector_variable_rotates(void) {
   return false; // not supported
 }
 

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2153,6 +2153,10 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return false; // not supported
 }
 
+bool Matcher::supports_vector_variable_rotates(VectorNode *n) {
+  return false; // not supported
+}
+
 const int Matcher::float_pressure(int default_pressure_threshold) {
   return default_pressure_threshold;
 }

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1550,6 +1550,10 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return false; // not supported
 }
 
+bool Matcher::supports_vector_variable_rotates(VectorNode *n) {
+  return false; // not supported
+}
+
 const int Matcher::float_pressure(int default_pressure_threshold) {
   return default_pressure_threshold;
 }

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1550,7 +1550,7 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return false; // not supported
 }
 
-bool Matcher::supports_vector_variable_rotates(VectorNode *n) {
+bool Matcher::supports_vector_variable_rotates(void) {
   return false; // not supported
 }
 

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1814,6 +1814,11 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return (UseAVX >= 2);
 }
 
+bool Matcher::supports_vector_variable_rotates(VectorNode *n) {
+  BasicType bt = n->vect_type()->element_basic_type();
+  return match_rule_supported_vector(n->Opcode(), n->length(), bt);
+}
+
 const bool Matcher::has_predicated_vectors(void) {
   bool ret_value = false;
   if (UseAVX > 2) {

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1814,9 +1814,8 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return (UseAVX >= 2);
 }
 
-bool Matcher::supports_vector_variable_rotates(VectorNode *n) {
-  BasicType bt = n->vect_type()->element_basic_type();
-  return match_rule_supported_vector(n->Opcode(), n->length(), bt);
+bool Matcher::supports_vector_variable_rotates(void) {
+  return true;
 }
 
 const bool Matcher::has_predicated_vectors(void) {

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -348,6 +348,9 @@ public:
   // Does the CPU supports vector variable shift instructions?
   static bool supports_vector_variable_shifts(void);
 
+  // Does the CPU supports vector vairable rotate instructions?
+  static bool supports_vector_variable_rotates(VectorNode *n);
+
   // CPU supports misaligned vectors store/load.
   static const bool misaligned_vectors_ok();
 

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -349,7 +349,7 @@ public:
   static bool supports_vector_variable_shifts(void);
 
   // Does the CPU supports vector vairable rotate instructions?
-  static bool supports_vector_variable_rotates(VectorNode *n);
+  static bool supports_vector_variable_rotates(void);
 
   // CPU supports misaligned vectors store/load.
   static const bool misaligned_vectors_ok();

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1172,7 +1172,8 @@ Node* VectorNode::degenerate_vector_rotate(Node* src, Node* cnt, bool is_rotate_
 Node* RotateLeftVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   int vlen = length();
   BasicType bt = vect_type()->element_basic_type();
-  if (!Matcher::match_rule_supported_vector(Op_RotateLeftV, vlen, bt)) {
+  if ((!in(2)->is_Con() && !Matcher::supports_vector_variable_rotates(this)) ||
+       !Matcher::match_rule_supported_vector(Op_RotateLeftV, vlen, bt)) {
     return VectorNode::degenerate_vector_rotate(in(1), in(2), true, vlen, bt, phase);
   }
   return NULL;
@@ -1181,7 +1182,8 @@ Node* RotateLeftVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 Node* RotateRightVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   int vlen = length();
   BasicType bt = vect_type()->element_basic_type();
-  if (!Matcher::match_rule_supported_vector(Op_RotateRightV, vlen, bt)) {
+  if ((!in(2)->is_Con() && !Matcher::supports_vector_variable_rotates(this)) ||
+       !Matcher::match_rule_supported_vector(Op_RotateRightV, vlen, bt)) {
     return VectorNode::degenerate_vector_rotate(in(1), in(2), false, vlen, bt, phase);
   }
   return NULL;

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1172,7 +1172,7 @@ Node* VectorNode::degenerate_vector_rotate(Node* src, Node* cnt, bool is_rotate_
 Node* RotateLeftVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   int vlen = length();
   BasicType bt = vect_type()->element_basic_type();
-  if ((!in(2)->is_Con() && !Matcher::supports_vector_variable_rotates(this)) ||
+  if ((!in(2)->is_Con() && !Matcher::supports_vector_variable_rotates()) ||
        !Matcher::match_rule_supported_vector(Op_RotateLeftV, vlen, bt)) {
     return VectorNode::degenerate_vector_rotate(in(1), in(2), true, vlen, bt, phase);
   }
@@ -1182,7 +1182,7 @@ Node* RotateLeftVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 Node* RotateRightVNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   int vlen = length();
   BasicType bt = vect_type()->element_basic_type();
-  if ((!in(2)->is_Con() && !Matcher::supports_vector_variable_rotates(this)) ||
+  if ((!in(2)->is_Con() && !Matcher::supports_vector_variable_rotates()) ||
        !Matcher::match_rule_supported_vector(Op_RotateRightV, vlen, bt)) {
     return VectorNode::degenerate_vector_rotate(in(1), in(2), false, vlen, bt, phase);
   }


### PR DESCRIPTION
Currently, for all CPUs, if optimizing RotateLeftV and RotateRightV with match rules in AD files, we have to implement both immediate and variable versions.

On aarch64, with match rules for vector rotation, immediate vector rotatation can be optimized with shift+insert instructions (i.e. SLI/SRI, ~20% improvements with an initial implementation).
However there woule be performance regression for variable version, due to SLI/SRI have no register version in NEON intruction set and there is no register version for right shift neither.
The instructions for match rules of vector rotate variable should be:
```
    mov w9, 32
    dup v13.4s, w9
    sub  v20.4s, v13.4S, v19.4s
    # For a loop, default version only has code below,
    # the code above (loop invariants) are put outside of a loop.
    sshl v17.4s, v16.4s, v19.4s
    neg v18.16b, v20.16b       # on aarch64, vector right shift is implemented as left shift by negative shift count
    ushl v16.4s, v16.4s, v18.4s
    orr v16.16b, v17.16b, v16.16b
```

With this patch, immediate vector rotation can be matched alone and optimized on CPUs like aarch64.

Verified with linux-x86_64-server-fastdebug tier1-3 and passed.
Also added immediate vector rotation tests to micro `test/micro/org/openjdk/bench/java/lang/RotateBenchmark.java`.
Tested the micro on a x86_64/aarch64 server and witnessed no regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257483](https://bugs.openjdk.java.net/browse/JDK-8257483): C2: Split immediate vector rotate from RotateLeftV and RotateRightV nodes


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1532/head:pull/1532`
`$ git checkout pull/1532`
