### PR TITLE
8257624: C2: PhaseMacroExpand::eliminate_macro_nodes() crashes on out-of-bounds access into macro node array

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2564,7 +2564,10 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
   while (progress) {
     progress = false;
     for (int i = C->macro_count(); i > 0; i--) {
-      Node * n = C->macro_node(i-1);
+      if (i > C->macro_count()) {
+        i = C->macro_count(); // more than 1 element can be eliminated at once
+      }
+      Node* n = C->macro_node(i-1);
       bool success = false;
       DEBUG_ONLY(int old_macro_count = C->macro_count();)
       if (n->is_AbstractLock()) {
@@ -2580,7 +2583,10 @@ void PhaseMacroExpand::eliminate_macro_nodes() {
   while (progress) {
     progress = false;
     for (int i = C->macro_count(); i > 0; i--) {
-      Node * n = C->macro_node(i-1);
+      if (i > C->macro_count()) {
+        i = C->macro_count(); // more than 1 element can be eliminated at once
+      }
+      Node* n = C->macro_node(i-1);
       bool success = false;
       DEBUG_ONLY(int old_macro_count = C->macro_count();)
       switch (n->class_id()) {


### PR DESCRIPTION
Elimination of a single macro node may trigger removal of some other macro nodes (e.g., see `PhaseMacroExpand::process_users_of_allocation()`  which can eliminate `AllocateCopy` if it is a user of `Allocate` node being scalar replaced). But `PhaseMacroExpand::eliminate_macro_nodes()` doesn't take it into account: it iterates over the array backwards one by one and if it is unfortunate to eliminate multiple elements when it is at the very end of the array, it crashes on an out-of-bounds access.

The fix is to adjust current position on every iteration. If there are multiple elements removed, current position can point at an element which is already processed, but that's benign.

Testing:
- [x] failing tests
- [x] hs-tier-1-6 w/ -XX:+AlwaysIncrementalInline

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257624](https://bugs.openjdk.java.net/browse/JDK-8257624): C2: PhaseMacroExpand::eliminate_macro_nodes() crashes on out-of-bounds access into macro node array


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1572/head:pull/1572`
`$ git checkout pull/1572`
