### PR TITLE
8257505: nsk/share/test/StressOptions stressTime is scaled in getter but not when printed

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/test/StressOptions.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/test/StressOptions.java
@@ -200,10 +200,10 @@ public class StressOptions {
      * @param out output stream
      */
     public void printInfo(PrintStream out) {
-        out.println("Stress time: " + time + " seconds");
-        out.println("Stress iterations factor: " + iterationsFactor);
-        out.println("Stress threads factor: " + threadsFactor);
-        out.println("Stress runs factor: " + runsFactor);
+        out.println("Stress time: " + getTime() + " seconds");
+        out.println("Stress iterations factor: " + getIterationsFactor());
+        out.println("Stress threads factor: " + getThreadsFactor());
+        out.println("Stress runs factor: " + getRunsFactor());
     }
 
     private void error(String msg) {


### PR DESCRIPTION
Please review this small change to print the correct stress time for tests using `StressOptions`.

Quite recently the `getTime()` method on `StressOptions` was changed to scale the stress time using the JTREG timeout factor. See: [JDK-8252522](https://bugs.openjdk.java.net/browse/JDK-8252522)

The `printInfo()` method was left using the raw `time` member and will thus output a different time from the one actually used. This change fixes this by using the getter. For consistency the other values are fetched by the getters as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257505](https://bugs.openjdk.java.net/browse/JDK-8257505): nsk/share/test/StressOptions stressTime is scaled in getter but not when printed


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1545/head:pull/1545`
`$ git checkout pull/1545`
