### PR TITLE
8257718: LogCompilation: late_inline doesnt work right for JDK 8 logs

### DIFF
--- a/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogParser.java
+++ b/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogParser.java
@@ -638,9 +638,9 @@ public class LogParser extends DefaultHandler implements ErrorHandler {
             }
         }
         if (e != null) {
-            throw new Error(msg, e);
+            throw new InternalError(msg, e);
         } else {
-            throw new Error(msg);
+            throw new InternalError(msg);
         }
     }
 


### PR DESCRIPTION
As I mentioned in the JBS, this change handles the case where late_inline does not contain inline_id.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257718](https://bugs.openjdk.java.net/browse/JDK-8257718): LogCompilation: late_inline doesnt work right for JDK 8 logs


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1641/head:pull/1641`
`$ git checkout pull/1641`
