### PR TITLE
8251438: Issues with our POSIX set_signal_handler()

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -22,7 +22,7 @@
  *
  */
 
-#include "precompiled/precompiled.hpp"
+#include "precompiled.hpp"
 
 #include "jvm.h"
 #include "logging/log.hpp"
@@ -46,6 +46,14 @@
 // signal chaining
 // signal handling (except suspend/resume)
 // suspend/resume
+
+// Glibc on Linux uses the SA_RESTORER flag to indicate
+// the use of a "signal trampoline". We have no interest
+// in this flag and need to ignore it when checking our
+// own flag settings.
+// Note: SA_RESTORER is not exposed through signal.h so we
+// have to hardwire its 0x04000000 value in the mask.
+LINUX_ONLY(const int SA_RESTORER_FLAG_MASK = ~0x04000000;)
 
 // Todo: provide a os::get_max_process_id() or similar. Number of processes
 // may have been configured, can be read more accurately from proc fs etc.
@@ -657,9 +665,19 @@ static const char* describe_sa_flags(int flags, char* buffer, size_t size) {
 
   strncpy(buffer, "none", size);
 
+  const unsigned int unknown_flag = ~(SA_NOCLDSTOP |
+                                      SA_ONSTACK   |
+                                      SA_NOCLDSTOP |
+                                      SA_RESTART   |
+                                      SA_SIGINFO   |
+                                      SA_NOCLDWAIT |
+                                      SA_NODEFER
+                                      AIX_ONLY(| SA_OLDSTYLE)
+                                      );
+
   const struct {
     // NB: i is an unsigned int here because SA_RESETHAND is on some
-    // systems 0x80000000, which is implicitly unsigned.  Assignining
+    // systems 0x80000000, which is implicitly unsigned.  Assigning
     // it to an int field would be an overflow in unsigned-to-signed
     // conversion.
     unsigned int i;
@@ -675,10 +693,10 @@ static const char* describe_sa_flags(int flags, char* buffer, size_t size) {
 #if defined(AIX)
     { SA_OLDSTYLE,  "SA_OLDSTYLE"  },
 #endif
-    { 0, NULL }
+    { unknown_flag, "NOT USED"     }
   };
 
-  for (idx = 0; flaginfo[idx].s && remaining > 1; idx++) {
+  for (idx = 0; flaginfo[idx].i != unknown_flag && remaining > 1; idx++) {
     if (flags & flaginfo[idx].i) {
       if (first) {
         jio_snprintf(p, remaining, "%s", flaginfo[idx].s);
@@ -690,6 +708,10 @@ static const char* describe_sa_flags(int flags, char* buffer, size_t size) {
       p += len;
       remaining -= len;
     }
+  }
+  unsigned int unknowns = flags & unknown_flag;
+  if (unknowns != 0) {
+    jio_snprintf(p, remaining, "|Unknown_flags:%x", unknowns);
   }
 
   buffer[size - 1] = '\0';
@@ -744,6 +766,9 @@ static void check_signal_handler(int sig) {
   }
 
   os_sigaction(sig, (struct sigaction*)NULL, &act);
+
+  // See comment for SA_RESTORER_FLAG_MASK
+  LINUX_ONLY(act.sa_flags &= SA_RESTORER_FLAG_MASK;)
 
   address thisHandler = get_signal_handler(act);
 
@@ -1314,6 +1339,9 @@ void PosixSignals::print_signal_handler(outputStream* st, int sig,
   struct sigaction sa;
   sigaction(sig, NULL, &sa);
 
+  // See comment for SA_RESTORER_FLAG_MASK
+  LINUX_ONLY(sa.sa_flags &= SA_RESTORER_FLAG_MASK;)
+
   st->print("%s: ", os::exception_name(sig, buf, buflen));
 
   address handler = get_signal_handler(sa);
@@ -1333,7 +1361,8 @@ void PosixSignals::print_signal_handler(outputStream* st, int sig,
   // May be, handler was resetted by VMError?
   if (rh != NULL) {
     handler = rh;
-    sa.sa_flags = VMError::get_resetted_sigflags(sig);
+    // See comment for SA_RESTORER_FLAG_MASK
+    sa.sa_flags = VMError::get_resetted_sigflags(sig) LINUX_ONLY(& SA_RESTORER_FLAG_MASK);
   }
 
   // Print textual representation of sa_flags.


### PR DESCRIPTION
This is a fix for a potential issue involving "The storage occupied by sa_handler and sa_sigaction may overlap, and a conforming application shall not use both simultaneously." https://pubs.opengroup.org/onlinepubs/009695399/functions/sigaction.html, when we in fact do assume different storages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251438](https://bugs.openjdk.java.net/browse/JDK-8251438): Issues with our POSIX set_signal_handler()


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1680/head:pull/1680`
`$ git checkout pull/1680`
