### PR TITLE
8257847: Tiered should publish MDO data pointer for interpreter after profile start

### DIFF
--- a/src/hotspot/share/compiler/tieredThresholdPolicy.cpp
+++ b/src/hotspot/share/compiler/tieredThresholdPolicy.cpp
@@ -831,7 +831,7 @@ void TieredThresholdPolicy::create_mdo(const methodHandle& mh, Thread* THREAD) {
     if (mdo != NULL) {
       JavaThread* jt = THREAD->as_Java_thread();
       frame last_frame = jt->last_frame();
-      if (last_frame.is_interpreted_frame()) {
+      if (last_frame.is_interpreted_frame() && mh == last_frame.interpreter_frame_method()) {
         int bci = last_frame.interpreter_frame_bci();
         address dp = mdo->bci_to_dp(bci);
         last_frame.interpreter_frame_set_mdp(dp);

--- a/src/hotspot/share/compiler/tieredThresholdPolicy.cpp
+++ b/src/hotspot/share/compiler/tieredThresholdPolicy.cpp
@@ -790,7 +790,7 @@ bool TieredThresholdPolicy::is_mature(Method* method) {
 // start profiling without waiting for the compiled method to arrive.
 // We also take the load on compilers into the account.
 bool TieredThresholdPolicy::should_create_mdo(const methodHandle& method, CompLevel cur_level) {
-  if (cur_level != CompLevel_none || force_comp_at_level_simple(method)) {
+  if (cur_level != CompLevel_none || force_comp_at_level_simple(method) || !ProfileInterpreter) {
     return false;
   }
   int i = method->invocation_count();
@@ -825,6 +825,18 @@ void TieredThresholdPolicy::create_mdo(const methodHandle& mh, Thread* THREAD) {
   }
   if (mh->method_data() == NULL) {
     Method::build_interpreter_method_data(mh, CHECK_AND_CLEAR);
+  }
+  if (ProfileInterpreter) {
+    MethodData* mdo = mh->method_data();
+    if (mdo != NULL) {
+      JavaThread* jt = THREAD->as_Java_thread();
+      frame last_frame = jt->last_frame();
+      if (last_frame.is_interpreted_frame()) {
+        int bci = last_frame.interpreter_frame_bci();
+        address dp = mdo->bci_to_dp(bci);
+        last_frame.interpreter_frame_set_mdp(dp);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Tiered policy may decide to start profiling in interpreter if C1 is overloaded with requests. It should publish an appropriate data pointer for the current bci in order for the interpreter to start profiling immediately and not wait for the second invocation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257847](https://bugs.openjdk.java.net/browse/JDK-8257847): Tiered should publish MDO data pointer for interpreter after profile start 


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 7cca428d09c8e9afecbce8ac608448a6566ffeb6
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1683/head:pull/1683`
`$ git checkout pull/1683`
