### PR TITLE
8257509: Strengthen requirements to call G1HeapVerifier::verify(VerifyOption)

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -471,9 +471,7 @@ bool G1HeapVerifier::should_verify(G1VerifyType type) {
 }
 
 void G1HeapVerifier::verify(VerifyOption vo) {
-  if (!SafepointSynchronize::is_at_safepoint()) {
-    log_info(gc, verify)("Skipping verification. Not at safepoint.");
-  }
+  assert(SafepointSynchronize::is_at_safepoint(), "must be at safepoint");
 
   assert(Thread::current()->is_VM_thread(),
          "Expected to be executed serially by the VM thread at this point");

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -472,7 +472,6 @@ bool G1HeapVerifier::should_verify(G1VerifyType type) {
 
 void G1HeapVerifier::verify(VerifyOption vo) {
   assert(SafepointSynchronize::is_at_safepoint(), "must be at safepoint");
-
   assert(Thread::current()->is_VM_thread(),
          "Expected to be executed serially by the VM thread at this point");
 

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -471,9 +471,7 @@ bool G1HeapVerifier::should_verify(G1VerifyType type) {
 }
 
 void G1HeapVerifier::verify(VerifyOption vo) {
-  assert(SafepointSynchronize::is_at_safepoint(), "must be at safepoint");
-  assert(Thread::current()->is_VM_thread(),
-         "Expected to be executed serially by the VM thread at this point");
+  assert_at_safepoint_on_vm_thread();
 
   log_debug(gc, verify)("Roots");
   VerifyRootsClosure rootsCl(vo);


### PR DESCRIPTION
Hi all,

  can I have reviews for this little change to strengthen the requirements for calling G1HeapVerifier::verify(VerifyOption)?

In particular, instead of the failed attempt to abort verification if we are not at a safepoint, assert that we are at a safepoint.

Testing: tier1-5 with no failures

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257509](https://bugs.openjdk.java.net/browse/JDK-8257509): Strengthen requirements to call G1HeapVerifier::verify(VerifyOption)


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 2fba7cc35c50776f54217e753fe1fcd960cc1d6b
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author) ⚠️ Review applies to 93da0d17cbde2c79a5f46f93957cefa657ef5c67


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1590/head:pull/1590`
`$ git checkout pull/1590`
