### PR TITLE
8257798: [PPC64] undefined reference to Klass::vtable_start_offset()

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -980,6 +980,8 @@ source_hpp %{
 
 source %{
 
+#include "oops/klass.inline.hpp"
+
 void PhaseOutput::pd_perform_mach_node_analysis() {
 }
 
@@ -3635,9 +3637,9 @@ encode %{
     Register Rtoc = (ra_) ? $constanttablebase : R2_TOC;
 
     int vtable_index = this->_vtable_index;
-    if (_vtable_index < 0) {
+    if (vtable_index < 0) {
       // Must be invalid_vtable_index, not nonvirtual_vtable_index.
-      assert(_vtable_index == Method::invalid_vtable_index, "correct sentinel value");
+      assert(vtable_index == Method::invalid_vtable_index, "correct sentinel value");
       Register ic_reg = as_Register(Matcher::inline_cache_reg_encode());
 
       // Virtual call relocation will point to ic load.
@@ -3663,7 +3665,7 @@ encode %{
 
       __ load_klass(R11_scratch1, R3);
 
-      int entry_offset = in_bytes(Klass::vtable_start_offset()) + _vtable_index * vtableEntry::size_in_bytes();
+      int entry_offset = in_bytes(Klass::vtable_start_offset()) + vtable_index * vtableEntry::size_in_bytes();
       int v_off = entry_offset + vtableEntry::method_offset_in_bytes();
       __ li(R19_method, v_off);
       __ ldx(R19_method/*method*/, R19_method/*method offset*/, R11_scratch1/*class*/);


### PR DESCRIPTION
We need to include "oops/klass.inline.hpp" in adlc generated cpp files. Otherwise we get linker errors with some gcc versions when it assumes that all usages are inlined.
Change also includes minor cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257798](https://bugs.openjdk.java.net/browse/JDK-8257798): [PPC64] undefined reference to Klass::vtable_start_offset()


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1660/head:pull/1660`
`$ git checkout pull/1660`
