### PR TITLE
8257502: Builds fail with new warnings after JDK-8256254

### DIFF
--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -920,7 +920,7 @@ static void gen_special_dispatch(MacroAssembler *masm,
     has_receiver = MethodHandles::ref_kind_has_receiver(ref_kind);
   } else {
     guarantee(special_dispatch == vmIntrinsics::_invokeBasic || special_dispatch == vmIntrinsics::_linkToNative,
-              "special_dispatch=%d", special_dispatch);
+              "special_dispatch=%d", vmIntrinsics::as_int(special_dispatch));
     has_receiver = true;
   }
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -1288,7 +1288,7 @@ static void gen_special_dispatch(MacroAssembler* masm,
   } else if (iid == vmIntrinsics::_invokeBasic) {
     has_receiver = true;
   } else {
-    fatal("unexpected intrinsic id %d", iid);
+    fatal("unexpected intrinsic id %d", vmIntrinsics::as_int(iid));
   }
 
   if (member_reg != noreg) {


### PR DESCRIPTION
Default `x86_32` and `s390x` builds fail after JDK-8256254, because of the new warning:

x86_32:

```
/home/shade/trunks/jdk/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp: In function 'void gen_special_dispatch(MacroAssembler*, const methodHandle&, const BasicType*, const VMRegPair*)':
/home/shade/trunks/jdk/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp:1291:11: error: format '%d' expects argument of type 'int', but argument 4 has type 'vmIntrinsics::ID' {aka 'vmIntrinsicID'} [-Werror=format=]
 1291 | fatal("unexpected intrinsic id %d", iid);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~
      | |
      | vmIntrinsics::ID {aka vmIntrinsicID}
   ... (rest of output omitted)
```

s390x:

```
/home/shade/trunks/jdk/src/hotspot/cpu/s390/sharedRuntime_s390.cpp: In function 'void gen_special_dispatch(MacroAssembler*, int, vmIntrinsics::ID, const BasicType*, const VMRegPair*)':
/home/shade/trunks/jdk/src/hotspot/cpu/s390/sharedRuntime_s390.cpp:923:15: error: format '%d' expects argument of type 'int', but argument 5 has type 'vmIntrinsics::ID' {aka 'vmIntrinsicID'} [-Werror=format=]
  923 | "special_dispatch=%d", special_dispatch);
      | ^~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~
      | |
   ... (rest of output omitted)
```
The fix is pretty trivial: do the same as other arches. I think it would have been caught by GH actions in #1237, if they actually ran...

Testing:
 - [x] Linux x86_32 fastdebug build
 - [x] Linux s390x fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257502](https://bugs.openjdk.java.net/browse/JDK-8257502): Builds fail with new warnings after JDK-8256254


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1536/head:pull/1536`
`$ git checkout pull/1536`
