### PR TITLE
8257803: Add -Xbatch to compiler/blackhole tests

### DIFF
--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeInstanceReturnTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeInstanceReturnTest.java
@@ -27,7 +27,7 @@
  *
  * @run main/othervm
  *      -Xmx1g
- *      -XX:TieredStopAtLevel=1
+ *      -Xbatch -XX:TieredStopAtLevel=1
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeInstanceReturnTest
@@ -39,7 +39,7 @@
  *
  * @run main/othervm
  *      -Xmx1g
- *      -XX:-TieredCompilation
+ *      -Xbatch -XX:-TieredCompilation
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeInstanceReturnTest
@@ -52,7 +52,7 @@
  *
  * @run main/othervm
  *      -Xmx1g -XX:-UseCompressedOops
- *      -XX:TieredStopAtLevel=1
+ *      -Xbatch -XX:TieredStopAtLevel=1
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeInstanceReturnTest
@@ -65,7 +65,7 @@
  *
  * @run main/othervm
  *      -Xmx1g -XX:-UseCompressedOops
- *      -XX:-TieredCompilation
+ *      -Xbatch -XX:-TieredCompilation
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeInstanceReturnTest

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeInstanceTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeInstanceTest.java
@@ -27,7 +27,7 @@
  *
  * @run main/othervm
  *      -Xmx1g
- *      -XX:TieredStopAtLevel=1
+ *      -Xbatch -XX:TieredStopAtLevel=1
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeInstanceTest
@@ -39,7 +39,7 @@
  *
  * @run main/othervm
  *      -Xmx1g
- *      -XX:-TieredCompilation
+ *      -Xbatch -XX:-TieredCompilation
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeInstanceTest
@@ -52,7 +52,7 @@
  *
  * @run main/othervm
  *      -Xmx1g -XX:-UseCompressedOops
- *      -XX:TieredStopAtLevel=1
+ *      -Xbatch -XX:TieredStopAtLevel=1
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeInstanceTest
@@ -65,7 +65,7 @@
  *
  * @run main/othervm
  *      -Xmx1g -XX:-UseCompressedOops
- *      -XX:-TieredCompilation
+ *      -Xbatch -XX:-TieredCompilation
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeInstanceTest

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeNonVoidWarning.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeNonVoidWarning.java
@@ -53,6 +53,7 @@ public class BlackholeNonVoidWarning {
        {
            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
                "-Xmx128m",
+               "-Xbatch",
                "-XX:CompileCommand=quiet",
                "-XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*",
                "compiler.blackhole.BlackholeNonVoidWarning",

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeNullCheckTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeNullCheckTest.java
@@ -27,7 +27,7 @@
  *
  * @run main/othervm
  *      -Xmx1g
- *      -XX:TieredStopAtLevel=1
+ *      -Xbatch -XX:TieredStopAtLevel=1
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeNullCheckTest
@@ -39,7 +39,7 @@
  *
  * @run main/othervm
  *      -Xmx1g
- *      -XX:-TieredCompilation
+ *      -Xbatch -XX:-TieredCompilation
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeNullCheckTest
@@ -52,7 +52,7 @@
  *
  * @run main/othervm
  *      -Xmx1g -XX:-UseCompressedOops
- *      -XX:TieredStopAtLevel=1
+ *      -Xbatch -XX:TieredStopAtLevel=1
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeNullCheckTest
@@ -65,7 +65,7 @@
  *
  * @run main/othervm
  *      -Xmx1g -XX:-UseCompressedOops
- *      -XX:-TieredCompilation
+ *      -Xbatch -XX:-TieredCompilation
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeNullCheckTest

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeStaticReturnTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeStaticReturnTest.java
@@ -27,7 +27,7 @@
  *
  * @run main/othervm
  *      -Xmx1g
- *      -XX:TieredStopAtLevel=1
+ *      -Xbatch -XX:TieredStopAtLevel=1
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeStaticReturnTest
@@ -39,7 +39,7 @@
  *
  * @run main/othervm
  *      -Xmx1g
- *      -XX:-TieredCompilation
+ *      -Xbatch -XX:-TieredCompilation
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeStaticReturnTest
@@ -52,7 +52,7 @@
  *
  * @run main/othervm
  *      -Xmx1g -XX:-UseCompressedOops
- *      -XX:TieredStopAtLevel=1
+ *      -Xbatch -XX:TieredStopAtLevel=1
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeStaticReturnTest
@@ -65,7 +65,7 @@
  *
  * @run main/othervm
  *      -Xmx1g -XX:-UseCompressedOops
- *      -XX:-TieredCompilation
+ *      -Xbatch -XX:-TieredCompilation
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeStaticReturnTest

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeStaticTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeStaticTest.java
@@ -27,7 +27,7 @@
  *
  * @run main/othervm
  *      -Xmx1g
- *      -XX:TieredStopAtLevel=1
+ *      -Xbatch -XX:TieredStopAtLevel=1
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeStaticTest
@@ -39,7 +39,7 @@
  *
  * @run main/othervm
  *      -Xmx1g
- *      -XX:-TieredCompilation
+ *      -Xbatch -XX:-TieredCompilation
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeStaticTest
@@ -52,7 +52,7 @@
  *
  * @run main/othervm
  *      -Xmx1g -XX:-UseCompressedOops
- *      -XX:TieredStopAtLevel=1
+ *      -Xbatch -XX:TieredStopAtLevel=1
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeStaticTest
@@ -65,7 +65,7 @@
  *
  * @run main/othervm
  *      -Xmx1g -XX:-UseCompressedOops
- *      -XX:-TieredCompilation
+ *      -Xbatch -XX:-TieredCompilation
  *      -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure
  *      -XX:CompileCommand=blackhole,compiler/blackhole/BlackholeTarget.bh_*
  *      compiler.blackhole.BlackholeStaticTest


### PR DESCRIPTION
Newly added tests miss `-Xbatch`, which makes them sensitive to compilation delays, especially when running in parallel with many other tests. There are already failures observed in current testing. While there might be other causes, this patch eliminates the most obvious one.

The run time of the tests are not affected, because the tests are still small.

Testing:
 - [x] `compiler/blackhole` tests running in larger `hotspot:tier1` suite (added separately, 5 of 5 runs pass)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257803](https://bugs.openjdk.java.net/browse/JDK-8257803): Add -Xbatch to compiler/blackhole tests


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1653/head:pull/1653`
`$ git checkout pull/1653`
