### PR TITLE
8252797: Non-PCH build fails on Ubuntu 16.4 when building with gtests

### DIFF
--- a/test/hotspot/gtest/unittest.hpp
+++ b/test/hotspot/gtest/unittest.hpp
@@ -48,6 +48,10 @@
 #undef F1
 #undef F2
 
+// A work around for GCC math header bug leaving isfinite() undefined,
+// see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=14608
+#include "utilities/globalDefinitions.hpp"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
This is a workaround for GCC 5.4 bug that is triggered by a particular pattern of math header usage as is the case here with our gtest suite.

Thank you to Mikael Vidstedt for finding the GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=14608 , triggered by gtest usage as described here https://github.com/google/googletest/commit/fe4d5f10840c5f62b984364a4d41719f1bc079a2

Thank you to Ioi for debugging the issue and coming up with the workaround used in this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252797](https://bugs.openjdk.java.net/browse/JDK-8252797): Non-PCH build fails on Ubuntu 16.4 when building with gtests


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1678/head:pull/1678`
`$ git checkout pull/1678`
