### PR TITLE
8257231: assert(!is_mcall || (call_returns[block->_pre_order] <= (uint) current_offset))

### DIFF
--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1696,14 +1696,15 @@ void PhaseOutput::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
       n->emit(*cb, C->regalloc());
       current_offset = cb->insts_size();
 
-      assert(!is_mcall || (call_returns[block->_pre_order] <= (uint) current_offset), "ret_addr_offset() not within emitted code");
-
       // Above we only verified that there is enough space in the instruction section.
       // However, the instruction may emit stubs that cause code buffer expansion.
       // Bail out here if expansion failed due to a lack of code cache space.
       if (C->failing()) {
         return;
       }
+
+      assert(!is_mcall || (call_returns[block->_pre_order] <= (uint)current_offset),
+             "ret_addr_offset() not within emitted code");
 
 #ifdef ASSERT
       uint n_size = n->size(C->regalloc());


### PR DESCRIPTION
The assert is executed directly after an emit-function that might have resulted in failure, and prior to the necessary error/failure detection. Moving the assert till after the failure exit solves the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257231](https://bugs.openjdk.java.net/browse/JDK-8257231): assert(!is_mcall || (call_returns[block->_pre_order] <= (uint) current_offset))


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1537/head:pull/1537`
`$ git checkout pull/1537`
