### PR TITLE
C2: Call to compute_separating_interferences has wrong argument order

### DIFF
--- a/src/hotspot/share/opto/coalesce.cpp
+++ b/src/hotspot/share/opto/coalesce.cpp
@@ -535,7 +535,7 @@ void PhaseConservativeCoalesce::union_helper( Node *lr1_node, Node *lr2_node, ui
 
 // Factored code from copy_copy that computes extra interferences from
 // lengthening a live range by double-coalescing.
-uint PhaseConservativeCoalesce::compute_separating_interferences(Node *dst_copy, Node *src_copy, Block *b, uint bindex, RegMask &rm, uint reg_degree, uint rm_size, uint lr1, uint lr2 ) {
+uint PhaseConservativeCoalesce::compute_separating_interferences(Node *dst_copy, Node *src_copy, Block *b, uint bindex, RegMask &rm, uint rm_size, uint reg_degree, uint lr1, uint lr2 ) {
 
   assert(!lrgs(lr1)._fat_proj, "cannot coalesce fat_proj");
   assert(!lrgs(lr2)._fat_proj, "cannot coalesce fat_proj");


### PR DESCRIPTION
**# [.../src/hotspot/share/opto/coalesce.hpp] -**
**112** uint compute_separating_interferences(Node *dst_copy, Node *src_copy, Block *b, uint bindex, RegMask &rm, **uint rm_size, uint reg_degree,** uint lr1, uint lr2);


**# [.../src/hotspot/share/opto/coalesce.cpp] -**
..........
**538** uint PhaseConservativeCoalesce::compute_separating_interferences(Node *dst_copy, Node *src_copy, Block *b, uint bindex, RegMask &rm, **uint reg_degree, uint rm_size,** uint lr1, uint lr2 ) {
.................
**747** reg_degree = compute_separating_interferences(dst_copy, src_copy, b, bindex, rm, **rm_size, reg_degree,** lr1, lr2 );


**# So fixing the argument order - [.../src/hotspot/share/opto/coalesce.cpp]**
-uint PhaseConservativeCoalesce::compute_separating_interferences(Node *dst_copy, Node *src_copy, Block *b, uint bindex, RegMask &rm, **uint reg_degree, uint rm_size,** uint lr1, uint lr2 ) {
+uint PhaseConservativeCoalesce::compute_separating_interferences(Node *dst_copy, Node *src_copy, Block *b, uint bindex, RegMask &rm, **uint rm_size, uint reg_degree,** uint lr1, uint lr2 ) {
