### PR TITLE
8257487: Include configuration name in summary

### DIFF
--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -238,6 +238,7 @@ AC_DEFUN_ONCE([HELP_PRINT_SUMMARY_AND_WARNINGS],
 
   printf "\n"
   printf "Configuration summary:\n"
+  printf "* Name:           $CONF_NAME\n"
   printf "* Debug level:    $DEBUG_LEVEL\n"
   printf "* HS debug level: $HOTSPOT_DEBUG_LEVEL\n"
   printf "* JVM variants:   $JVM_VARIANTS\n"


### PR DESCRIPTION
According to the enhancement request:

It would be nice and convenient to include the configuration name in the configuration summary, for example ("Name" being new):

```
Configuration summary:
* Name: my-conf
* Debug level: release
* HS debug level: product
* JVM variants: server
...
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257487](https://bugs.openjdk.java.net/browse/JDK-8257487): Include configuration name in summary


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1534/head:pull/1534`
`$ git checkout pull/1534`
