### PR TITLE
8257518: LogCompilation: java.lang.InternalError with JFR turned on

### DIFF
--- a/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogParser.java
+++ b/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogParser.java
@@ -716,7 +716,12 @@ public class LogParser extends DefaultHandler implements ErrorHandler {
                 Compilation c = log.compiles.get(ble.getId());
                 if (c == null) {
                     if (!(ble instanceof NMethod)) {
-                        throw new InternalError("only nmethods should have a null compilation, here's a " + ble.getClass());
+                        if (ble instanceof MakeNotEntrantEvent && ((MakeNotEntrantEvent) ble).getCompileKind().equals("c2n")) {
+                            // this is ok for c2n
+                            assert ((MakeNotEntrantEvent) ble).getLevel().equals("0") : "Should be level 0";
+                        } else {
+                            throw new InternalError("only nmethods should have a null compilation, here's a " + ble.getClass());
+                        }
                     }
                     continue;
                 }
@@ -1071,8 +1076,12 @@ public class LogParser extends DefaultHandler implements ErrorHandler {
             String id = makeId(atts);
             NMethod nm = nmethods.get(id);
             if (nm == null) reportInternalError("nm == null");
-            LogEvent e = new MakeNotEntrantEvent(Double.parseDouble(search(atts, "stamp")), id,
+            MakeNotEntrantEvent e = new MakeNotEntrantEvent(Double.parseDouble(search(atts, "stamp")), id,
                                                  atts.getValue("zombie") != null, nm);
+            String compileKind = atts.getValue("compile_kind");
+            e.setCompileKind(compileKind);
+            String level = atts.getValue("level");
+            e.setLevel(level);
             events.add(e);
         } else if (qname.equals("uncommon_trap")) {
             String id = atts.getValue("compile_id");

--- a/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/MakeNotEntrantEvent.java
+++ b/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/MakeNotEntrantEvent.java
@@ -42,6 +42,16 @@ class MakeNotEntrantEvent extends BasicLogEvent {
      */
     private NMethod nmethod;
 
+    /**
+     * The compilation level.
+     */
+    private String level;
+
+    /**
+     * The compile kind.
+     */
+    private String compileKind;
+
     MakeNotEntrantEvent(double s, String i, boolean z, NMethod nm) {
         super(s, i);
         zombie = z;
@@ -63,4 +73,37 @@ class MakeNotEntrantEvent extends BasicLogEvent {
     public boolean isZombie() {
         return zombie;
     }
+
+  /**
+   * @return the level
+   */
+  public String getLevel() {
+      return level;
+  }
+
+  /**
+   * @param level the level to set
+   */
+  public void setLevel(String level) {
+      this.level = level;
+  }
+
+    /**
+   * @return the compileKind
+   */
+  public String getCompileKind() {
+      return compileKind;
+  }
+
+  /**
+   * @param compileKind the compileKind to set
+   */
+  public void setCompileKind(String compileKind) {
+      this.compileKind = compileKind;
+  }
+
+  public String toString() {
+      return "MakeNotEntrantEvent zombie:" + isZombie() + ", id:" + getId() + ", kind:" + getCompileKind();
+  }
+
 }

--- a/src/utils/LogCompilation/src/test/java/com/sun/hotspot/tools/compiler/TestLogCompilation.java
+++ b/src/utils/LogCompilation/src/test/java/com/sun/hotspot/tools/compiler/TestLogCompilation.java
@@ -76,12 +76,22 @@ public class TestLogCompilation {
         "-Xbatch"
     };
 
+    static final String setupArgsJFR[] = {
+        "java",
+        "-XX:+IgnoreUnrecognizedVMOptions",
+        "-XX:+UnlockDiagnosticVMOptions",
+        "-XX:+LogCompilation",
+        "-XX:LogFile=target/jfr.log",
+        "-XX:StartFlightRecording=dumponexit=true,filename=rwrecording.jfr"
+    };
+
     static final String allSetupArgs[][] = {
         setupArgsTieredVersion,
         setupArgsTiered,
         setupArgsTieredBatch,
         setupArgsNoTiered,
-        setupArgsNoTieredBatch
+        setupArgsNoTieredBatch,
+        setupArgsJFR
     };
 
     @Parameters
@@ -92,7 +102,8 @@ public class TestLogCompilation {
             {"./target/tiered_short.log"},
             {"./target/tiered_short_batch.log"},
             {"./target/no_tiered_short.log"},
-            {"./target/no_tiered_short_batch.log"}
+            {"./target/no_tiered_short_batch.log"},
+            {"./target/jfr.log"},
         };
         assert data.length == allSetupArgs.length : "Files dont match args.";
         return Arrays.asList(data);


### PR DESCRIPTION
…ing app with JFR turned on

JBS: https://bugs.openjdk.java.net/browse/JDK-8257518

I added a test case with JFR turned on that produces the same c2n as in the original case. Tested with 8, 11, and 15.
Thanks,
Eric

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257518](https://bugs.openjdk.java.net/browse/JDK-8257518): LogCompilation: java.lang.InternalError with JFR turned on


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1649/head:pull/1649`
`$ git checkout pull/1649`
