### PR TITLE
8257724: Incorrect package of the linked class in BaseSSLSocketImpl

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,8 +98,9 @@ abstract class BaseSSLSocketImpl extends SSLSocket {
     //
 
     /**
-     * Returns the unique {@link java.nio.SocketChannel SocketChannel} object
-     * associated with this socket, if any.
+     * Returns the unique {@link java.nio.channels.SocketChannel SocketChannel}
+     * object associated with this socket, if any.
+     *
      * @see java.net.Socket#getChannel
      */
     @Override


### PR DESCRIPTION
In sun.security.ssl.BaseSSLSocketImpl.java, the package of SocketChannel in the getChannel() spec is java.nio, which is incorrect. It should be java.nio.channels.

Doc cleanup only, no new regression test.

Bug: https://bugs.openjdk.java.net/browse/JDK-8257724

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257724](https://bugs.openjdk.java.net/browse/JDK-8257724): Incorrect package of the linked class in BaseSSLSocketImpl


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1605/head:pull/1605`
`$ git checkout pull/1605`
