### PR TITLE
8257517: LogCompilation: Add -z to the help messages

### DIFF
--- a/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogCompilation.java
+++ b/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogCompilation.java
@@ -60,6 +60,7 @@ public class LogCompilation extends DefaultHandler implements ErrorHandler {
         System.out.println("  -s:   sort events by start time (default)");
         System.out.println("  -e:   sort events by elapsed time");
         System.out.println("  -n:   sort events by name and start");
+        System.out.println("  -z:   sort events by compiled code size");
         System.out.println("  -C:   compare logs (give files to compare on command line)");
         System.out.println("  -d:   do not print compilation IDs");
         System.exit(exitcode);


### PR DESCRIPTION
I forgot to add a help message with JDK-8255965.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257517](https://bugs.openjdk.java.net/browse/JDK-8257517): LogCompilation: Add -z to the help messages


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1640/head:pull/1640`
`$ git checkout pull/1640`
