### PR TITLE
JDK-8257547: Handle multiple prereqs on the same line in deps files

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -243,7 +243,7 @@ ifeq ($(ALLOW_ABSOLUTE_PATHS_IN_OUTPUT)-$(FILE_MACRO_CFLAGS), false-)
   # leading spaces. There may also be multiple entries on the same line, so start
   # with splitting such lines.
   # Non GNU sed (BSD on macosx) cannot substitue in literal \n using regex.
-  # Instead use bash escaped literal newline. To avoid having unmatched quotes
+  # Instead use a bash escaped literal newline. To avoid having unmatched quotes
   # ruin the ability for an editor to properly syntax highlight this file, define
   # that newline sequence as a separate variable and add the closing quote behind
   # a comment.

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -240,12 +240,16 @@ ifeq ($(ALLOW_ABSOLUTE_PATHS_IN_OUTPUT)-$(FILE_MACRO_CFLAGS), false-)
   # When compiling with relative paths, the deps file may come out with relative
   # paths, and that path may start with './'. First remove any leading ./, then
   # add WORKSPACE_ROOT to any line not starting with /, while allowing for
-  # leading spaces.
+  # leading spaces. There may also be multiple entries on the same line, so start
+  # with splitting such lines.
   define fix-deps-file
 	$(SED) \
-	    -e 's|^\([ ]*\)\./|\1|' \
-	    -e '/^[ ]*[^/ ]/s|^\([ ]*\)|\1$(WORKSPACE_ROOT)/|' \
-	    $1.tmp > $1
+	    -e 's|\([^ ]\) \{1,\}\([^\\:]\)|\1 \\\n \2|g' \
+	    $1.tmp \
+	    | $(SED) \
+	        -e 's|^\([ ]*\)\./|\1|' \
+	        -e '/^[ ]*[^/ ]/s|^\([ ]*\)|\1$(WORKSPACE_ROOT)/|' \
+	        > $1
   endef
 else
   # By default the MakeCommandRelative macro does nothing.

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -242,9 +242,15 @@ ifeq ($(ALLOW_ABSOLUTE_PATHS_IN_OUTPUT)-$(FILE_MACRO_CFLAGS), false-)
   # add WORKSPACE_ROOT to any line not starting with /, while allowing for
   # leading spaces. There may also be multiple entries on the same line, so start
   # with splitting such lines.
+  # Non GNU sed (BSD on macosx) cannot substitue in literal \n using regex.
+  # Instead use bash escaped literal newline. To avoid having unmatched quotes
+  # ruin the ability for an editor to properly syntax highlight this file, define
+  # that newline sequence as a separate variable and add the closing quote behind
+  # a comment.
+  sed_newline := \'$$'\n''#'
   define fix-deps-file
 	$(SED) \
-	    -e 's|\([^ ]\) \{1,\}\([^\\:]\)|\1 \\\n \2|g' \
+	    -e 's|\([^ ]\) \{1,\}\([^\\:]\)|\1 \\$(sed_newline) \2|g' \
 	    $1.tmp \
 	    | $(SED) \
 	        -e 's|^\([ ]*\)\./|\1|' \

--- a/test/make/TestFixDepsFile.gmk
+++ b/test/make/TestFixDepsFile.gmk
@@ -1,0 +1,66 @@
+#
+# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+default: all
+
+include $(SPEC)
+include MakeBase.gmk
+include UtilsForTests.gmk
+
+THIS_FILE := $(TOPDIR)/test/make/FixDepsFile.gmk
+DEPS := $(THIS_FILE) \
+    $(TOPDIR)/make/common/NativeCompilation.gmk \
+    #
+
+OUTPUT_DIR := $(TESTMAKE_OUTPUTDIR)/fix-deps-file
+$(call MakeDir, $(OUTPUT_DIR))
+
+################################################################################
+# The relevant case to test is when absolute paths aren't allowed.
+ALLOW_ABSOLUTE_PATHS_IN_OUTPUT := false
+FILE_MACRO_CFLAGS :=
+include NativeCompilation.gmk
+
+DEPS_FILE := $(OUTPUT_DIR)/deps.d
+
+test-fix-deps-file:
+	$(ECHO) "foo/bar1: \\" > $(DEPS_FILE).tmp
+	$(ECHO) "foo/baz1" >> $(DEPS_FILE).tmp
+	$(ECHO) "foo/bar : bar \\" >> $(DEPS_FILE).tmp
+	$(ECHO) " ./bar/baz /foo/baz" >> $(DEPS_FILE).tmp
+	$(call fix-deps-file, $(DEPS_FILE))
+	$(ECHO) "$(WORKSPACE_ROOT)/foo/bar1: \\" > $(DEPS_FILE).expected
+	$(ECHO) "$(WORKSPACE_ROOT)/foo/baz1" >> $(DEPS_FILE).expected
+	$(ECHO) "$(WORKSPACE_ROOT)/foo/bar : \\" >> $(DEPS_FILE).expected
+	$(ECHO) " $(WORKSPACE_ROOT)/bar \\" >> $(DEPS_FILE).expected
+	$(ECHO) " $(WORKSPACE_ROOT)/bar/baz \\" >> $(DEPS_FILE).expected
+	$(ECHO) " /foo/baz" >> $(DEPS_FILE).expected
+	$(DIFF) $(DEPS_FILE).expected $(DEPS_FILE)
+
+TEST_TARGETS := test-fix-deps-file
+
+################################################################################
+
+all: $(TEST_TARGETS)

--- a/test/make/TestMake.gmk
+++ b/test/make/TestMake.gmk
@@ -36,6 +36,9 @@ java-compilation:
 copy-files:
 	+$(MAKE) -f TestCopyFiles.gmk $(TEST_SUBTARGET)
 
+fix-deps-file:
+	+$(MAKE) -f TestFixDepsFile.gmk $(TEST_SUBTARGET)
+
 idea:
 	+$(MAKE) -f TestIdea.gmk $(TEST_SUBTARGET)
 
@@ -46,7 +49,8 @@ configure:
 	$(BASH) $(TOPDIR)/test/make/autoconf/test-configure.sh \
 	    "$(AUTOCONF)" "$(TOPDIR)" "$(TEST_SUPPORT_DIR)"
 
-TARGETS += make-base java-compilation copy-files idea compile-commands configure
+TARGETS += make-base java-compilation copy-files fix-deps-file idea \
+    compile-commands configure
 
 all: $(TARGETS)
 


### PR DESCRIPTION
After fixing JDK-8256810 and starting to look into backporting it, I discovered more potential failing cases. Certain versions of GCC may sometimes output multiple prerequisite files on the same line. I think the easiest way to handle this new issue is to split such lines.

When splitting lines, we need to make sure to not just split on any space. Some compilers output the : of the rule with a leading space, and already split lines will have a space before the backslash.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257547](https://bugs.openjdk.java.net/browse/JDK-8257547): Handle multiple prereqs on the same line in deps files


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**) ⚠️ Review applies to 0c854066af2e12ab111a985c658dc32d0caede02


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1548/head:pull/1548`
`$ git checkout pull/1548`
