### PR TITLE
8257668: SA JMap - skip non-java thread stack dump for heap dump

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ThreadStackTrace.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ThreadStackTrace.java
@@ -47,7 +47,6 @@ public class ThreadStackTrace {
 
     public void dumpStack(int maxDepth) {
         if (!thread.isJavaThread()) {
-            System.out.println("dumpStack: not java Thread.");
             return;
         }
         try {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
@@ -715,10 +715,7 @@ public class HeapHprofBinWriter extends AbstractHeapGraphWriter {
 
                 // dump thread stack trace
                 ThreadStackTrace st = new ThreadStackTrace(thread);
-                if (thread.isJavaThread()) {
-                    // only dump java thread stack
-                    st.dumpStack(-1);
-                }
+                st.dumpStack(-1);
                 numThreads++;
 
                 // write HPROF_FRAME records for this thread's stack trace

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
@@ -715,7 +715,10 @@ public class HeapHprofBinWriter extends AbstractHeapGraphWriter {
 
                 // dump thread stack trace
                 ThreadStackTrace st = new ThreadStackTrace(thread);
-                st.dumpStack(-1);
+                if (thread.isJavaThread()) {
+                    // only dump java thread stack
+                    st.dumpStack(-1);
+                }
                 numThreads++;
 
                 // write HPROF_FRAME records for this thread's stack trace


### PR DESCRIPTION
when use SA JMap dump commands, such as "jhsdb jmap --binaryheap" or "dump heap" with "jhsdb clhsdb", it keep printing "dumpStack: not java Thread.". 
Skip non-java thread stack dump to avoid printing the message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257668](https://bugs.openjdk.java.net/browse/JDK-8257668): SA JMap - skip non-java thread stack dump for heap dump


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to f4df6c53b6a70113639e53e7b18ea2d8ace1ab94
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1593/head:pull/1593`
`$ git checkout pull/1593`
