### PR TITLE
8257813: [redo] C2: Filter type in PhiNode::Value() for induction variables of trip-counted integer loops

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1105,9 +1105,9 @@ const Type* PhiNode::Value(PhaseGVN* phase) const {
           if (bt != BoolTest::ne) {
             if (stride_t->hi_as_long() < 0) {          // Down-counter loop
               swap(lo, hi);
-              return TypeInteger::make(MIN2(lo->lo_as_long(), hi->lo_as_long()), hi->hi_as_long(), 3, l->bt());
+              return TypeInteger::make(MIN2(lo->lo_as_long(), hi->lo_as_long()), hi->hi_as_long(), 3, l->bt())->filter_speculative(_type);
             } else if (stride_t->lo_as_long() >= 0) {
-              return TypeInteger::make(lo->lo_as_long(), MAX2(lo->hi_as_long(), hi->hi_as_long()), 3, l->bt());
+              return TypeInteger::make(lo->lo_as_long(), MAX2(lo->hi_as_long(), hi->hi_as_long()), 3, l->bt())->filter_speculative(_type);
             }
           }
         }

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1328,7 +1328,7 @@ bool SuperWord::reduction(Node* s1, Node* s2) {
   bool retValue = false;
   int d1 = depth(s1);
   int d2 = depth(s2);
-  if (d1 + 1 == d2) {
+  if (d2 > d1) {
     if (s1->is_reduction() && s2->is_reduction()) {
       // This is an ordered set, so s1 should define s2
       for (DUIterator_Fast imax, i = s1->fast_outs(imax); i < imax; i++) {


### PR DESCRIPTION
I looked at why 8250607 (C2: Filter type in PhiNode::Value() for induction variables of trip-counted integer loops) causes
auto-vectorization to fail sometimes and AFAICT, detection of reductions fails because with 8250607 the shape of the loop body is slightly different. So 8250607 reveals an underlying limitation. In SuperWord::reduction() the test that checks for depths in the dependency graph is too strict. In a chain of reduction operations, s2 is not guaranteed to be a depth of s1 + 1 because it may depend on an operation other than s1. I think that test should be depth(s2) > depth(s1).

What I'm observing for the case where vectorization fails is:

`1142  OrI  === _  1170  1143  [[ 1130 ]]  !orig=983,324,897 !jvms: RedTest_int::orReductionImplement @ bci:52 (line 181)
`
at depth 11

that depends on

`1170  OrI  === _  1207  1171  [[ 1142 ]]  !orig=1003,858,324,897 !jvms: RedTest_int::orReductionImplement @ bci:52 (line 181)`

at depth 9 and:

`1143  AddI  === _  1144  1150  [[ 1139  1142 ]]  !orig=984,268,[323] !jvms: RedTest_int::orReductionImplement @ bci:44 (line 180)`

at depth 10.

In SuperWord::reduction(), s1 = 1170 and s2 = 1142.

If now I disable the change in PhiNode::Value() and the reduction is correctly detected, 1142 is at depth 11 and 1170 at depth 10. 1170 is at depth 10 (instead of 9) because the dependency graph includes a CastII that is optimized out with the change in PhiNode::Value() .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257813](https://bugs.openjdk.java.net/browse/JDK-8257813): [redo] C2: Filter type in PhiNode::Value() for induction variables of trip-counted integer loops


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1658/head:pull/1658`
`$ git checkout pull/1658`
