### PR TITLE
8257772: Vectorizing clear memory operation using AVX-512 masked operations

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4927,6 +4927,8 @@ void MacroAssembler::verified_entry(int framesize, int stack_bang_size, bool fp_
   }
 }
 
+#if COMPILER2_OR_JVMCI
+
 // clear memory of size 'cnt' qwords, starting at 'base' using XMM/YMM/ZMM registers
 void MacroAssembler::xmm_clear_mem(Register base, Register cnt, Register rtmp, XMMRegister xtmp) {
   // cnt - number of qwords (8-byte words).
@@ -5112,6 +5114,9 @@ void MacroAssembler::clear_mem(Register base, Register cnt, Register tmp, XMMReg
 
   BIND(DONE);
 }
+
+#endif //COMPILER2_OR_JVMCI
+
 
 void MacroAssembler::generate_fill(BasicType t, bool aligned,
                                    Register to, Register value, Register count,
@@ -8132,6 +8137,9 @@ void MacroAssembler::evmovdqu(BasicType type, KRegister kmask, Address dst, XMMR
   }
 }
 
+#if COMPILER2_OR_JVMCI
+
+
 // Set memory operation for length "less than" 64 bytes.
 void MacroAssembler::fill64_masked_avx(uint shift, Register dst, int disp,
                                        XMMRegister xmm, KRegister mask, Register length,
@@ -8184,6 +8192,9 @@ void MacroAssembler::fill64_avx(Register dst, int disp, XMMRegister xmm, bool us
     evmovdquq(Address(dst, disp), xmm, Assembler::AVX_512bit);
   }
 }
+
+#endif //COMPILER2_OR_JVMCI
+
 
 #ifdef _LP64
 void MacroAssembler::convert_f2i(Register dst, XMMRegister src) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1680,8 +1680,11 @@ public:
   // if 'is_large' is set, do not try to produce short loop
   void clear_mem(Register base, Register cnt, Register rtmp, XMMRegister xtmp, bool is_large);
 
+  // clear memory initialization sequence for constant size;
+  void clear_mem(Register base, int cnt, Register rtmp, XMMRegister xtmp);
+
   // clear memory of size 'cnt' qwords, starting at 'base' using XMM/YMM registers
-  void xmm_clear_mem(Register base, Register cnt, XMMRegister xtmp);
+  void xmm_clear_mem(Register base, Register cnt, Register rtmp, XMMRegister xtmp);
 
   // Fill primitive arrays
   void generate_fill(BasicType t, bool aligned,
@@ -1835,6 +1838,19 @@ public:
   void copy64_avx(Register dst, Register src, Register index, XMMRegister xmm,
                   bool conjoint, int shift = Address::times_1, int offset = 0,
                   bool use64byteVector = false);
+
+  void fill64_masked_avx(int shift, Register dst, int disp,
+                         XMMRegister xmm, KRegister mask, Register length,
+                         Register temp, bool use64byteVector = false);
+
+  void fill32_masked_avx(int shift, Register dst, int disp,
+                         XMMRegister xmm, KRegister mask, Register length,
+                         Register temp);
+
+  void fill32_avx(Register dst, int disp, XMMRegister xmm);
+
+  void fill64_avx(Register dst, int dis, XMMRegister xmm, bool use64byteVector = false);
+
 #endif // COMPILER2_OR_JVMCI
 
 #endif // _LP64

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1850,8 +1850,6 @@ public:
   void copy64_avx(Register dst, Register src, Register index, XMMRegister xmm,
                   bool conjoint, int shift = Address::times_1, int offset = 0,
                   bool use64byteVector = false);
-
-
 #endif // COMPILER2_OR_JVMCI
 
 #endif // _LP64

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1803,6 +1803,18 @@ public:
   void byte_array_inflate(Register src, Register dst, Register len,
                           XMMRegister tmp1, Register tmp2);
 
+  void fill64_masked_avx(uint shift, Register dst, int disp,
+                         XMMRegister xmm, KRegister mask, Register length,
+                         Register temp, bool use64byteVector = false);
+
+  void fill32_masked_avx(uint shift, Register dst, int disp,
+                         XMMRegister xmm, KRegister mask, Register length,
+                         Register temp);
+
+  void fill32_avx(Register dst, int disp, XMMRegister xmm);
+
+  void fill64_avx(Register dst, int dis, XMMRegister xmm, bool use64byteVector = false);
+
 #ifdef _LP64
   void convert_f2i(Register dst, XMMRegister src);
   void convert_d2i(Register dst, XMMRegister src);
@@ -1839,17 +1851,6 @@ public:
                   bool conjoint, int shift = Address::times_1, int offset = 0,
                   bool use64byteVector = false);
 
-  void fill64_masked_avx(int shift, Register dst, int disp,
-                         XMMRegister xmm, KRegister mask, Register length,
-                         Register temp, bool use64byteVector = false);
-
-  void fill32_masked_avx(int shift, Register dst, int disp,
-                         XMMRegister xmm, KRegister mask, Register length,
-                         Register temp);
-
-  void fill32_avx(Register dst, int disp, XMMRegister xmm);
-
-  void fill64_avx(Register dst, int dis, XMMRegister xmm, bool use64byteVector = false);
 
 #endif // COMPILER2_OR_JVMCI
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86_arrayCopy_avx3.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_arrayCopy_avx3.cpp
@@ -248,7 +248,6 @@ void MacroAssembler::copy64_avx(Register dst, Register src, Register index, XMMR
   }
 }
 
-
 #endif // COMPILER2_OR_JVMCI
 
 #endif

--- a/src/hotspot/cpu/x86/macroAssembler_x86_arrayCopy_avx3.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_arrayCopy_avx3.cpp
@@ -248,61 +248,6 @@ void MacroAssembler::copy64_avx(Register dst, Register src, Register index, XMMR
   }
 }
 
-// Set memory operation for length "less than" 64 bytes.
-void MacroAssembler::fill64_masked_avx(int shift, Register dst, int disp,
-                                       XMMRegister xmm, KRegister mask, Register length,
-                                       Register temp, bool use64byteVector) {
-  assert(MaxVectorSize >= 32, "vector length should be >= 32");
-  BasicType type[] = { T_BYTE,  T_SHORT,  T_INT,   T_LONG};
-  if (!use64byteVector) {
-    fill32_avx(dst, disp, xmm);
-    subq(length, 32 >> shift);
-    fill32_masked_avx(shift, dst, disp + 32, xmm, mask, length, temp);
-  } else {
-    assert(MaxVectorSize == 64, "vector length != 64");
-    mov64(temp, 1);
-    shlxq(temp, temp, length);
-    decq(temp);
-    if (type[shift] == T_BYTE) {
-      kmovql(mask, temp);
-    } else {
-      kmovwl(mask, temp);
-    }
-    evmovdqu(type[shift], mask, Address(dst, disp), xmm, Assembler::AVX_512bit);
-  }
-}
-
-
-void MacroAssembler::fill32_masked_avx(int shift, Register dst, int disp,
-                                       XMMRegister xmm, KRegister mask, Register length,
-                                       Register temp) {
-  assert(MaxVectorSize >= 32, "vector length should be >= 32");
-  BasicType type[] = {T_BYTE,  T_SHORT,  T_INT,   T_LONG};
-  mov64(temp, 1);
-  shlxq(temp, temp, length);
-  decq(temp);
-  kmovwl(mask, temp);
-  evmovdqu(type[shift], mask, Address(dst, disp), xmm, Assembler::AVX_256bit);
-}
-
-
-void MacroAssembler::fill32_avx(Register dst, int disp, XMMRegister xmm) {
-  assert(MaxVectorSize >= 32, "vector length should be >= 32");
-  vmovdqu(Address(dst, disp), xmm);
-}
-
-
-void MacroAssembler::fill64_avx(Register dst, int disp, XMMRegister xmm, bool use64byteVector) {
-  assert(MaxVectorSize >= 32, "vector length should be >= 32");
-  BasicType type[] = {T_BYTE,  T_SHORT,  T_INT,   T_LONG};
-  if (!use64byteVector) {
-    fill32_avx(dst, disp, xmm);
-    fill32_avx(dst, disp + 32, xmm);
-  } else {
-    evmovdquq(Address(dst, disp), xmm, Assembler::AVX_512bit);
-  }
-}
-
 
 #endif // COMPILER2_OR_JVMCI
 

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1528,6 +1528,14 @@ void VM_Version::get_processor_features() {
     }
   }
 
+#ifdef COMPILER2
+  if (is_intel() && MaxVectorSize > 16) {
+    if (FLAG_IS_DEFAULT(UseFastStosb)) {
+      UseFastStosb = false;
+    }
+  }
+#endif
+
   // Use XMM/YMM MOVDQU instruction for Object Initialization
   if (!UseFastStosb && UseSSE >= 2 && UseUnalignedLoadStores) {
     if (FLAG_IS_DEFAULT(UseXMMForObjInit)) {

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1601,6 +1601,7 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
         return false;
       }
       break;
+    case Op_ClearArray:
     case Op_VectorMaskGen:
     case Op_LoadVectorMasked:
     case Op_StoreVectorMasked:

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -11439,7 +11439,7 @@ instruct MoveL2D_reg_reg_sse(regD dst, eRegL src, regD tmp) %{
 // =======================================================================
 // fast clearing of an array
 instruct rep_stos(eCXRegI cnt, eDIRegP base, regD tmp, eAXRegI zero, Universe dummy, eFlagsReg cr) %{
-  predicate(!((ClearArrayNode*)n)->is_large());
+  predicate(!((ClearArrayNode*)n)->is_large() && !n->in(2)->bottom_type()->is_int()->is_con());
   match(Set dummy (ClearArray cnt base));
   effect(USE_KILL cnt, USE_KILL base, TEMP tmp, KILL zero, KILL cr);
 
@@ -11544,6 +11544,18 @@ instruct rep_stos_large(eCXRegI cnt, eDIRegP base, regD tmp, eAXRegI zero, Unive
                  $tmp$$XMMRegister, true);
   %}
   ins_pipe( pipe_slow );
+%}
+
+instruct rep_stos_im(immI cnt, eRegP base, regD tmp, rRegI zero, Universe dummy, eFlagsReg cr)
+%{
+  predicate(!((ClearArrayNode*)n)->is_large() && n->in(2)->bottom_type()->is_int()->is_con());
+  match(Set dummy (ClearArray cnt base));
+  effect(TEMP tmp,TEMP zero,  KILL cr);
+  format %{ "clear_mem_imm $base , $cnt  \n\t" %}
+  ins_encode %{
+   __ clear_mem($base$$Register, $cnt$$constant, $zero$$Register, $tmp$$XMMRegister);
+  %}
+  ins_pipe(pipe_slow);
 %}
 
 instruct string_compareL(eDIRegP str1, eCXRegI cnt1, eSIRegP str2, eDXRegI cnt2,

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -11550,7 +11550,7 @@ instruct rep_stos_im(immI cnt, eRegP base, regD tmp, rRegI zero, Universe dummy,
 %{
   predicate(!((ClearArrayNode*)n)->is_large() && n->in(2)->bottom_type()->is_int()->is_con());
   match(Set dummy (ClearArray cnt base));
-  effect(TEMP tmp,TEMP zero,  KILL cr);
+  effect(TEMP tmp, TEMP zero, KILL cr);
   format %{ "clear_mem_imm $base , $cnt  \n\t" %}
   ins_encode %{
    __ clear_mem($base$$Register, $cnt$$constant, $zero$$Register, $tmp$$XMMRegister);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -10747,7 +10747,7 @@ instruct MoveL2D_reg_reg(regD dst, rRegL src) %{
 instruct rep_stos(rcx_RegL cnt, rdi_RegP base, regD tmp, rax_RegI zero,
                   Universe dummy, rFlagsReg cr)
 %{
-  predicate(!((ClearArrayNode*)n)->is_large());
+  predicate(!((ClearArrayNode*)n)->is_large() && !n->in(2)->bottom_type()->is_long()->is_con());
   match(Set dummy (ClearArray cnt base));
   effect(USE_KILL cnt, USE_KILL base, TEMP tmp, KILL zero, KILL cr);
 
@@ -10849,6 +10849,18 @@ instruct rep_stos_large(rcx_RegL cnt, rdi_RegP base, regD tmp, rax_RegI zero,
   ins_encode %{
     __ clear_mem($base$$Register, $cnt$$Register, $zero$$Register,
                  $tmp$$XMMRegister, true);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct rep_stos_im(immL cnt, rRegP base, regD tmp, rRegI zero, Universe dummy, rFlagsReg cr)
+%{
+  predicate(!((ClearArrayNode*)n)->is_large() && n->in(2)->bottom_type()->is_long()->is_con());
+  match(Set dummy (ClearArray cnt base));
+  effect(TEMP tmp,TEMP zero,  KILL cr);
+  format %{ "clear_mem_imm $base , $cnt  \n\t" %}
+  ins_encode %{
+   __ clear_mem($base$$Register, $cnt$$constant, $zero$$Register, $tmp$$XMMRegister);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -10857,7 +10857,7 @@ instruct rep_stos_im(immL cnt, rRegP base, regD tmp, rRegI zero, Universe dummy,
 %{
   predicate(!((ClearArrayNode*)n)->is_large() && n->in(2)->bottom_type()->is_long()->is_con());
   match(Set dummy (ClearArray cnt base));
-  effect(TEMP tmp,TEMP zero,  KILL cr);
+  effect(TEMP tmp, TEMP zero, KILL cr);
   format %{ "clear_mem_imm $base , $cnt  \n\t" %}
   ins_encode %{
    __ clear_mem($base$$Register, $cnt$$constant, $zero$$Register, $tmp$$XMMRegister);

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -3052,6 +3052,8 @@ Node *ClearArrayNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // Assemblers are responsible to produce fast hardware clears for it.
   if (size > InitArrayShortSize) {
     return new ClearArrayNode(in(0), in(1), in(2), in(3), true);
+  } else if (size > 2 && Matcher::match_rule_supported_vector(Op_ClearArray, 4, T_LONG)) {
+    return NULL;
   }
   Node *mem = in(1);
   if( phase->type(mem)==Type::TOP ) return NULL;

--- a/test/micro/org/openjdk/bench/vm/compiler/ClearMemory.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ClearMemory.java
@@ -41,6 +41,21 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class ClearMemory {
+  class Payload8 {
+    public long f0;
+    public long f1;
+    public long f2;
+    public long f3;
+    public long f4;
+    public long f5;
+    public long f6;
+    public long f7;
+
+    public Payload8() {
+      this.f0 = 1;
+    }
+  }
+
   class Payload7 {
     public long f0;
     public long f1;
@@ -91,58 +106,73 @@ public class ClearMemory {
     }
   }
 
-  class Payload3 {
-    public long f0;
-    public long f1;
-    public long f2;
-
-    public Payload3() {
-      this.f0 = 1;
-    }
-  }
-
   @Setup
   public void Setup() {
   }
 
   @Benchmark
-  public void testClearMemory7(Blackhole bh)  {
-    Payload7 [] objs = new Payload7[1000];
-    for(int i = 0 ; i < objs.length ; i++) {
-      objs[i] = new Payload7();
-    }
+  public void testClearMemory1K(Blackhole bh)  {
+    Object [] objs = new Object[64];
     bh.consume(objs);
   }
   @Benchmark
-  public void testClearMemory6(Blackhole bh)  {
-    Payload6 [] objs = new Payload6[1000];
-    for(int i = 0 ; i < objs.length ; i++) {
-      objs[i] = new Payload6();
-    }
+  public void testClearMemory2K(Blackhole bh)  {
+    Object [] objs = new Object[128];
     bh.consume(objs);
   }
   @Benchmark
-  public void testClearMemory5(Blackhole bh)  {
-    Payload5 [] objs = new Payload5[1000];
-    for(int i = 0 ; i < objs.length ; i++) {
-      objs[i] = new Payload5();
-    }
+  public void testClearMemory4K(Blackhole bh)  {
+    Object [] objs = new Object[256];
     bh.consume(objs);
   }
   @Benchmark
-  public void testClearMemory4(Blackhole bh)  {
-    Payload4 [] objs = new Payload4[1000];
-    for(int i = 0 ; i < objs.length ; i++) {
-      objs[i] = new Payload4();
-    }
+  public void testClearMemory8K(Blackhole bh)  {
+    Object [] objs = new Object[512];
     bh.consume(objs);
   }
   @Benchmark
-  public void testClearMemory3(Blackhole bh)  {
-    Payload3 [] objs = new Payload3[1000];
-    for(int i = 0 ; i < objs.length ; i++) {
-      objs[i] = new Payload3();
-    }
+  public void testClearMemory16K(Blackhole bh)  {
+    Object [] objs = new Object[1024];
     bh.consume(objs);
+  }
+  @Benchmark
+  public void testClearMemory32K(Blackhole bh)  {
+    Object [] objs = new Object[2048];
+    bh.consume(objs);
+  }
+  @Benchmark
+  public void testClearMemory1M(Blackhole bh)  {
+    Object [] objs = new Object[65536];
+    bh.consume(objs);
+  }
+  @Benchmark
+  public void testClearMemory8M(Blackhole bh)  {
+    Object [] objs = new Object[524288];
+    bh.consume(objs);
+  }
+  @Benchmark
+  public void testClearMemory56B(Blackhole bh)  {
+    Payload7 obj = new Payload7();
+    bh.consume(obj);
+  }
+  @Benchmark
+  public void testClearMemory48B(Blackhole bh)  {
+    Payload6 obj = new Payload6();
+    bh.consume(obj);
+  }
+  @Benchmark
+  public void testClearMemory40B(Blackhole bh)  {
+    Payload5 obj = new Payload5();
+    bh.consume(obj);
+  }
+  @Benchmark
+  public void testClearMemory32B(Blackhole bh)  {
+    Payload4 obj = new Payload4();
+    bh.consume(obj);
+  }
+  @Benchmark
+  public void testClearMemory24B(Blackhole bh)  {
+    Payload4 obj = new Payload4();
+    bh.consume(obj);
   }
 }

--- a/test/micro/org/openjdk/bench/vm/compiler/ClearMemory.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ClearMemory.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Fork;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(jvmArgsPrepend = {"-XX:-EliminateAllocations", "-XX:-DoEscapeAnalysis"})
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class ClearMemory {
+  class Payload7 {
+    public long f0;
+    public long f1;
+    public long f2;
+    public long f3;
+    public long f4;
+    public long f5;
+    public long f6;
+
+    public Payload7() {
+      this.f0 = 1;
+    }
+  }
+
+  class Payload6 {
+    public long f0;
+    public long f1;
+    public long f2;
+    public long f3;
+    public long f4;
+    public long f5;
+
+    public Payload6() {
+      this.f0 = 1;
+    }
+  }
+
+  class Payload5 {
+    public long f0;
+    public long f1;
+    public long f2;
+    public long f3;
+    public long f4;
+
+    public Payload5() {
+      this.f0 = 1;
+    }
+  }
+
+  class Payload4 {
+    public long f0;
+    public long f1;
+    public long f2;
+    public long f3;
+
+    public Payload4() {
+      this.f0 = 1;
+    }
+  }
+
+  class Payload3 {
+    public long f0;
+    public long f1;
+    public long f2;
+
+    public Payload3() {
+      this.f0 = 1;
+    }
+  }
+
+  @Setup
+  public void Setup() {
+  }
+
+  @Benchmark
+  public void testClearMemory7(Blackhole bh)  {
+    Payload7 [] objs = new Payload7[1000];
+    for(int i = 0 ; i < objs.length ; i++) {
+      objs[i] = new Payload7();
+    }
+    bh.consume(objs);
+  }
+  @Benchmark
+  public void testClearMemory6(Blackhole bh)  {
+    Payload6 [] objs = new Payload6[1000];
+    for(int i = 0 ; i < objs.length ; i++) {
+      objs[i] = new Payload6();
+    }
+    bh.consume(objs);
+  }
+  @Benchmark
+  public void testClearMemory5(Blackhole bh)  {
+    Payload5 [] objs = new Payload5[1000];
+    for(int i = 0 ; i < objs.length ; i++) {
+      objs[i] = new Payload5();
+    }
+    bh.consume(objs);
+  }
+  @Benchmark
+  public void testClearMemory4(Blackhole bh)  {
+    Payload4 [] objs = new Payload4[1000];
+    for(int i = 0 ; i < objs.length ; i++) {
+      objs[i] = new Payload4();
+    }
+    bh.consume(objs);
+  }
+  @Benchmark
+  public void testClearMemory3(Blackhole bh)  {
+    Payload3 [] objs = new Payload3[1000];
+    for(int i = 0 ; i < objs.length ; i++) {
+      objs[i] = new Payload3();
+    }
+    bh.consume(objs);
+  }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/ClearMemory.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ClearMemory.java
@@ -41,138 +41,138 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class ClearMemory {
-  class Payload8 {
-    public long f0;
-    public long f1;
-    public long f2;
-    public long f3;
-    public long f4;
-    public long f5;
-    public long f6;
-    public long f7;
+    class Payload8 {
+        public long f0;
+        public long f1;
+        public long f2;
+        public long f3;
+        public long f4;
+        public long f5;
+        public long f6;
+        public long f7;
 
-    public Payload8() {
-      this.f0 = 1;
+        public Payload8() {
+            this.f0 = 1;
+        }
     }
-  }
 
-  class Payload7 {
-    public long f0;
-    public long f1;
-    public long f2;
-    public long f3;
-    public long f4;
-    public long f5;
-    public long f6;
+    class Payload7 {
+        public long f0;
+        public long f1;
+        public long f2;
+        public long f3;
+        public long f4;
+        public long f5;
+        public long f6;
 
-    public Payload7() {
-      this.f0 = 1;
+        public Payload7() {
+            this.f0 = 1;
+        }
     }
-  }
 
-  class Payload6 {
-    public long f0;
-    public long f1;
-    public long f2;
-    public long f3;
-    public long f4;
-    public long f5;
+    class Payload6 {
+        public long f0;
+        public long f1;
+        public long f2;
+        public long f3;
+        public long f4;
+        public long f5;
 
-    public Payload6() {
-      this.f0 = 1;
+        public Payload6() {
+            this.f0 = 1;
+        }
     }
-  }
 
-  class Payload5 {
-    public long f0;
-    public long f1;
-    public long f2;
-    public long f3;
-    public long f4;
+    class Payload5 {
+        public long f0;
+        public long f1;
+        public long f2;
+        public long f3;
+        public long f4;
 
-    public Payload5() {
-      this.f0 = 1;
+        public Payload5() {
+            this.f0 = 1;
+        }
     }
-  }
 
-  class Payload4 {
-    public long f0;
-    public long f1;
-    public long f2;
-    public long f3;
+    class Payload4 {
+        public long f0;
+        public long f1;
+        public long f2;
+        public long f3;
 
-    public Payload4() {
-      this.f0 = 1;
+        public Payload4() {
+            this.f0 = 1;
+        }
     }
-  }
 
-  @Setup
-  public void Setup() {
-  }
+    @Setup
+    public void Setup() {
+    }
 
-  @Benchmark
-  public void testClearMemory1K(Blackhole bh)  {
-    Object [] objs = new Object[64];
-    bh.consume(objs);
-  }
-  @Benchmark
-  public void testClearMemory2K(Blackhole bh)  {
-    Object [] objs = new Object[128];
-    bh.consume(objs);
-  }
-  @Benchmark
-  public void testClearMemory4K(Blackhole bh)  {
-    Object [] objs = new Object[256];
-    bh.consume(objs);
-  }
-  @Benchmark
-  public void testClearMemory8K(Blackhole bh)  {
-    Object [] objs = new Object[512];
-    bh.consume(objs);
-  }
-  @Benchmark
-  public void testClearMemory16K(Blackhole bh)  {
-    Object [] objs = new Object[1024];
-    bh.consume(objs);
-  }
-  @Benchmark
-  public void testClearMemory32K(Blackhole bh)  {
-    Object [] objs = new Object[2048];
-    bh.consume(objs);
-  }
-  @Benchmark
-  public void testClearMemory1M(Blackhole bh)  {
-    Object [] objs = new Object[65536];
-    bh.consume(objs);
-  }
-  @Benchmark
-  public void testClearMemory8M(Blackhole bh)  {
-    Object [] objs = new Object[524288];
-    bh.consume(objs);
-  }
-  @Benchmark
-  public void testClearMemory56B(Blackhole bh)  {
-    Payload7 obj = new Payload7();
-    bh.consume(obj);
-  }
-  @Benchmark
-  public void testClearMemory48B(Blackhole bh)  {
-    Payload6 obj = new Payload6();
-    bh.consume(obj);
-  }
-  @Benchmark
-  public void testClearMemory40B(Blackhole bh)  {
-    Payload5 obj = new Payload5();
-    bh.consume(obj);
-  }
-  @Benchmark
-  public void testClearMemory32B(Blackhole bh)  {
-    Payload4 obj = new Payload4();
-    bh.consume(obj);
-  }
-  @Benchmark
-  public void testClearMemory24B(Blackhole bh)  {
-    Payload4 obj = new Payload4();
-    bh.consume(obj);
-  }
+    @Benchmark
+    public void testClearMemory1K(Blackhole bh)  {
+        Object [] objs = new Object[64];
+        bh.consume(objs);
+    }
+    @Benchmark
+    public void testClearMemory2K(Blackhole bh)  {
+        Object [] objs = new Object[128];
+        bh.consume(objs);
+    }
+    @Benchmark
+    public void testClearMemory4K(Blackhole bh)  {
+        Object [] objs = new Object[256];
+        bh.consume(objs);
+    }
+    @Benchmark
+    public void testClearMemory8K(Blackhole bh)  {
+        Object [] objs = new Object[512];
+        bh.consume(objs);
+    }
+    @Benchmark
+    public void testClearMemory16K(Blackhole bh)  {
+        Object [] objs = new Object[1024];
+        bh.consume(objs);
+    }
+    @Benchmark
+    public void testClearMemory32K(Blackhole bh)  {
+        Object [] objs = new Object[2048];
+        bh.consume(objs);
+    }
+    @Benchmark
+    public void testClearMemory1M(Blackhole bh)  {
+        Object [] objs = new Object[65536];
+        bh.consume(objs);
+    }
+    @Benchmark
+    public void testClearMemory8M(Blackhole bh)  {
+        Object [] objs = new Object[524288];
+        bh.consume(objs);
+    }
+    @Benchmark
+    public void testClearMemory56B(Blackhole bh)  {
+        Payload7 obj = new Payload7();
+        bh.consume(obj);
+    }
+    @Benchmark
+    public void testClearMemory48B(Blackhole bh)  {
+        Payload6 obj = new Payload6();
+        bh.consume(obj);
+    }
+    @Benchmark
+    public void testClearMemory40B(Blackhole bh)  {
+        Payload5 obj = new Payload5();
+        bh.consume(obj);
+    }
+    @Benchmark
+    public void testClearMemory32B(Blackhole bh)  {
+        Payload4 obj = new Payload4();
+        bh.consume(obj);
+    }
+    @Benchmark
+    public void testClearMemory24B(Blackhole bh)  {
+        Payload4 obj = new Payload4();
+        bh.consume(obj);
+    }
 }


### PR DESCRIPTION
A newly allocated memory is initialized either using user provided initialization values for various fields or setting the memory to zero as per java semantics (System initialization).

C2 compiler creates ClearArray Node in order to perform system initialization. ClearArray accepts the number of Heap Words to be initialized, this number can be constant or a non-constant value. For constant number of heap words less than InitArrayShortSize (default value 64 bytes) currently compiler generates StoreL nodes which does the initialization at the granularity of 8 bytes.

This patch vectorizes the initializing store operations for constant sized heap word less than InitArrayShortSize by emitting special instruction sequence for various tail sizes.

In addition existing implementation for initialization under UseXMMForObjInit is extended to use masked operation to optimize tail initialization sequence. In case AVX3Threshold is set to 0 then new initialization sequence uses 64 byte ZMM registers.

Following are the performance stats collected using  micro-benchmark included with the patch.

Testing : Tier1-Tier3 level tests are clean.

System Configuration : Cascadelake, Intel Xeon Platinum 8280L @ 2.7 GHz, 2 socket, 28 cores per socket.

### Baseline:
```
Benchmark                        Mode  Cnt          Score   Error  Units
ClearMemory.testClearMemory16K  thrpt    2    1427741.069          ops/s
ClearMemory.testClearMemory1K   thrpt    2   47628368.596          ops/s
ClearMemory.testClearMemory1M   thrpt    2      27388.979          ops/s
ClearMemory.testClearMemory24B  thrpt    2  167681010.419          ops/s
ClearMemory.testClearMemory2K   thrpt    2   22043948.290          ops/s
ClearMemory.testClearMemory32B  thrpt    2  168599498.817          ops/s
ClearMemory.testClearMemory32K  thrpt    2     775985.067          ops/s
ClearMemory.testClearMemory40B  thrpt    2  153375273.800          ops/s
ClearMemory.testClearMemory48B  thrpt    2  145328531.804          ops/s
ClearMemory.testClearMemory4K   thrpt    2    6492257.452          ops/s
ClearMemory.testClearMemory56B  thrpt    2  122376321.652          ops/s
ClearMemory.testClearMemory8K   thrpt    2    2857444.413          ops/s
ClearMemory.testClearMemory8M   thrpt    2       3461.674          ops/s
```
### With Optimization:
```
Benchmark                        Mode  Cnt          Score   Error  Units
ClearMemory.testClearMemory16K  thrpt    2    2529701.368          ops/s
ClearMemory.testClearMemory1K   thrpt    2   50276682.550          ops/s
ClearMemory.testClearMemory1M   thrpt    2      27458.588          ops/s
ClearMemory.testClearMemory24B  thrpt    2  178751174.642          ops/s
ClearMemory.testClearMemory2K   thrpt    2   22574802.694          ops/s
ClearMemory.testClearMemory32B  thrpt    2  176630844.950          ops/s
ClearMemory.testClearMemory32K  thrpt    2    1297627.181          ops/s
ClearMemory.testClearMemory40B  thrpt    2  167469550.653          ops/s
ClearMemory.testClearMemory48B  thrpt    2  159391163.006          ops/s
ClearMemory.testClearMemory4K   thrpt    2    9045158.643          ops/s
ClearMemory.testClearMemory56B  thrpt    2  134550172.421          ops/s
ClearMemory.testClearMemory8K   thrpt    2    4581450.664          ops/s
ClearMemory.testClearMemory8M   thrpt    2       3446.834          ops/s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257772](https://bugs.openjdk.java.net/browse/JDK-8257772): Vectorizing clear memory operation using AVX-512 masked operations


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1631/head:pull/1631`
`$ git checkout pull/1631`
