### PR TITLE
8257574: C2: "failed: parsing found no loops but there are some" assert failure

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3663,25 +3663,23 @@ bool PhaseIdealLoop::process_expensive_nodes() {
 
 #ifdef ASSERT
 bool PhaseIdealLoop::only_has_infinite_loops() {
-  for (LoopTreeIterator iter(_ltree_root); !iter.done(); iter.next()) {
-    IdealLoopTree* lpt = iter.current();
-    if (lpt->is_innermost()) {
-      uint i = 1;
-      for (; i < C->root()->req(); i++) {
-        Node* in = C->root()->in(i);
-        if (in != NULL &&
-            in->Opcode() == Op_Halt &&
-            in->in(0)->is_Proj() &&
-            in->in(0)->in(0)->Opcode() == Op_NeverBranch &&
-            in->in(0)->in(0)->in(0) == lpt->_head) {
-          break;
-        }
-      }
-      if (i == C->root()->req()) {
-        return false;
+  for (IdealLoopTree* l = _ltree_root->_child; l != NULL; l = l->_next) {
+    uint i = 1;
+    for (; i < C->root()->req(); i++) {
+      Node* in = C->root()->in(i);
+      if (in != NULL &&
+          in->Opcode() == Op_Halt &&
+          in->in(0)->is_Proj() &&
+          in->in(0)->in(0)->Opcode() == Op_NeverBranch &&
+          in->in(0)->in(0)->in(0) == l->_head) {
+        break;
       }
     }
+    if (i == C->root()->req()) {
+      return false;
+    }
   }
+
   return true;
 }
 #endif

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopNotInnerMost.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopNotInnerMost.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8257574
+ * @summary C2: "failed: parsing found no loops but there are some" assert failure
+ *
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestInfiniteLoopNotInnerMost::test TestInfiniteLoopNotInnerMost
+ *
+ */
+public class TestInfiniteLoopNotInnerMost {
+    public static void main(String[] args) {
+        test(false);
+    }
+
+    private static void test(boolean flag) {
+        if (flag) {
+            while (true) {
+                for (int i = 1; i < 100; i *= 2) {
+
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The assert fires because the loop only has an infinite loop which
causes the has_loops flag to be cleared. But because a NeverBranch is
also added to the graph on the next pass of loop opts (for
verification), C2 finds a loop and that's inconsistent with the
has_loops flag. This is supposed to be handled by the
only_has_infinite_loops() call in the assert but not in this case
because the loop is not an innermost loop.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257574](https://bugs.openjdk.java.net/browse/JDK-8257574): C2: "failed: parsing found no loops but there are some" assert failure


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1556/head:pull/1556`
`$ git checkout pull/1556`
