### PR TITLE
8253762: JFR: getField(String) should be able to access subfields

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/EventType.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/EventType.java
@@ -66,6 +66,9 @@ public final class EventType {
     /**
      * Returns the field with the specified name, or {@code null} if it doesn't
      * exist.
+     * <p>
+     * It's possible to index into a nested field by using {@code "."} (for
+     * instance {@code "thread.group.parent.name}").
      *
      * @param name of the field to get, not {@code null}
      *
@@ -82,7 +85,12 @@ public final class EventType {
             }
             cache = newCache;
         }
-        return cache.get(name);
+        ValueDescriptor result = cache.get(name);
+        if (result == null) {
+            // Cache doesn't contain subfields
+            result = platformEventType.getField(name);
+        }
+        return result;
     }
 
     /**

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -192,7 +192,7 @@ public class RecordedObject {
      * <p>
      * It's possible to index into a nested field by using {@code "."} (for
      * instance {@code "thread.group.parent.name}").
-     * 
+     *
      * @param name name of the field to get, not {@code null}
      *
      * @return {@code true} if the field exists, {@code false} otherwise

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -189,7 +189,10 @@ public class RecordedObject {
     /**
      * Returns {@code true} if a field with the given name exists, {@code false}
      * otherwise.
-     *
+     * <p>
+     * It's possible to index into a nested field by using {@code "."} (for
+     * instance {@code "thread.group.parent.name}").
+     * 
      * @param name name of the field to get, not {@code null}
      *
      * @return {@code true} if the field exists, {@code false} otherwise

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Type.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Type.java
@@ -191,6 +191,26 @@ public class Type implements Comparable<Type> {
        return getName() + "(" + getId() + ")";
     }
 
+    public ValueDescriptor getField(String name) {
+        int dotIndex = name.indexOf(".");
+        if (dotIndex > 0) {
+            String pre = name.substring(0, dotIndex);
+            String post = name.substring(dotIndex + 1);
+            ValueDescriptor subField = getField(pre);
+            if (subField != null) {
+                Type type = PrivateAccess.getInstance().getType(subField);
+                return type.getField(post);
+            }
+        } else {
+            for (ValueDescriptor v : getFields()) {
+                if (name.equals(v.getName())) {
+                    return v;
+                }
+            }
+        }
+        return null;
+    }
+
     public List<ValueDescriptor> getFields() {
         if (fields instanceof ArrayList) {
             ((ArrayList<ValueDescriptor>) fields).trimToSize();

--- a/test/jdk/jdk/jfr/api/metadata/eventtype/TestGetField.java
+++ b/test/jdk/jdk/jfr/api/metadata/eventtype/TestGetField.java
@@ -54,7 +54,7 @@ public class TestGetField {
         v = type.getField("eventThread.group.name");
         Asserts.assertNotNull(v, "getField(eventThread.group.name) was null");
         Asserts.assertEquals(v.getTypeName(), "java.lang.String", "eventThread.group.name was not type java.lang.String");
-        
+
         v = type.getField("myStatic");
         Asserts.assertNull(v, "got static field");
 
@@ -64,7 +64,7 @@ public class TestGetField {
         v = type.getField("");
         Asserts.assertNull(v, "got field for empty name");
 
-        
+
         try {
             v = type.getField(null);
             Asserts.fail("No Exception when getField(null)");

--- a/test/jdk/jdk/jfr/api/metadata/eventtype/TestGetField.java
+++ b/test/jdk/jdk/jfr/api/metadata/eventtype/TestGetField.java
@@ -44,13 +44,17 @@ public class TestGetField {
         EventType type = EventType.getEventType(MyEvent.class);
 
         ValueDescriptor v = type.getField("myByte");
-        Asserts.assertNotNull(v, "getFiled(myByte) was null");
+        Asserts.assertNotNull(v, "getField(myByte) was null");
         Asserts.assertEquals(v.getTypeName(), "byte", "myByte was not type byte");
 
         v = type.getField("myInt");
-        Asserts.assertNotNull(v, "getFiled(myInt) was null");
+        Asserts.assertNotNull(v, "getField(myInt) was null");
         Asserts.assertEquals(v.getTypeName(), "int", "myInt was not type int");
 
+        v = type.getField("eventThread.group.name");
+        Asserts.assertNotNull(v, "getField(eventThread.group.name) was null");
+        Asserts.assertEquals(v.getTypeName(), "java.lang.String", "eventThread.group.name was not type java.lang.String");
+        
         v = type.getField("myStatic");
         Asserts.assertNull(v, "got static field");
 
@@ -60,6 +64,7 @@ public class TestGetField {
         v = type.getField("");
         Asserts.assertNull(v, "got field for empty name");
 
+        
         try {
             v = type.getField(null);
             Asserts.fail("No Exception when getField(null)");


### PR DESCRIPTION
Allow EventType::getFiled(String) to access subfields, similar to getValue(String) for values.

Testing: jdk/jdk/jfr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253762](https://bugs.openjdk.java.net/browse/JDK-8253762): JFR: getField(String) should be able to access subfields


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1606/head:pull/1606`
`$ git checkout pull/1606`
