### PR TITLE
8243614: Typo in ReentrantLock's Javadoc

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/ReentrantLock.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/ReentrantLock.java
@@ -84,7 +84,7 @@ import jdk.internal.vm.annotation.ReservedStackAccess;
  *     try {
  *       // ... method body
  *     } finally {
- *       lock.unlock()
+ *       lock.unlock();
  *     }
  *   }
  * }}</pre>


### PR DESCRIPTION
Add missing semicolon

Martin's first github pr.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8243614](https://bugs.openjdk.java.net/browse/JDK-8243614): Typo in ReentrantLock's Javadoc


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1633/head:pull/1633`
`$ git checkout pull/1633`
