### PR TITLE
8231286: HTML font size too large with high-DPI scaling and W3C_UNIT_LENGTHS

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -2862,18 +2862,15 @@ public class CSS implements Serializable {
             lengthMapping.put("cm", 28.3464f);
             lengthMapping.put("pc", 12f);
             lengthMapping.put("in", 72f);
-            int res = 72;
-            try {
-                res = Toolkit.getDefaultToolkit().getScreenResolution();
-            } catch (HeadlessException e) {
-            }
+
             // mapping according to the CSS2 spec
-            w3cLengthMapping.put("pt", res / 72f);
-            w3cLengthMapping.put("px", 1f);
-            w3cLengthMapping.put("mm", res / 25.4f);
-            w3cLengthMapping.put("cm", res / 2.54f);
-            w3cLengthMapping.put("pc", res / 6f);
-            w3cLengthMapping.put("in", (float) res);
+            // https://drafts.csswg.org/css-values-3/#absolute-lengths
+            w3cLengthMapping.put("pt", 1.3f); //1/72 of 1in
+            w3cLengthMapping.put("px", 1f); //1/96 of 1in
+            w3cLengthMapping.put("mm", 3.77952f); //1/10 of 1cm
+            w3cLengthMapping.put("cm", 37.7952f); //96px/2.54
+            w3cLengthMapping.put("pc", 16f); //1/6 of 1in
+            w3cLengthMapping.put("in", 96f); //96px
         }
 
         LengthUnit(String value, short defaultType, float defaultValue) {

--- a/test/jdk/javax/swing/text/html/CSS/HtmlFontSizeTest.java
+++ b/test/jdk/javax/swing/text/html/CSS/HtmlFontSizeTest.java
@@ -44,7 +44,7 @@ public class HtmlFontSizeTest {
 
     private static void test(boolean w3ccheck) {
         JFrame frame = null;
-	JLabel label = null;
+        JLabel label = null;
         try {
             frame = new JFrame();
             frame.setLayout(new BorderLayout());
@@ -56,7 +56,7 @@ public class HtmlFontSizeTest {
 
             if (w3ccheck) {
                 htmlPane.putClientProperty(JEditorPane.W3C_LENGTH_UNITS, Boolean.TRUE);
-	    }
+            }
 
             HTMLEditorKit kit = new HTMLEditorKit();
             htmlPane.setEditorKit(kit);
@@ -101,10 +101,10 @@ public class HtmlFontSizeTest {
         System.out.println("frame height with W3C:" + framesize1);
         System.out.println("frame height without W3C:" + framesize2);
 
-	float ratio = (float)framesize1.width/(float)framesize2.width;
-	System.out.println("framesize1.width/framesize2.width " + ratio);
+        float ratio = (float)framesize1.width/(float)framesize2.width;
+        System.out.println("framesize1.width/framesize2.width " + ratio);
 
-	String str = String.format("%.1g%n",ratio);
+        String str = String.format("%.1g%n",ratio);
         if (str.compareTo(String.format("%.1g%n",1.3f)) != 0) {
             throw new RuntimeException("HTML font size too large with high-DPI scaling and W3C_UNIT_LENGTHS");
         }

--- a/test/jdk/javax/swing/text/html/CSS/HtmlFontSizeTest.java
+++ b/test/jdk/javax/swing/text/html/CSS/HtmlFontSizeTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8231286
+ * @key headful
+ * @summary  Verifies if HTML font size too large with high-DPI scaling and W3C_UNIT_LENGTHS
+ * @run main/othervm -Dsun.java2d.uiScale=1.0 HtmlFontSizeTest
+ */
+import java.awt.BorderLayout;
+import java.awt.Font;
+import java.awt.Rectangle;
+
+import javax.swing.JFrame;
+import javax.swing.JEditorPane;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import javax.swing.text.Document;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.StyleSheet;
+
+public class HtmlFontSizeTest {
+    static Rectangle framesize1, framesize2;
+
+    private static void test(boolean w3ccheck) {
+        JFrame frame = null;
+	JLabel label = null;
+        try {
+            frame = new JFrame();
+            frame.setLayout(new BorderLayout());
+            label = new JLabel("This is 16 pt.");
+            label.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 16));
+
+            JEditorPane htmlPane = new JEditorPane();
+            htmlPane.setEditable(false);
+
+            if (w3ccheck) {
+                htmlPane.putClientProperty(JEditorPane.W3C_LENGTH_UNITS, Boolean.TRUE);
+	    }
+
+            HTMLEditorKit kit = new HTMLEditorKit();
+            htmlPane.setEditorKit(kit);
+
+            StyleSheet styleSheet = kit.getStyleSheet();
+            styleSheet.addRule("body { font-family: SansSerif; font-size: 16pt; }");
+
+            String htmlString = "<html>\n"
+                                + "<body>\n"
+                                + "<p>This should be 16 pt.</p>\n"
+                                + "</body>\n"
+                                + "</html>";
+
+            Document doc = kit.createDefaultDocument();
+            htmlPane.setDocument(doc);
+            htmlPane.setText(htmlString);
+
+            frame.add(label, BorderLayout.NORTH);
+            frame.add(htmlPane, BorderLayout.CENTER);
+            frame.setUndecorated(true);
+            frame.pack();
+            frame.setVisible(true);
+            frame.setLocationRelativeTo(null);
+
+            if (w3ccheck) {
+                framesize1 = frame.getBounds();
+            } else {
+                framesize2 = frame.getBounds();
+            }
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            test(false);
+            test(true);
+        });
+        System.out.println("frame height with W3C:" + framesize1);
+        System.out.println("frame height without W3C:" + framesize2);
+
+	float ratio = (float)framesize1.width/(float)framesize2.width;
+	System.out.println("framesize1.width/framesize2.width " + ratio);
+
+	String str = String.format("%.1g%n",ratio);
+        if (str.compareTo(String.format("%.1g%n",1.3f)) != 0) {
+            throw new RuntimeException("HTML font size too large with high-DPI scaling and W3C_UNIT_LENGTHS");
+        }
+    }
+}


### PR DESCRIPTION
Issue is when using a JEditorPane to render HTML views with W3C_UNIT_LENGTHS enabled, font-sizes set using CSS are much larger than the same font size outside the HTML.
It's because CSS LengthUnit uses screen resolution to calculate units so for hidpi screens, the html font size is bigger. 
Fix is to calculate the units based on the CSS absolute length mentioned in https://drafts.csswg.org/css-values-3/#absolute-lengths so hidpi scaling is not applied twice in CSS and again by Java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8231286](https://bugs.openjdk.java.net/browse/JDK-8231286): HTML font size too large with high-DPI scaling and W3C_UNIT_LENGTHS


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1628/head:pull/1628`
`$ git checkout pull/1628`
