### PR TITLE
8257632: C2: Late inlining attempt on a call with a dead memory crashes

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -363,6 +363,12 @@ void LateInlineCallGenerator::do_late_inline() {
     assert(Compile::current()->inlining_incrementally(), "shouldn't happen during parsing");
     return;
   }
+  if (call->in(TypeFunc::Memory)->is_MergeMem()) {
+    MergeMemNode* merge_mem = call->in(TypeFunc::Memory)->as_MergeMem();
+    if (merge_mem->base_memory() == merge_mem->empty_memory()) {
+      return; // dead path
+    }
+  }
 
   // check for unreachable loop
   CallProjections callprojs;

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1460,6 +1460,7 @@ void GraphKit::replace_in_map(Node* old, Node* neww) {
 Node* GraphKit::memory(uint alias_idx) {
   MergeMemNode* mem = merged_memory();
   Node* p = mem->memory_at(alias_idx);
+  assert(p != mem->empty_memory(), "empty");
   _gvn.set_type(p, Type::MEMORY);  // must be mapped
   return p;
 }


### PR DESCRIPTION
Attempt to inline through a call with a dead memory (but not a TOP yet) ends up badly.

The fix is to detect such case and avoid inlining letting the problematic call die during the next cleanup iteration.   

Testing:
- [x] hs-tier1-6 w/ -XX:+AlwaysIncrementalInlining

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257632](https://bugs.openjdk.java.net/browse/JDK-8257632): C2: Late inlining attempt on a call with a dead memory crashes


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1582/head:pull/1582`
`$ git checkout pull/1582`
