### PR TITLE
8252807: The jdk.jfr.Recording.getStream does not work when toDisk is disabled

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
@@ -594,7 +594,7 @@ public final class Recording implements Closeable {
      *         {@code start}
      *
      * @throws IOException if a stream can't be opened
-     * 
+     *
      * @see #setToDisk(boolean)
      */
     public InputStream getStream(Instant start, Instant end) throws IOException {

--- a/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
@@ -578,7 +578,7 @@ public final class Recording implements Closeable {
      * <p>
      * The stream may contain some data outside the specified range.
      * <p>
-     * If the recording is not written to disk, a stream can't be created
+     * If the recording is not to disk, a stream can't be created
      * and {@code null} is returned.
      *
      * @param start the start time for the stream, or {@code null} to get data from
@@ -594,6 +594,8 @@ public final class Recording implements Closeable {
      *         {@code start}
      *
      * @throws IOException if a stream can't be opened
+     * 
+     * @see #setToDisk(boolean)
      */
     public InputStream getStream(Instant start, Instant end) throws IOException {
         if (start != null && end != null && end.isBefore(start)) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
@@ -577,6 +577,9 @@ public final class Recording implements Closeable {
      * Creates a data stream for a specified interval.
      * <p>
      * The stream may contain some data outside the specified range.
+     * <p>
+     * If the recording is not written to disk, a stream can't be created
+     * and {@code null} is returned.
      *
      * @param start the start time for the stream, or {@code null} to get data from
      *        start time of the recording
@@ -585,7 +588,7 @@ public final class Recording implements Closeable {
      *        present time.
      *
      * @return an input stream, or {@code null} if no data is available in the
-     *         interval.
+     *         interval, or the recording was not recorded to disk 
      *
      * @throws IllegalArgumentException if {@code end} happens before
      *         {@code start}

--- a/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/Recording.java
@@ -588,7 +588,7 @@ public final class Recording implements Closeable {
      *        present time.
      *
      * @return an input stream, or {@code null} if no data is available in the
-     *         interval, or the recording was not recorded to disk 
+     *         interval, or the recording was not recorded to disk
      *
      * @throws IllegalArgumentException if {@code end} happens before
      *         {@code start}


### PR DESCRIPTION
Clarify that an InputStream can't be returned when calling Recording::getStream() on an in memory recording.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252807](https://bugs.openjdk.java.net/browse/JDK-8252807): The jdk.jfr.Recording.getStream does not work when toDisk is disabled


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**) ⚠️ Review applies to c5ed97926012a0caab859b160affb0b36d9a0265


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1592/head:pull/1592`
`$ git checkout pull/1592`
