### PR TITLE
8257750: writeBuffer field of java.io.DataOutputStream should be final

### DIFF
--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -50,7 +50,7 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
      */
     private byte[] bytearr = null;
 
-    private final byte writeBuffer[] = new byte[8];
+    private final byte[] writeBuffer = new byte[8];
 
     /**
      * Creates a new data output stream to write data to the specified

--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -50,6 +50,8 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
      */
     private byte[] bytearr = null;
 
+    private final byte writeBuffer[] = new byte[8];
+
     /**
      * Creates a new data output stream to write data to the specified
      * underlying output stream. The counter {@code written} is
@@ -206,8 +208,6 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
         out.write(writeBuffer, 0, 4);
         incCount(4);
     }
-
-    private byte writeBuffer[] = new byte[8];
 
     /**
      * Writes a {@code long} to the underlying output stream as eight


### PR DESCRIPTION
Please review this trivial change to make the `writeBuffer` array field final and move it to the beginning of the class where other fields are declared.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257750](https://bugs.openjdk.java.net/browse/JDK-8257750): writeBuffer field of java.io.DataOutputStream should be final


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to c994c07c2dffd2f51dfed8c1737e044d2456b7dd


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1627/head:pull/1627`
`$ git checkout pull/1627`
