### PR TITLE
8257575: C2: "failed: only phis" assert failure in loop strip mining verification

### DIFF
--- a/test/hotspot/jtreg/compiler/loopstripmining/TestEliminatedLoadPinnedOnBackedge.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestEliminatedLoadPinnedOnBackedge.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8257575
+ * @summary C2: "failed: only phis" assert failure in loop strip mining verfication
+ *
+ * @run main/othervm -XX:LoopUnrollLimit=0 -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestEliminatedLoadPinnedOnBackedge::notInlined
+ *                    -XX:CompileCommand=inline,TestEliminatedLoadPinnedOnBackedge::inlined TestEliminatedLoadPinnedOnBackedge
+ *
+ */
+
+public class TestEliminatedLoadPinnedOnBackedge {
+    private static Object field2;
+
+    final static int iters = 2000;
+
+    public static void main(String[] args) {
+        boolean[] flags = new boolean[iters];
+        for (int i = 0; i < iters; i++) {
+            flags[i] = i < iters/2;
+        }
+        for (int i = 0; i < 20_000; i++) {
+            test1(flags);
+            test2(flags, 1);
+            test3(flags);
+            inlined(new Object(), 1);
+            inlined(new Object(), 4);
+            inlined2(42);
+            inlined2(0x42);
+        }
+    }
+
+    static int field;
+
+    private static int test1(boolean[] flags) {
+        int k = 2;
+        for (; k < 4; k *= 2) {
+        }
+        int[] array = new int[10];
+        notInlined(array);
+        // This load commons with the load on the backedge after the
+        // outer strip mined loop is expanded.
+        int v = array[0];
+        array[1] = 42;
+        // No use for o. Allocation removed at macro expansion time.
+        Object o = new Object();
+        inlined(o, k);
+        int i = 0;
+        for (; ; ) {
+            synchronized (array) {
+            }
+            if (i >= iters) {
+                break;
+            }
+            v = array[0]; // This load ends up on the backedge
+            if (flags[i]) {
+                inlined2(array[1]);
+            }
+            i++;
+        }
+        return v;
+    }
+
+    private static int test2(boolean[] flags, int d) {
+        int k = 2;
+        for (; k < 4; k *= 2) {
+        }
+        int[] array = new int[10];
+        notInlined(array);
+        int v = array[0];
+        array[1] = 42;
+        Object o = new Object();
+        inlined(o, k);
+        int i = 0;
+        for (; ; ) {
+            synchronized (array) {
+            }
+            if (d == 0) {}
+            if (i >= iters) {
+                break;
+            }
+            v = (array[0] + array[2]) / d;
+            if (flags[i]) {
+                inlined2(array[1]);
+            }
+            i++;
+        }
+        return v;
+    }
+
+    private static int test3(boolean[] flags) {
+        int k = 2;
+        for (; k < 4; k *= 2) {
+        }
+        int[] array = new int[10];
+        notInlined(array);
+        int v1 = array[0];
+        int v2 = array[2];
+        array[1] = 42;
+        Object o = new Object();
+        inlined(o, k);
+        int i = 0;
+        for (; ; ) {
+            synchronized (array) {
+            }
+            if (i >= iters) {
+                break;
+            }
+            v1 = array[0];
+            v2 = array[2];
+            if (flags[i]) {
+                inlined2(array[1]);
+            }
+            i++;
+        }
+        return v1 + v2;
+    }
+
+    private static void inlined2(int i) {
+        if (i != 42) {
+            field = 42;
+        }
+    }
+
+    private static void inlined(Object o, int i) {
+        if (i != 4) {
+            field2 = o;
+        }
+    }
+
+    private static void notInlined(int[] array) {
+        java.util.Arrays.fill(array, 1);
+    }
+}


### PR DESCRIPTION
The loop in the test is a counted loop with a load pinned on the
backedge. The loop is strip mined. When the outer loop is expanded, it
ends up with a load on the backedge too as it must mirror the inner
loop. The load is input to a Phi. After expansion, the load on the
backedge of the outer loop is found to be rendundant with a dominating
load. That causes the Phi to be eliminated. The load on the backedge
of the inner loop is not eliminated. As a result, verification code
finds the inner and outer loops to have a different number of Phis
which is unexpected.

The load on the backedge of the inner loop could be eliminated. It's
not because it's not enqueued to be processed by the IGVN after loop
strip mining expansion. But beyond this immediate problem, because
IGVN processes each load separately, I think it's possible that it
succeeds in eliminating one of the loads but not the other (the graph
could have changed too much in the meantime). Because of that concern
and because it's a corner case, I think the most robust fix is to
relax the assert.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257575](https://bugs.openjdk.java.net/browse/JDK-8257575): C2: "failed: only phis" assert failure in loop strip mining verification


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1555/head:pull/1555`
`$ git checkout pull/1555`
