### PR TITLE
8257622: MemoryAccess methods are missing @ForceInline annotations

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
@@ -95,6 +95,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a byte value read from {@code segment}.
      */
+    @ForceInline
     public static byte getByteAtOffset(MemorySegment segment, long offset) {
         Objects.requireNonNull(segment);
         return (byte)byte_handle.get(segment, offset);
@@ -107,6 +108,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the byte value to be written.
      */
+    @ForceInline
     public static void setByteAtOffset(MemorySegment segment, long offset, byte value) {
         Objects.requireNonNull(segment);
         byte_handle.set(segment, offset, value);
@@ -123,6 +125,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a char value read from {@code segment}.
      */
+    @ForceInline
     public static char getCharAtOffset(MemorySegment segment, long offset) {
         return getCharAtOffset(segment, offset, ByteOrder.nativeOrder());
     }
@@ -138,6 +141,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the char value to be written.
      */
+    @ForceInline
     public static void setCharAtOffset(MemorySegment segment, long offset, char value) {
         setCharAtOffset(segment, offset, ByteOrder.nativeOrder(), value);
     }
@@ -153,6 +157,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a short value read from {@code segment}.
      */
+    @ForceInline
     public static short getShortAtOffset(MemorySegment segment, long offset) {
         return getShortAtOffset(segment, offset, ByteOrder.nativeOrder());
     }
@@ -168,6 +173,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the short value to be written.
      */
+    @ForceInline
     public static void setShortAtOffset(MemorySegment segment, long offset, short value) {
         setShortAtOffset(segment, offset, ByteOrder.nativeOrder(), value);
     }
@@ -183,6 +189,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return an int value read from {@code segment}.
      */
+    @ForceInline
     public static int getIntAtOffset(MemorySegment segment, long offset) {
         return getIntAtOffset(segment, offset, ByteOrder.nativeOrder());
     }
@@ -198,6 +205,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the int value to be written.
      */
+    @ForceInline
     public static void setIntAtOffset(MemorySegment segment, long offset, int value) {
         setIntAtOffset(segment, offset, ByteOrder.nativeOrder(), value);
     }
@@ -213,6 +221,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a float value read from {@code segment}.
      */
+    @ForceInline
     public static float getFloatAtOffset(MemorySegment segment, long offset) {
         return getFloatAtOffset(segment, offset, ByteOrder.nativeOrder());
     }
@@ -228,6 +237,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the float value to be written.
      */
+    @ForceInline
     public static void setFloatAtOffset(MemorySegment segment, long offset, float value) {
         setFloatAtOffset(segment, offset, ByteOrder.nativeOrder(), value);
     }
@@ -243,6 +253,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a long value read from {@code segment}.
      */
+    @ForceInline
     public static long getLongAtOffset(MemorySegment segment, long offset) {
         return getLongAtOffset(segment, offset, ByteOrder.nativeOrder());
     }
@@ -258,6 +269,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the long value to be written.
      */
+    @ForceInline
     public static void setLongAtOffset(MemorySegment segment, long offset, long value) {
         setLongAtOffset(segment, offset, ByteOrder.nativeOrder(), value);
     }
@@ -273,6 +285,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a double value read from {@code segment}.
      */
+    @ForceInline
     public static double getDoubleAtOffset(MemorySegment segment, long offset) {
         return getDoubleAtOffset(segment, offset, ByteOrder.nativeOrder());
     }
@@ -288,6 +301,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the double value to be written.
      */
+    @ForceInline
     public static void setDoubleAtOffset(MemorySegment segment, long offset, double value) {
         setDoubleAtOffset(segment, offset, ByteOrder.nativeOrder(), value);
     }
@@ -304,6 +318,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a memory address read from {@code segment}.
      */
+    @ForceInline
     public static MemoryAddress getAddressAtOffset(MemorySegment segment, long offset) {
         Objects.requireNonNull(segment);
         return (MemoryAddress)address_handle.get(segment, offset);
@@ -321,6 +336,7 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the memory address to be written (expressed as an {@link Addressable} instance).
      */
+    @ForceInline
     public static void setAddressAtOffset(MemorySegment segment, long offset, Addressable value) {
         Objects.requireNonNull(segment);
         Objects.requireNonNull(value);
@@ -340,6 +356,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a char value read from {@code segment}.
      */
+    @ForceInline
     public static char getCharAtOffset(MemorySegment segment, long offset, ByteOrder order) {
         Objects.requireNonNull(segment);
         Objects.requireNonNull(order);
@@ -359,6 +376,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the char value to be written.
      */
+    @ForceInline
     public static void setCharAtOffset(MemorySegment segment, long offset, ByteOrder order, char value) {
         Objects.requireNonNull(segment);
         Objects.requireNonNull(order);
@@ -378,6 +396,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a short value read from {@code segment}.
      */
+    @ForceInline
     public static short getShortAtOffset(MemorySegment segment, long offset, ByteOrder order) {
         Objects.requireNonNull(segment);
         Objects.requireNonNull(order);
@@ -397,6 +416,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the short value to be written.
      */
+    @ForceInline
     public static void setShortAtOffset(MemorySegment segment, long offset, ByteOrder order, short value) {
         Objects.requireNonNull(segment);
         Objects.requireNonNull(order);
@@ -416,6 +436,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return an int value read from {@code segment}.
      */
+    @ForceInline
     public static int getIntAtOffset(MemorySegment segment, long offset, ByteOrder order) {
         Objects.requireNonNull(segment);
         Objects.requireNonNull(order);
@@ -435,6 +456,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the int value to be written.
      */
+    @ForceInline
     public static void setIntAtOffset(MemorySegment segment, long offset, ByteOrder order, int value) {
         Objects.requireNonNull(segment);
         Objects.requireNonNull(order);
@@ -454,6 +476,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a float value read from {@code segment}.
      */
+    @ForceInline
     public static float getFloatAtOffset(MemorySegment segment, long offset, ByteOrder order) {
         Objects.requireNonNull(segment);
         Objects.requireNonNull(order);
@@ -473,6 +496,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the float value to be written.
      */
+    @ForceInline
     public static void setFloatAtOffset(MemorySegment segment, long offset, ByteOrder order, float value) {
         Objects.requireNonNull(segment);
         Objects.requireNonNull(order);
@@ -492,6 +516,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a long value read from {@code segment}.
      */
+    @ForceInline
     public static long getLongAtOffset(MemorySegment segment, long offset, ByteOrder order) {
         Objects.requireNonNull(segment);
         Objects.requireNonNull(order);
@@ -511,6 +536,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the long value to be written.
      */
+    @ForceInline
     public static void setLongAtOffset(MemorySegment segment, long offset, ByteOrder order, long value) {
         Objects.requireNonNull(segment);
         Objects.requireNonNull(order);
@@ -530,6 +556,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a double value read from {@code segment}.
      */
+    @ForceInline
     public static double getDoubleAtOffset(MemorySegment segment, long offset, ByteOrder order) {
         Objects.requireNonNull(segment);
         Objects.requireNonNull(order);
@@ -549,6 +576,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the double value to be written.
      */
+    @ForceInline
     public static void setDoubleAtOffset(MemorySegment segment, long offset, ByteOrder order, double value) {
         Objects.requireNonNull(segment);
         Objects.requireNonNull(order);
@@ -566,6 +594,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @return a byte value read from {@code segment}.
      */
+    @ForceInline
     public static byte getByte(MemorySegment segment) {
         return getByteAtOffset(segment, 0L);
     }
@@ -580,6 +609,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param value the byte value to be written.
      */
+    @ForceInline
     public static void setByte(MemorySegment segment, byte value) {
         setByteAtOffset(segment, 0L, value);
     }
@@ -594,6 +624,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @return a char value read from {@code segment}.
      */
+    @ForceInline
     public static char getChar(MemorySegment segment) {
         return getCharAtOffset(segment, 0L);
     }
@@ -608,6 +639,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param value the char value to be written.
      */
+    @ForceInline
     public static void setChar(MemorySegment segment, char value) {
         setCharAtOffset(segment, 0L, value);
     }
@@ -622,6 +654,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @return a short value read from {@code segment}.
      */
+    @ForceInline
     public static short getShort(MemorySegment segment) {
         return getShortAtOffset(segment, 0L);
     }
@@ -636,6 +669,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param value the short value to be written.
      */
+    @ForceInline
     public static void setShort(MemorySegment segment, short value) {
         setShortAtOffset(segment, 0L, value);
     }
@@ -650,6 +684,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @return an int value read from {@code segment}.
      */
+    @ForceInline
     public static int getInt(MemorySegment segment) {
         return getIntAtOffset(segment, 0L);
     }
@@ -664,6 +699,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param value the int value to be written.
      */
+    @ForceInline
     public static void setInt(MemorySegment segment, int value) {
         setIntAtOffset(segment, 0L, value);
     }
@@ -678,6 +714,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @return a float value read from {@code segment}.
      */
+    @ForceInline
     public static float getFloat(MemorySegment segment) {
         return getFloatAtOffset(segment, 0L);
     }
@@ -692,6 +729,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param value the float value to be written.
      */
+    @ForceInline
     public static void setFloat(MemorySegment segment, float value) {
         setFloatAtOffset(segment, 0L, value);
     }
@@ -706,6 +744,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @return a long value read from {@code segment}.
      */
+    @ForceInline
     public static long getLong(MemorySegment segment) {
         return getLongAtOffset(segment, 0L);
     }
@@ -720,6 +759,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param value the long value to be written.
      */
+    @ForceInline
     public static void setLong(MemorySegment segment, long value) {
         setLongAtOffset(segment, 0L, value);
     }
@@ -734,6 +774,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @return a double value read from {@code segment}.
      */
+    @ForceInline
     public static double getDouble(MemorySegment segment) {
         return getDoubleAtOffset(segment, 0L);
     }
@@ -748,6 +789,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param value the double value to be written.
      */
+    @ForceInline
     public static void setDouble(MemorySegment segment, double value) {
         setDoubleAtOffset(segment, 0L, value);
     }
@@ -762,6 +804,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @return a memory address read from {@code segment}.
      */
+    @ForceInline
     public static MemoryAddress getAddress(MemorySegment segment) {
         return getAddressAtOffset(segment, 0L);
     }
@@ -776,6 +819,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param value the memory address to be written (expressed as an {@link Addressable} instance).
      */
+    @ForceInline
     public static void setAddress(MemorySegment segment, Addressable value) {
         setAddressAtOffset(segment, 0L, value);
     }
@@ -791,6 +835,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a char value read from {@code segment}.
      */
+    @ForceInline
     public static char getChar(MemorySegment segment, ByteOrder order) {
         return getCharAtOffset(segment, 0L, order);
     }
@@ -806,6 +851,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the char value to be written.
      */
+    @ForceInline
     public static void setChar(MemorySegment segment, ByteOrder order, char value) {
         setCharAtOffset(segment, 0L, order, value);
     }
@@ -821,6 +867,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a short value read from {@code segment}.
      */
+    @ForceInline
     public static short getShort(MemorySegment segment, ByteOrder order) {
         return getShortAtOffset(segment, 0L, order);
     }
@@ -836,6 +883,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the short value to be written.
      */
+    @ForceInline
     public static void setShort(MemorySegment segment, ByteOrder order, short value) {
         setShortAtOffset(segment, 0L, order, value);
     }
@@ -851,6 +899,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return an int value read from {@code segment}.
      */
+    @ForceInline
     public static int getInt(MemorySegment segment, ByteOrder order) {
         return getIntAtOffset(segment, 0L, order);
     }
@@ -866,6 +915,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the int value to be written.
      */
+    @ForceInline
     public static void setInt(MemorySegment segment, ByteOrder order, int value) {
         setIntAtOffset(segment, 0L, order, value);
     }
@@ -881,6 +931,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a float value read from {@code segment}.
      */
+    @ForceInline
     public static float getFloat(MemorySegment segment, ByteOrder order) {
         return getFloatAtOffset(segment, 0L, order);
     }
@@ -896,6 +947,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the float value to be written.
      */
+    @ForceInline
     public static void setFloat(MemorySegment segment, ByteOrder order, float value) {
         setFloatAtOffset(segment, 0L, order, value);
     }
@@ -911,6 +963,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a long value read from {@code segment}.
      */
+    @ForceInline
     public static long getLong(MemorySegment segment, ByteOrder order) {
         return getLongAtOffset(segment, 0L, order);
     }
@@ -926,6 +979,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the long value to be written.
      */
+    @ForceInline
     public static void setLong(MemorySegment segment, ByteOrder order, long value) {
         setLongAtOffset(segment, 0L, order, value);
     }
@@ -941,6 +995,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a double value read from {@code segment}.
      */
+    @ForceInline
     public static double getDouble(MemorySegment segment, ByteOrder order) {
         return getDoubleAtOffset(segment, 0L, order);
     }
@@ -956,6 +1011,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the double value to be written.
      */
+    @ForceInline
     public static void setDouble(MemorySegment segment, ByteOrder order, double value) {
         setDoubleAtOffset(segment, 0L, order, value);
     }
@@ -971,6 +1027,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 2)}.
      * @return a char value read from {@code segment} at the element index specified by {@code index}.
      */
+    @ForceInline
     public static char getCharAtIndex(MemorySegment segment, long index) {
         return getCharAtOffset(segment, scale(segment, index, 2));
     }
@@ -986,6 +1043,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 2)}.
      * @param value the char value to be written.
      */
+    @ForceInline
     public static void setCharAtIndex(MemorySegment segment, long index, char value) {
         setCharAtOffset(segment, scale(segment, index, 2), value);
     }
@@ -1001,6 +1059,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 2)}.
      * @return a short value read from {@code segment} at the element index specified by {@code index}.
      */
+    @ForceInline
     public static short getShortAtIndex(MemorySegment segment, long index) {
         return getShortAtOffset(segment, scale(segment, index, 2));
     }
@@ -1016,6 +1075,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 2)}.
      * @param value the short value to be written.
      */
+    @ForceInline
     public static void setShortAtIndex(MemorySegment segment, long index, short value) {
         setShortAtOffset(segment, scale(segment, index, 2), value);
     }
@@ -1031,6 +1091,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 4)}.
      * @return an int value read from {@code segment} at the element index specified by {@code index}.
      */
+    @ForceInline
     public static int getIntAtIndex(MemorySegment segment, long index) {
         return getIntAtOffset(segment, scale(segment, index, 4));
     }
@@ -1046,6 +1107,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 4)}.
      * @param value the int value to be written.
      */
+    @ForceInline
     public static void setIntAtIndex(MemorySegment segment, long index, int value) {
         setIntAtOffset(segment, scale(segment, index, 4), value);
     }
@@ -1061,6 +1123,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 4)}.
      * @return a float value read from {@code segment} at the element index specified by {@code index}.
      */
+    @ForceInline
     public static float getFloatAtIndex(MemorySegment segment, long index) {
         return getFloatAtOffset(segment, scale(segment, index, 4));
     }
@@ -1076,6 +1139,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 4)}.
      * @param value the float value to be written.
      */
+    @ForceInline
     public static void setFloatAtIndex(MemorySegment segment, long index, float value) {
         setFloatAtOffset(segment, scale(segment, index, 4), value);
     }
@@ -1091,6 +1155,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @return a long value read from {@code segment} at the element index specified by {@code index}.
      */
+    @ForceInline
     public static long getLongAtIndex(MemorySegment segment, long index) {
         return getLongAtOffset(segment, scale(segment, index, 8));
     }
@@ -1106,6 +1171,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @param value the long value to be written.
      */
+    @ForceInline
     public static void setLongAtIndex(MemorySegment segment, long index, long value) {
         setLongAtOffset(segment, scale(segment, index, 8), value);
     }
@@ -1121,6 +1187,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @return a double value read from {@code segment} at the element index specified by {@code index}.
      */
+    @ForceInline
     public static double getDoubleAtIndex(MemorySegment segment, long index) {
         return getDoubleAtOffset(segment, scale(segment, index, 8));
     }
@@ -1136,6 +1203,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @param value the double value to be written.
      */
+    @ForceInline
     public static void setDoubleAtIndex(MemorySegment segment, long index, double value) {
         setDoubleAtOffset(segment, scale(segment, index, 8), value);
     }
@@ -1151,6 +1219,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @return a memory address read from {@code segment} at the element index specified by {@code index}.
      */
+    @ForceInline
     public static MemoryAddress getAddressAtIndex(MemorySegment segment, long index) {
         return getAddressAtOffset(segment, scale(segment, index, (int)MemoryLayouts.ADDRESS.byteSize()));
     }
@@ -1166,6 +1235,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @param value the memory address to be written (expressed as an {@link Addressable} instance).
      */
+    @ForceInline
     public static void setAddressAtIndex(MemorySegment segment, long index, Addressable value) {
         setAddressAtOffset(segment, scale(segment, index, (int)MemoryLayouts.ADDRESS.byteSize()), value);
     }
@@ -1182,6 +1252,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a char value read from {@code segment} at the element index specified by {@code index}.
      */
+    @ForceInline
     public static char getCharAtIndex(MemorySegment segment, long index, ByteOrder order) {
         return getCharAtOffset(segment, scale(segment, index, 2), order);
     }
@@ -1198,6 +1269,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the char value to be written.
      */
+    @ForceInline
     public static void setCharAtIndex(MemorySegment segment, long index, ByteOrder order, char value) {
         setCharAtOffset(segment, scale(segment, index, 2), order, value);
     }
@@ -1214,6 +1286,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a short value read from {@code segment} at the element index specified by {@code index}.
      */
+    @ForceInline
     public static short getShortAtIndex(MemorySegment segment, long index, ByteOrder order) {
         return getShortAtOffset(segment, scale(segment, index, 2), order);
     }
@@ -1230,6 +1303,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the short value to be written.
      */
+    @ForceInline
     public static void setShortAtIndex(MemorySegment segment, long index, ByteOrder order, short value) {
         setShortAtOffset(segment, scale(segment, index, 2), order, value);
     }
@@ -1246,6 +1320,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return an int value read from {@code segment} at the element index specified by {@code index}.
      */
+    @ForceInline
     public static int getIntAtIndex(MemorySegment segment, long index, ByteOrder order) {
         return getIntAtOffset(segment, scale(segment, index, 4), order);
     }
@@ -1262,6 +1337,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the int value to be written.
      */
+    @ForceInline
     public static void setIntAtIndex(MemorySegment segment, long index, ByteOrder order, int value) {
         setIntAtOffset(segment, scale(segment, index, 4), order, value);
     }
@@ -1278,6 +1354,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a float value read from {@code segment} at the element index specified by {@code index}.
      */
+    @ForceInline
     public static float getFloatAtIndex(MemorySegment segment, long index, ByteOrder order) {
         return getFloatAtOffset(segment, scale(segment, index, 4), order);
     }
@@ -1294,6 +1371,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the float value to be written.
      */
+    @ForceInline
     public static void setFloatAtIndex(MemorySegment segment, long index, ByteOrder order, float value) {
         setFloatAtOffset(segment, scale(segment, index, 4), order, value);
     }
@@ -1310,6 +1388,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a long value read from {@code segment} at the element index specified by {@code index}.
      */
+    @ForceInline
     public static long getLongAtIndex(MemorySegment segment, long index, ByteOrder order) {
         return getLongAtOffset(segment, scale(segment, index, 8), order);
     }
@@ -1326,6 +1405,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the long value to be written.
      */
+    @ForceInline
     public static void setLongAtIndex(MemorySegment segment, long index, ByteOrder order, long value) {
         setLongAtOffset(segment, scale(segment, index, 8), order, value);
     }
@@ -1342,6 +1422,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @return a double value read from {@code segment} at the element index specified by {@code index}.
      */
+    @ForceInline
     public static double getDoubleAtIndex(MemorySegment segment, long index, ByteOrder order) {
         return getDoubleAtOffset(segment, scale(segment, index, 8), order);
     }
@@ -1358,6 +1439,7 @@ public final class MemoryAccess {
      * @param order the specified byte order.
      * @param value the double value to be written.
      */
+    @ForceInline
     public static void setDoubleAtIndex(MemorySegment segment, long index, ByteOrder order, double value) {
         setDoubleAtOffset(segment, scale(segment, index, 8), order, value);
     }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantFP.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantFP.java
@@ -69,10 +69,10 @@ public class LoopOverNonConstantFP {
         unsafe_addrIn = unsafe.allocateMemory(ALLOC_SIZE);
         unsafe_addrOut = unsafe.allocateMemory(ALLOC_SIZE);
         for (int i = 0; i < ELEM_SIZE; i++) {
-            unsafe.putDouble(unsafe_addrIn + (i * CARRIER_SIZE) , i);
+            unsafe.putDouble(unsafe_addrIn + (i * CARRIER_SIZE), i);
         }
         for (int i = 0; i < ELEM_SIZE; i++) {
-            unsafe.putDouble(unsafe_addrOut + (i * CARRIER_SIZE) , i);
+            unsafe.putDouble(unsafe_addrOut + (i * CARRIER_SIZE), i);
         }
         segmentIn = MemorySegment.allocateNative(ALLOC_SIZE);
         segmentOut = MemorySegment.allocateNative(ALLOC_SIZE);

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantFP.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantFP.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.incubator.foreign;
+
+import jdk.incubator.foreign.MemoryAccess;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import sun.misc.Unsafe;
+
+import java.lang.invoke.VarHandle;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.incubator.foreign.MemoryLayout.PathElement.sequenceElement;
+import static jdk.incubator.foreign.MemoryLayouts.JAVA_DOUBLE;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(3)
+public class LoopOverNonConstantFP {
+
+    static final Unsafe unsafe = Utils.unsafe;
+
+    static final int ELEM_SIZE = 1_000_000;
+    static final int CARRIER_SIZE = (int)JAVA_DOUBLE.byteSize();
+    static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
+
+    MemorySegment segmentIn, segmentOut;
+    long unsafe_addrIn, unsafe_addrOut;
+    ByteBuffer byteBufferIn, byteBufferOut;
+
+    @Setup
+    public void setup() {
+        unsafe_addrIn = unsafe.allocateMemory(ALLOC_SIZE);
+        unsafe_addrOut = unsafe.allocateMemory(ALLOC_SIZE);
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            unsafe.putDouble(unsafe_addrIn + (i * CARRIER_SIZE) , i);
+        }
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            unsafe.putDouble(unsafe_addrOut + (i * CARRIER_SIZE) , i);
+        }
+        segmentIn = MemorySegment.allocateNative(ALLOC_SIZE);
+        segmentOut = MemorySegment.allocateNative(ALLOC_SIZE);
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            MemoryAccess.setDoubleAtIndex(segmentIn, i, i);
+        }
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            MemoryAccess.setDoubleAtIndex(segmentOut, i, i);
+        }
+        byteBufferIn = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
+        byteBufferOut = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            byteBufferIn.putDouble(i * CARRIER_SIZE , i);
+        }
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            byteBufferOut.putDouble(i * CARRIER_SIZE , i);
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        segmentIn.close();
+        segmentOut.close();
+        unsafe.invokeCleaner(byteBufferIn);
+        unsafe.invokeCleaner(byteBufferOut);
+        unsafe.freeMemory(unsafe_addrIn);
+        unsafe.freeMemory(unsafe_addrOut);
+    }
+
+    @Benchmark
+    public void unsafe_loop() {
+        for (int i = 0; i < ELEM_SIZE; i ++) {
+            unsafe.putDouble(unsafe_addrOut + (i * CARRIER_SIZE),
+                    unsafe.getDouble(unsafe_addrIn + (i * CARRIER_SIZE)) +
+                    unsafe.getDouble(unsafe_addrOut + (i * CARRIER_SIZE)));
+        }
+    }
+
+    @Benchmark
+    public void segment_loop() {
+        for (int i = 0; i < ELEM_SIZE; i ++) {
+            MemoryAccess.setDoubleAtIndex(segmentOut, i,
+                    MemoryAccess.getDoubleAtIndex(segmentIn, i) +
+                    MemoryAccess.getDoubleAtIndex(segmentOut, i));
+        }
+    }
+
+    @Benchmark
+    public void BB_loop() {
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            byteBufferOut.putDouble(i * CARRIER_SIZE,
+                    byteBufferIn.getDouble(i * CARRIER_SIZE) +
+                    byteBufferOut.getDouble(i * CARRIER_SIZE));
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/UnrolledAccess.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/UnrolledAccess.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.jdk.incubator.foreign;
+
+import static jdk.incubator.foreign.MemoryAccess.*;
+import jdk.incubator.foreign.*;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import sun.misc.Unsafe;
+import java.util.concurrent.TimeUnit;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Field;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(3)
+public class UnrolledAccess {
+
+    static final Unsafe U = Utils.unsafe;
+
+    final static int SIZE = 1024;
+
+    static final VarHandle LONG_HANDLE = MemoryLayout.ofSequence(SIZE, MemoryLayouts.JAVA_LONG)
+            .varHandle(long.class, MemoryLayout.PathElement.sequenceElement());
+
+    @State(Scope.Benchmark)
+    public static class Data {
+
+        final double[] inputArray;
+        final double[] outputArray;
+        final long inputAddress;
+        final long outputAddress;
+        final MemorySegment inputSegment;
+        final MemorySegment outputSegment;
+
+
+        public Data() {
+            this.inputArray = new double[SIZE];
+            this.outputArray = new double[SIZE];
+            this.inputAddress = U.allocateMemory(8 * SIZE);
+            this.outputAddress = U.allocateMemory(8 * SIZE);
+            this.inputSegment = MemoryAddress.ofLong(inputAddress).asSegmentRestricted(8*SIZE);
+            this.outputSegment = MemoryAddress.ofLong(outputAddress).asSegmentRestricted(8*SIZE);
+        }
+    }
+
+    @Benchmark
+    public void unsafe_loop(Data state) {
+        final long ia = state.inputAddress;
+        final long oa = state.outputAddress;
+        for(int i = 0; i < SIZE; i+=4) {
+            U.putLong(oa + 8*i, U.getLong(ia + 8*i) + U.getLong(oa + 8*i));
+            U.putLong(oa + 8*(i+1), U.getLong(ia + 8*(i+1)) + U.getLong(oa + 8*(i+1)));
+            U.putLong(oa + 8*(i+2), U.getLong(ia + 8*(i+2)) + U.getLong(oa + 8*(i+2)));
+            U.putLong(oa + 8*(i+3), U.getLong(ia + 8*(i+3)) + U.getLong(oa + 8*(i+3)));
+        }
+    }
+
+    @Benchmark
+    public void handle_loop(Data state) {
+        final MemorySegment is = state.inputSegment;
+        final MemorySegment os = state.outputSegment;
+
+        for(int i = 0; i < SIZE; i+=4) {
+            LONG_HANDLE.set(os, (long) (i),   (long) LONG_HANDLE.get(is, (long) (i))   + (long) LONG_HANDLE.get(os, (long) (i)));
+            LONG_HANDLE.set(os, (long) (i+1), (long) LONG_HANDLE.get(is, (long) (i+1)) + (long) LONG_HANDLE.get(os, (long) (i+1)));
+            LONG_HANDLE.set(os, (long) (i+2), (long) LONG_HANDLE.get(is, (long) (i+2)) + (long) LONG_HANDLE.get(os, (long) (i+2)));
+            LONG_HANDLE.set(os, (long) (i+3), (long) LONG_HANDLE.get(is, (long) (i+3)) + (long) LONG_HANDLE.get(os, (long) (i+3)));
+        }
+    }
+
+    @Benchmark
+    public void static_handle_loop(Data state) {
+        final MemorySegment is = state.inputSegment;
+        final MemorySegment os = state.outputSegment;
+
+        for(int i = 0; i < SIZE; i+=4) {
+            setLongAtIndex(os, i,getLongAtIndex(is, i) + MemoryAccess.getLongAtIndex(os, i));
+            setLongAtIndex(os, i+1,getLongAtIndex(is, i+1) + getLongAtIndex(os, i+1));
+            setLongAtIndex(os, i+2,getLongAtIndex(is, i+2) + getLongAtIndex(os, i+2));
+            setLongAtIndex(os, i+3,getLongAtIndex(is, i+3) + getLongAtIndex(os, i+3));
+        }
+    }
+}


### PR DESCRIPTION
The accessor methods in the `MemoryAccess` class are missing `@ForceInline` annotations. This causes odd behavior on certain benchmarks, especially if these methods are called many times in the body of a single method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257622](https://bugs.openjdk.java.net/browse/JDK-8257622): MemoryAccess methods are missing @ForceInline annotations


### Reviewers
 * @Nrakron (no known github.com user name / role) ⚠️ Review applies to b2965389689b81c270daf1cb9eea44a14b6ba55b
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to b2965389689b81c270daf1cb9eea44a14b6ba55b
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to b2965389689b81c270daf1cb9eea44a14b6ba55b


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1570/head:pull/1570`
`$ git checkout pull/1570`
