### PR TITLE
8257147: [TESTBUG] Set a larger default loop count for the VectorAPI jtreg tests

### DIFF
--- a/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Byte128VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Byte128VectorLoadStoreTests
  *
  */
 
@@ -50,7 +50,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);

--- a/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
@@ -50,7 +50,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);

--- a/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Byte128VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Byte128VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);
@@ -1234,7 +1234,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
@@ -57,7 +57,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);
@@ -1234,7 +1234,7 @@ public class Byte128VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
@@ -50,7 +50,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);

--- a/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Byte256VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Byte256VectorLoadStoreTests
  *
  */
 
@@ -50,7 +50,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);

--- a/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Byte256VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Byte256VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);
@@ -1234,7 +1234,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
@@ -57,7 +57,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);
@@ -1234,7 +1234,7 @@ public class Byte256VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Byte512VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Byte512VectorLoadStoreTests
  *
  */
 
@@ -50,7 +50,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);

--- a/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
@@ -50,7 +50,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);

--- a/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Byte512VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Byte512VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);
@@ -1234,7 +1234,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
@@ -57,7 +57,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);
@@ -1234,7 +1234,7 @@ public class Byte512VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Byte64VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Byte64VectorLoadStoreTests
  *
  */
 
@@ -50,7 +50,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);

--- a/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
@@ -50,7 +50,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);

--- a/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
@@ -57,7 +57,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);
@@ -1234,7 +1234,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Byte64VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Byte64VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);
@@ -1234,7 +1234,7 @@ public class Byte64VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
@@ -25,7 +25,7 @@
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
- *      ByteMaxVectorLoadStoreTests
+ *      -XX:-TieredCompilation ByteMaxVectorLoadStoreTests
  *
  */
 
@@ -54,7 +54,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
@@ -54,7 +54,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch ByteMaxVectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation ByteMaxVectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;
@@ -1239,7 +1239,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
@@ -57,7 +57,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
     static final VectorSpecies<Byte> SPECIES =
                 ByteVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;
@@ -1239,7 +1239,7 @@ public class ByteMaxVectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Double128VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Double128VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);

--- a/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);

--- a/test/jdk/jdk/incubator/vector/Double128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorTests.java
@@ -57,7 +57,7 @@ public class Double128VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);
@@ -1357,7 +1357,7 @@ public class Double128VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Double128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Double128VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Double128VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Double128VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);
@@ -1357,7 +1357,7 @@ public class Double128VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);

--- a/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Double256VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Double256VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);

--- a/test/jdk/jdk/incubator/vector/Double256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorTests.java
@@ -57,7 +57,7 @@ public class Double256VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);
@@ -1357,7 +1357,7 @@ public class Double256VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Double256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Double256VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Double256VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Double256VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);
@@ -1357,7 +1357,7 @@ public class Double256VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);

--- a/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Double512VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Double512VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);

--- a/test/jdk/jdk/incubator/vector/Double512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorTests.java
@@ -57,7 +57,7 @@ public class Double512VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);
@@ -1357,7 +1357,7 @@ public class Double512VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Double512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Double512VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Double512VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Double512VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);
@@ -1357,7 +1357,7 @@ public class Double512VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);

--- a/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Double64VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Double64VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);

--- a/test/jdk/jdk/incubator/vector/Double64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorTests.java
@@ -57,7 +57,7 @@ public class Double64VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);
@@ -1357,7 +1357,7 @@ public class Double64VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Double64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Double64VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Double64VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Double64VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);
@@ -1357,7 +1357,7 @@ public class Double64VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
@@ -25,7 +25,7 @@
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
- *      DoubleMaxVectorLoadStoreTests
+ *      -XX:-TieredCompilation DoubleMaxVectorLoadStoreTests
  *
  */
 
@@ -55,7 +55,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
@@ -55,7 +55,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch DoubleMaxVectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation DoubleMaxVectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;
@@ -1362,7 +1362,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
@@ -57,7 +57,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
     static final VectorSpecies<Double> SPECIES =
                 DoubleVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;
@@ -1362,7 +1362,7 @@ public class DoubleMaxVectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);

--- a/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Float128VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Float128VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);

--- a/test/jdk/jdk/incubator/vector/Float128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Float128VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Float128VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Float128VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);
@@ -1367,7 +1367,7 @@ public class Float128VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Float128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorTests.java
@@ -57,7 +57,7 @@ public class Float128VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);
@@ -1367,7 +1367,7 @@ public class Float128VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Float256VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Float256VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);

--- a/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);

--- a/test/jdk/jdk/incubator/vector/Float256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorTests.java
@@ -57,7 +57,7 @@ public class Float256VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);
@@ -1367,7 +1367,7 @@ public class Float256VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Float256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Float256VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Float256VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Float256VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);
@@ -1367,7 +1367,7 @@ public class Float256VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);

--- a/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Float512VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Float512VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);

--- a/test/jdk/jdk/incubator/vector/Float512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorTests.java
@@ -57,7 +57,7 @@ public class Float512VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);
@@ -1367,7 +1367,7 @@ public class Float512VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Float512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Float512VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Float512VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Float512VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);
@@ -1367,7 +1367,7 @@ public class Float512VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Float64VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Float64VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);

--- a/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);

--- a/test/jdk/jdk/incubator/vector/Float64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Float64VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Float64VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Float64VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);
@@ -1367,7 +1367,7 @@ public class Float64VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Float64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorTests.java
@@ -57,7 +57,7 @@ public class Float64VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);
@@ -1367,7 +1367,7 @@ public class Float64VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
@@ -25,7 +25,7 @@
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
- *      FloatMaxVectorLoadStoreTests
+ *      -XX:-TieredCompilation FloatMaxVectorLoadStoreTests
  *
  */
 
@@ -55,7 +55,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
@@ -55,7 +55,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
@@ -57,7 +57,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;
@@ -1372,7 +1372,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch FloatMaxVectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation FloatMaxVectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
     static final VectorSpecies<Float> SPECIES =
                 FloatVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;
@@ -1372,7 +1372,7 @@ public class FloatMaxVectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Int128VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Int128VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);

--- a/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);

--- a/test/jdk/jdk/incubator/vector/Int128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorTests.java
@@ -57,7 +57,7 @@ public class Int128VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);
@@ -1195,7 +1195,7 @@ public class Int128VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Int128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Int128VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Int128VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Int128VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);
@@ -1195,7 +1195,7 @@ public class Int128VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);

--- a/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Int256VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Int256VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);

--- a/test/jdk/jdk/incubator/vector/Int256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Int256VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Int256VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Int256VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);
@@ -1195,7 +1195,7 @@ public class Int256VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Int256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorTests.java
@@ -57,7 +57,7 @@ public class Int256VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);
@@ -1195,7 +1195,7 @@ public class Int256VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);

--- a/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Int512VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Int512VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);

--- a/test/jdk/jdk/incubator/vector/Int512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Int512VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Int512VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Int512VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);
@@ -1195,7 +1195,7 @@ public class Int512VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Int512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorTests.java
@@ -57,7 +57,7 @@ public class Int512VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);
@@ -1195,7 +1195,7 @@ public class Int512VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);

--- a/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Int64VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Int64VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);

--- a/test/jdk/jdk/incubator/vector/Int64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Int64VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Int64VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Int64VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);
@@ -1195,7 +1195,7 @@ public class Int64VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Int64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorTests.java
@@ -57,7 +57,7 @@ public class Int64VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);
@@ -1195,7 +1195,7 @@ public class Int64VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
@@ -55,7 +55,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
@@ -25,7 +25,7 @@
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
- *      IntMaxVectorLoadStoreTests
+ *      -XX:-TieredCompilation IntMaxVectorLoadStoreTests
  *
  */
 
@@ -55,7 +55,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
@@ -57,7 +57,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;
@@ -1200,7 +1200,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch IntMaxVectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation IntMaxVectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
     static final VectorSpecies<Integer> SPECIES =
                 IntVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;
@@ -1200,7 +1200,7 @@ public class IntMaxVectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Long128VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Long128VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);

--- a/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);

--- a/test/jdk/jdk/incubator/vector/Long128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Long128VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Long128VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Long128VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);
@@ -1216,7 +1216,7 @@ public class Long128VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Long128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorTests.java
@@ -57,7 +57,7 @@ public class Long128VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);
@@ -1216,7 +1216,7 @@ public class Long128VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Long256VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Long256VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);

--- a/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);

--- a/test/jdk/jdk/incubator/vector/Long256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Long256VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Long256VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Long256VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);
@@ -1216,7 +1216,7 @@ public class Long256VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Long256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorTests.java
@@ -57,7 +57,7 @@ public class Long256VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);
@@ -1216,7 +1216,7 @@ public class Long256VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);

--- a/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Long512VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Long512VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);

--- a/test/jdk/jdk/incubator/vector/Long512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorTests.java
@@ -57,7 +57,7 @@ public class Long512VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);
@@ -1216,7 +1216,7 @@ public class Long512VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Long512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Long512VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Long512VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Long512VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);
@@ -1216,7 +1216,7 @@ public class Long512VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Long64VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Long64VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);

--- a/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);

--- a/test/jdk/jdk/incubator/vector/Long64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorTests.java
@@ -57,7 +57,7 @@ public class Long64VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);
@@ -1216,7 +1216,7 @@ public class Long64VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Long64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Long64VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Long64VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Long64VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);
@@ -1216,7 +1216,7 @@ public class Long64VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
@@ -25,7 +25,7 @@
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
- *      LongMaxVectorLoadStoreTests
+ *      -XX:-TieredCompilation LongMaxVectorLoadStoreTests
  *
  */
 
@@ -55,7 +55,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
@@ -55,7 +55,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch LongMaxVectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation LongMaxVectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;
@@ -1221,7 +1221,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
@@ -57,7 +57,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
     static final VectorSpecies<Long> SPECIES =
                 LongVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;
@@ -1221,7 +1221,7 @@ public class LongMaxVectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Short128VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Short128VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);

--- a/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);

--- a/test/jdk/jdk/incubator/vector/Short128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorTests.java
@@ -57,7 +57,7 @@ public class Short128VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);
@@ -1224,7 +1224,7 @@ public class Short128VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Short128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Short128VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Short128VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Short128VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_128;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 128);
@@ -1224,7 +1224,7 @@ public class Short128VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);

--- a/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Short256VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Short256VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);

--- a/test/jdk/jdk/incubator/vector/Short256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorTests.java
@@ -57,7 +57,7 @@ public class Short256VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);
@@ -1224,7 +1224,7 @@ public class Short256VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Short256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Short256VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Short256VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Short256VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_256;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 256);
@@ -1224,7 +1224,7 @@ public class Short256VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Short512VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Short512VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);

--- a/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);

--- a/test/jdk/jdk/incubator/vector/Short512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Short512VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Short512VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Short512VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);
@@ -1224,7 +1224,7 @@ public class Short512VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Short512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorTests.java
@@ -57,7 +57,7 @@ public class Short512VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_512;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 512);
@@ -1224,7 +1224,7 @@ public class Short512VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
- * @run testng Short64VectorLoadStoreTests
+ * @run testng/othervm -XX:-TieredCompilation Short64VectorLoadStoreTests
  *
  */
 
@@ -51,7 +51,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);

--- a/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
@@ -51,7 +51,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);

--- a/test/jdk/jdk/incubator/vector/Short64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorTests.java
@@ -57,7 +57,7 @@ public class Short64VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);
@@ -1224,7 +1224,7 @@ public class Short64VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/Short64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch Short64VectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Short64VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class Short64VectorTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_64;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 
     static final int BUFFER_REPS = Integer.getInteger("jdk.incubator.vector.test.buffer-vectors", 25000 / 64);
@@ -1224,7 +1224,7 @@ public class Short64VectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
@@ -55,7 +55,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
@@ -25,7 +25,7 @@
  * @test
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
- *      ShortMaxVectorLoadStoreTests
+ *      -XX:-TieredCompilation ShortMaxVectorLoadStoreTests
  *
  */
 
@@ -55,7 +55,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch ShortMaxVectorTests
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation ShortMaxVectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //
@@ -57,7 +57,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;
@@ -1229,7 +1229,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
@@ -57,7 +57,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
     static final VectorSpecies<Short> SPECIES =
                 ShortVector.SPECIES_MAX;
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
     static VectorShape getMaxBit() {
         return VectorShape.S_Max_BIT;
@@ -1229,7 +1229,7 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/VectorReshapeTests.java
+++ b/test/jdk/jdk/incubator/vector/VectorReshapeTests.java
@@ -40,7 +40,7 @@ import jdk.incubator.vector.VectorSpecies;
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
- *      VectorReshapeTests
+ *      -XX:-TieredCompilation VectorReshapeTests
  */
 
 @Test

--- a/test/jdk/jdk/incubator/vector/config.sh
+++ b/test/jdk/jdk/incubator/vector/config.sh
@@ -38,7 +38,7 @@ TEMPLATE_FILE="unit_tests.template"
 TESTNG_JAR="${TESTNG_PLUGIN}/plugins/org.testng.source_6.13.1.r201712040515.jar"
 TESTNG_RUN_JAR="${TESTNG_PLUGIN}/plugins/org.testng_6.13.1.r201712040515.jar"
 JCOMMANDER_JAR="${TESTNG_PLUGIN}/plugins/com.beust.jcommander_1.72.0.jar"
-TEST_ITER_COUNT=100
+TEST_ITER_COUNT=1000
 
 PERF_TEMPLATE_FILE="perf_tests.template"
 PERF_SCALAR_TEMPLATE_FILE="perf_scalar_tests.template"

--- a/test/jdk/jdk/incubator/vector/config.sh
+++ b/test/jdk/jdk/incubator/vector/config.sh
@@ -38,7 +38,7 @@ TEMPLATE_FILE="unit_tests.template"
 TESTNG_JAR="${TESTNG_PLUGIN}/plugins/org.testng.source_6.13.1.r201712040515.jar"
 TESTNG_RUN_JAR="${TESTNG_PLUGIN}/plugins/org.testng_6.13.1.r201712040515.jar"
 JCOMMANDER_JAR="${TESTNG_PLUGIN}/plugins/com.beust.jcommander_1.72.0.jar"
-TEST_ITER_COUNT=1000
+TEST_ITER_COUNT=100
 
 PERF_TEMPLATE_FILE="perf_tests.template"
 PERF_SCALAR_TEMPLATE_FILE="perf_scalar_tests.template"

--- a/test/jdk/jdk/incubator/vector/templates/Unit-header.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-header.template
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch $vectorteststype$
+ * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation $vectorteststype$
  */
 
 #warn This file is preprocessed before being compiled
@@ -79,7 +79,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
                 $Type$Vector.SPECIES_$bits$;
 #end[MaxBit]
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
 
 #if[MaxBit]
     static VectorShape getMaxBit() {
@@ -1466,7 +1466,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/templates/Unit-header.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-header.template
@@ -79,7 +79,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
                 $Type$Vector.SPECIES_$bits$;
 #end[MaxBit]
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 100);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 1000);
 
 #if[MaxBit]
     static VectorShape getMaxBit() {
@@ -1466,7 +1466,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
     // Test all shuffle related operations.
     static void shuffleTest() {
         // To test backend instructions, make sure that C2 is used.
-        for (int loop = 0; loop < INVOC_COUNT * INVOC_COUNT; loop++) {
+        for (int loop = 0; loop < 10 * INVOC_COUNT; loop++) {
             iotaShuffle();
         }
     }

--- a/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
+++ b/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
@@ -70,7 +70,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
                 $Type$Vector.SPECIES_$bits$;
 #end[MaxBit]
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
 
 #if[MaxBit]
     static VectorShape getMaxBit() {

--- a/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
+++ b/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
@@ -26,9 +26,9 @@
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
 #if[MaxBit]
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
- *      $vectorteststype$
+ *      -XX:-TieredCompilation $vectorteststype$
 #else[MaxBit]
- * @run testng $vectorteststype$
+ * @run testng/othervm -XX:-TieredCompilation $vectorteststype$
 #end[MaxBit]
  *
  */
@@ -70,7 +70,7 @@ public class $vectorteststype$ extends AbstractVectorTest {
                 $Type$Vector.SPECIES_$bits$;
 #end[MaxBit]
 
-    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 500);
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 10);
 
 #if[MaxBit]
     static VectorShape getMaxBit() {


### PR DESCRIPTION
The current default loop count of VectorAPI tests is too small (10 for load/store tests, 100 for arithmetic tests) to make the tests compiled with C2. This makes some potential issues not be reported as expected.

This patch fixes it by setting a larger default iteration.

The whole tests running time increases with this patch. Here is the results on two different types of machines:

Running with "`-conc:10`":
```
             Before     After
System A     5m30s      6m43s
System B     5m1s       6m31s
```

Running with "`-conc:1`":
```
             Before     After
System A     26m52s     45m6s
System B     30m3s      43m30s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257147](https://bugs.openjdk.java.net/browse/JDK-8257147): [TESTBUG] Set a larger default loop count for the VectorAPI jtreg tests


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1621/head:pull/1621`
`$ git checkout pull/1621`
