### PR TITLE
8058176: [mlvm] tests should tolerate exceptions caused by code cache exhaustion

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -144,7 +144,7 @@ vmTestbase/jit/escape/LockCoarsening/LockCoarsening001.java 8148743 generic-all
 vmTestbase/jit/escape/LockCoarsening/LockCoarsening002.java 8208259 generic-all
 
 vmTestbase/vm/mlvm/indy/func/jvmti/redefineClassInBootstrap/TestDescription.java 8013267 generic-all
-vmTestbase/vm/mlvm/meth/stress/jdi/breakpointInCompiledCode/Test.java 8058176 generic-all
+vmTestbase/vm/mlvm/meth/stress/jdi/breakpointInCompiledCode/Test.java 8257761 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2none_a/TestDescription.java 8013267 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_b/TestDescription.java 8013267 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_b/TestDescription.java 8013267 generic-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -144,12 +144,6 @@ vmTestbase/jit/escape/LockCoarsening/LockCoarsening001.java 8148743 generic-all
 vmTestbase/jit/escape/LockCoarsening/LockCoarsening002.java 8208259 generic-all
 
 vmTestbase/vm/mlvm/indy/func/jvmti/redefineClassInBootstrap/TestDescription.java 8013267 generic-all
-vmTestbase/vm/mlvm/meth/func/java/throwException/Test.java 8058176 generic-all
-vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java#id1 8058176 generic-all
-vmTestbase/vm/mlvm/meth/stress/compiler/i2c_c2i/Test.java 8058176 generic-all
-vmTestbase/vm/mlvm/meth/stress/compiler/sequences/Test.java 8058176 generic-all
-vmTestbase/vm/mlvm/meth/stress/gc/callSequencesDuringGC/Test.java 8058176 generic-all
-vmTestbase/vm/mlvm/meth/stress/java/sequences/Test.java 8058176 generic-all
 vmTestbase/vm/mlvm/meth/stress/jdi/breakpointInCompiledCode/Test.java 8058176 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2none_a/TestDescription.java 8013267 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_b/TestDescription.java 8013267 generic-all

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/func/java/throwException/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/func/java/throwException/Test.java
@@ -55,11 +55,15 @@ import vm.mlvm.meth.share.MHTransformationGen;
 import vm.mlvm.meth.share.RandomArgumentGen;
 import vm.mlvm.meth.share.RandomArgumentsGen;
 import vm.mlvm.meth.share.transform.v2.MHMacroTF;
+import vm.mlvm.share.DefaultThrowableTolerance;
+import vm.mlvm.share.Env;
 import vm.mlvm.share.MlvmTest;
+import vm.mlvm.share.ThrowableTolerance;
 
 public class Test extends MlvmTest {
 
-    public static void main(String[] args) { MlvmTest.launch(args); }
+    private static final ThrowableTolerance THROWABLE_TOLERANCE =
+        DefaultThrowableTolerance.CODE_CACHE_OOME_ALLOWED;
 
     public static class Example {
         private Throwable t;
@@ -105,9 +109,24 @@ public class Test extends MlvmTest {
                 }
             }
 
+            if (THROWABLE_TOLERANCE.isAcceptable(t)) {
+                return true;
+            }
+
             getLog().complain("Got wrong exception!");
             t.printStackTrace(getLog().getOutStream());
             return false;
         }
     }
+
+    public static void main(String[] args) {
+        Env.setThrowableTolerance(THROWABLE_TOLERANCE);
+
+        try {
+            MlvmTest.launch(args);
+        } catch (Throwable t) {
+            THROWABLE_TOLERANCE.ignoreOrRethrow(t);
+        }
+    }
+
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
@@ -82,6 +82,7 @@ import java.lang.invoke.MethodType;
 import vm.mlvm.meth.share.Argument;
 import vm.mlvm.meth.share.MHTransformationGen;
 import vm.mlvm.meth.share.RandomArgumentsGen;
+import vm.mlvm.share.DefaultThrowableTolerance;
 import vm.mlvm.share.Env;
 import vm.mlvm.share.MlvmTest;
 import vm.mlvm.share.MultiThreadedTest;
@@ -167,5 +168,14 @@ public class Test extends MultiThreadedTest {
         return true;
     }
 
-    public static void main(String[] args) { MlvmTest.launch(args); }
+    public static void main(String[] args) {
+        var throwableTolerance = DefaultThrowableTolerance.CODE_CACHE_OOME_ALLOWED;
+        Env.setThrowableTolerance(throwableTolerance);
+
+        try {
+            MlvmTest.launch(args);
+        } catch (Throwable t) {
+            throwableTolerance.ignoreOrRethrow(t);
+        }
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/sequences/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/sequences/Test.java
@@ -58,6 +58,8 @@ import nsk.share.test.Stresser;
 import vm.mlvm.meth.share.Argument;
 import vm.mlvm.meth.share.MHTransformationGen;
 import vm.mlvm.meth.share.RandomArgumentsGen;
+import vm.mlvm.share.DefaultThrowableTolerance;
+import vm.mlvm.share.Env;
 import vm.mlvm.share.MlvmTest;
 import vm.mlvm.share.MultiThreadedTest;
 
@@ -105,5 +107,14 @@ public class Test extends MultiThreadedTest {
         return true;
     }
 
-    public static void main(String[] args) { MlvmTest.launch(args); }
+    public static void main(String[] args) {
+        var throwableTolerance = DefaultThrowableTolerance.CODE_CACHE_OOME_ALLOWED;
+        Env.setThrowableTolerance(throwableTolerance);
+
+        try {
+            MlvmTest.launch(args);
+        } catch (Throwable t) {
+            throwableTolerance.ignoreOrRethrow(t);
+        }
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/gc/callSequencesDuringGC/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/gc/callSequencesDuringGC/Test.java
@@ -61,13 +61,11 @@ import nsk.share.test.Stresser;
 import vm.mlvm.meth.share.Argument;
 import vm.mlvm.meth.share.MHTransformationGen;
 import vm.mlvm.meth.share.RandomArgumentsGen;
+import vm.mlvm.share.DefaultThrowableTolerance;
+import vm.mlvm.share.Env;
 import vm.mlvm.share.MlvmTest;
 
 public class Test extends MlvmTest {
-
-    public static void main(String[] args) {
-        MlvmTest.launch(args);
-    }
 
     @Override
     public boolean run() throws Throwable {
@@ -139,4 +137,16 @@ public class Test extends MlvmTest {
         }
 
     }
+
+    public static void main(String[] args) {
+        var throwableTolerance = DefaultThrowableTolerance.CODE_CACHE_OOME_ALLOWED;
+        Env.setThrowableTolerance(throwableTolerance);
+
+        try {
+            MlvmTest.launch(args);
+        } catch (Throwable t) {
+            throwableTolerance.ignoreOrRethrow(t);
+        }
+    }
+
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/java/sequences/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/java/sequences/Test.java
@@ -60,13 +60,11 @@ import java.lang.invoke.MethodType;
 import vm.mlvm.meth.share.Argument;
 import vm.mlvm.meth.share.MHTransformationGen;
 import vm.mlvm.meth.share.RandomArgumentsGen;
+import vm.mlvm.share.DefaultThrowableTolerance;
+import vm.mlvm.share.Env;
 import vm.mlvm.share.MlvmTest;
 
 public class Test extends MlvmTest {
-
-    public static void main(String[] args) {
-        MlvmTest.launch(args);
-    }
 
     public static class Example {
         private Argument[] finalArgs;
@@ -115,5 +113,16 @@ public class Test extends MlvmTest {
         }
 
         return true;
+    }
+
+    public static void main(String[] args) {
+        var throwableTolerance = DefaultThrowableTolerance.CODE_CACHE_OOME_ALLOWED;
+        Env.setThrowableTolerance(throwableTolerance);
+
+        try {
+            MlvmTest.launch(args);
+        } catch (Throwable t) {
+            throwableTolerance.ignoreOrRethrow(t);
+        }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/DefaultThrowableTolerance.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/DefaultThrowableTolerance.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package vm.mlvm.share;
+
+/**
+ * A collection of default implementations for {@link ThrowableTolerance}.
+ */
+public class DefaultThrowableTolerance {
+
+    /**
+     * Does not accept any Throwable
+     *
+     * @param ignored Added to satisfy the interface API, always ignored.
+     * @return Always false
+     */
+    public static final ThrowableTolerance INTOLERANT = (Throwable ignored) -> { return false; };
+
+    /**
+     * Accepts only OutOfMemoryError with cause having 'Out of space' substring.
+     *
+     * Is useful for Code Cache depletion errors, for example. Scans the Throwable
+     * hierarchy in search for acceptable Throwable as an underlying cause.
+     * @param what Added to satisfy the interface API, is ignored.
+     * @return Always false
+     */
+    public static final ThrowableTolerance CODE_CACHE_OOME_ALLOWED = (Throwable what) -> {
+        Throwable cause = what;
+        do {
+            if (cause instanceof VirtualMachineError
+                    && cause.getMessage().matches(".*[Oo]ut of space.*")) {
+                return true;
+            }
+            cause = cause != null ? cause.getCause() : null;
+        } while (cause != null && cause != what);
+        return false;
+    };
+}

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/Env.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/Env.java
@@ -36,6 +36,7 @@ public class Env {
     private static class StaticHolder {
         public static ArgumentParser argParser;
         public static Log log;
+        public static ThrowableTolerance throwableTolerance = DefaultThrowableTolerance.INTOLERANT;
         static {
             init(new String[0]);
         }
@@ -48,6 +49,14 @@ public class Env {
             StaticHolder.argParser = ap;
             StaticHolder.log = new Log(System.out, StaticHolder.argParser);
         }
+    }
+
+    public static ThrowableTolerance getThrowableTolerance() {
+        return StaticHolder.throwableTolerance;
+    }
+
+    public static void setThrowableTolerance(ThrowableTolerance to) {
+        StaticHolder.throwableTolerance = to;
     }
 
     public static ArgumentParser getArgParser() {
@@ -169,7 +178,9 @@ public class Env {
     }
 
     public static void complain(Throwable t, String msg, Object... args) {
-        getLog().complain(new LazyFormatString(msg, args), t);
+        if (!StaticHolder.throwableTolerance.isAcceptable(t)) {
+           getLog().complain(new LazyFormatString(msg, args), t);
+        }
     }
 
     /**

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/MlvmTestExecutor.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/MlvmTestExecutor.java
@@ -378,20 +378,18 @@ public class MlvmTestExecutor {
                 }
 
                 boolean instancePassed;
-                if (expectedExceptions.size() == 0) {
+                try {
                     instancePassed = instance.run();
-                } else {
-                    try {
-                        instance.run();
+                    if (!expectedExceptions.isEmpty()) {
                         Env.complain("Expected exceptions: " + expectedExceptions + ", but caught none");
                         instancePassed = false;
-                    } catch (Throwable e) {
-                        if (checkExpectedException(expectedExceptions, e)) {
-                            instancePassed = true;
-                        } else {
-                            Env.complain(e, "Expected exceptions: " + expectedExceptions + ", but caught: ");
-                            instancePassed = false;
-                        }
+                    }
+                } catch (Throwable t) {
+                    if (checkExpectedException(expectedExceptions, t)) {
+                        instancePassed = true;
+                    } else {
+                        Env.complain(t, "Expected exceptions: " + expectedExceptions + ", but caught: ");
+                        instancePassed = false;
                     }
                 }
 
@@ -468,7 +466,7 @@ public class MlvmTestExecutor {
             }
         }
 
-        return false;
+        return Env.getThrowableTolerance().isAcceptable(caught);
     }
 
     private static class RunnableWrapper extends MlvmTest {

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/ThrowableTolerance.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/ThrowableTolerance.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+package vm.mlvm.share;
+
+/**
+ * A utility interface for allowing to control ignored or acceptable exceptions
+ */
+public interface ThrowableTolerance {
+
+    /**
+     * Checks if passed Throwable is acceptable.
+     * @param what Exception to check
+     * @return Whether the exception is acceptable or not.
+     */
+    boolean isAcceptable(Throwable what);
+
+    /**
+     * Checks if passed Throwable is acceptable and ignores it, or rethrows otherwise.
+     * @param what Exception to check
+     */
+    default void ignoreOrRethrow(Throwable what) {
+        if (!isAcceptable(what)) {
+            Env.throwAsUncheckedException(what); // Report inacceptable exception
+        }
+    }
+
+}


### PR DESCRIPTION
1. Normalise meth/stress/compiler/i2c_c2i/Test.java to use MultiThreadedTest framework;
2. Adjust MultiThreadedTest in order to accomodate the i2c_c2i test (add prepareThread method and logic);
3. Add ThrowableTolerance and DefaultThrowableTolerance as ways to control what Throwables are accepted;
4. Adjust MultiThreadedTest to catch Throwables and check if they are accepted;
5. Adjust individual tests to catch possible Throwables and check if they are accepted;
6. Un-problemlist the failing tests.

Testing: vmTestBase/vm/mlvm/meth/stress and vmTestBase/vm/mlvm/func tests run on macos-linux-windows in x64-debug configurations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8058176](https://bugs.openjdk.java.net/browse/JDK-8058176): [mlvm] tests should tolerate exceptions caused by code cache exhaustion


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1622/head:pull/1622`
`$ git checkout pull/1622`
