### PR TITLE
8254802: ThrowingPushPromisesAsStringCustom.java fails in "try throwing in GET_BODY"

### DIFF
--- a/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
@@ -724,6 +724,7 @@ public class Http2TestServerConnection {
                 //System.err.printf("TestServer: received frame %s\n", frame);
                 int stream = frame.streamid();
                 int next = nextstream;
+                int nextPush = nextPushStreamId;
                 if (stream == 0) {
                     if (frame.type() == WindowUpdateFrame.TYPE) {
                         WindowUpdateFrame wup = (WindowUpdateFrame) frame;
@@ -771,10 +772,15 @@ public class Http2TestServerConnection {
                                 // but the continuation, even after a reset
                                 // should be handle gracefully by the client
                                 // anyway.
-                            } else if (stream < next) {
-                                // We may receive a reset on a stream that has already
+                            } else if ((stream & 0x01) == 0x01 && stream < next) {
+                                // We may receive a reset on a client stream that has already
                                 // been closed. Just ignore it.
                                 System.err.println("TestServer: received ResetFrame on closed stream: " + stream);
+                                System.err.println(frame);
+                            } else if ((stream & 0x01) == 0x00 && stream < nextPush) {
+                                // We may receive a reset on a push stream that has already
+                                // been closed. Just ignore it.
+                                System.err.println("TestServer: received ResetFrame on closed push stream: " + stream);
                                 System.err.println(frame);
                             } else {
                                 System.err.println("TestServer: Unexpected frame on: " + stream);

--- a/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
@@ -723,6 +723,7 @@ public class Http2TestServerConnection {
                 }
                 //System.err.printf("TestServer: received frame %s\n", frame);
                 int stream = frame.streamid();
+                int next = nextstream;
                 if (stream == 0) {
                     if (frame.type() == WindowUpdateFrame.TYPE) {
                         WindowUpdateFrame wup = (WindowUpdateFrame) frame;
@@ -770,6 +771,11 @@ public class Http2TestServerConnection {
                                 // but the continuation, even after a reset
                                 // should be handle gracefully by the client
                                 // anyway.
+                            } else if (stream < next) {
+                                // We may receive a reset on a stream that has already
+                                // been closed. Just ignore it.
+                                System.err.println("TestServer: received ResetFrame on closed stream: " + stream);
+                                System.err.println(frame);
                             } else {
                                 System.err.println("TestServer: Unexpected frame on: " + stream);
                                 System.err.println(frame);

--- a/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
@@ -772,12 +772,12 @@ public class Http2TestServerConnection {
                                 // but the continuation, even after a reset
                                 // should be handle gracefully by the client
                                 // anyway.
-                            } else if ((stream & 0x01) == 0x01 && stream < next) {
+                            } else if (isClientStreamId(stream) && stream < next) {
                                 // We may receive a reset on a client stream that has already
                                 // been closed. Just ignore it.
                                 System.err.println("TestServer: received ResetFrame on closed stream: " + stream);
                                 System.err.println(frame);
-                            } else if ((stream & 0x01) == 0x00 && stream < nextPush) {
+                            } else if (isServerStreamId(stream) && stream < nextPush) {
                                 // We may receive a reset on a push stream that has already
                                 // been closed. Just ignore it.
                                 System.err.println("TestServer: received ResetFrame on closed push stream: " + stream);
@@ -800,6 +800,14 @@ public class Http2TestServerConnection {
             }
             close(ErrorFrame.PROTOCOL_ERROR);
         }
+    }
+
+    static boolean isClientStreamId(int streamid) {
+        return (streamid & 0x01) == 0x01;
+    }
+
+    static boolean isServerStreamId(int streamid) {
+        return (streamid & 0x01) == 0x00;
     }
 
     /** Encodes an group of headers, without any ordering guarantees. */


### PR DESCRIPTION
Hi,

Please find below a fix that fixes an issue in Http2TestServerConnection - where the 
connection will be closed by the test server if the test server receives a RESET from the client
after the stream has been closed.

This issue has made the ThrowingPushPromisesAsStringCustom test fail from time to time, but
the debug traces have eventually revealed what was the issue:

```
DEBUG: [readLoop] [818ms] FramesDecoder Got frame: RESET: length=4, streamid=24, flags=0 Error: Stream cancelled
TestServer: Unexpected frame on: 24
RESET: length=4, streamid=24, flags=0 Error: Stream cancelled
Http server reader thread shutdown
java.io.IOException: Unexpected frame
at Http2TestServerConnection.readLoop(Http2TestServerConnection.java:776)
at Http2TestServerConnection$ConnectionThread.run(Http2TestServerConnection.java:438)
Server connection to /127.0.0.1:39830 stopping. 5 streams 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254802](https://bugs.openjdk.java.net/browse/JDK-8254802): ThrowingPushPromisesAsStringCustom.java fails in "try throwing in GET_BODY"


### Reviewers
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1567/head:pull/1567`
`$ git checkout pull/1567`
