### PR TITLE
8257651: LambdaEagerInit.java test failed in 2 different ways

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -333,6 +333,7 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/DumpClassList.java \
  -runtime/cds/appcds/DumpClassListWithLF.java \
  -runtime/cds/appcds/ExtraSymbols.java \
+ -runtime/cds/appcds/LambdaEagerInit.java \
  -runtime/cds/appcds/LambdaProxyClasslist.java \
  -runtime/cds/appcds/LongClassListPath.java \
  -runtime/cds/appcds/LotsOfClasses.java \

--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaEagerInit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaEagerInit.java
@@ -35,6 +35,7 @@
  *          from the archive if the property is not set.
  * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds test-classes
+ * @compile ../../../../../lib/jdk/test/lib/Asserts.java
  * @run main/othervm LambdaEagerInit
  */
 


### PR DESCRIPTION
Please review this simple change for fixing the 2 issues as described in the bug report.

- exclude the test from the hotspot_appcds_dynamic test group.

- compile Asserts.java so that the class file will be located under the following dir `.../JTwork/classes/.../runtime/cds/appcds/LambdaEagerInit.d/jdk/test/lib/`

Passed hs-tier4 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257651](https://bugs.openjdk.java.net/browse/JDK-8257651): LambdaEagerInit.java test failed in 2 different ways


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1616/head:pull/1616`
`$ git checkout pull/1616`
