### PR TITLE
8257701: Shenandoah: objArrayKlass metadata is not marked with chunked arrays

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.inline.hpp
@@ -111,6 +111,11 @@ inline void ShenandoahConcurrentMark::do_chunked_array_start(ShenandoahObjToScan
   objArrayOop array = objArrayOop(obj);
   int len = array->length();
 
+  // Mark objArray klass metadata
+  if (Devirtualizer::do_metadata(cl)) {
+    Devirtualizer::do_klass(cl, array->klass());
+  }
+
   if (len <= (int) ObjArrayMarkingStride*2) {
     // A few slices only, process directly
     array->oop_iterate_range(cl, 0, len);


### PR DESCRIPTION
Usually, marking code calls Klass::oop_oop_iterate(), where it marks object klass metadata.

Shenandoah introduced chunked array processing a while ago to breakup marking a large array into chunks, then call oop_iterate_range() to mark individual chunk. Unfortunately, oop_iterate_range() does not iterate over object klass metadata, so we end up missing the mark of object array klass metadata.

Thanks for @lmao (Liang Mao) reporting the bug.

- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257701](https://bugs.openjdk.java.net/browse/JDK-8257701): Shenandoah: objArrayKlass metadata is not marked with chunked arrays


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1602/head:pull/1602`
`$ git checkout pull/1602`
