### PR TITLE
8255381: com/sun/jdi/EATests.java should not suspend graal threads

### DIFF
--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -2109,7 +2109,7 @@ class EARelockingObjectCurrentlyWaitingOn extends EATestCaseBaseDebugger {
             inWait = env.targetMainThread.frame(0).location().method().name().equals("wait");
             if (!inWait) {
                 msg("Target not yet in java.lang.Object.wait(long).");
-                env.vm().resume();
+                env.targetMainThread.resume();
             }
         } while(!inWait);
         StackFrame testMethodFrame = env.targetMainThread.frame(4);

--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -1271,8 +1271,9 @@ class EAMaterializeLocalAtObjectPollReturnReturn extends EATestCaseBaseDebugger 
             try {
                 o = getLocalRef(env.targetMainThread.frame(0), XYVAL_NAME, "xy");
             } catch (Exception e) {
-                msg("The local variable xy is out of scope because we suspended at the wrong bci. Resume and try again! (" + (++retryCount) + ")");
-                env.vm().resume();
+                ++retryCount;
+                msg("The local variable xy is out of scope because we suspended at the wrong bci. Resume and try again! (" + retryCount + ")");
+                env.targetMainThread.resume();
                 if ((retryCount % 10) == 0) {
                     Thread.sleep(200);
                 }

--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -448,15 +448,25 @@ abstract class EATestCaseBaseDebugger  extends EATestCaseBaseShared {
         }
     }
 
+    /**
+     * Set a breakpoint in the given method and resume all threads. The
+     * breakpoint is configured to suspend just the thread that reaches it
+     * instead of all threads. This is important when running with graal.
+     */
+    public BreakpointEvent resumeTo(String clsName, String methodName, String signature) {
+        boolean suspendThreadOnly = true;
+        return env.resumeTo(clsName, methodName, signature, suspendThreadOnly);
+    }
+
     public void resumeToWarmupDone() throws Exception {
         msg("resuming to " + TARGET_TESTCASE_BASE_NAME + ".warmupDone()V");
-        env.resumeTo(TARGET_TESTCASE_BASE_NAME, "warmupDone", "()V");
+        resumeTo(TARGET_TESTCASE_BASE_NAME, "warmupDone", "()V");
         testCase = env.targetMainThread.frame(0).thisObject();
     }
 
     public void resumeToTestCaseDone() {
         msg("resuming to " + TARGET_TESTCASE_BASE_NAME + ".testCaseDone()V");
-        env.resumeTo(TARGET_TESTCASE_BASE_NAME, "testCaseDone", "()V");
+        resumeTo(TARGET_TESTCASE_BASE_NAME, "testCaseDone", "()V");
     }
 
     public void checkPostConditions() throws Exception {
@@ -798,11 +808,6 @@ abstract class EATestCaseBaseTarget extends EATestCaseBaseShared implements Runn
 
 
     public boolean warmupDone;
-    // With UseJVMCICompiler it is possible that a compilation is made a
-    // background compilation even though -Xbatch is given (e.g. if JVMCI is not
-    // yet fully initialized). Therefore it is possible that the test method has
-    // not reached the highest compilation level after warm-up.
-    public boolean testMethodReachedHighestCompLevel;
 
     public volatile Object biasToBeRevoked;
 
@@ -915,7 +920,7 @@ abstract class EATestCaseBaseTarget extends EATestCaseBaseShared implements Runn
                     testCaseName + ": test method not found at depth " + testMethodDepth);
             // check if the frame is (not) deoptimized as expected
             if (!DeoptimizeObjectsALot) {
-                if (testFrameShouldBeDeoptimized() && testMethodReachedHighestCompLevel) {
+                if (testFrameShouldBeDeoptimized()) {
                     Asserts.assertTrue(WB.isFrameDeoptimized(testMethodDepth+1),
                             testCaseName + ": expected test method frame at depth " + testMethodDepth + " to be deoptimized");
                 } else {
@@ -969,16 +974,24 @@ abstract class EATestCaseBaseTarget extends EATestCaseBaseShared implements Runn
         } catch (NoSuchMethodException | SecurityException e) {
             Asserts.fail("could not check compilation level of", e);
         }
-        // Background compilation (-Xbatch) cannot always be disabled with JVMCI
-        // compiler (e.g. if JVMCI is not yet fully initialized), therefore it
-        // is possible that due to background compilation we reach here before
-        // the test method is compiled on the highest level.
         int highestLevel = CompilerUtils.getMaxCompilationLevel();
         int compLevel = WB.getMethodCompilationLevel(m);
-        testMethodReachedHighestCompLevel = highestLevel == compLevel;
         if (!UseJVMCICompiler) {
             Asserts.assertEQ(highestLevel, compLevel,
                              m + " not on expected compilation level");
+        } else {
+            // Background compilation (-Xbatch) will block a thread with timeout
+            // (see CompileBroker::wait_for_jvmci_completion()). Therefore it is
+            // possible to reach here before the main test method is compiled.
+            // In that case we wait for it to be compiled.
+            while (compLevel != highestLevel) {
+                msg(TESTMETHOD_DEFAULT_NAME + " is compiled on level " + compLevel +
+                    ". Wait until highes level (" + highestLevel + ") is reached.");
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException e) { /* ignored */ }
+                compLevel = WB.getMethodCompilationLevel(m);
+            }
         }
     }
 
@@ -1140,7 +1153,7 @@ class EAGetWithoutMaterializeTarget extends EATestCaseBaseTarget {
 class EAGetWithoutMaterialize extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         ObjectReference o = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "xy");
         checkPrimitiveField(o, FD.I, "x", 4);
@@ -1164,7 +1177,7 @@ class EAMaterializeLocalVariableUponGet extends EATestCaseBaseDebugger {
     private ObjectReference o;
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         // check 1.
         o = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "xy");
@@ -1203,7 +1216,7 @@ class EAMaterializeLocalVariableUponGetTarget extends EATestCaseBaseTarget {
 // call that will return another object
 class EAMaterializeLocalAtObjectReturn extends EATestCaseBaseDebugger {
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         ObjectReference o = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "xy");
         checkPrimitiveField(o, FD.I, "x", 4);
@@ -1248,17 +1261,21 @@ class EAMaterializeLocalAtObjectReturnTarget extends EATestCaseBaseTarget {
 class EAMaterializeLocalAtObjectPollReturnReturn extends EATestCaseBaseDebugger {
     public void runTestCase() throws Exception {
         msg("Resume " + env.targetMainThread);
-        env.targetMainThread.resume();
+        env.vm().resume();
         waitUntilTargetHasEnteredEndlessLoop();
         ObjectReference o = null;
+        int retryCount = 0;
         do {
             env.targetMainThread.suspend();
             printStack(env.targetMainThread);
             try {
                 o = getLocalRef(env.targetMainThread.frame(0), XYVAL_NAME, "xy");
             } catch (Exception e) {
-                msg("The local variable xy is out of scope because we suspended at the wrong bci. Resume and try again!");
-                env.targetMainThread.resume();
+                msg("The local variable xy is out of scope because we suspended at the wrong bci. Resume and try again! (" + (++retryCount) + ")");
+                env.vm().resume();
+                if ((retryCount % 10) == 0) {
+                    Thread.sleep(200);
+                }
             }
         } while (o == null);
         checkPrimitiveField(o, FD.I, "x", 4);
@@ -1327,7 +1344,7 @@ class EAMaterializeIntArrayTarget extends EATestCaseBaseTarget {
 
 class EAMaterializeIntArray extends EATestCaseBaseDebugger {
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         int[] expectedVals = {1, 2, 3};
         checkLocalPrimitiveArray(bpe.thread().frame(1), "nums", FD.I, expectedVals);
@@ -1352,7 +1369,7 @@ class EAMaterializeLongArrayTarget extends EATestCaseBaseTarget {
 
 class EAMaterializeLongArray extends EATestCaseBaseDebugger {
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         long[] expectedVals = {1, 2, 3};
         checkLocalPrimitiveArray(bpe.thread().frame(1), "nums", FD.J, expectedVals);
@@ -1377,7 +1394,7 @@ class EAMaterializeFloatArrayTarget extends EATestCaseBaseTarget {
 
 class EAMaterializeFloatArray extends EATestCaseBaseDebugger {
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         float[] expectedVals = {1.1f, 2.2f, 3.3f};
         checkLocalPrimitiveArray(bpe.thread().frame(1), "nums", FD.F, expectedVals);
@@ -1402,7 +1419,7 @@ class EAMaterializeDoubleArrayTarget extends EATestCaseBaseTarget {
 
 class EAMaterializeDoubleArray extends EATestCaseBaseDebugger {
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         double[] expectedVals = {1.1d, 2.2d, 3.3d};
         checkLocalPrimitiveArray(bpe.thread().frame(1), "nums", FD.D, expectedVals);
@@ -1427,7 +1444,7 @@ class EAMaterializeObjectArrayTarget extends EATestCaseBaseTarget {
 
 class EAMaterializeObjectArray extends EATestCaseBaseDebugger {
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         ReferenceType clazz = bpe.thread().frame(0).location().declaringType();
         ObjectReference[] expectedVals = {
@@ -1465,7 +1482,7 @@ class EAMaterializeObjectWithConstantAndNotConstantValuesTarget extends EATestCa
 
 class EAMaterializeObjectWithConstantAndNotConstantValues extends EATestCaseBaseDebugger {
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         ObjectReference o = getLocalRef(bpe.thread().frame(1), "ILFDO", "o");
         checkPrimitiveField(o, FD.I, "i", 1);
@@ -1508,7 +1525,7 @@ class EAMaterializeObjReferencedBy2LocalsTarget extends EATestCaseBaseTarget {
 class EAMaterializeObjReferencedBy2Locals extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         ObjectReference xy = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "xy");
         ObjectReference alias = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "alias");
@@ -1539,7 +1556,7 @@ class EAMaterializeObjReferencedBy2LocalsAndModifyTarget extends EATestCaseBaseT
 class EAMaterializeObjReferencedBy2LocalsAndModify extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         ObjectReference alias = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "alias");
         setField(alias, "x", env.vm().mirrorOf(42));
@@ -1580,7 +1597,7 @@ class EAMaterializeObjReferencedBy2LocalsInDifferentVirtFramesTarget extends EAT
 class EAMaterializeObjReferencedBy2LocalsInDifferentVirtFrames extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         ObjectReference xy = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "xy");
         ObjectReference alias = getLocalRef(bpe.thread().frame(1), "testMethod_inlined", "alias", XYVAL_NAME);
@@ -1623,7 +1640,7 @@ class EAMaterializeObjReferencedBy2LocalsInDifferentVirtFramesAndModifyTarget ex
 class EAMaterializeObjReferencedBy2LocalsInDifferentVirtFramesAndModify extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         ObjectReference alias = getLocalRef(bpe.thread().frame(1), "testMethod_inlined", "alias", XYVAL_NAME);
         setField(alias, "x", env.vm().mirrorOf(42));
@@ -1669,7 +1686,7 @@ class EAMaterializeObjReferencedFromOperandStackTarget extends EATestCaseBaseTar
 class EAMaterializeObjReferencedFromOperandStack extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         ObjectReference xy1 = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "xy1");
         checkPrimitiveField(xy1, FD.I, "x", 2);
@@ -1689,7 +1706,7 @@ class EAMaterializeObjReferencedFromOperandStack extends EATestCaseBaseDebugger 
 class EAMaterializeLocalVariableUponGetAfterSetInteger extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         setLocal(bpe.thread().frame(1), "i", env.vm().mirrorOf(43));
         ObjectReference o = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "xy");
@@ -1727,7 +1744,7 @@ class EAMaterializeLocalVariableUponGetAfterSetIntegerTarget extends EATestCaseB
 class EARelockingSimple extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference o = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "l1");
@@ -1754,7 +1771,7 @@ class EARelockingSimpleTarget extends EATestCaseBaseTarget {
 class EARelockingSimple_2 extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference o = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "l1");
@@ -1804,7 +1821,7 @@ class EARelockingRecursiveTarget extends EATestCaseBaseTarget {
 class EARelockingRecursive extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference o = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "l1");
@@ -1846,7 +1863,7 @@ class EARelockingNestedInflatedTarget extends EATestCaseBaseTarget {
 class EARelockingNestedInflated extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference o = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "l1");
@@ -1863,7 +1880,7 @@ class EARelockingNestedInflated extends EATestCaseBaseDebugger {
 class EARelockingNestedInflated_02 extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference o = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "l1");
@@ -1903,7 +1920,7 @@ class EARelockingNestedInflated_02Target extends EATestCaseBaseTarget {
 class EARelockingArgEscapeLWLockedInCalleeFrame extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference o = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "l1");
@@ -1942,7 +1959,7 @@ class EARelockingArgEscapeLWLockedInCalleeFrameTarget extends EATestCaseBaseTarg
 class EARelockingArgEscapeLWLockedInCalleeFrame_2 extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference o = getLocalRef(bpe.thread().frame(2), XYVAL_NAME, "l1");
@@ -1988,7 +2005,7 @@ class EARelockingArgEscapeLWLockedInCalleeFrame_3 extends EATestCaseBaseDebugger
     public static final String XYVAL_LOCAL_NAME = EARelockingArgEscapeLWLockedInCalleeFrame_3Target.XYValLocal.class.getName();
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference o = getLocalRef(bpe.thread().frame(1), XYVAL_LOCAL_NAME, "l1");
@@ -2037,7 +2054,7 @@ class EARelockingArgEscapeLWLockedInCalleeFrame_4 extends EATestCaseBaseDebugger
     public static final String XYVAL_LOCAL_NAME = EARelockingArgEscapeLWLockedInCalleeFrame_4Target.XYValLocal.class.getName();
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference o = getLocalRef(bpe.thread().frame(1), XYVAL_LOCAL_NAME, "l1");
@@ -2082,7 +2099,7 @@ class EARelockingArgEscapeLWLockedInCalleeFrame_4Target extends EATestCaseBaseTa
 class EARelockingObjectCurrentlyWaitingOn extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        env.targetMainThread.resume();
+        env.vm().resume();
         boolean inWait = false;
         do {
             Thread.sleep(100);
@@ -2091,7 +2108,7 @@ class EARelockingObjectCurrentlyWaitingOn extends EATestCaseBaseDebugger {
             inWait = env.targetMainThread.frame(0).location().method().name().equals("wait");
             if (!inWait) {
                 msg("Target not yet in java.lang.Object.wait(long).");
-                env.targetMainThread.resume();
+                env.vm().resume();
             }
         } while(!inWait);
         StackFrame testMethodFrame = env.targetMainThread.frame(4);
@@ -2184,7 +2201,7 @@ class EARelockingObjectCurrentlyWaitingOnTarget extends EATestCaseBaseTarget {
 class EADeoptFrameAfterReadLocalObject_01 extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference xy = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "xy");
@@ -2239,7 +2256,7 @@ class EADeoptFrameAfterReadLocalObject_01BTarget extends EATestCaseBaseTarget {
 class EADeoptFrameAfterReadLocalObject_01B extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference xy = getLocalRef(bpe.thread().frame(1), "callee", "xy", XYVAL_NAME);
@@ -2256,7 +2273,7 @@ class EADeoptFrameAfterReadLocalObject_01B extends EATestCaseBaseDebugger {
 class EADeoptFrameAfterReadLocalObject_02 extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference xy = getLocalRef(bpe.thread().frame(1), "dontinline_callee", "xy", XYVAL_NAME);
@@ -2302,7 +2319,7 @@ class EADeoptFrameAfterReadLocalObject_02Target extends EATestCaseBaseTarget {
 class EADeoptFrameAfterReadLocalObject_02B extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference xy = getLocalRef(bpe.thread().frame(1), "dontinline_callee", "xy", XYVAL_NAME);
@@ -2351,7 +2368,7 @@ class EADeoptFrameAfterReadLocalObject_02BTarget extends EATestCaseBaseTarget {
 class EADeoptFrameAfterReadLocalObject_02C extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         @SuppressWarnings("unused")
         ObjectReference xy = getLocalRef(bpe.thread().frame(1), "dontinline_callee_accessed_by_debugger", "xy", XYVAL_NAME);
@@ -2405,7 +2422,7 @@ class EADeoptFrameAfterReadLocalObject_02CTarget extends EATestCaseBaseTarget {
 class EADeoptFrameAfterReadLocalObject_03 extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         ObjectReference xy = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "xy");
         setField(xy, "x", env.vm().mirrorOf(1));
@@ -2462,7 +2479,7 @@ class EAGetOwnedMonitors extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
         msg("resume");
-        env.targetMainThread.resume();
+        env.vm().resume();
         waitUntilTargetHasEnteredEndlessLoop();
         // In contrast to JVMTI, JDWP requires a target thread to be suspended, before the owned monitors can be queried
         msg("suspend target");
@@ -2511,7 +2528,7 @@ class EAEntryCount extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
         msg("resume");
-        env.targetMainThread.resume();
+        env.vm().resume();
         waitUntilTargetHasEnteredEndlessLoop();
         // In contrast to JVMTI, JDWP requires a target thread to be suspended, before the owned monitors can be queried
         msg("suspend target");
@@ -2538,7 +2555,7 @@ class EAEntryCount extends EATestCaseBaseDebugger {
 class EAPopFrameNotInlined extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         printStack(bpe.thread());
         msg("PopFrame");
         bpe.thread().popFrames(bpe.thread().frame(0));
@@ -2590,7 +2607,7 @@ class EAPopFrameNotInlinedTarget extends EATestCaseBaseTarget {
 class EAPopFrameNotInlinedReallocFailure extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         ThreadReference thread = bpe.thread();
         printStack(thread);
         // frame[0]: EATestCaseBaseTarget.dontinline_brkpt()
@@ -2683,7 +2700,7 @@ class EAPopInlinedMethodWithScalarReplacedObjectsReallocFailure extends EATestCa
 
     public void runTestCase() throws Exception {
         ThreadReference thread = env.targetMainThread;
-        thread.resume();
+        env.vm().resume();
         waitUntilTargetHasEnteredEndlessLoop();
 
         thread.suspend();
@@ -2800,7 +2817,7 @@ class EAPopInlinedMethodWithScalarReplacedObjectsReallocFailureTarget extends EA
 class EAForceEarlyReturnNotInlined extends EATestCaseBaseDebugger {
 
     public void runTestCase() throws Exception {
-        BreakpointEvent bpe = env.resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
         ThreadReference thread = bpe.thread();
         printStack(thread);
         // frame[0]: EATestCaseBaseTarget.dontinline_brkpt()
@@ -2867,7 +2884,7 @@ class EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjects extends EATestC
 
     public void runTestCase() throws Exception {
         ThreadReference thread = env.targetMainThread;
-        thread.resume();
+        env.vm().resume();
         waitUntilTargetHasEnteredEndlessLoop();
 
         thread.suspend();
@@ -2951,7 +2968,7 @@ class EAForceEarlyReturnOfInlinedMethodWithScalarReplacedObjectsReallocFailure e
 
     public void runTestCase() throws Exception {
         ThreadReference thread = env.targetMainThread;
-        thread.resume();
+        env.vm().resume();
         waitUntilTargetHasEnteredEndlessLoop();
 
         thread.suspend();
@@ -3073,7 +3090,7 @@ class EAGetInstancesOfReferenceType extends EATestCaseBaseDebugger {
         ReferenceType cls = ((ClassObjectReference)getField(testCase, "cls")).reflectedType();
         msg("reflected type is " + cls);
         msg("resume");
-        env.targetMainThread.resume();
+        env.vm().resume();
         waitUntilTargetHasEnteredEndlessLoop();
         // do this while thread is running!
         msg("Retrieve instances of " + cls.name());

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -839,6 +839,12 @@ abstract public class TestScaffold extends TargetAdapter {
 
     public BreakpointEvent resumeTo(String clsName, String methodName,
                                          String methodSignature) {
+        return resumeTo(clsName, methodName, methodSignature, false /* suspendThread */);
+    }
+
+    public BreakpointEvent resumeTo(String clsName, String methodName,
+                                    String methodSignature,
+                                    boolean suspendThread) {
         ReferenceType rt = findReferenceType(clsName);
         if (rt == null) {
             rt = resumeToPrepareOf(clsName).referenceType();
@@ -850,7 +856,7 @@ abstract public class TestScaffold extends TargetAdapter {
                     + clsName + "." + methodName + ":" + methodSignature);
         }
 
-        return resumeTo(method.location());
+        return resumeTo(method.location(), suspendThread);
     }
 
     public BreakpointEvent resumeTo(String clsName, int lineNumber) throws AbsentInformationException {


### PR DESCRIPTION
This fixes a bug in the test test/jdk/com/sun/jdi/EATests.java that caused
timeout failures when graal is enabled.

The fix is to avoid suspending all threads when a breakpoint is reached and then resume
just the main thread again. This pattern was used in the test case
EAMaterializeLocalAtObjectPollReturnReturn. It caused timeouts because graal
threads remained suspended and, running with -Xbatch, the main thread waited
(with timeout) for completion of compile tasks.
The fix was applied to all breakpoints in the test. All explicit suspend calls now apply only
to the main test thread and all explicit resume calls apply to all java threads.

Testing: duration of the test case EAMaterializeLocalAtObjectPollReturnReturn is
reduced from 30s to 10s.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255381](https://bugs.openjdk.java.net/browse/JDK-8255381): com/sun/jdi/EATests.java should not suspend graal threads


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1625/head:pull/1625`
`$ git checkout pull/1625`
