### PR TITLE
8257725: No throws of SSLHandshakeException

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,8 +98,9 @@ abstract class BaseSSLSocketImpl extends SSLSocket {
     //
 
     /**
-     * Returns the unique {@link java.nio.SocketChannel SocketChannel} object
-     * associated with this socket, if any.
+     * Returns the unique {@link java.nio.channels.SocketChannel SocketChannel}
+     * object associated with this socket, if any.
+     *
      * @see java.net.Socket#getChannel
      */
     @Override

--- a/src/java.base/share/classes/sun/security/ssl/StatusResponseManager.java
+++ b/src/java.base/share/classes/sun/security/ssl/StatusResponseManager.java
@@ -258,9 +258,6 @@ final class StatusResponseManager {
      *
      * @return an unmodifiable {@code Map} containing the certificate and
      *      its usually
-     *
-     * @throws SSLHandshakeException if an unsupported
-     *      {@code CertStatusRequest} is provided.
      */
     Map<X509Certificate, byte[]> get(CertStatusRequestType type,
             CertStatusRequest request, X509Certificate[] chain, long delay,


### PR DESCRIPTION
In the StatusResponseManager.get() method spec, the SSLHandshakeException is declared as throws exception. However, no such checked-exception would be thrown in the method implementation. 

/** 
... 
 * @throws SSLHandshakeException if an unsupported 
 * {@code CertStatusRequest} is provided. 
 */ 
Map<X509Certificate, byte[]> get(CertStatusRequestType type, 
            CertStatusRequest request, X509Certificate[] chain, long delay, 
            TimeUnit unit) {

As the exception is a checked-exception, and is not declared in the method, it is safe to remove the throws spec.

Cleanup only, no new regression test.

Bug: https://bugs.openjdk.java.net/browse/JDK-8257725

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257725](https://bugs.openjdk.java.net/browse/JDK-8257725): No throws of SSLHandshakeException


### Reviewers
 * [Jamil Nimeh](https://openjdk.java.net/census#jnimeh) (@jnimeh - **Reviewer**) ⚠️ Review applies to 13d8478475da13c7f676e02d600be25caceba213


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1607/head:pull/1607`
`$ git checkout pull/1607`
