### PR TITLE
8257623: vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java shouldn't use timeout

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java
@@ -38,7 +38,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm/native/manual/timeout=240
+ * @run main/othervm/native/manual
  *      -agentlib:resexhausted=-waittime=5
  *      -XX:-UseGCOverheadLimit
  *      -Xms16m


### PR DESCRIPTION
The test is manual and shouldn't use the timeout

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257623](https://bugs.openjdk.java.net/browse/JDK-8257623): vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java shouldn't use timeout


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1573/head:pull/1573`
`$ git checkout pull/1573`
