### PR TITLE
8238812: assert(false) failed: bad AD file

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1552,6 +1552,18 @@ void PhaseIterGVN::add_users_to_worklist( Node *n ) {
         }
       }
       if (use_op == Op_CmpI) {
+        // Put If on worklist to enable fold_compares optimization (see IfNode::cmpi_folds)
+        if (use->outcnt() > 0) {
+          for (uint i = 0; i < use->outcnt(); i++) {
+            Node* bol = use->raw_out(i);
+            if (bol->outcnt() > 0) {
+              Node* iff = bol->raw_out(0);
+              if (iff->Opcode() == Op_If && iff->outcnt() == 2) {
+                add_users_to_worklist0(bol);
+              }
+            }
+          }
+        }
         Node* phi = countedloop_phi_from_cmp((CmpINode*)use, n);
         if (phi != NULL) {
           // If an opaque node feeds into the limit condition of a

--- a/test/hotspot/jtreg/compiler/c2/Test8238812.java
+++ b/test/hotspot/jtreg/compiler/c2/Test8238812.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8238812
+ * @summary Fix c2 assert(false) failed: bad AD file
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.c2.Test8238812::test 
+ *                   -XX:CompileCommand=dontinline,compiler.c2.Test8238812::test
+ *                   -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -XX:+UseSwitchProfiling
+ *                   compiler.c2.Test8238812
+ */
+
+package compiler.c2;
+
+public class Test8238812 {
+
+    public static void test() {
+        int i4, i5=99, i6, i9=89;
+        for (i4 = 12; i4 < 365; i4++) {
+            for (i6 = 5; i6 > 1; i6--) {
+                switch ((i6 * 5) + 11) {
+                case 13:
+                case 19:
+                case 26:
+                case 31:
+                case 35:
+                case 41:
+                case 43:
+                case 61:
+                case 71:
+                case 83:
+                case 314:
+                    i9 = i5;
+                    break;
+                }
+            }
+        }
+    }
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10; i++) {
+            test();
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/c2/Test8238812.java
+++ b/test/hotspot/jtreg/compiler/c2/Test8238812.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8238812
  * @summary Fix c2 assert(false) failed: bad AD file
- * @run main/othervm -XX:CompileCommand=compileonly,compiler.c2.Test8238812::test 
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.c2.Test8238812::test
  *                   -XX:CompileCommand=dontinline,compiler.c2.Test8238812::test
  *                   -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -XX:+UseSwitchProfiling
  *                   compiler.c2.Test8238812


### PR DESCRIPTION
Request help to review this 8238812 fix.

<JBS> https://bugs.openjdk.java.net/browse/JDK-8238812

Found the root cause of the problem as that the following type 
two If checks are not folded into one for the sample test:

 170 ConI === 0 [[ 171 ]] #int:31
 171 CmpI === _ 144 170 [[ 172 179 ]]
 172 Bool === _ 171 [[ 173 ]] [ne]

 173 If === 158 172 [[ 176 177 ]]
 176 IfFalse === 173 [[ 168 ]] #0
 177 IfTrue === 173 [[ 180 ]] #1
 179 Bool === _ 171 [[ 180 ]] [lt]

 180 If === 177 179 [[ 181 182 ]]
 181 IfTrue === 180 [[ 168 ]] #1
 182 IfFalse === 180 [[ 218 ]] #0

Where 144 is the value and the ifs check for:
value != 31
value < 31

Now if we reach 182 IfFalse, the following holds:
   value != 31 && !(value < 31)
=> value != 31 && value >= 31
=> value > 31

But the type of value (144) becomes #int:16..31 :
 140 ConI === 0 [[ 141 ]] #int:2
 135 Phi === 534 481 528 [[ ... ]] #int:1..4 #tripcount
 141 LShiftI === _ 135 140 [[ 142 ]] #int:4..16
 143 ConI === 0 [[ 144 ]] #int:11
 142 AddI === _ 141 135 [[ 144 500 485 ]] #int:5..20
 144 AddI === _ 142 143 [[ ... ]] #int:16..31

And that means that value > 31 is always false and should be folded.
The root cause of the bug is that this does not happen.
Understood that the fix by Tobias for JDK-8236721 should optimize exactly above type cases
https://hg.openjdk.java.net/jdk/jdk/rev/9c53fdf6ba63

Found the IfNode::fold_compares optmization (and 8236721 related changes by Tobias)
is not called for 180-If, after the type of 144-AddI is set to #int:16..31.
because the _worklist is not correctly updated!

Proposed changes helped to add the required If node to _worklist (after the correct type setting of related value)
and with this change no failure due to existing fold_compares optimization happening later on.
Sample test passed and found no issues with various tier testing.

/reviewer credit thartmann

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8238812](https://bugs.openjdk.java.net/browse/JDK-8238812): assert(false) failed: bad AD file


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1563/head:pull/1563`
`$ git checkout pull/1563`
