### PR TITLE
8257641: Shenandoah: Query is_at_shenandoah_safepoint() from control thread should return false

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -122,6 +122,7 @@ class ShenandoahHeap : public CollectedHeap {
   friend class ShenandoahGCSession;
   friend class ShenandoahGCStateResetter;
   friend class ShenandoahParallelObjectIterator;
+  friend class ShenandoahSafepoint;
 // ---------- Locks that guard important data structures in Heap
 //
 private:
@@ -451,10 +452,8 @@ private:
 
   ShenandoahPhaseTimings*    _phase_timings;
 
+  ShenandoahControlThread*   control_thread()          { return _control_thread;    }
   ShenandoahMarkCompact*     full_gc()                 { return _full_gc;           }
-
-public:
-  ShenandoahControlThread*   control_thread() const    { return _control_thread;    }
 
 public:
   ShenandoahCollectorPolicy* shenandoah_policy() const { return _shenandoah_policy; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -451,8 +451,10 @@ private:
 
   ShenandoahPhaseTimings*    _phase_timings;
 
-  ShenandoahControlThread*   control_thread()          { return _control_thread;    }
   ShenandoahMarkCompact*     full_gc()                 { return _full_gc;           }
+
+public:
+  ShenandoahControlThread*   control_thread() const    { return _control_thread;    }
 
 public:
   ShenandoahCollectorPolicy* shenandoah_policy() const { return _shenandoah_policy; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -147,9 +147,15 @@ public:
   static inline bool is_at_shenandoah_safepoint() {
     if (!SafepointSynchronize::is_at_safepoint()) return false;
 
+    Thread* const thr = Thread::current();
+    // Shenandoah GC specific safepoints are scheduled by control thread,
+    // so that, querying from control thread can not happen during those
+    // safepoints.
+    if (thr == ShenandoahHeap::heap()->control_thread()) return false;
+
     // This is not VM thread, cannot see what VM thread is doing,
     // so pretend this is a proper Shenandoah safepoint
-    if (!Thread::current()->is_VM_thread()) return true;
+    if (!thr->is_VM_thread()) return true;
 
     // Otherwise check we are at proper operation type
     VM_Operation* vm_op = VMThread::vm_operation();

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -148,9 +148,9 @@ public:
     if (!SafepointSynchronize::is_at_safepoint()) return false;
 
     Thread* const thr = Thread::current();
-    // Shenandoah GC specific safepoints are scheduled by control thread,
-    // so that, querying from control thread can not happen during those
-    // safepoints.
+    // Shenandoah GC specific safepoints are scheduled by control thread.
+    // So if we are enter here from control thread, then we are definitely not
+    // at Shenandoah safepoint, but at something else.
     if (thr == ShenandoahHeap::heap()->control_thread()) return false;
 
     // This is not VM thread, cannot see what VM thread is doing,


### PR DESCRIPTION
Since Shenandoah GC safepoints are scheduled by control thread, so that, if querying comes from control thread, the answer should be false.

is_at_shenandoah_safepoint() is still not reliable, even after JDK-8253778, we may consider to scratch it.

- [x] hotspot_gc_shenandoah x86_64 and x86_32

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257641](https://bugs.openjdk.java.net/browse/JDK-8257641): Shenandoah: Query is_at_shenandoah_safepoint() from control thread should return false


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1600/head:pull/1600`
`$ git checkout pull/1600`
