### PR TITLE
8257817: Shenandoah: Don't race with conc-weak-in-progress flag in weak-LRB

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -104,14 +104,14 @@ inline oop ShenandoahBarrierSet::load_reference_barrier(oop obj, T* load_addr) {
 
   // Prevent resurrection of unreachable phantom (i.e. weak-native) references.
   if (HasDecorator<decorators, ON_PHANTOM_OOP_REF>::value && obj != NULL &&
-      _heap->is_concurrent_weak_root_in_progress() &&
+      _heap->is_evacuation_in_progress() &&
       !_heap->marking_context()->is_marked(obj)) {
     return NULL;
   }
 
   // Prevent resurrection of unreachable weak references.
   if ((HasDecorator<decorators, ON_WEAK_OOP_REF>::value || HasDecorator<decorators, ON_UNKNOWN_OOP_REF>::value) &&
-      obj != NULL && _heap->is_concurrent_weak_root_in_progress() &&
+      obj != NULL && _heap->is_evacuation_in_progress() &&
       !_heap->marking_context()->is_marked_strong(obj)) {
     return NULL;
   }


### PR DESCRIPTION
The weak-LRB code is currently subject to a race. Consider this sequence of events between a Java thread and GC threads:
During conc-weak-root-in-progress:
- Java: Load referent out of Reference, it is unreachable but not-yet-cleared
- GC: Clears referent
- GC: Concurrently turn off conc-weak-root-in-progress
- Java: Checks conc-weak-root-in-progress, sees that it's false, continues to use/evac it -> successfully resurrected unreachable object. This must not happen.

AFAICT, this also affects conc-class-unloading and weak-roots. 

Proposed fix is to check for evac-in-progress instead. This should be acceptable because this is not a very common path and not very performance-sensitive.

 - [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8257817](https://bugs.openjdk.java.net/browse/JDK-8257817): Shenandoah: Don't race with conc-weak-in-progress flag in weak-LRB


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1662/head:pull/1662`
`$ git checkout pull/1662`
