### PR TITLE
8235784: java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java fails due to timeout with fastdebug bits

### DIFF
--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8154556
- * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsChar
- * @run testng/othervm -Diters=20000                         VarHandleTestByteArrayAsChar
- * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAsChar
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsChar
+ * @run testng/othervm/timeout=360 -Diters=20000                         VarHandleTestByteArrayAsChar
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAsChar
  */
 
 import org.testng.annotations.DataProvider;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8154556
- * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsDouble
- * @run testng/othervm -Diters=20000                         VarHandleTestByteArrayAsDouble
- * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAsDouble
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsDouble
+ * @run testng/othervm/timeout=360 -Diters=20000                         VarHandleTestByteArrayAsDouble
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAsDouble
  */
 
 import org.testng.annotations.DataProvider;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8154556
- * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsFloat
- * @run testng/othervm -Diters=20000                         VarHandleTestByteArrayAsFloat
- * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAsFloat
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsFloat
+ * @run testng/othervm/timeout=360 -Diters=20000                         VarHandleTestByteArrayAsFloat
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAsFloat
  */
 
 import org.testng.annotations.DataProvider;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8154556
- * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsInt
- * @run testng/othervm -Diters=20000                         VarHandleTestByteArrayAsInt
- * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAsInt
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsInt
+ * @run testng/othervm/timeout=360 -Diters=20000                         VarHandleTestByteArrayAsInt
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAsInt
  */
 
 import org.testng.annotations.DataProvider;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8154556
- * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsLong
- * @run testng/othervm -Diters=20000                         VarHandleTestByteArrayAsLong
- * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAsLong
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsLong
+ * @run testng/othervm/timeout=360 -Diters=20000                         VarHandleTestByteArrayAsLong
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAsLong
  */
 
 import org.testng.annotations.DataProvider;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8154556
- * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsShort
- * @run testng/othervm -Diters=20000                         VarHandleTestByteArrayAsShort
- * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAsShort
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAsShort
+ * @run testng/othervm/timeout=360 -Diters=20000                         VarHandleTestByteArrayAsShort
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAsShort
  */
 
 import org.testng.annotations.DataProvider;

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestByteArrayView.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestByteArrayView.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8154556
- * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAs$Type$
- * @run testng/othervm -Diters=20000                         VarHandleTestByteArrayAs$Type$
- * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAs$Type$
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestByteArrayAs$Type$
+ * @run testng/othervm/timeout=360 -Diters=20000                         VarHandleTestByteArrayAs$Type$
+ * @run testng/othervm/timeout=360 -Diters=20000 -XX:-TieredCompilation  VarHandleTestByteArrayAs$Type$
  */
 
 import org.testng.annotations.DataProvider;


### PR DESCRIPTION
VarHandleTestByteArrayAsInt.java intermittently fails only fastdebug build and slow mac os machines.   I can't reproduce this locally.  It fails on jdk 16 internal testing on a few builds.  I propose to increase the timeout and see if that is adequate or not.  We will re-examine this test if the increased timeout is not adequate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8235784](https://bugs.openjdk.java.net/browse/JDK-8235784): java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java fails due to timeout with fastdebug bits


### Reviewers
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1603/head:pull/1603`
`$ git checkout pull/1603`
