### PR TITLE
8257805: Add compiler/blackhole tests to tier1

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -97,6 +97,7 @@ hotspot_slow_compiler = \
 
 tier1_compiler_1 = \
   compiler/arraycopy/ \
+  compiler/blackhole/ \
   compiler/c1/ \
   compiler/c2/ \
   -compiler/c2/Test6850611.java \


### PR DESCRIPTION
JDK-8252505 added new tests. They are short, and were supposed to run in tier1. Unfortunately, they are in `compiler/blackhole` directory, not in `compiler/c1` or `compiler/c2`, which would get them included into tier1 automatically. So, we need to include them to tier1 directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257805](https://bugs.openjdk.java.net/browse/JDK-8257805): Add compiler/blackhole tests to tier1


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1654/head:pull/1654`
`$ git checkout pull/1654`
