### PR TITLE
8251843: jfr/tool/TestPrintJSON.java fails intermittently

### DIFF
--- a/test/jdk/jdk/jfr/tool/EndTicksComparator.java
+++ b/test/jdk/jdk/jfr/tool/EndTicksComparator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.tool;
+
+import java.util.Comparator;
+import jdk.jfr.consumer.RecordedEvent;
+
+public class EndTicksComparator implements Comparator<RecordedEvent> {
+    public long readEndTicks(RecordedEvent event) {
+        long timestamp = event.getLong("startTime");
+        if (event.hasField("duration")) {
+            timestamp += event.getLong("duration");
+        }
+        return timestamp;
+    }
+
+    @Override
+    public int compare(RecordedEvent a, RecordedEvent b) {
+        return Long.compare(readEndTicks(a), readEndTicks(b));
+    }
+}

--- a/test/jdk/jdk/jfr/tool/TestPrintJSON.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintJSON.java
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package jdk.jfr.tool;
 
 import java.lang.reflect.Field;
@@ -151,6 +152,4 @@ public class TestPrintJSON {
         String jfrText = String.valueOf(jfrObject);
         Asserts.assertEquals(jfrText, jsonText, "Primitive values don't match. JSON = " + jsonText);
     }
-
-    
 }

--- a/test/jdk/jdk/jfr/tool/TestPrintJSON.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintJSON.java
@@ -51,7 +51,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @library /test/lib /test/jdk
  * @modules jdk.jfr
  *
- * @run main/othervm --add-opens jdk.jfr/jdk.jfr.consumer=ALL-UNNAMED jdk.jfr.tool.TestPrintJSON
+ * @run main/othervm jdk.jfr.tool.TestPrintJSON
  */
 public class TestPrintJSON {
 
@@ -152,25 +152,5 @@ public class TestPrintJSON {
         Asserts.assertEquals(jfrText, jsonText, "Primitive values don't match. JSON = " + jsonText);
     }
 
-    public static class EndTicksComparator implements Comparator<RecordedEvent> {
-        private final Field field;
-
-        public EndTicksComparator() throws Exception {
-            field = RecordedEvent.class.getDeclaredField("endTimeTicks");
-            field.setAccessible(true);
-        }
-
-        public long readEndTicks(RecordedEvent event) {
-            try {
-                return (Long) field.get(event);
-            } catch (Exception e) {
-                throw new InternalError("Could not read field", e);
-            }
-        }
-
-        @Override
-        public int compare(RecordedEvent a, RecordedEvent b) {
-            return Long.compare(readEndTicks(a), readEndTicks(b));
-        }
-    }
+    
 }

--- a/test/jdk/jdk/jfr/tool/TestPrintJSON.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintJSON.java
@@ -25,11 +25,9 @@
 
 package jdk.jfr.tool;
 
-import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 

--- a/test/jdk/jdk/jfr/tool/TestPrintXML.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintXML.java
@@ -96,7 +96,7 @@ public class TestPrintXML {
 
         // Verify that all data was written correctly
         List<RecordedEvent> events = RecordingFile.readAllEvents(recordingFile);
-        Collections.sort(events, (e1, e2) -> e1.getEndTime().compareTo(e2.getEndTime()));
+        Collections.sort(events, new EndTicksComparator());
         Iterator<RecordedEvent> it = events.iterator();
         for (XMLEvent xmlEvent : handler.events) {
             RecordedEvent re = it.next();


### PR DESCRIPTION
The 'jfr' tool can print events in JSON and XML and the result is verified by reading the same file using the jdk.jfr.consumer API. The method RecordedEvent::getEndTime() exposes timestamps with nano-precision (java.time.Instant), while the tool sorts them according to ticks.  It is believed that  events with different ticks timestamp in some circumstances may get the same nano-precision timestamp. This leads to events not arriving in the same order and the test fails.

Fix is to sort events in the test by ticks as well
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251843](https://bugs.openjdk.java.net/browse/JDK-8251843): jfr/tool/TestPrintJSON.java fails intermittently


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1589/head:pull/1589`
`$ git checkout pull/1589`
