### PR TITLE
8257670: sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java reports leaks

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java
@@ -36,7 +36,7 @@ import jdk.test.lib.util.FileUtils;
  * @library /test/lib
  * @run main/manual SSLSocketLeak
  */
-// Note: this test is not reliabe, run it manually.
+// Note: this test is not reliable, run it manually.
 public class SSLSocketLeak {
 
     private static final int NUM_TEST_SOCK = 500;

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java
@@ -30,12 +30,13 @@ import jdk.test.lib.util.FileUtils;
 
 /*
  * @test
- * @bug 8256818
+ * @bug 8256818 8257670
  * @summary Test that creating and closing SSL Sockets without bind/connect
  *          will not leave leaking socket file descriptors
  * @library /test/lib
- * @run main/othervm SSLSocketLeak
+ * @run main/manual SSLSocketLeak
  */
+// Note: this test is not reliabe, run it manually.
 public class SSLSocketLeak {
 
     private static final int NUM_TEST_SOCK = 500;


### PR DESCRIPTION
This test case, sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java, may be not reliable if there are some other test cases or applications running at the same time.  It's a good manual test, but might be not suitable for OpenJDK automation regression test if it could be impacted.  Move it to manual test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257670](https://bugs.openjdk.java.net/browse/JDK-8257670): sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java reports leaks


### Reviewers
 * [Jamil Nimeh](https://openjdk.java.net/census#jnimeh) (@jnimeh - **Reviewer**) ⚠️ Review applies to 4324892c2cc68fb7be5d76e91f84e574a5177bc1


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1681/head:pull/1681`
`$ git checkout pull/1681`
