### PR TITLE
8257736: InputStream from BodyPublishers.ofInputStream() leaks when IOE happens

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/RequestPublishers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/RequestPublishers.java
@@ -418,6 +418,11 @@ public final class RequestPublishers {
                 nextBuffer.position(0);
                 return n;
             } catch (IOException ex) {
+                need2Read = false;
+                haveNext = false;
+                try {
+                    is.close();
+                } catch (IOException ex2) {}
                 return -1;
             }
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/RequestPublishers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/RequestPublishers.java
@@ -398,7 +398,7 @@ public final class RequestPublishers {
 //            return error;
 //        }
 
-        private int read() {
+        private int read() throws IOException {
             if (eof)
                 return -1;
             nextBuffer = bufSupplier.get();
@@ -406,35 +406,44 @@ public final class RequestPublishers {
             byte[] buf = nextBuffer.array();
             int offset = nextBuffer.arrayOffset();
             int cap = nextBuffer.capacity();
-            try {
-                int n = is.read(buf, offset, cap);
-                if (n == -1) {
-                    eof = true;
-                    is.close();
-                    return -1;
-                }
-                //flip
-                nextBuffer.limit(n);
-                nextBuffer.position(0);
-                return n;
-            } catch (IOException ex) {
-                need2Read = false;
-                haveNext = false;
-                try {
-                    is.close();
-                } catch (IOException ex2) {}
+            int n = is.read(buf, offset, cap);
+            if (n == -1) {
+                eof = true;
                 return -1;
+            }
+            nextBuffer.limit(n);
+            nextBuffer.position(0);
+            return n;
+        }
+
+        /**
+         * Close stream in this instance.
+         * UncheckedIOException may be thrown if IOE happens at InputStream::close.
+         */
+        private void closeStream() {
+            try {
+                is.close();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
             }
         }
 
         @Override
         public synchronized boolean hasNext() {
             if (need2Read) {
-                haveNext = read() != -1;
-                if (haveNext) {
+                try {
+                    haveNext = read() != -1;
+                    if (haveNext) {
+                        need2Read = false;
+                    }
+                } catch (IOException e) {
+                    haveNext = false;
                     need2Read = false;
+                } finally {
+                    if (!haveNext) {
+                        closeStream();
+                    }
                 }
-                return haveNext;
             }
             return haveNext;
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/RequestPublishers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/RequestPublishers.java
@@ -411,6 +411,7 @@ public final class RequestPublishers {
                 eof = true;
                 return -1;
             }
+            //flip
             nextBuffer.limit(n);
             nextBuffer.position(0);
             return n;
@@ -439,6 +440,7 @@ public final class RequestPublishers {
                 } catch (IOException e) {
                     haveNext = false;
                     need2Read = false;
+                    throw new UncheckedIOException(e);
                 } finally {
                     if (!haveNext) {
                         closeStream();

--- a/test/jdk/java/net/httpclient/StreamCloseTest.java
+++ b/test/jdk/java/net/httpclient/StreamCloseTest.java
@@ -116,7 +116,11 @@ public class StreamCloseTest {
         HttpRequest request = requestBuilder.copy()
                                             .POST(BodyPublishers.ofInputStream(() -> in))
                                             .build();
-        client.send(request, BodyHandlers.discarding());
+        try {
+            client.send(request, BodyHandlers.discarding());
+        } catch (IOException e) {
+            // expected
+        }
         Assert.assertTrue(in.closeCalled, "InputStream was not closed!");
     }
 }

--- a/test/jdk/java/net/httpclient/StreamCloseTest.java
+++ b/test/jdk/java/net/httpclient/StreamCloseTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, NTT DATA.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8257736
+ * @modules java.net.http
+ *          java.logging
+ *          jdk.httpserver
+ * @library /test/lib
+ * @compile ../../../com/sun/net/httpserver/LogFilter.java
+ * @compile ../../../com/sun/net/httpserver/EchoHandler.java
+ * @compile ../../../com/sun/net/httpserver/FileServerHandler.java
+ * @build jdk.test.lib.net.SimpleSSLContext
+ * @build LightWeightHttpServer
+ * @build jdk.test.lib.Platform
+ * @run testng/othervm/java.security.policy=RequestBodyTest.policy StreamCloseTest
+ */
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Redirect;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.net.URI;
+
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+public class StreamCloseTest {
+
+    private static class TestInputStream extends InputStream {
+        private final boolean exceptionTest;
+        private volatile boolean closeCalled;
+
+        public TestInputStream(boolean exceptionTest) {
+            super();
+            this.exceptionTest = exceptionTest;
+            this.closeCalled = false;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (exceptionTest) {
+                throw new IOException("test");
+            }
+            return -1;
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCalled = true;
+        }
+    }
+
+    private static HttpClient client;
+
+    private static HttpRequest.Builder requestBuilder;
+
+    @BeforeTest
+    public void setup() throws Exception {
+        LightWeightHttpServer.initServer();
+        client = HttpClient.newBuilder()
+                           .version(Version.HTTP_1_1)
+                           .followRedirects(Redirect.ALWAYS)
+                           .build();
+        URI uri = URI.create(LightWeightHttpServer.httproot + "echo/foo");
+        requestBuilder = HttpRequest.newBuilder(uri);
+    }
+
+    @AfterTest
+    public void teardown() throws Exception {
+        LightWeightHttpServer.stop();
+    }
+
+    @Test
+    public void normallyCloseTest() throws Exception{
+        TestInputStream in = new TestInputStream(false);
+        HttpRequest request = requestBuilder.copy()
+                                            .POST(BodyPublishers.ofInputStream(() -> in))
+                                            .build();
+        client.send(request, BodyHandlers.discarding());
+        Assert.assertTrue(in.closeCalled, "InputStream was not closed!");
+    }
+
+    @Test
+    public void closeTestOnException() throws Exception{
+        TestInputStream in = new TestInputStream(true);
+        HttpRequest request = requestBuilder.copy()
+                                            .POST(BodyPublishers.ofInputStream(() -> in))
+                                            .build();
+        client.send(request, BodyHandlers.discarding());
+        Assert.assertTrue(in.closeCalled, "InputStream was not closed!");
+    }
+}


### PR DESCRIPTION
`InputStream` from `BodyPublishers.ofInputStream()` is usually closed when the stream reaches EOF. However IOE handler returns without closing.

I confirmed this problem in `BodyPublishers.ofInputStream()`, but I think `BodyPublishers.ofFile()`has same problem because it also use `StreamIterator`as well as `ofInputStream()`.


# How to reproduce:

Following code (Test.java) attempts to post body from `TestInputStream` which throws IOE in `read()`. "close called" is shown on the console if `close()` is called.

```
import java.io.*;
import java.net.*;
import java.net.http.*;

public class Test{

  private static class TestInputStream extends InputStream{

    public TestInputStream(){
      super();
      System.out.println("test c'tor");
    }

    @Override
    public int read() throws IOException{
      System.out.println("read called");
      throw new IOException("test");
    }

    @Override
    public void close() throws IOException{
      System.out.println("close called");
      super.close();
    }

  }

  public static void main(String[] args) throws Exception{
    var http = HttpClient.newHttpClient();
    var request = HttpRequest.newBuilder()
                             .uri(URI.create("http://httpbin.org/post"))
                             .POST(HttpRequest.BodyPublishers.ofInputStream(() -> new TestInputStream()))
                             .build();
    http.send(request, HttpResponse.BodyHandlers.discarding());
    System.out.println("Press any key to exit...");
    System.in.read();
  }
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257736](https://bugs.openjdk.java.net/browse/JDK-8257736): InputStream from BodyPublishers.ofInputStream() leaks when IOE happens


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1614/head:pull/1614`
`$ git checkout pull/1614`
