### PR TITLE
8257241: CDS should not handle disableEagerInitialization for archived lambda proxy classes

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1684,8 +1684,7 @@ InstanceKlass* SystemDictionaryShared::get_shared_nest_host(InstanceKlass* lambd
 }
 
 InstanceKlass* SystemDictionaryShared::prepare_shared_lambda_proxy_class(InstanceKlass* lambda_ik,
-                                                                         InstanceKlass* caller_ik,
-                                                                         bool initialize, TRAPS) {
+                                                                         InstanceKlass* caller_ik, TRAPS) {
   Handle class_loader(THREAD, caller_ik->class_loader());
   Handle protection_domain;
   PackageEntry* pkg_entry = get_package_entry_from_class_name(class_loader, caller_ik->name());
@@ -1726,9 +1725,7 @@ InstanceKlass* SystemDictionaryShared::prepare_shared_lambda_proxy_class(Instanc
     SystemDictionary::post_class_load_event(&class_load_start_event, loaded_lambda, ClassLoaderData::class_loader_data(class_loader()));
   }
 
-  if (initialize) {
-    loaded_lambda->initialize(CHECK_NULL);
-  }
+  loaded_lambda->initialize(CHECK_NULL);
 
   return loaded_lambda;
 }

--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -304,8 +304,7 @@ public:
                                                       Symbol* instantiated_method_type) NOT_CDS_RETURN_(NULL);
   static InstanceKlass* get_shared_nest_host(InstanceKlass* lambda_ik) NOT_CDS_RETURN_(NULL);
   static InstanceKlass* prepare_shared_lambda_proxy_class(InstanceKlass* lambda_ik,
-                                                          InstanceKlass* caller_ik,
-                                                          bool initialize, TRAPS) NOT_CDS_RETURN_(NULL);
+                                                          InstanceKlass* caller_ik, TRAPS) NOT_CDS_RETURN_(NULL);
   static bool check_linking_constraints(InstanceKlass* klass, TRAPS) NOT_CDS_RETURN_(false);
   static void record_linking_constraint(Symbol* name, InstanceKlass* klass,
                                      Handle loader1, Handle loader2, TRAPS) NOT_CDS_RETURN;

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -194,8 +194,7 @@ JVM_LookupLambdaProxyClassFromArchive(JNIEnv* env, jclass caller,
                                       jobject invokedType,
                                       jobject methodType,
                                       jobject implMethodMember,
-                                      jobject instantiatedMethodType,
-                                      jboolean initialize);
+                                      jobject instantiatedMethodType);
 
 JNIEXPORT jboolean JNICALL
 JVM_IsCDSDumpingEnabled(JNIEnv* env);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3825,8 +3825,7 @@ JVM_ENTRY(jclass, JVM_LookupLambdaProxyClassFromArchive(JNIEnv* env,
                                                         jobject invokedType,
                                                         jobject methodType,
                                                         jobject implMethodMember,
-                                                        jobject instantiatedMethodType,
-                                                        jboolean initialize))
+                                                        jobject instantiatedMethodType))
   JVMWrapper("JVM_LookupLambdaProxyClassFromArchive");
 #if INCLUDE_CDS
 
@@ -3860,7 +3859,7 @@ JVM_ENTRY(jclass, JVM_LookupLambdaProxyClassFromArchive(JNIEnv* env,
                                                                                    method_type, m, instantiated_method_type);
   jclass jcls = NULL;
   if (lambda_ik != NULL) {
-    InstanceKlass* loaded_lambda = SystemDictionaryShared::prepare_shared_lambda_proxy_class(lambda_ik, caller_ik, initialize, THREAD);
+    InstanceKlass* loaded_lambda = SystemDictionaryShared::prepare_shared_lambda_proxy_class(lambda_ik, caller_ik, THREAD);
     jcls = loaded_lambda == NULL ? NULL : (jclass) JNIHandles::make_local(THREAD, loaded_lambda->java_mirror());
   }
   return jcls;

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -263,37 +263,37 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
      * registers the lambda proxy class for including into the CDS archive.
      */
     private Class<?> spinInnerClass() throws LambdaConversionException {
-        // include lambda proxy class in CDS archive at dump time
-        if (CDS.isDumpingArchive()) {
-            Class<?> innerClass = generateInnerClass();
-            LambdaProxyClassArchive.register(targetClass,
-                                             samMethodName,
-                                             invokedType,
-                                             samMethodType,
-                                             implMethod,
-                                             instantiatedMethodType,
-                                             isSerializable,
-                                             markerInterfaces,
-                                             additionalBridges,
-                                             innerClass);
-            return innerClass;
-        }
+        // CDS does not handle disableEagerInitialization.
+        if (!disableEagerInitialization) {
+            // include lambda proxy class in CDS archive at dump time
+            if (CDS.isDumpingArchive()) {
+                Class<?> innerClass = generateInnerClass();
+                LambdaProxyClassArchive.register(targetClass,
+                                                 samMethodName,
+                                                 invokedType,
+                                                 samMethodType,
+                                                 implMethod,
+                                                 instantiatedMethodType,
+                                                 isSerializable,
+                                                 markerInterfaces,
+                                                 additionalBridges,
+                                                 innerClass);
+                return innerClass;
+            }
 
-        // load from CDS archive if present
-        Class<?> innerClass = LambdaProxyClassArchive.find(targetClass,
-                                                           samMethodName,
-                                                           invokedType,
-                                                           samMethodType,
-                                                           implMethod,
-                                                           instantiatedMethodType,
-                                                           isSerializable,
-                                                           markerInterfaces,
-                                                           additionalBridges,
-                                                           !disableEagerInitialization);
-        if (innerClass == null) {
-            innerClass = generateInnerClass();
+            // load from CDS archive if present
+            Class<?> innerClass = LambdaProxyClassArchive.find(targetClass,
+                                                               samMethodName,
+                                                               invokedType,
+                                                               samMethodType,
+                                                               implMethod,
+                                                               instantiatedMethodType,
+                                                               isSerializable,
+                                                               markerInterfaces,
+                                                               additionalBridges);
+            if (innerClass != null) return innerClass;
         }
-        return innerClass;
+        return generateInnerClass();
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/LambdaProxyClassArchive.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaProxyClassArchive.java
@@ -50,8 +50,7 @@ final class LambdaProxyClassArchive {
                                                    MethodType invokedType,
                                                    MethodType samMethodType,
                                                    MemberName implMethod,
-                                                   MethodType instantiatedMethodType,
-                                                   boolean initialize);
+                                                   MethodType instantiatedMethodType);
 
     /**
      * Registers the lambdaProxyClass into CDS archive.
@@ -101,16 +100,15 @@ final class LambdaProxyClassArchive {
                          MethodType instantiatedMethodType,
                          boolean isSerializable,
                          Class<?>[] markerInterfaces,
-                         MethodType[] additionalBridges,
-                         boolean initialize) {
+                         MethodType[] additionalBridges) {
         if (CDS.isDumpingArchive())
             throw new IllegalStateException("cannot load class from CDS archive at dump time");
 
-        if (!loadedByBuiltinLoader(caller) || !initialize ||
+        if (!loadedByBuiltinLoader(caller) ||
             !CDS.isSharingEnabled() || isSerializable || markerInterfaces.length > 0 || additionalBridges.length > 0)
             return null;
 
         return findFromArchive(caller, invokedName, invokedType, samMethodType,
-                               implMethod.internalMemberName(), instantiatedMethodType, initialize);
+                               implMethod.internalMemberName(), instantiatedMethodType);
     }
 }

--- a/src/java.base/share/native/libjava/LambdaProxyClassArchive.c
+++ b/src/java.base/share/native/libjava/LambdaProxyClassArchive.c
@@ -51,9 +51,8 @@ Java_java_lang_invoke_LambdaProxyClassArchive_findFromArchive(JNIEnv *env, jclas
                                                             jobject invokedType,
                                                             jobject methodType,
                                                             jobject implMethodMember,
-                                                            jobject instantiatedMethodType,
-                                                            jboolean initialize) {
+                                                            jobject instantiatedMethodType) {
     return JVM_LookupLambdaProxyClassFromArchive(env, caller, invokedName, invokedType,
                                                  methodType, implMethodMember,
-                                                 instantiatedMethodType, initialize);
+                                                 instantiatedMethodType);
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaEagerInit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaEagerInit.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8257241
+ * @summary Run the LambdaEagerInitTest.java test in static CDS archive mode.
+ *          Create a base archive with the -Djdk.internal.lambda.disableEagerInitialization=true property.
+ *          Run with the archive with and without specifying the property.
+ *          With the disableEagerInit set to true, lambda proxy classes will not
+ *          be archived. During runtime, lambda proxy classes will not be loaded
+ *          from the archive.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @compile ../../../../../jdk/java/lang/invoke/lambda/LambdaEagerInitTest.java
+ * @run main/othervm LambdaEagerInit
+ */
+
+import java.io.File;
+
+import jdk.test.lib.cds.CDSOptions;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class LambdaEagerInit {
+    public static void main(String[] args) throws Exception {
+        testImpl();
+    }
+
+    private static final String classDir = System.getProperty("test.classes");
+    private static final String mainClass = "LambdaEagerInitTest";
+    private static final String testProperty = "-Djdk.internal.lambda.disableEagerInitialization=true";
+
+    static void testImpl() throws Exception {
+        String appJar = JarBuilder.build("lambda_eager", new File(classDir), null);
+        String archiveName = mainClass + ".jsa";
+
+        // create base archive with the -Djdk.internal.lambda.disableEagerInitialization=true property
+        CDSOptions opts = (new CDSOptions())
+            .addPrefix(testProperty,
+                       "-Xlog:class+load,cds")
+            .setArchiveName(archiveName);
+        CDSTestUtils.createArchiveAndCheck(opts);
+
+        // run with archive with the -Djdk.internal.lambda.disableEagerInitialization=true property
+        CDSOptions runOpts = (new CDSOptions())
+            .addPrefix("-cp", appJar, testProperty,  "-Xlog:class+load,cds=debug")
+            .setArchiveName(archiveName)
+            .setUseVersion(false)
+            .addSuffix(mainClass);
+        OutputAnalyzer output = CDSTestUtils.runWithArchive(runOpts);
+        output.shouldMatch(".class.load. java.util.stream.Collectors[$][$]Lambda[$].*/0x.*source:.*java.*util.*stream.*Collectors")
+              .shouldNotMatch(".cds.*Loaded.*lambda.*proxy")
+              .shouldHaveExitValue(0);
+
+        // run with archive without the -Djdk.internal.lambda.disableEagerInitialization=true property
+        runOpts = (new CDSOptions())
+            .addPrefix("-cp", appJar, "-Xlog:class+load,cds=debug")
+            .setArchiveName(archiveName)
+            .setUseVersion(false)
+            .addSuffix(mainClass);
+        output = CDSTestUtils.runWithArchive(runOpts);
+        output.shouldMatch(".class.load. java.util.stream.Collectors[$][$]Lambda[$].*/0x.*source:.*java.*util.*stream.*Collectors")
+              .shouldNotMatch(".cds.*Loaded.*lambda.*proxy")
+              .shouldHaveExitValue(0);
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaEagerInit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaEagerInit.java
@@ -49,8 +49,12 @@ public class LambdaEagerInit {
         createArchiveWithEagerInitializationEnabled();
         testWithEagerInitializationEnabled();
         testWithEagerInitializationDisabled();
-        testDefaultArchiveWithEagerInitializationEnabled();
-        testDefaultArchiveWithEagerInitializationDisabled();
+        // Skip testing with default CDS archive on aarch64 platform because
+        // default archive isn't being generated on that platform.
+        if (!("aarch64".equals(System.getProperty("os.arch")))) {
+            testDefaultArchiveWithEagerInitializationEnabled();
+            testDefaultArchiveWithEagerInitializationDisabled();
+        }
     }
 
     private static final String classDir = System.getProperty("test.classes");

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/LambdaEagerInitTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/LambdaEagerInitTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8242451
+ * @library /test/lib
+ * @summary Test that the LAMBDA_INSTANCE$ field is present depending
+ *          on disableEagerInitialization
+ * @run main LambdaEagerInitTest
+ * @run main/othervm -Djdk.internal.lambda.disableEagerInitialization=true LambdaEagerInitTest
+ */
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static jdk.test.lib.Asserts.*;
+
+public class LambdaEagerInitTest {
+
+    interface H {Object m(String s);}
+
+    private static Set<String> allowedStaticFields(boolean nonCapturing) {
+        Set<String> s = new HashSet<>();
+        if (Boolean.getBoolean("jdk.internal.lambda.disableEagerInitialization")) {
+            if (nonCapturing) s.add("LAMBDA_INSTANCE$");
+        }
+        return s;
+    }
+
+    private void nonCapturingLambda() {
+        H la = s -> s;
+        assertEquals("hi", la.m("hi"));
+        Class<? extends H> c1 = la.getClass();
+        verifyLambdaClass(la.getClass(), true);
+    }
+
+    private void capturingLambda() {
+        H la = s -> concat(s, "foo");
+        assertEquals("hi foo", la.m("hi"));
+        verifyLambdaClass(la.getClass(), false);
+    }
+
+    private void verifyLambdaClass(Class<?> c, boolean nonCapturing) {
+        Set<String> staticFields = new HashSet<>();
+        Set<String> instanceFields = new HashSet<>();
+        for (Field f : c.getDeclaredFields()) {
+            if (Modifier.isStatic(f.getModifiers())) {
+                staticFields.add(f.getName());
+            } else {
+                instanceFields.add(f.getName());
+            }
+        }
+        assertEquals(instanceFields.size(), nonCapturing ? 0 : 1, "Unexpected instance fields");
+        assertEquals(staticFields, allowedStaticFields(nonCapturing), "Unexpected static fields");
+    }
+
+    private String concat(String... ss) {
+        return Arrays.stream(ss).collect(Collectors.joining(" "));
+    }
+
+    public static void main(String[] args) {
+        LambdaEagerInitTest test = new LambdaEagerInitTest();
+        test.nonCapturingLambda();
+        test.capturingLambda();
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/LambdaEagerInitTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/LambdaEagerInitTest.java
@@ -21,14 +21,9 @@
  * questions.
  */
 
-/**
- * @test
- * @bug 8242451
- * @library /test/lib
- * @summary Test that the LAMBDA_INSTANCE$ field is present depending
- *          on disableEagerInitialization
- * @run main LambdaEagerInitTest
- * @run main/othervm -Djdk.internal.lambda.disableEagerInitialization=true LambdaEagerInitTest
+/*
+ * This file is copied from open/test/jdk/java/lang/invoke/lambda.
+ * It is being used as the main class for the appcds/LambdaEagerInit.java test.
  */
 
 import java.lang.reflect.Field;


### PR DESCRIPTION
Please review this change which includes:

- If the `jdk.internal.lambda.disableEagerInitialization`property is enabled, the `InnerClassLambdaMetafactory` will not involve CDS to archive lambda proxy classes or to find them from an archive.

- Not passing the `initialize` (same as `!disableEagerInitialization`) to `LambdaProxyClassArchive.find` and eventually to the `JVM_LookupLambdaProxyClassFromArchive` function.

Testing:

- [x] all cds/appcds tests locally on linux-x64

- [x] tiers 1 - 4 (in progress)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257241](https://bugs.openjdk.java.net/browse/JDK-8257241): CDS should not handle disableEagerInitialization for archived lambda proxy classes


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to fc10e77fd03ffce6c7efdb5bcbed7922c73f14d2
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to 812777b3e69bfceea328df34149cb0964aa8625a
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to fc10e77fd03ffce6c7efdb5bcbed7922c73f14d2


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1542/head:pull/1542`
`$ git checkout pull/1542`
