### PR TITLE
8257620: Do not use objc_msgSend_stret to get macOS version

### DIFF
--- a/src/java.base/macosx/native/libjava/java_props_macosx.c
+++ b/src/java.base/macosx/native/libjava/java_props_macosx.c
@@ -236,11 +236,16 @@ void setOSNameAndVersion(java_props_t *sprops) {
 
     char* osVersionCStr = NULL;
     // Mac OS 10.9 includes the [NSProcessInfo operatingSystemVersion] function,
-    // but it's not in the 10.9 SDK.  So, call it via objc_msgSend_stret.
+    // but it's not in the 10.9 SDK.  So, call it via NSInvocation.
     if ([[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)]) {
-        OSVerStruct (*procInfoFn)(id rec, SEL sel) = (OSVerStruct(*)(id, SEL))objc_msgSend_stret;
-        OSVerStruct osVer = procInfoFn([NSProcessInfo processInfo],
-                                       @selector(operatingSystemVersion));
+        OSVerStruct osVer;
+        NSMethodSignature *sig = [[NSProcessInfo processInfo] methodSignatureForSelector:
+                @selector(operatingSystemVersion)];
+        NSInvocation *invoke = [NSInvocation invocationWithMethodSignature:sig];
+        invoke.selector = @selector(operatingSystemVersion);
+        [invoke invokeWithTarget:[NSProcessInfo processInfo]];
+        [invoke getReturnValue:&osVer];
+
         NSString *nsVerStr;
         if (osVer.patchVersion == 0) { // Omit trailing ".0"
             nsVerStr = [NSString stringWithFormat:@"%ld.%ld",


### PR DESCRIPTION
Please review a small change that replaces use of objc_msgSend_stret in macOS platform code with pure ObjC code. It's also a prerequisite for macOS/AArch64 support, where objc_msgSend_stret is not available.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257620](https://bugs.openjdk.java.net/browse/JDK-8257620): Do not use objc_msgSend_stret to get macOS version


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1569/head:pull/1569`
`$ git checkout pull/1569`
