### PR TITLE
JDK-8257604: JNI_ArgumentPusherVaArg leaks valist

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -869,7 +869,6 @@ class JNI_ArgumentPusher : public SignatureIterator {
 
 
 class JNI_ArgumentPusherVaArg : public JNI_ArgumentPusher {
- protected:
   va_list _ap;
 
   void set_ap(va_list rap) {
@@ -903,6 +902,10 @@ class JNI_ArgumentPusherVaArg : public JNI_ArgumentPusher {
   JNI_ArgumentPusherVaArg(jmethodID method_id, va_list rap)
       : JNI_ArgumentPusher(Method::resolve_jmethod_id(method_id)) {
     set_ap(rap);
+  }
+
+  ~JNI_ArgumentPusherVaArg() {
+    va_end(_ap);
   }
 
   virtual void push_arguments_on(JavaCallArguments* arguments) {


### PR DESCRIPTION
JNI_ArgumentPusherVaArg copies the given argument list pointer (va_copy) but never releases it. A call to va_end is missing.

AFAICS this coding is old. Interestingly, in jdk8 I find this:

```
   0:   inline void set_ap(va_list rap) {
   0: #ifdef va_copy
   0:     va_copy(_ap, rap);
   0: #elif defined (__va_copy)
   0:     __va_copy(_ap, rap);
   0: #else
   0:     _ap = rap;
   0: #endif
   0:   }
```

`_ap = rap` seems a strangely relaxed way of doing this. But I do not know the history behind that.

I could not find any usage of the original arg pointer, so maybe the `va_copy()` is not even needed. The jdk8 coding seems to indicate that too. But since I was not 100% sure I kept the `va_copy()` and added a `va_end()`.

I also made this private (removed the `protected`) since there are no child classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257604](https://bugs.openjdk.java.net/browse/JDK-8257604): JNI_ArgumentPusherVaArg leaks valist


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1565/head:pull/1565`
`$ git checkout pull/1565`
