### PR TITLE
8257855: Example SafeVarargsNotApplicableToRecordAccessors breaks test tools/javac/diags/CheckExamples.java

### DIFF
--- a/test/langtools/tools/javac/diags/examples/SafeVarargsNotApplicableToRecordAccessors.java
+++ b/test/langtools/tools/javac/diags/examples/SafeVarargsNotApplicableToRecordAccessors.java
@@ -23,8 +23,5 @@
 
 // key: compiler.err.varargs.invalid.trustme.anno
 // key: compiler.misc.varargs.trustme.on.non.varargs.accessor
-// key: compiler.note.preview.filename
-// key: compiler.note.preview.recompile
-// options: --enable-preview -source ${jdk.version}
 
 record R(@SafeVarargs String... s) {}


### PR DESCRIPTION
Hi,

Please review this patch which is removing some keys and one option to test: `test/langtools/tools/javac/diags/examples/SafeVarargsNotApplicableToRecordAccessors.java` The PR that pushed the fix (JDK-8254784)[https://bugs.openjdk.java.net/browse/JDK-8254784] for was developed in parallel with the one that made records a standard feature in Java. I forgot to remove these options before pushing the final version of the code,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257855](https://bugs.openjdk.java.net/browse/JDK-8257855): Example SafeVarargsNotApplicableToRecordAccessors breaks test tools/javac/diags/CheckExamples.java


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1682/head:pull/1682`
`$ git checkout pull/1682`
