### PR TITLE
8257511: JDK-8254082 brings regression to AbstractStringBuilder.insert(int dstOffset, CharSequence s, int start, int end)

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -1717,7 +1717,7 @@ abstract class AbstractStringBuilder implements Appendable, CharSequence {
         if (getCoder() != str.coder()) {
             inflate();
         }
-        str.getBytes(value, off, index, coder, end);
+        str.getBytes(value, off, index, coder, end - off);
     }
 
     private void putStringAt(int index, String str) {

--- a/test/jdk/java/lang/StringBuilder/Insert.java
+++ b/test/jdk/java/lang/StringBuilder/Insert.java
@@ -44,7 +44,8 @@ public class Insert {
         // 8254082 made the String variant cause an AIOOBE, fixed in 8257511
         assertEquals("efabc", new StringBuilder("abc").insert(0, "def",                      1, 3).toString());
         assertEquals("efabc", new StringBuilder("abc").insert(0, new StringBuilder("def"),   1, 3).toString());
-        assertEquals("efabc", new StringBuilder("abc").insert(0, new char[] {'d', 'e', 'f'}, 1, 3).toString());
+        // insert(I[CII) and insert(ILjava/lang/CharSequence;II) are inconsistently specified
+        assertEquals("efabc", new StringBuilder("abc").insert(0, new char[] {'d', 'e', 'f'}, 1, 2).toString());
     }
 
 }

--- a/test/jdk/java/lang/StringBuilder/Insert.java
+++ b/test/jdk/java/lang/StringBuilder/Insert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,15 +21,30 @@
  * questions.
  */
 
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
 /**
  * @test
- * @bug 4914802
- * @summary Test Insert method for infinite loop
+ * @run testng Insert
+ * @bug 4914802 8257511
+ * @summary Test StringBuilder.insert sanity tests
  */
-
+@Test
 public class Insert {
-   public static void main (String argv[]) throws Exception {
-       StringBuilder sb = new StringBuilder();
-       sb.insert(0, false);
-   }
+
+    public void insertFalse() {
+        // Caused an infinite loop before 4914802
+        StringBuilder sb = new StringBuilder();
+        assertEquals("false", sb.insert(0, false).toString());
+    }
+
+    public void insertOffset() {
+        // 8254082 made the String variant cause an AIOOBE, fixed in 8257511
+        assertEquals("efabc", new StringBuilder("abc").insert(0, "def",                      1, 3).toString());
+        assertEquals("efabc", new StringBuilder("abc").insert(0, new StringBuilder("def"),   1, 3).toString());
+        assertEquals("efabc", new StringBuilder("abc").insert(0, new char[] {'d', 'e', 'f'}, 1, 3).toString());
+    }
+
 }


### PR DESCRIPTION
This patch fixes a place where we failed to adjust properly for getBytes taking a length rather than end offset. (Something the public API in AbstractStringBuilder is apparently inconsistent about..)

Although this was caught by JCK testing, this patch adds a few trivial sanity tests to get at least some sanity checking into tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257511](https://bugs.openjdk.java.net/browse/JDK-8257511): JDK-8254082 brings regression to AbstractStringBuilder.insert(int dstOffset, CharSequence s, int start, int end)


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1541/head:pull/1541`
`$ git checkout pull/1541`
