### PR TITLE
8254939: macOS: unused function 'replicate4_imm'

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2371,19 +2371,6 @@ int vec_spill_helper(CodeBuffer *cbuf, bool do_size, bool is_load,
   return size+offset_size;
 }
 
-static inline jint replicate4_imm(int con, int width) {
-  // Load a constant of "width" (in bytes) and replicate it to fill 32bit.
-  assert(width == 1 || width == 2, "only byte or short types here");
-  int bit_width = width * 8;
-  jint val = con;
-  val &= (1 << bit_width) - 1;  // mask off sign bits
-  while(bit_width < 32) {
-    val |= (val << bit_width);
-    bit_width <<= 1;
-  }
-  return val;
-}
-
 static inline jlong replicate8_imm(int con, int width) {
   // Load a constant of "width" (in bytes) and replicate it to fill 64bit.
   assert(width == 1 || width == 2 || width == 4, "only byte, short or int types here");


### PR DESCRIPTION
Removed an unused function to resolve build warnings.

/issue add 8254939

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254939](https://bugs.openjdk.java.net/browse/JDK-8254939): macOS: unused function 'replicate4_imm'


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1643/head:pull/1643`
`$ git checkout pull/1643`
