### PR TITLE
8257673: Build fails without shenandoahgc after JDK-8257563

### DIFF
--- a/src/hotspot/share/jvmci/compilerRuntime.cpp
+++ b/src/hotspot/share/jvmci/compilerRuntime.cpp
@@ -29,6 +29,7 @@
 #include "interpreter/linkResolver.hpp"
 #include "jvmci/compilerRuntime.hpp"
 #include "oops/cpCache.inline.hpp"
+#include "oops/klass.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/frame.inline.hpp"


### PR DESCRIPTION
Hi all,

Please review this one-line change, which fixes the build failure without shenandoahgc.

Testing:
 - Build tests without shenandoahgc and PCH on Linux/x64

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257673](https://bugs.openjdk.java.net/browse/JDK-8257673): Build fails without shenandoahgc after JDK-8257563


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1594/head:pull/1594`
`$ git checkout pull/1594`
