### PR TITLE
8257639: Update usage of "type" terminology in java.lang.Enum & java.lang.Record

### DIFF
--- a/src/java.base/share/classes/java/lang/Enum.java
+++ b/src/java.base/share/classes/java/lang/Enum.java
@@ -40,14 +40,14 @@ import java.util.Optional;
 import static java.util.Objects.requireNonNull;
 
 /**
- * This is the common base class of all Java language enumeration types.
+ * This is the common base class of all Java language enumeration classes.
  *
  * More information about enums, including descriptions of the
  * implicitly declared methods synthesized by the compiler, can be
  * found in section {@jls 8.9} of <cite>The Java Language
  * Specification</cite>.
  *
- * Enumeration types are all serializable and receive special handling
+ * Enumeration classes are all serializable and receive special handling
  * by the serialization mechanism. The serialized representation used
  * for enum constants cannot be customized. Declarations of methods
  * and fields that would otherwise interact with serialization are
@@ -59,7 +59,7 @@ import static java.util.Objects.requireNonNull;
  * {@linkplain java.util.EnumSet set} and {@linkplain
  * java.util.EnumMap map} implementations are available.
  *
- * @param <E> The enum type subclass
+ * @param <E> The enum class subclass
  * @serial exclude
  * @author  Josh Bloch
  * @author  Neal Gafter
@@ -71,7 +71,7 @@ import static java.util.Objects.requireNonNull;
  * @since   1.5
  */
 @SuppressWarnings("serial") // No serialVersionUID needed due to
-                            // special-casing of enum types.
+                            // special-casing of enum classes.
 public abstract class Enum<E extends Enum<E>>
         implements Constable, Comparable<E>, Serializable {
     /**
@@ -126,7 +126,7 @@ public abstract class Enum<E extends Enum<E>>
     /**
      * Sole constructor.  Programmers cannot invoke this constructor.
      * It is for use by code emitted by the compiler in response to
-     * enum type declarations.
+     * enum class declarations.
      *
      * @param name - The name of this enum constant, which is the identifier
      *               used to declare it.
@@ -142,7 +142,7 @@ public abstract class Enum<E extends Enum<E>>
     /**
      * Returns the name of this enum constant, as contained in the
      * declaration.  This method may be overridden, though it typically
-     * isn't necessary or desirable.  An enum type should override this
+     * isn't necessary or desirable.  An enum class should override this
      * method when a more "programmer-friendly" string form exists.
      *
      * @return the name of this enum constant
@@ -238,39 +238,39 @@ public abstract class Enum<E extends Enum<E>>
     /**
      * Returns the enum constant of the specified enum type with the
      * specified name.  The name must match exactly an identifier used
-     * to declare an enum constant in this type.  (Extraneous whitespace
+     * to declare an enum constant in this class.  (Extraneous whitespace
      * characters are not permitted.)
      *
-     * <p>Note that for a particular enum type {@code T}, the
+     * <p>Note that for a particular enum class {@code T}, the
      * implicitly declared {@code public static T valueOf(String)}
      * method on that enum may be used instead of this method to map
      * from a name to the corresponding enum constant.  All the
-     * constants of an enum type can be obtained by calling the
+     * constants of an enum class can be obtained by calling the
      * implicit {@code public static T[] values()} method of that
-     * type.
+     * class.
      *
-     * @param <T> The enum type whose constant is to be returned
-     * @param enumType the {@code Class} object of the enum type from which
+     * @param <T> The enum class whose constant is to be returned
+     * @param enumClass the {@code Class} object of the enum class from which
      *      to return a constant
      * @param name the name of the constant to return
-     * @return the enum constant of the specified enum type with the
+     * @return the enum constant of the specified enum class with the
      *      specified name
-     * @throws IllegalArgumentException if the specified enum type has
+     * @throws IllegalArgumentException if the specified enum class has
      *         no constant with the specified name, or the specified
-     *         class object does not represent an enum type
-     * @throws NullPointerException if {@code enumType} or {@code name}
+     *         class object does not represent an enum class
+     * @throws NullPointerException if {@code enumClass} or {@code name}
      *         is null
      * @since 1.5
      */
-    public static <T extends Enum<T>> T valueOf(Class<T> enumType,
+    public static <T extends Enum<T>> T valueOf(Class<T> enumClass,
                                                 String name) {
-        T result = enumType.enumConstantDirectory().get(name);
+        T result = enumClass.enumConstantDirectory().get(name);
         if (result != null)
             return result;
         if (name == null)
             throw new NullPointerException("Name is null");
         throw new IllegalArgumentException(
-            "No enum constant " + enumType.getCanonicalName() + "." + name);
+            "No enum constant " + enumClass.getCanonicalName() + "." + name);
     }
 
     /**
@@ -307,13 +307,13 @@ public abstract class Enum<E extends Enum<E>>
         /**
          * Constructs a nominal descriptor for the specified {@code enum} class and name.
          *
-         * @param constantType a {@link ClassDesc} describing the {@code enum} class
+         * @param constantClass a {@link ClassDesc} describing the {@code enum} class
          * @param constantName the unqualified name of the enum constant
          * @throws NullPointerException if any argument is null
          * @jvms 4.2.2 Unqualified Names
          */
-        private EnumDesc(ClassDesc constantType, String constantName) {
-            super(ConstantDescs.BSM_ENUM_CONSTANT, requireNonNull(constantName), requireNonNull(constantType));
+        private EnumDesc(ClassDesc constantClass, String constantName) {
+            super(ConstantDescs.BSM_ENUM_CONSTANT, requireNonNull(constantName), requireNonNull(constantClass));
         }
 
         /**

--- a/src/java.base/share/classes/java/lang/Enum.java
+++ b/src/java.base/share/classes/java/lang/Enum.java
@@ -59,7 +59,7 @@ import static java.util.Objects.requireNonNull;
  * {@linkplain java.util.EnumSet set} and {@linkplain
  * java.util.EnumMap map} implementations are available.
  *
- * @param <E> The enum class subclass
+ * @param <E> The type of the enum subclass
  * @serial exclude
  * @author  Josh Bloch
  * @author  Neal Gafter

--- a/src/java.base/share/classes/java/lang/Enum.java
+++ b/src/java.base/share/classes/java/lang/Enum.java
@@ -236,7 +236,7 @@ public abstract class Enum<E extends Enum<E>>
     }
 
     /**
-     * Returns the enum constant of the specified enum type with the
+     * Returns the enum constant of the specified enum class with the
      * specified name.  The name must match exactly an identifier used
      * to declare an enum constant in this class.  (Extraneous whitespace
      * characters are not permitted.)

--- a/src/java.base/share/classes/java/lang/Record.java
+++ b/src/java.base/share/classes/java/lang/Record.java
@@ -101,7 +101,7 @@ public abstract class Record {
      *
      * @implSpec
      * The implicitly provided implementation returns {@code true} if
-     * and only if the argument is an instance of the same record type
+     * and only if the argument is an instance of the same record class
      * as this record, and each component of this record is equal to
      * the corresponding component of the argument; otherwise, {@code
      * false} is returned. Equality of a component {@code c} is


### PR DESCRIPTION
This change applies a stricter semantic distinction of 'type' versus 'class and interface'. This is based on the JLS changes described in the "Consistent Class and Interface Terminology" document: https://download.java.net/java/early_access/jdk16/docs/specs/class-terminology-jls.html.

The following rules were applied:
- 'class' and/or 'interface' are used when referring to the class/interface itself
- 'type' is used when referring to the type of a variable or expression

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257639](https://bugs.openjdk.java.net/browse/JDK-8257639): Update usage of "type" terminology in java.lang.Enum & java.lang.Record


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1670/head:pull/1670`
`$ git checkout pull/1670`
