### PR TITLE
8257793: Shenandoah: SATB barrier should only filter out already strongly marked oops

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -328,7 +328,7 @@ inline oop ShenandoahHeap::evacuate_object(oop p, Thread* thread) {
 
 inline bool ShenandoahHeap::requires_marking(const void* entry) const {
   oop obj = oop(entry);
-  return !_marking_context->is_marked(obj);
+  return !_marking_context->is_marked_strong(obj);
 }
 
 inline bool ShenandoahHeap::in_collection_set(oop p) const {


### PR DESCRIPTION
SATB barrier intercepts oops for later marking, and those oops will be marked as strongly reachable. So that, it can only filter out oops that already strongly marked, not if they are only weakly marked.

- [x] hotspot_gc_shenandoah
- [x] nightly pipeline

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257793](https://bugs.openjdk.java.net/browse/JDK-8257793): Shenandoah: SATB barrier should only filter out already strongly marked oops


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1655/head:pull/1655`
`$ git checkout pull/1655`
