### PR TITLE
8196090: javax/swing/JComboBox/6559152/bug6559152.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -740,7 +740,6 @@ javax/swing/JSplitPane/4201995/bug4201995.java 8079127 generic-all
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
-javax/swing/JComboBox/6559152/bug6559152.java 8196090 windows-all,macosx-all
 javax/swing/JComboBox/8032878/bug8032878.java 8196092,8196439 windows-all,macosx-all,linux-all
 javax/swing/JComboBox/8072767/bug8072767.java 8196093 windows-all,macosx-all
 javax/swing/JFileChooser/4524490/bug4524490.java 8042380 generic-all

--- a/test/jdk/javax/swing/JComboBox/4199622/bug4199622.java
+++ b/test/jdk/javax/swing/JComboBox/4199622/bug4199622.java
@@ -68,6 +68,7 @@ public class bug4199622 extends JFrame implements ActionListener {
 
         setSize(300, 300);
         pack();
+        setLocationRelativeTo(null);
     }
 
     @Override
@@ -83,7 +84,7 @@ public class bug4199622 extends JFrame implements ActionListener {
         if (robot == null) {
             try {
                 robot = new Robot();
-                robot.setAutoDelay(20);
+                robot.setAutoDelay(100);
             } catch (AWTException e) {
                 throw new RuntimeException("Can't create robot. Test failed", e);
             }

--- a/test/jdk/javax/swing/JComboBox/4515752/DefaultButtonTest.java
+++ b/test/jdk/javax/swing/JComboBox/4515752/DefaultButtonTest.java
@@ -59,6 +59,7 @@ public class DefaultButtonTest extends JFrame implements ActionListener {
         getContentPane().add(new DefaultPanel(this));
         pack();
         setVisible(true);
+        setLocationRelativeTo(null);
     }
 
     public static void test() {
@@ -108,16 +109,12 @@ public class DefaultButtonTest extends JFrame implements ActionListener {
             // Change value, changing focus should fire an ActionEvent.
             robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_BACK_SPACE);
-            robot.waitForIdle();
             robot.keyRelease(KeyEvent.VK_BACK_SPACE);
             robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_SHIFT);
-            robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_TAB);
-            robot.waitForIdle();
-            robot.keyRelease(KeyEvent.VK_SHIFT);
-            robot.waitForIdle();
             robot.keyRelease(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_SHIFT);
             robot.waitForIdle();
             testEditChange(true);
             robot.waitForIdle();

--- a/test/jdk/javax/swing/JComboBox/4743225/bug4743225.java
+++ b/test/jdk/javax/swing/JComboBox/4743225/bug4743225.java
@@ -63,6 +63,7 @@ public class bug4743225 extends JFrame {
         });
         add(cb);
         pack();
+        setLocationRelativeTo(null);
     }
 
     public static BasicComboPopup getPopup() {
@@ -78,7 +79,7 @@ public class bug4743225 extends JFrame {
     public static void main(String... args) throws Exception {
 
         Robot robot = new Robot();
-        robot.setAutoDelay(20);
+        robot.setAutoDelay(100);
 
         SwingUtilities.invokeAndWait(new Runnable() {
             public void run() {


### PR DESCRIPTION
Test seems to fail in mach5 nightly testing when ran in a group of all JComboBox tests.
Modified few tests that were run prior to running this test by moving the frame to centre of screen, adjusting the event delay time to more consistent value in sync with other test and also made this test's frame gain focus by clicking on the frame, as it seems the frame does not get focus sometime so that keyevent does not get registered causing it to fail.
Ran bunch of JComboBox test that were run prior to this tests in normal run, along with this test, in mach5 which is ok. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8196090](https://bugs.openjdk.java.net/browse/JDK-8196090): javax/swing/JComboBox/6559152/bug6559152.java fails


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1666/head:pull/1666`
`$ git checkout pull/1666`
