### PR TITLE
8255583: Investigate creating a test to trigger the condition in KeepAliveStreamCleaner

### DIFF
--- a/test/jdk/sun/net/www/http/KeepAliveStreamCleaner/KeepAliveStreamCleanerTestDriver.java
+++ b/test/jdk/sun/net/www/http/KeepAliveStreamCleaner/KeepAliveStreamCleanerTestDriver.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/sun/net/www/http/KeepAliveStreamCleaner/KeepAliveStreamCleanerTestDriver.java
+++ b/test/jdk/sun/net/www/http/KeepAliveStreamCleaner/KeepAliveStreamCleanerTestDriver.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @modules java.base/sun.net.www.http
+ * @run testng java.base/sun.net.www.http.KeepAliveStreamCleanerTest
+ */

--- a/test/jdk/sun/net/www/http/KeepAliveStreamCleaner/java.base/sun/net/www/http/KeepAliveStreamCleanerTest.java
+++ b/test/jdk/sun/net/www/http/KeepAliveStreamCleaner/java.base/sun/net/www/http/KeepAliveStreamCleanerTest.java
@@ -1,0 +1,17 @@
+package sun.net.www.http;
+
+import org.testng.annotations.Test;
+
+@Test
+public class KeepAliveStreamCleanerTest {
+
+    /*
+    Tests that KeepAliveStreamCleaner run does not throw an
+    IllegalMonitorState Exception.
+     */
+    @Test
+    public void keepAliveStreamCleanerTest() {
+        KeepAliveStreamCleaner kase = new KeepAliveStreamCleaner();
+        kase.run();
+    }
+}

--- a/test/jdk/sun/net/www/http/KeepAliveStreamCleaner/java.base/sun/net/www/http/KeepAliveStreamCleanerTest.java
+++ b/test/jdk/sun/net/www/http/KeepAliveStreamCleaner/java.base/sun/net/www/http/KeepAliveStreamCleanerTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package sun.net.www.http;
 
 import org.testng.annotations.Test;


### PR DESCRIPTION
The KeepAliveStreamCleaner in sun.net.ww.http package had been previously seen to fail with an IllegalMonitorStateException. This failure was caused by the use of `wait()` in a non synchronized block. This failure was mitigated through use of `await()` instead as is shown below (code can be viewed on L119 in src/java.base/share/classes/sun/net/www/http/KeepAliveStreamCleaner.java).

```
...
long timeout = TIMEOUT;
    while ((kace = poll()) == null) {
            waiter.await(timeout, TimeUnit.MILLISECONDS); 
...
```
While the code throwing the exception was fixed, a regression test was not made. So this patch adds a simple white-box test which calls the KeepAliveStreamCleaner's run method. `waiter.wait()` should always fail if not used in a synchronized block or method, so the test verifies that it is not used.  
