### PR TITLE
8257621: JFR StringPool misses cached items across consecutive recordings

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -322,6 +322,7 @@ public final class PlatformRecorder {
                 dumpMemoryToDestination(recording);
             }
             jvm.endRecording();
+            StringPool.reset();
             disableEvents();
         } else {
             RepositoryChunk newChunk = null;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/StringPool.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/StringPool.java
@@ -44,6 +44,9 @@ public final class StringPool {
     public static long addString(String s) {
         return sp.addString(s);
     }
+    public static void reset() {
+        sp.reset();
+    }
     private static boolean getCurrentEpoch() {
         return unsafe.getByte(epochAddress) == 1;
     }


### PR DESCRIPTION
This addresses 8257621 by resetting the Java cache when a recording is stopped and there are no other recordings still running. The reproducer described in 8257621 no longer exhibits the bug with this change. However, I'm not sure if there are other edge cases missed, or if this fits with the expected design of the StringPool, Recording and Chunk systems. Any insight would be appreciated; I'm willing to adjust as needed.

On:
Linux (Fedora 31), jtreg 5.1-b01 configured with flags --disable-warnings-as-errors --with-jtreg=/path/to/jtreg-5.1-b01/

I have run the following with this patch applied:
`make run-test TEST=":jdk_jfr"`
`make run-test-tier1`

The test `jdk.jfr.api.event.TestShouldCommit` fails for me but I believe it is fragile and not relevant to the change proposed here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257621](https://bugs.openjdk.java.net/browse/JDK-8257621): JFR StringPool misses cached items across consecutive recordings


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1576/head:pull/1576`
`$ git checkout pull/1576`
