### PR TITLE
8257630: C2: ReplacedNodes doesn't handle non-CFG multi nodes

### DIFF
--- a/src/hotspot/share/opto/replacednodes.cpp
+++ b/src/hotspot/share/opto/replacednodes.cpp
@@ -120,7 +120,7 @@ static void enqueue_use(Node* n, Node* use, Unique_Node_List& work) {
   }
 }
 
-// Perfom node replacement following late inlining
+// Perform node replacement following late inlining.
 void ReplacedNodes::apply(Compile* C, Node* ctl) {
   // ctl is the control on exit of the method that was late inlined
   if (is_empty()) {
@@ -144,20 +144,22 @@ void ReplacedNodes::apply(Compile* C, Node* ctl) {
       work.clear();
       enqueue_use(initial, use, work);
       bool replace = true;
-      // Check that this use is dominated by ctl. Go ahead with the
-      // replacement if it is.
+      // Check that this use is dominated by ctl. Go ahead with the replacement if it is.
       while (work.size() != 0 && replace) {
         Node* n = work.pop();
         if (use->outcnt() == 0) {
           continue;
         }
         if (n->is_CFG() || (n->in(0) != NULL && !n->in(0)->is_top())) {
-          int depth = 0;
-          Node *m = n;
+          // Skip projections, since some of the multi nodes aren't CFG (e.g., LoadStore and SCMemProj).
+          if (n->is_Proj()) {
+            n = n->in(0);
+          }
           if (!n->is_CFG()) {
             n = n->in(0);
           }
           assert(n->is_CFG(), "should be CFG now");
+          int depth = 0;
           while(n != ctl) {
             n = IfNode::up_one_dom(n);
             depth++;


### PR DESCRIPTION
When looking up an immediate CFG node, ReplacedNodes assumes that control input is always a CFG node. 
It's not always the case: for example, a projection on a non-CFG multi node (`SCMemProj` and `LoadStore` respectively).

Proposed fix is to skip projection nodes first before checking for CFG.

Testing:
- [x] hs-tier1-6 w/ -XX:+AlwaysIncrementalInlining

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257630](https://bugs.openjdk.java.net/browse/JDK-8257630): C2: ReplacedNodes doesn't handle non-CFG multi nodes


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1580/head:pull/1580`
`$ git checkout pull/1580`
