### PR TITLE
8253797: [cgroups v2] Account for the fact that swap accounting is disabled on some systems

### DIFF
--- a/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
+++ b/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
@@ -239,25 +239,33 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
             fail("memory.stat[sock]", oldVal, newVal);
         }
 
-        oldVal = metrics.getMemoryAndSwapLimit();
-        long valSwap = getLongLimitValueFromFile("memory.swap.max");
-        long valMemory = getLongLimitValueFromFile("memory.max");
-        if (valSwap == UNLIMITED) {
-            newVal = valSwap;
+        long memAndSwapLimit = metrics.getMemoryAndSwapLimit();
+        long memLimit = metrics.getMemoryLimit();
+        // Only test swap memory limits if we can. On systems with swapaccount=0
+        // we cannot, as swap limits are disabled.
+        if (memAndSwapLimit <= memLimit) {
+            System.out.println("No swap memory limits, test case(s) skipped");
         } else {
-            assert valMemory >= 0;
-            newVal = valSwap + valMemory;
-        }
-        if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
-            fail("memory.swap.max", oldVal, newVal);
-        }
+            oldVal = memAndSwapLimit;
+            long valSwap = getLongLimitValueFromFile("memory.swap.max");
+            long valMemory = getLongLimitValueFromFile("memory.max");
+            if (valSwap == UNLIMITED) {
+                newVal = valSwap;
+            } else {
+                assert valMemory >= 0;
+                newVal = valSwap + valMemory;
+            }
+            if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
+                fail("memory.swap.max", oldVal, newVal);
+            }
 
-        oldVal = metrics.getMemoryAndSwapUsage();
-        long swapUsage = getLongValueFromFile("memory.swap.current");
-        long memUsage = getLongValueFromFile("memory.current");
-        newVal = swapUsage + memUsage;
-        if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
-            fail("memory.swap.current", oldVal, newVal);
+            oldVal = metrics.getMemoryAndSwapUsage();
+            long swapUsage = getLongValueFromFile("memory.swap.current");
+            long memUsage = getLongValueFromFile("memory.current");
+            newVal = swapUsage + memUsage;
+            if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
+                fail("memory.swap.current", oldVal, newVal);
+            }
         }
 
         oldVal = metrics.getMemorySoftLimit();


### PR DESCRIPTION
This has been implemented for cgroups v1 with [JDK-8250984](https://bugs.openjdk.java.net/browse/JDK-8250984) but was lacking some tooling support for cgroups v2. With podman 2.2.0 release this could now be implemented (and tested). The idea is the same as for the cgroups v1 fix. If we've got no swap limit capabilities, return the memory limit only.

Note that for cgroups v2 doesn't implement CgroupV1Metrics (obviously) and, thus, doesn't have `getMemoryAndSwapFailCount()` and `getMemoryAndSwapMaxUsage()`.

Testing:
- [x] submit testing
- [x] container tests on cgroups v2 with swapaccount=0.
- [x] Manual container tests involving `-XshowSettings:system` on cgroups v2.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253797](https://bugs.openjdk.java.net/browse/JDK-8253797): [cgroups v2] Account for the fact that swap accounting is disabled on some systems


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1672/head:pull/1672`
`$ git checkout pull/1672`
