### PR TITLE
8257434: jpackage fails to create rpm on Fedora Linux

### DIFF
--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
@@ -5,19 +5,19 @@ Release: APPLICATION_RELEASE
 License: APPLICATION_LICENSE_TYPE
 Vendor: APPLICATION_VENDOR
 
-%if "xAPPLICATION_PREFIX" != x
+%if "xAPPLICATION_PREFIX" != "x"
 Prefix: APPLICATION_PREFIX
 %endif
 
 Provides: APPLICATION_PACKAGE
 
-%if "xAPPLICATION_GROUP" != x
+%if "xAPPLICATION_GROUP" != "x"
 Group: APPLICATION_GROUP
 %endif
 
 Autoprov: 0
 Autoreq: 0
-%if "xPACKAGE_DEFAULT_DEPENDENCIES" != x || "xPACKAGE_CUSTOM_DEPENDENCIES" != x
+%if "xPACKAGE_DEFAULT_DEPENDENCIES" != "x" || "xPACKAGE_CUSTOM_DEPENDENCIES" != "x"
 Requires: PACKAGE_DEFAULT_DEPENDENCIES PACKAGE_CUSTOM_DEPENDENCIES
 %endif
 
@@ -43,7 +43,7 @@ APPLICATION_DESCRIPTION
 rm -rf %{buildroot}
 install -d -m 755 %{buildroot}APPLICATION_DIRECTORY
 cp -r %{_sourcedir}APPLICATION_DIRECTORY/* %{buildroot}APPLICATION_DIRECTORY
-%if "xAPPLICATION_LICENSE_FILE" != x
+%if "xAPPLICATION_LICENSE_FILE" != "x"
   %define license_install_file %{_defaultlicensedir}/%{name}-%{version}/%{basename:APPLICATION_LICENSE_FILE}
   install -d -m 755 "%{buildroot}%{dirname:%{license_install_file}}"
   install -m 644 "APPLICATION_LICENSE_FILE" "%{buildroot}%{license_install_file}"
@@ -53,12 +53,12 @@ cp -r %{_sourcedir}APPLICATION_DIRECTORY/* %{buildroot}APPLICATION_DIRECTORY
 comm -23 %{app_filelist} %{filesystem_filelist} > %{package_filelist}
 sed -i -e 's/.*/%dir "&"/' %{package_filelist}
 (cd %{buildroot} && find . -not -type d) | sed -e 's/^\.//' -e 's/.*/"&"/' >> %{package_filelist}
-%if "xAPPLICATION_LICENSE_FILE" != x
+%if "xAPPLICATION_LICENSE_FILE" != "x"
   sed -i -e 's|"%{license_install_file}"||' -e '/^$/d' %{package_filelist}
 %endif
 
 %files -f %{package_filelist}
-%if "xAPPLICATION_LICENSE_FILE" != x
+%if "xAPPLICATION_LICENSE_FILE" != "x"
   %license "%{license_install_file}"
 %endif
 


### PR DESCRIPTION
Add missing quotes to `%if` expressions in spec template. Required by rpmbuild 4.16.0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257434](https://bugs.openjdk.java.net/browse/JDK-8257434): jpackage fails to create rpm on Fedora Linux


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1551/head:pull/1551`
`$ git checkout pull/1551`
