### PR TITLE
8245956: JavaCompiler still uses File API instead of Path API in a specific case

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -741,11 +741,11 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
     @Override @DefinedBy(Api.COMPILER)
     public ClassLoader getClassLoader(Location location) {
         checkNotModuleOrientedLocation(location);
-        Collection<? extends Path> paths = getLocationAsPaths(location);
-        if (paths == null)
+        Collection<? extends Path> searchPath = getLocationAsPaths(location);
+        if (searchPath == null)
             return null;
         ListBuffer<URL> lb = new ListBuffer<>();
-        for (Path p : paths) {
+        for (Path p : searchPath) {
             try {
                 lb.append(p.toUri().toURL());
             } catch (MalformedURLException e) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -741,13 +741,13 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
     @Override @DefinedBy(Api.COMPILER)
     public ClassLoader getClassLoader(Location location) {
         checkNotModuleOrientedLocation(location);
-        Iterable<? extends File> path = getLocation(location);
-        if (path == null)
+        Collection<? extends Path> paths = getLocationAsPaths(location);
+        if (paths == null)
             return null;
         ListBuffer<URL> lb = new ListBuffer<>();
-        for (File f: path) {
+        for (Path p : paths) {
             try {
-                lb.append(f.toURI().toURL());
+                lb.append(p.toUri().toURL());
             } catch (MalformedURLException e) {
                 throw new AssertionError(e);
             }

--- a/test/langtools/tools/javac/T8245956/T8245956.java
+++ b/test/langtools/tools/javac/T8245956/T8245956.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8245956
- * @summary JavaCompiler still uses files API instead of Path API in a specific case
+ * @summary JavaCompiler still uses File API instead of Path API in a specific case
  * @run main T8245956
  */
 
@@ -60,6 +60,7 @@ public class T8245956 {
                 classPath.add(fsPath);
                 fileManager.setLocationFromPaths(StandardLocation.CLASS_PATH, classPath);
                 fileManager.getClassLoader(StandardLocation.CLASS_PATH);  // Should not generate any exceptions.
+                System.out.println("The method getClassLoader terminated normally.\n");
             }
         }
     }

--- a/test/langtools/tools/javac/T8245956/T8245956.java
+++ b/test/langtools/tools/javac/T8245956/T8245956.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8245956
+ * @summary JavaCompiler still uses files API instead of Path API in a specific case
+ * @run main T8245956
+ */
+
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+
+public class T8245956 {
+    public static void main(String[] args) throws Exception {
+        Path zipFilePath = Path.of("T8245956.zip");
+        URI zipFileUri = zipFilePath.toUri();
+        URI jarZipFileUri = URI.create("jar:" + zipFileUri.toString());
+        Map<String, String> env = new LinkedHashMap<>();
+        env.put("create", "true");
+        try (FileSystem fs = FileSystems.newFileSystem(jarZipFileUri, env)) {
+            Path fsPath = fs.getPath("");
+            JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+            DiagnosticCollector<JavaFileObject> diagnosticCollector = new DiagnosticCollector<>();
+            try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnosticCollector, null, null)) {
+                List<Path> classPath = new ArrayList<>();
+                classPath.add(fsPath);
+                fileManager.setLocationFromPaths(StandardLocation.CLASS_PATH, classPath);
+                fileManager.getClassLoader(StandardLocation.CLASS_PATH);  // Should not generate any exceptions.
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

`JavacFileManager.getClassLoader` uses `getLocation` which causes exception in some situations.
This patch uses `getLocationAsPaths` instead of `getLocation` to solve it.
Thanks you for taking the time to review.

Best Regards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8245956](https://bugs.openjdk.java.net/browse/JDK-8245956): JavaCompiler still uses File API instead of Path API in a specific case


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1553/head:pull/1553`
`$ git checkout pull/1553`
