### PR TITLE
8257565: epsilonBarrierSet.hpp should not include barrierSetAssembler

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1238,6 +1238,7 @@ definitions %{
 source_hpp %{
 
 #include "asm/macroAssembler.hpp"
+#include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
 #include "gc/shared/collectedHeap.hpp"

--- a/src/hotspot/cpu/aarch64/jvmciCodeInstaller_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jvmciCodeInstaller_aarch64.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "precompiled.hpp"
+#include "asm/macroAssembler.hpp"
 #include "jvmci/jvmci.hpp"
 #include "jvmci/jvmciCodeInstaller.hpp"
 #include "jvmci/jvmciRuntime.hpp"

--- a/src/hotspot/share/gc/epsilon/epsilonBarrierSet.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilonBarrierSet.hpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -25,7 +26,6 @@
 #ifndef SHARE_GC_EPSILON_EPSILONBARRIERSET_HPP
 #define SHARE_GC_EPSILON_EPSILONBARRIERSET_HPP
 
-#include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/barrierSet.hpp"
 
 // No interaction with application is required for Epsilon, and therefore

--- a/src/hotspot/share/gc/epsilon/epsilonBarrierSet.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilonBarrierSet.hpp
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
Please review this trivial fix:

epsilonBarrierSet.hpp is included (recursively via access.hpp) by many CPP files. It unncessarily includes of barrierSetAssembler.hpp, which causes many of the native code assembler header files to be unnecessarily included by many HotSpot CPP files that do not deal with native code assembly.

Removing this one line reduced the total number of header inclusion for building HotSpot from 260096 to 258193, or about 0.8%.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257565](https://bugs.openjdk.java.net/browse/JDK-8257565): epsilonBarrierSet.hpp should not include barrierSetAssembler


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 3949a648f7e133f0159ee674fe06af9ccacb6c03
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 3949a648f7e133f0159ee674fe06af9ccacb6c03
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 82b910855e9d25fe55a0ed2beda08d01bf67c6dc


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1554/head:pull/1554`
`$ git checkout pull/1554`
