### PR TITLE
8256641: CDS VM operations do not lock the heap 

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -472,6 +472,7 @@ bool G1HeapVerifier::should_verify(G1VerifyType type) {
 
 void G1HeapVerifier::verify(VerifyOption vo) {
   assert_at_safepoint_on_vm_thread();
+  assert(Heap_lock->is_locked(), "heap must be locked");
 
   log_debug(gc, verify)("Roots");
   VerifyRootsClosure rootsCl(vo);

--- a/src/hotspot/share/gc/shared/gcVMOperations.cpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.cpp
@@ -46,6 +46,32 @@
 #include "gc/g1/g1Policy.hpp"
 #endif // INCLUDE_G1GC
 
+bool VM_GC_Sync_Operation::doit_prologue() {
+  Heap_lock->lock();
+
+  // Check invocations
+  if (skip_operation()) {
+    // skip collection
+    Heap_lock->unlock();
+    _prologue_succeeded = false;
+  } else {
+    _prologue_succeeded = true;
+  }
+  return _prologue_succeeded;
+}
+
+void VM_GC_Sync_Operation::doit_epilogue() {
+  if (Universe::has_reference_pending_list()) {
+    Heap_lock->notify_all();
+  }
+  Heap_lock->unlock();
+}
+
+void VM_Verify::doit() {
+  Universe::heap()->prepare_for_verify();
+  Universe::verify();
+}
+
 VM_GC_Operation::~VM_GC_Operation() {
   CollectedHeap* ch = Universe::heap();
   ch->soft_ref_policy()->set_all_soft_refs_clear(false);
@@ -94,18 +120,7 @@ bool VM_GC_Operation::doit_prologue() {
               proper_unit_for_byte_size(NewSize)));
   }
 
-  // If the GC count has changed someone beat us to the collection
-  Heap_lock->lock();
-
-  // Check invocations
-  if (skip_operation()) {
-    // skip collection
-    Heap_lock->unlock();
-    _prologue_succeeded = false;
-  } else {
-    _prologue_succeeded = true;
-  }
-  return _prologue_succeeded;
+  return VM_GC_Sync_Operation::doit_prologue();
 }
 
 
@@ -113,10 +128,8 @@ void VM_GC_Operation::doit_epilogue() {
   // Clean up old interpreter OopMap entries that were replaced
   // during the GC thread root traversal.
   OopMapCache::cleanup_old_entries();
-  if (Universe::has_reference_pending_list()) {
-    Heap_lock->notify_all();
-  }
-  Heap_lock->unlock();
+
+  VM_GC_Sync_Operation::doit_epilogue();
 }
 
 bool VM_GC_HeapInspection::skip_operation() const {

--- a/src/hotspot/share/gc/shared/gcVMOperations.hpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.hpp
@@ -39,17 +39,27 @@
 // a set of operations (VM_Operation) related to GC.
 //
 //  VM_Operation
-//      VM_GC_Operation
-//          VM_GC_HeapInspection
-//          VM_GenCollectFull
-//          VM_GenCollectFullConcurrent
-//          VM_ParallelGCSystemGC
-//          VM_CollectForAllocation
-//              VM_GenCollectForAllocation
-//              VM_ParallelGCFailedAllocation
+//      VM_GC_Sync_Operation
+//        VM_GC_Operation
+//            VM_GC_HeapInspection
+//            VM_PopulateDynamicDumpSharedSpace
+//            VM_GenCollectFull
+//            VM_GenCollectFullConcurrent
+//            VM_ParallelGCSystemGC
+//            VM_CollectForAllocation
+//                VM_GenCollectForAllocation
+//                VM_ParallelGCFailedAllocation
+//        VM_Verify
+//        VM_PopulateDumpSharedSpace
+//
+//  VM_GC_Sync_Operation
+//   - base class that implements synchronization with other VM operations of the
+//     same kind using the Heap_lock, not actually doing a GC.
+//
 //  VM_GC_Operation
-//   - implements methods common to all classes in the hierarchy:
-//     prevents multiple gc requests and manages lock on heap;
+//   - implements methods common to all operations that perform garbage collections,
+//     checking that the VM is in a state to do GC and also preventing multiple GC
+//     requests.
 //
 //  VM_GC_HeapInspection
 //   - prints class histogram on SIGBREAK if PrintClassHistogram
@@ -68,13 +78,46 @@
 //   - these operations preform full collection of heaps of
 //     different kind
 //
+//  VM_Verify
+//   - verifies the heap
+//
+//  VM_PopulateDynamicDumpSharedSpace
+//   - populates the CDS archive area with the information from the archive file.
+//
+//  VM_PopulateDumpSharedSpace
+//   - creates the CDS archive
+//
 
-class VM_GC_Operation: public VM_Operation {
+class VM_GC_Sync_Operation : public VM_Operation {
+
+  bool _prologue_succeeded;
+protected:
+
+  virtual bool skip_operation() const { return false; }
+public:
+
+  VM_GC_Sync_Operation() : VM_Operation(), _prologue_succeeded(false) { }
+
+  // Acquire the reference synchronization lock
+  virtual bool doit_prologue();
+  // Do notifyAll (if needed) and release held lock
+  virtual void doit_epilogue();
+
+  // Returns whether doit_prologue succeeded
+  bool prologue_succeeded() const { return _prologue_succeeded; }
+};
+
+class VM_Verify : public VM_GC_Sync_Operation {
+ public:
+  VMOp_Type type() const { return VMOp_Verify; }
+  void doit();
+};
+
+class VM_GC_Operation: public VM_GC_Sync_Operation {
  protected:
   uint           _gc_count_before;         // gc count before acquiring PLL
   uint           _full_gc_count_before;    // full gc count before acquiring PLL
   bool           _full;                    // whether a "full" collection
-  bool           _prologue_succeeded;      // whether doit_prologue succeeded
   GCCause::Cause _gc_cause;                // the putative cause for this gc op
   bool           _gc_locked;               // will be set if gc was locked
 
@@ -84,9 +127,8 @@ class VM_GC_Operation: public VM_Operation {
   VM_GC_Operation(uint gc_count_before,
                   GCCause::Cause _cause,
                   uint full_gc_count_before = 0,
-                  bool full = false) {
+                  bool full = false) : VM_GC_Sync_Operation() {
     _full = full;
-    _prologue_succeeded = false;
     _gc_count_before    = gc_count_before;
 
     // A subclass constructor will likely overwrite the following
@@ -112,7 +154,6 @@ class VM_GC_Operation: public VM_Operation {
   virtual void doit_epilogue();
 
   virtual bool allow_nested_vm_operations() const  { return true; }
-  bool prologue_succeeded() const { return _prologue_succeeded; }
 
   void set_gc_locked() { _gc_locked = true; }
   bool gc_locked() const  { return _gc_locked; }

--- a/src/hotspot/share/gc/shared/gcVMOperations.hpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.hpp
@@ -39,26 +39,26 @@
 // a set of operations (VM_Operation) related to GC.
 //
 //  VM_Operation
-//      VM_GC_Sync_Operation
-//        VM_GC_Operation
-//            VM_GC_HeapInspection
-//            VM_PopulateDynamicDumpSharedSpace
-//            VM_GenCollectFull
-//            VM_GenCollectFullConcurrent
-//            VM_ParallelGCSystemGC
-//            VM_CollectForAllocation
-//                VM_GenCollectForAllocation
-//                VM_ParallelGCFailedAllocation
-//        VM_Verify
-//        VM_PopulateDumpSharedSpace
+//    VM_GC_Sync_Operation
+//      VM_GC_Operation
+//        VM_GC_HeapInspection
+//        VM_PopulateDynamicDumpSharedSpace
+//        VM_GenCollectFull
+//        VM_GenCollectFullConcurrent
+//        VM_ParallelGCSystemGC
+//        VM_CollectForAllocation
+//          VM_GenCollectForAllocation
+//          VM_ParallelGCFailedAllocation
+//      VM_Verify
+//      VM_PopulateDumpSharedSpace
 //
 //  VM_GC_Sync_Operation
-//   - base class that implements synchronization with other VM operations of the
+//   - implements only synchronization with other VM operations of the
 //     same kind using the Heap_lock, not actually doing a GC.
 //
 //  VM_GC_Operation
 //   - implements methods common to all operations that perform garbage collections,
-//     checking that the VM is in a state to do GC and also preventing multiple GC
+//     checking that the VM is in a state to do GC and preventing multiple GC
 //     requests.
 //
 //  VM_GC_HeapInspection
@@ -89,22 +89,14 @@
 //
 
 class VM_GC_Sync_Operation : public VM_Operation {
-
-  bool _prologue_succeeded;
-protected:
-
-  virtual bool skip_operation() const { return false; }
 public:
 
-  VM_GC_Sync_Operation() : VM_Operation(), _prologue_succeeded(false) { }
+  VM_GC_Sync_Operation() : VM_Operation() { }
 
-  // Acquire the reference synchronization lock
+  // Acquires the Heap_lock.
   virtual bool doit_prologue();
-  // Do notifyAll (if needed) and release held lock
+  // Releases the Heap_lock.
   virtual void doit_epilogue();
-
-  // Returns whether doit_prologue succeeded
-  bool prologue_succeeded() const { return _prologue_succeeded; }
 };
 
 class VM_Verify : public VM_GC_Sync_Operation {
@@ -118,6 +110,7 @@ class VM_GC_Operation: public VM_GC_Sync_Operation {
   uint           _gc_count_before;         // gc count before acquiring PLL
   uint           _full_gc_count_before;    // full gc count before acquiring PLL
   bool           _full;                    // whether a "full" collection
+  bool           _prologue_succeeded;      // whether doit_prologue succeeded
   GCCause::Cause _gc_cause;                // the putative cause for this gc op
   bool           _gc_locked;               // will be set if gc was locked
 
@@ -129,6 +122,7 @@ class VM_GC_Operation: public VM_GC_Sync_Operation {
                   uint full_gc_count_before = 0,
                   bool full = false) : VM_GC_Sync_Operation() {
     _full = full;
+    _prologue_succeeded = false;
     _gc_count_before    = gc_count_before;
 
     // A subclass constructor will likely overwrite the following
@@ -150,10 +144,11 @@ class VM_GC_Operation: public VM_GC_Sync_Operation {
 
   // Acquire the reference synchronization lock
   virtual bool doit_prologue();
-  // Do notifyAll (if needed) and release held lock
+  // Do notify_all (if needed) and release held lock
   virtual void doit_epilogue();
 
   virtual bool allow_nested_vm_operations() const  { return true; }
+  bool prologue_succeeded() const { return _prologue_succeeded; }
 
   void set_gc_locked() { _gc_locked = true; }
   bool gc_locked() const  { return _gc_locked; }

--- a/src/hotspot/share/gc/shared/gcVMOperations.hpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.hpp
@@ -107,8 +107,8 @@ class VM_Verify : public VM_GC_Sync_Operation {
 
 class VM_GC_Operation: public VM_GC_Sync_Operation {
  protected:
-  uint           _gc_count_before;         // gc count before acquiring PLL
-  uint           _full_gc_count_before;    // full gc count before acquiring PLL
+  uint           _gc_count_before;         // gc count before acquiring the Heap_lock
+  uint           _full_gc_count_before;    // full gc count before acquiring the Heap_lock
   bool           _full;                    // whether a "full" collection
   bool           _prologue_succeeded;      // whether doit_prologue succeeded
   GCCause::Cause _gc_cause;                // the putative cause for this gc op
@@ -142,9 +142,10 @@ class VM_GC_Operation: public VM_GC_Sync_Operation {
   }
   ~VM_GC_Operation();
 
-  // Acquire the reference synchronization lock
+  // Acquire the Heap_lock and determine if this VM operation should be executed
+  // (i.e. not skipped). Return this result, and also store it in _prologue_succeeded.
   virtual bool doit_prologue();
-  // Do notify_all (if needed) and release held lock
+  // Notify the Heap_lock if needed and release it.
   virtual void doit_epilogue();
 
   virtual bool allow_nested_vm_operations() const  { return true; }

--- a/src/hotspot/share/gc/z/zDriver.cpp
+++ b/src/hotspot/share/gc/z/zDriver.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "gc/shared/gcId.hpp"
 #include "gc/shared/gcLocker.hpp"
+#include "gc/shared/gcVMOperations.hpp"
 #include "gc/shared/isGCActiveMark.hpp"
 #include "gc/z/zBreakpoint.hpp"
 #include "gc/z/zCollectedHeap.hpp"

--- a/src/hotspot/share/memory/dynamicArchive.cpp
+++ b/src/hotspot/share/memory/dynamicArchive.cpp
@@ -27,6 +27,7 @@
 #include "classfile/classLoaderData.inline.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionaryShared.hpp"
+#include "gc/shared/gcVMOperations.hpp"
 #include "logging/log.hpp"
 #include "memory/archiveBuilder.hpp"
 #include "memory/archiveUtils.inline.hpp"
@@ -541,10 +542,10 @@ void DynamicArchiveBuilder::write_archive(char* serialized_data) {
   log_info(cds, dynamic)("%d klasses; %d symbols", num_klasses, num_symbols);
 }
 
-class VM_PopulateDynamicDumpSharedSpace: public VM_Operation {
+class VM_PopulateDynamicDumpSharedSpace: public VM_GC_Sync_Operation {
   DynamicArchiveBuilder* _builder;
 public:
-  VM_PopulateDynamicDumpSharedSpace(DynamicArchiveBuilder* builder) : _builder(builder) {}
+  VM_PopulateDynamicDumpSharedSpace(DynamicArchiveBuilder* builder) : VM_GC_Sync_Operation(), _builder(builder) {}
   VMOp_Type type() const { return VMOp_PopulateDumpSharedSpace; }
   void doit() {
     ResourceMark rm;

--- a/src/hotspot/share/memory/heapShared.cpp
+++ b/src/hotspot/share/memory/heapShared.cpp
@@ -33,6 +33,7 @@
 #include "classfile/systemDictionaryShared.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "gc/shared/gcLocker.hpp"
+#include "gc/shared/gcVMOperations.hpp"
 #include "logging/log.hpp"
 #include "logging/logMessage.hpp"
 #include "logging/logStream.hpp"
@@ -655,8 +656,10 @@ static void verify_the_heap(Klass* k, const char* which) {
     ResourceMark rm;
     log_info(cds, heap)("Verify heap %s initializing static field(s) in %s",
                         which, k->external_name());
+
     VM_Verify verify_op;
     VMThread::execute(&verify_op);
+
     if (!FLAG_IS_DEFAULT(VerifyArchivedFields)) {
       // If VerifyArchivedFields has a non-default value (e.g., specified on the command-line), do
       // more expensive checks.

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -38,6 +38,7 @@
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/gcId.hpp"
 #include "gc/shared/gcLocker.inline.hpp"
+#include "gc/shared/gcVMOperations.hpp"
 #include "gc/shared/oopStorage.hpp"
 #include "gc/shared/oopStorageSet.hpp"
 #include "gc/shared/workgroup.hpp"

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -156,11 +156,6 @@ void VM_ZombieAll::doit() {
 
 #endif // !PRODUCT
 
-void VM_Verify::doit() {
-  Universe::heap()->prepare_for_verify();
-  Universe::verify();
-}
-
 bool VM_PrintThreads::doit_prologue() {
   // Get Heap_lock if concurrent locks will be dumped
   if (_print_concurrent_locks) {

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -277,13 +277,6 @@ class VM_ZombieAll: public VM_Operation {
 };
 #endif // PRODUCT
 
-class VM_Verify: public VM_Operation {
- public:
-  VMOp_Type type() const { return VMOp_Verify; }
-  void doit();
-};
-
-
 class VM_PrintThreads: public VM_Operation {
  private:
   outputStream* _out;


### PR DESCRIPTION
Hi all,

  can I get reviews for this change that adds missing synchronization of CDS related VM operations with other heap operations?

`VM_PopulateDumpSharedSpace`, `VM_PopulateDynamicDumpSharedSpace` and `VM_Verify` are used during CDS operation, one for creating the CDS archive (eventually doing a GC), one for mapping in the CDS archive into the heap, and the last one for verification.

(Fwiw, imho the first two are awfully close and should be renamed to be better distinguishable, but that's another matter)

They all in one way or the other need to synchronize with garbage collection as they may either do a GC or just do verification, as actual (STW-)gc returns an uninitialized block of memory that is not parseable; and before that block of memory can be initialized, another VM operation like one of the mentioned could be started otherwise seeing that uninitialized memory and crashing.

The existing mechanism to prevent this kind of interference is taking the `Heap_lock`, so the suggested solution is based on having all these VM operations descend from a new `VM_GC_Sync_Operation` `VM_Operation` which does that (and only that), split out from `VM_GC_Operation`.

There some points I would like to bring up in advance in this change that may be contentious:
- each VM Operation could handle `Heap_lock` by itself, which I considered to be too error-prone.
- the need for `VM_Verify` to coordinate with garbage collections is new and has been introduced with [JDK-8253081](https://bugs.openjdk.java.net/browse/JDK-8253081) as since then a Java thread might execute it - that's why this hasn't been a problem before. That could be undone (removed), but I kind of believe that with more expected changes to the CDS mechanism in the future the additional full-heap verification after loading the archive is worth the additional effort.
One (implementation) drawback is that since ZGC also uses `VM_Verify`, that operation now gets the `Heap_lock` too, and is kind of also using some part of the "set of operations related to GC" in general but did not so before, keeping almost completely separate. Testing did not show an issue, and I tried to look at the code carefully to see whether there could be issues with no result. (I.e. I couldn't find an issue). Obviously I'd like to ask you to look over this again.
- so this change adds a new VM Operation class called `VM_GC_Sync_Operation` that splits off the handling of `Heap_lock` (i.e. the actual synchronization` from `VM_GC_Operation`. The reason is that I do not think the logic for the gc VM operation that prevents multiple back-to-back GC operations is a good fit for any of the `VM_Populate*` or even `VM_Verify` operations.

Testing: tier1-5; test case attached to the CR; other known reproducers (runtime/valhalla/inlinetypes/InlineOops.java in the Valhalla repo)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256641](https://bugs.openjdk.java.net/browse/JDK-8256641): CDS VM operations do not lock the heap


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 213fbeed9ea87fc112d479322cccdf89df4c6fe9


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1661/head:pull/1661`
`$ git checkout pull/1661`
