### PR TITLE
8236413: AbstractConnectTimeout should tolerate both NoRouteToHostException and UnresolvedAddressException

### DIFF
--- a/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
+++ b/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The timeout tests extending AbstractConnectTimeout have been relaxed to accept a
ConnectException wrapping NoRouteToHostException.
These test have been observed failing intermittently with ConnectException wrapping
java.nio.channels.UnresolvedAddressException instead - presumably a transient network
failure caused this other exception to be thrown.

The test logic should be relaxed to accept UnresolvedAddressException as possible
cause in ConnectException too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236413](https://bugs.openjdk.java.net/browse/JDK-8236413): AbstractConnectTimeout should tolerate both NoRouteToHostException and UnresolvedAddressException


### Reviewers
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1629/head:pull/1629`
`$ git checkout pull/1629`
