### PR TITLE
8257817: Shenandoah: Don't race with conc-weak-in-progress flag in weak-LRB

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2063,15 +2063,16 @@ void ShenandoahHeap::op_weak_roots() {
       ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_weak_roots_work);
       ShenandoahConcurrentWeakRootsEvacUpdateTask task(ShenandoahPhaseTimings::conc_weak_roots_work);
       workers()->run_task(&task);
-      if (!ShenandoahConcurrentRoots::should_do_concurrent_class_unloading()) {
-        set_concurrent_weak_root_in_progress(false);
-      }
     }
 
     // Perform handshake to flush out dead oops
     {
       ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_roots_rendezvous);
       rendezvous_threads();
+    }
+
+    if (!ShenandoahConcurrentRoots::should_do_concurrent_class_unloading()) {
+      set_concurrent_weak_root_in_progress(false);
     }
   }
 }


### PR DESCRIPTION
After concurrent weak root processing, it should perform handshake first to ensure there are no dirty loads (loads have yet processed by barriers) in Java thread, before it resets conc-weak-root-in-progress flag.

- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257817](https://bugs.openjdk.java.net/browse/JDK-8257817): Shenandoah: Don't race with conc-weak-in-progress flag in weak-LRB


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1673/head:pull/1673`
`$ git checkout pull/1673`
