### PR TITLE
8257769: Cipher.getParameters() throws NPE for ChaCha20-Poly1305

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -226,6 +226,11 @@ abstract class ChaCha20Cipher extends CipherSpi {
     protected AlgorithmParameters engineGetParameters() {
         AlgorithmParameters params = null;
         if (mode == MODE_AEAD) {
+            // In a pre-initialized state or any state without a nonce value
+            // this call should cause a random nonce to be generated.
+            if (!initialized || nonce == null) {
+                nonce = createRandomNonce(null);
+            }
             try {
                 // Place the 12-byte nonce into a DER-encoded OCTET_STRING
                 params = AlgorithmParameters.getInstance("ChaCha20-Poly1305");

--- a/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
@@ -207,7 +207,7 @@ abstract class ChaCha20Cipher extends CipherSpi {
      */
     @Override
     protected byte[] engineGetIV() {
-        return nonce.clone();
+        return (nonce != null) ? nonce.clone() : null;
     }
 
     /**
@@ -229,7 +229,8 @@ abstract class ChaCha20Cipher extends CipherSpi {
             // In a pre-initialized state or any state without a nonce value
             // this call should cause a random nonce to be generated, but
             // not attached to the object.
-            byte[] nonceData = initialized ? nonce : createRandomNonce(null);
+            byte[] nonceData = (initialized || nonce != null) ? nonce :
+                    createRandomNonce(null);
             try {
                 // Place the 12-byte nonce into a DER-encoded OCTET_STRING
                 params = AlgorithmParameters.getInstance("ChaCha20-Poly1305");
@@ -508,7 +509,7 @@ abstract class ChaCha20Cipher extends CipherSpi {
      *
      * @return a 12-byte array containing the random nonce.
      */
-    private byte[] createRandomNonce(SecureRandom random) {
+    private static byte[] createRandomNonce(SecureRandom random) {
         byte[] newNonce = new byte[12];
         SecureRandom rand = (random != null) ? random : new SecureRandom();
         rand.nextBytes(newNonce);

--- a/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
@@ -227,15 +227,14 @@ abstract class ChaCha20Cipher extends CipherSpi {
         AlgorithmParameters params = null;
         if (mode == MODE_AEAD) {
             // In a pre-initialized state or any state without a nonce value
-            // this call should cause a random nonce to be generated.
-            if (!initialized || nonce == null) {
-                nonce = createRandomNonce(null);
-            }
+            // this call should cause a random nonce to be generated, but
+            // not attached to the object.
+            byte[] nonceData = initialized ? nonce : createRandomNonce(null);
             try {
                 // Place the 12-byte nonce into a DER-encoded OCTET_STRING
                 params = AlgorithmParameters.getInstance("ChaCha20-Poly1305");
                 params.init((new DerValue(
-                        DerValue.tag_OctetString, nonce).toByteArray()));
+                        DerValue.tag_OctetString, nonceData).toByteArray()));
             } catch (NoSuchAlgorithmException | IOException exc) {
                 throw new RuntimeException(exc);
             }


### PR DESCRIPTION
This fix corrects a problem where ChaCha20-Poly1305 objects prior to init throw NPE when getParameters() is called.  It will now generate parameters containing a random nonce on each pre-init call to getParameters(). Post-initialization calls to the getParameters() method will always return the same set of parameters until the next initialization occurs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257769](https://bugs.openjdk.java.net/browse/JDK-8257769): Cipher.getParameters() throws NPE for ChaCha20-Poly1305


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to b9a244820c4a641ffdc9db11546635afdedbc08b
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**) ⚠️ Review applies to 0f74545b38ac0850ca5cd8f976bad582860ce8db


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1644/head:pull/1644`
`$ git checkout pull/1644`
