### PR TITLE
8257799: Update JLS cross-references in java.compiler

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
+++ b/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
@@ -392,7 +392,7 @@ public enum SourceVersion {
      * literal, or null literal, {@code false} otherwise.
      * @jls 3.9 Keywords
      * @jls 3.10.3 Boolean Literals
-     * @jls 3.10.7 The Null Literal
+     * @jls 3.10.8 The Null Literal
      */
     public static boolean isKeyword(CharSequence s) {
         return isKeyword(s, latest());
@@ -410,7 +410,7 @@ public enum SourceVersion {
      * literal, or null literal, {@code false} otherwise.
      * @jls 3.9 Keywords
      * @jls 3.10.3 Boolean Literals
-     * @jls 3.10.7 The Null Literal
+     * @jls 3.10.8 The Null Literal
      * @since 9
      */
     public static boolean isKeyword(CharSequence s, SourceVersion version) {

--- a/src/java.compiler/share/classes/javax/lang/model/element/VariableElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/VariableElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/VariableElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/VariableElement.java
@@ -73,7 +73,7 @@ public interface VariableElement extends Element {
      * otherwise
      *
      * @see Elements#getConstantExpression(Object)
-     * @jls 15.28 Constant Expression
+     * @jls 15.29 Constant Expressions
      * @jls 4.12.4 final Variables
      */
     Object getConstantValue();


### PR DESCRIPTION
A few of the @jls tags in the java.compiler module don't make the corresponding JLS section anymore; the null literal section and constant expression sections were renumbered.

This change makes corrects the mismatches.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257799](https://bugs.openjdk.java.net/browse/JDK-8257799): Update JLS cross-references in java.compiler


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to 6490dcb9cda91c922a1509d817bd99075ca5494d


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1642/head:pull/1642`
`$ git checkout pull/1642`
