### PR TITLE
8257788: Class fields could be local in the SunJSSE provider

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CertStatusExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertStatusExtension.java
@@ -323,8 +323,6 @@ final class CertStatusExtension {
 
         final List<ResponderId> responderIds;
         final List<Extension> extensions;
-        private final int ridListLen;
-        private final int extListLen;
 
         static {
             OCSPStatusRequest ocspReq = null;
@@ -360,7 +358,7 @@ final class CertStatusExtension {
             List<Extension> exts = new ArrayList<>();
             ByteBuffer m = ByteBuffer.wrap(encoded);
 
-            this.ridListLen = Record.getInt16(m);
+            int ridListLen = Record.getInt16(m);
             if (m.remaining() < (ridListLen + 2)) {
                 throw new SSLProtocolException(
                         "Invalid OCSP status request: insufficient data");
@@ -384,7 +382,7 @@ final class CertStatusExtension {
             }
 
             byte[] extListBytes = Record.getBytes16(m);
-            this.extListLen = extListBytes.length;
+            int extListLen = extListBytes.length;
             if (extListLen > 0) {
                 try {
                     DerInputStream dis = new DerInputStream(extListBytes);

--- a/src/java.base/share/classes/sun/security/ssl/HKDF.java
+++ b/src/java.base/share/classes/sun/security/ssl/HKDF.java
@@ -44,7 +44,6 @@ import java.util.Objects;
  * derivation process.
  */
 final class HKDF {
-    private final String hmacAlg;
     private final Mac hmacObj;
     private final int hmacLen;
 
@@ -61,7 +60,7 @@ final class HKDF {
     HKDF(String hashAlg) throws NoSuchAlgorithmException {
         Objects.requireNonNull(hashAlg,
                 "Must provide underlying HKDF Digest algorithm.");
-        hmacAlg = "Hmac" + hashAlg.replace("-", "");
+        String hmacAlg = "Hmac" + hashAlg.replace("-", "");
         hmacObj = Mac.getInstance(hmacAlg);
         hmacLen = hmacObj.getMacLength();
     }

--- a/src/java.base/share/classes/sun/security/ssl/SSLSecretDerivation.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSecretDerivation.java
@@ -60,19 +60,15 @@ final class SSLSecretDerivation implements SSLKeyDerivation {
         (byte)0x48, (byte)0x98, (byte)0xB9, (byte)0x5B
     };
 
-    private final HandshakeContext context;
-    private final String hkdfAlg;
     private final HashAlg hashAlg;
     private final SecretKey secret;
     private final byte[] transcriptHash;  // handshake messages transcript hash
 
     SSLSecretDerivation(
             HandshakeContext context, SecretKey secret) {
-        this.context = context;
         this.secret = secret;
         this.hashAlg = context.negotiatedCipherSuite.hashAlg;
-        this.hkdfAlg =
-                "HKDF-Expand/Hmac" + hashAlg.name.replace("-", "");
+        String hkdfAlg = "HKDF-Expand/Hmac" + hashAlg.name.replace("-", "");
         context.handshakeHash.update();
         this.transcriptHash = context.handshakeHash.digest();
     }

--- a/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java
@@ -203,14 +203,10 @@ enum SSLTrafficKeyDerivation implements SSLKeyDerivationGenerator {
 
     @SuppressWarnings("deprecation")
     static final class LegacyTrafficKeyDerivation implements SSLKeyDerivation {
-        private final HandshakeContext context;
-        private final SecretKey masterSecret;
         private final TlsKeyMaterialSpec keyMaterialSpec;
 
         LegacyTrafficKeyDerivation(
                 HandshakeContext context, SecretKey masterSecret) {
-            this.context = context;
-            this.masterSecret = masterSecret;
 
             CipherSuite cipherSuite = context.negotiatedCipherSuite;
             ProtocolVersion protocolVersion = context.negotiatedProtocol;


### PR DESCRIPTION
In the SunJSSE provider implementation, there are a few class fields are not used other than the constructors. Those fields could be removed and replaced with local variables.

Bug: https://bugs.openjdk.java.net/browse/JDK-8257788

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257788](https://bugs.openjdk.java.net/browse/JDK-8257788): Class fields could be local in the SunJSSE provider


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1634/head:pull/1634`
`$ git checkout pull/1634`
