### PR TITLE
8257591: Remove suppression of record preview related warnings in java.lang

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -269,7 +269,6 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @since 1.8
      */
-    @SuppressWarnings("preview")
     public String toGenericString() {
         if (isPrimitive()) {
             return toString();
@@ -3548,7 +3547,6 @@ public final class Class<T> implements java.io.Serializable,
     private native Method[]      getDeclaredMethods0(boolean publicOnly);
     private native Constructor<T>[] getDeclaredConstructors0(boolean publicOnly);
     private native Class<?>[]   getDeclaredClasses0();
-    @SuppressWarnings("preview")
     private native RecordComponent[] getRecordComponents0();
     private native boolean      isRecord0();
 

--- a/src/java.base/share/classes/java/lang/reflect/RecordComponent.java
+++ b/src/java.base/share/classes/java/lang/reflect/RecordComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,6 @@ public final class RecordComponent implements AnnotatedElement {
     private transient FieldRepository genericInfo;
     private byte[] annotations;
     private byte[] typeAnnotations;
-    @SuppressWarnings("preview")
     private RecordComponent root;
 
     // only the JVM can create record components
@@ -189,7 +188,6 @@ public final class RecordComponent implements AnnotatedElement {
         if ((declAnnos = declaredAnnotations) == null) {
             synchronized (this) {
                 if ((declAnnos = declaredAnnotations) == null) {
-                    @SuppressWarnings("preview")
                     RecordComponent root = this.root;
                     if (root != null) {
                         declAnnos = root.declaredAnnotations();

--- a/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,6 @@ public class ObjectMethods {
 
     static {
         try {
-            @SuppressWarnings("preview")
             Class<ObjectMethods> OBJECT_METHODS_CLASS = ObjectMethods.class;
             MethodHandles.Lookup publicLookup = MethodHandles.publicLookup();
             MethodHandles.Lookup lookup = MethodHandles.lookup();

--- a/test/jdk/java/lang/invoke/unreflect/UnreflectTest.java
+++ b/test/jdk/java/lang/invoke/unreflect/UnreflectTest.java
@@ -21,10 +21,10 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8238358 8247444
- * @run testng/othervm --enable-preview UnreflectTest
+ * @run testng/othervm UnreflectTest
  * @summary Test Lookup::unreflectSetter and Lookup::unreflectVarHandle on
  *          trusted final fields (declared in hidden classes and records)
  */
@@ -99,7 +99,6 @@ public class UnreflectTest {
      * Test Lookup::unreflectSetter and Lookup::unreflectVarHandle that
      * cannot write the value of a non-static final field in a record class
      */
-    @SuppressWarnings("preview")
     public void testFieldsInRecordClass() throws Throwable {
         assertTrue(TestRecord.class.isRecord());
         Object o = new TestRecord(1);

--- a/test/jdk/java/lang/reflect/records/RecordPermissionsTest.java
+++ b/test/jdk/java/lang/reflect/records/RecordPermissionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 8235369
  * @summary Security manager checks for record related core reflection
- * @compile --enable-preview -source ${jdk.version} RecordPermissionsTest.java
- * @run testng/othervm/java.security.policy=allPermissions.policy --enable-preview RecordPermissionsTest
+ * @compile RecordPermissionsTest.java
+ * @run testng/othervm/java.security.policy=allPermissions.policy RecordPermissionsTest
  */
 
 import java.net.URL;

--- a/test/jdk/java/lang/reflect/records/RecordReflectionTest.java
+++ b/test/jdk/java/lang/reflect/records/RecordReflectionTest.java
@@ -25,9 +25,9 @@
  * @test
  * @bug 8235369 8235550 8247444
  * @summary reflection test for records
- * @compile --enable-preview -source ${jdk.version} RecordReflectionTest.java
- * @run testng/othervm --enable-preview RecordReflectionTest
- * @run testng/othervm/java.security.policy=allPermissions.policy --enable-preview RecordReflectionTest
+ * @compile RecordReflectionTest.java
+ * @run testng/othervm RecordReflectionTest
+ * @run testng/othervm/java.security.policy=allPermissions.policy RecordReflectionTest
  */
 
 import java.lang.annotation.*;


### PR DESCRIPTION
Records exit preview in JDK 16. This change removes preview related suppression warnings in some source files and removes the '--enable-preview' option for compilation and execution of some tests that use record classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257591](https://bugs.openjdk.java.net/browse/JDK-8257591): Remove suppression of record preview related warnings in java.lang


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1591/head:pull/1591`
`$ git checkout pull/1591`
