### PR TITLE
8257740: Compiler crash when compiling type annotation on multicatch inside lambda

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -2065,10 +2065,22 @@ public class LambdaToMethod extends TreeTranslator {
                     case LOCAL_VAR:
                         ret = new VarSymbol(sym.flags() & FINAL, sym.name, sym.type, translatedSym);
                         ((VarSymbol) ret).pos = ((VarSymbol) sym).pos;
+                        // If sym.data == ElementKind.EXCEPTION_PARAMETER,
+                        // set ret.data = ElementKind.EXCEPTION_PARAMETER too.
+                        // Because method com.sun.tools.javac.jvm.Code.fillExceptionParameterPositions and
+                        // com.sun.tools.javac.jvm.Code.fillLocalVarPosition would use it.
+                        // See JDK-8257740 for more information.
+                        if (((VarSymbol) sym).isExceptionParameter()) {
+                            ((VarSymbol) ret).setData(ElementKind.EXCEPTION_PARAMETER);
+                        }
                         break;
                     case PARAM:
                         ret = new VarSymbol((sym.flags() & FINAL) | PARAMETER, sym.name, types.erasure(sym.type), translatedSym);
                         ((VarSymbol) ret).pos = ((VarSymbol) sym).pos;
+                        // Set ret.data. Same as case LOCAL_VAR above.
+                        if (((VarSymbol) sym).isExceptionParameter()) {
+                            ((VarSymbol) ret).setData(ElementKind.EXCEPTION_PARAMETER);
+                        }
                         break;
                     default:
                         Assert.error(skind.name());

--- a/test/langtools/tools/javac/T8257740/T8257740_1.java
+++ b/test/langtools/tools/javac/T8257740/T8257740_1.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8257740
+ * @summary Compiler crash when compiling type annotation on uni-catch inside lambda
+ * @run compile T8257740_1.java
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+public class T8257740_1 {
+    @Target(ElementType.TYPE_USE)
+    @interface T8257740_1_Anno { }
+
+    void test() {
+        Runnable r = () -> {
+            try {
+                System.out.println();
+            } catch (@T8257740_1_Anno Exception e) { // uni-catch
+                e.printStackTrace();
+            }
+        };
+    }
+}

--- a/test/langtools/tools/javac/T8257740/T8257740_2.java
+++ b/test/langtools/tools/javac/T8257740/T8257740_2.java
@@ -39,7 +39,7 @@ public class T8257740_2 {
         Runnable r = () -> {
             try {
                 System.out.println();
-            } catch (@T8257740_2_Anno Exception e) { // multi-catch
+            } catch (@T8257740_2_Anno Exception | Error e) { // multi-catch
                 e.printStackTrace();
             }
         };

--- a/test/langtools/tools/javac/T8257740/T8257740_2.java
+++ b/test/langtools/tools/javac/T8257740/T8257740_2.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8257740
+ * @summary Compiler crash when compiling type annotation on multi-catch inside lambda
+ * @run compile T8257740_2.java
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+public class T8257740_2 {
+    @Target(ElementType.TYPE_USE)
+    @interface T8257740_2_Anno { }
+
+    void test() {
+        Runnable r = () -> {
+            try {
+                System.out.println();
+            } catch (@T8257740_2_Anno Exception e) { // multi-catch
+                e.printStackTrace();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Hi all,

When translating a lambda expression to method, the method `LambdaToMethod.LambdaAnalyzerPreprocessor.LambdaTranslationContext.translate(final Symbol sym, LambdaSymbolKind skind)` creates new VarSymbol(s) according to the old VarSymbol(s). But this `translate` method doesn't set the field `data`  of the new VarSymbol. Maybe it is because the field `data` is unused in later phase.

Unfortunately, `com.sun.tools.javac.jvm.Code.fillExceptionParameterPositions` and `com.sun.tools.javac.jvm.Code.fillLocalVarPosition` would use the field `data` if the `data` is `ElementKind.EXCEPTION_PARAMETER`.

It causes the exception_index won't be set in `fillExceptionParameterPositions`. Later, if the exception_index is used, the compiler will crash with error `java.lang.AssertionError: exception_index is not set`.

This patch fixes it and adds corresponding test cases.
In my patch, I only set the field ` data`  if  the `data` is `ElementKind.EXCEPTION_PARAMETER`. Because I don't see another situation that the field `data` would be used.

Thank your for taking the time to review.

Best Regards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257740](https://bugs.openjdk.java.net/browse/JDK-8257740): Compiler crash when compiling type annotation on multicatch inside lambda


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1648/head:pull/1648`
`$ git checkout pull/1648`
