### PR TITLE
8257194: Add 'foreign linker API' in 'jdk.incubator.foreign' module desc/summary

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/module-info.java
+++ b/src/jdk.incubator.foreign/share/classes/module-info.java
@@ -24,7 +24,7 @@
  */
 
 /**
- * Defines the experimental foreign memory access API.
+ * Defines an API for accessing foreign memory and calling foreign functions, directly from Java.
  *
  * {@Incubating}
  *


### PR DESCRIPTION
This simple patch updates the jaavdoc in the module-info file of jdk.incubator.foreign to reflect the fact that support of foreign function calls has been added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257194](https://bugs.openjdk.java.net/browse/JDK-8257194): Add 'foreign linker API' in 'jdk.incubator.foreign' module desc/summary


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1671/head:pull/1671`
`$ git checkout pull/1671`
