### PR TITLE
8252412: [macos11] File-based loading of dynamic libraries deprecated

### DIFF
--- a/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
+++ b/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
@@ -94,6 +94,14 @@ class PlatformPCSC {
         return s;
     }
 
+    private static boolean isMac() {
+        try {
+            return System.getProperty("os.name").startsWith("Mac");
+        } catch (final SecurityException ex) {
+            return true;
+        }
+    }
+
     private static String getLibraryName() throws IOException {
         // if system property is set, use that library
         String lib = expand(System.getProperty(PROP_NAME, "").trim());
@@ -110,10 +118,10 @@ class PlatformPCSC {
             // if LIB2 exists, use that
             return lib;
         }
-        lib = PCSC_FRAMEWORK;
-        if (new File(lib).isFile()) {
-            // if PCSC.framework exists, use that
-            return lib;
+        if (isMac()) {
+            // Do not attempt to check framework presence by path on Mac,
+            // compare issue JDK-8252412.
+            return PCSC_FRAMEWORK;
         }
         throw new IOException("No PC/SC library found on this system");
     }


### PR DESCRIPTION
According to [1], Mac OS Big Sur 11.0.1 ships with a linker cache that
no longer allows testing for the presence of libraries by file
system. Instead, library presence should be checked by calling dlopen()
directly. For finding the PCSC library on Mac OS this means, that we can
skip the file system presence check and let the parent code attempt to
load the framework library directly.

Manually tested to work on Mac OS Big Sur, no unit test as platform and
OS version specific behavior.

[1] https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-release-notes#Kernel

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8252412](https://bugs.openjdk.java.net/browse/JDK-8252412): [macos11] File-based loading of dynamic libraries deprecated


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1667/head:pull/1667`
`$ git checkout pull/1667`
