### PR TITLE
8257561: Some code is not vectorized after 8251925 and 8250607

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1105,11 +1105,9 @@ const Type* PhiNode::Value(PhaseGVN* phase) const {
           if (bt != BoolTest::ne) {
             if (stride_t->hi_as_long() < 0) {          // Down-counter loop
               swap(lo, hi);
-              return TypeInteger::make(MIN2(lo->lo_as_long(), hi->lo_as_long()), hi->hi_as_long(), 3,
-                                       l->bt())->filter_speculative(_type);
+              return TypeInteger::make(MIN2(lo->lo_as_long(), hi->lo_as_long()), hi->hi_as_long(), 3, l->bt());
             } else if (stride_t->lo_as_long() >= 0) {
-              return TypeInteger::make(lo->lo_as_long(), MAX2(lo->hi_as_long(), hi->hi_as_long()), 3,
-                                       l->bt())->filter_speculative(_type);
+              return TypeInteger::make(lo->lo_as_long(), MAX2(lo->hi_as_long(), hi->hi_as_long()), 3, l->bt());
             }
           }
         }

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3995,16 +3995,14 @@ bool SWPointer::offset_plus_k(Node* n, bool negate) {
         assert(!is_main_loop_member(n), "sanity");
         n = n->in(1);
       }
-
-      // Check if 'n' can really be used as invariant (not in main loop and dominating the pre loop).
-      if (invariant(n)) {
-        _negate_invar = negate;
-        _invar = n;
-        NOT_PRODUCT(_tracer.offset_plus_k_10(n, _invar, _negate_invar, _offset);)
-        return true;
-      }
     }
-    return false;
+    // Check if 'n' can really be used as invariant (not in main loop and dominating the pre loop).
+    if (invariant(n)) {
+      _negate_invar = negate;
+      _invar = n;
+      NOT_PRODUCT(_tracer.offset_plus_k_10(n, _invar, _negate_invar, _offset);)
+      return true;
+    }
   }
 
   NOT_PRODUCT(_tracer.offset_plus_k_11(n);)


### PR DESCRIPTION
I noticed that some our tests are not vectorized since JDK 16 b24. I found it was caused by small RFE change [8250607](https://bugs.openjdk.java.net/browse/JDK-8250607) and incorrect code move in changes for [8251925](https://bugs.openjdk.java.net/browse/JDK-8251925).
I reverted those changes and got back all vectorized tests.

Tested: tier1-4, precheckin-comp, 100 runs of renaissance test (fixed by 8251925).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257561](https://bugs.openjdk.java.net/browse/JDK-8257561): Some code is not vectorized after 8251925 and 8250607


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1584/head:pull/1584`
`$ git checkout pull/1584`
