### PR TITLE
8257796: [TESTBUG] TestUseSHA512IntrinsicsOptionOnSupportedCPU.java fails on x86_32

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8035968
  * @summary Verify UseSHA512Intrinsics option processing on supported CPU.
+ * @requires os.arch!="x86" & os.arch!="i386"
  * @library /test/lib testcases /
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
Hi all,

TestUseSHA512IntrinsicsOptionOnSupportedCPU.java failed on our x86_32 platforms.

For x86, UseSHA512Intrinsics is only supported on x86_64 [1].
So It shouldn't be run on x86_32.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/vm_version_x86.cpp#L972

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257796](https://bugs.openjdk.java.net/browse/JDK-8257796): [TESTBUG] TestUseSHA512IntrinsicsOptionOnSupportedCPU.java fails on x86_32


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1639/head:pull/1639`
`$ git checkout pull/1639`
