### PR TITLE
8257572: Deprecate the archaic signal-chaining interfaces: sigset and signal

### DIFF
--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -128,6 +128,7 @@ endif
 
 ifeq ($(call isTargetOsType, unix), true)
   ifeq ($(STATIC_BUILD), false)
+    LIBJSIG_CFLAGS += -DHOTSPOT_VM_DISTRO='"$(HOTSPOT_VM_DISTRO)"'
     $(eval $(call SetupJdkLibrary, BUILD_LIBJSIG, \
         NAME := jsig, \
         OPTIMIZATION := LOW, \

--- a/src/java.base/unix/native/libjsig/jsig.c
+++ b/src/java.base/unix/native/libjsig/jsig.c
@@ -29,6 +29,8 @@
  * libthread to interpose the signal handler installation functions:
  * sigaction(), signal(), sigset().
  * Used for signal-chaining. See RFE 4381843.
+ * Use of signal() and sigset() is now deprecated as these old API's should
+ * not be used - sigaction is the only truly supported API.
  */
 
 #include "jni.h"
@@ -99,6 +101,10 @@ static sa_handler_t call_os_signal(int sig, sa_handler_t disp,
   sa_handler_t res;
 
   if (os_signal == NULL) {
+    // Deprecation warning first time through
+    printf(HOTSPOT_VM_DISTRO " VM warning: the use of signal() and sigset() "
+           "for signal chaining was deprecated in version 16.0 and will "
+           "be removed in a future release. Use sigaction() instead.\n");
     if (!is_sigset) {
       os_signal = (signal_function_t)dlsym(RTLD_NEXT, "signal");
     } else {


### PR DESCRIPTION
The signal-chaining facility was introduced in JDK 1.4 nearly 20 years ago and supported three different Linux signal API's: sigset, signal and sigaction:

https://docs.oracle.com/javase/8/docs/technotes/guides/vm/signal-chaining.html

Only sigaction is a Posix supported API for multi-threaded processes, that we can use cross-platform. Both signal and sigset are obsolete and have undefined behaviour in a multi-threaded process. From the Linux man pages:

sigset: This API is obsolete: new applications should use the POSIX signal API (sigaction(2), sigprocmask(2), etc.)

signal: The behavior of signal() varies across UNIX versions, and has also varied historically across different versions of Linux. Avoid its use: use sigaction(2) instead.

We should deprecate the use of signal and sigset in JDK 16 with a view to their removal in JDK 17.

A CSR request has been filed.

Testing: hotspot/jtreg/runtime/signal tests

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257572](https://bugs.openjdk.java.net/browse/JDK-8257572): Deprecate the archaic signal-chaining interfaces: sigset and signal


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1587/head:pull/1587`
`$ git checkout pull/1587`
