### PR TITLE
8052260: Reference.isEnqueued() spec does not match the long-standing behavior returning true iff it's in the ref queue

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -425,8 +425,8 @@ public abstract class Reference<T> {
      * but not enqueued due to the race condition.
      *
      * @deprecated
-     * This method was never implemented to test if a reference object has
-     * been cleared and enqueued as it was previously specified since 1.2.
+     * This method was originally specified to test if a reference object has
+     * been cleared and enqueued but was never implemented to do this test.
      * This method could be misused due to the inherent race condition
      * or without an associated {@code ReferenceQueue}.
      * An application relying on this method to release critical resources

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -411,14 +411,35 @@ public abstract class Reference<T> {
     /* -- Queue operations -- */
 
     /**
-     * Tells whether or not this reference object has been enqueued, either by
-     * the program or by the garbage collector.  If this reference object was
-     * not registered with a queue when it was created, then this method will
-     * always return {@code false}.
+     * Tests if this reference object is in its associated queue, if any.
+     * This method returns {@code true} only if all of the following conditions
+     * are met:
+     * <ul>
+     * <li>this reference object was registered with a queue when it was created; and
+     * <li>the garbage collector has added this reference object to the queue
+     *     or {@link #enqueue()} is called; and
+     * <li>this reference object is not yet removed from the queue.
+     * </ul>
+     * Otherwise, this method returns {@code false}.
+     * This method may return {@code false} if this reference object has been cleared
+     * but not enqueued due to the race condition.
      *
-     * @return   {@code true} if and only if this reference object has
-     *           been enqueued
+     * @deprecated
+     * This method was never implemented to test if a reference object has
+     * been cleared and enqueued as it was previously specified since 1.2.
+     * This method could be misused due to the inherent race condition
+     * or without an associated {@code ReferenceQueue}.
+     * An application relying on this method to release critical resources
+     * could cause serious performance issue.
+     * An application should use {@link ReferenceQueue} to reliably determine
+     * what reference objects that have been enqueued or
+     * {@link #refersTo(Object) refersTo(null)} to determine if this reference
+     * object has been cleared.
+     *
+     * @return   {@code true} if and only if this reference object is
+     *           in its associated queue (if any).
      */
+    @Deprecated(since="16")
     public boolean isEnqueued() {
         return (this.queue == ReferenceQueue.ENQUEUED);
     }

--- a/src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java
+++ b/src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java
@@ -160,6 +160,7 @@ public abstract class PhantomCleanable<T> extends PhantomReference<T>
      *
      * @throws UnsupportedOperationException always
      */
+    @SuppressWarnings("deprecation")
     @Override
     public final boolean isEnqueued() {
         throw new UnsupportedOperationException("isEnqueued");


### PR DESCRIPTION
`Reference::isEnqueued` method was never implemented as it was initially specified since 1.2. The specification says that it tests if this reference object has been enqueued, but the long-standing behavior is to test if this reference object is in its associated queue, only reflecting the state at the time when this method is executed. The implementation doesn't do what the specification promised, which might cause serious bugs if unnoticed. For example, an application that relies on this method to release critical resources could cause serious performance issues, in particular when this method is misused on Reference objects without an associated queue.  `Reference::refersTo(null)` is the better recommended way to test if a Reference object has been cleared.

This proposes to deprecate `Reference::isEnqueued`.  Also the spec is updated to match the long-standing behavior.

CSR: https://bugs.openjdk.java.net/browse/JDK-8189386

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8052260](https://bugs.openjdk.java.net/browse/JDK-8052260): Reference.isEnqueued() spec does not match the long-standing behavior returning true iff it's in the ref queue


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1684/head:pull/1684`
`$ git checkout pull/1684`
