### PR TITLE
8257872: UL: -Xlog does not check number of options

### DIFF
--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -362,8 +362,13 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
       *next = '\0';
       str = next + 1;
     } else {
+      str = NULL;
       break;
     }
+  }
+
+  if (str != NULL) {
+    log_warning(logging)("Options are specified more than the max number in -Xlog.");
   }
 
   // Parse and apply the separated configuration options

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -368,7 +368,7 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
   }
 
   if (str != NULL) {
-    log_warning(logging)("Options are specified more than the max number in -Xlog.");
+    log_warning(logging)("Ignoring excess -Xlog options: \"%s\"", str);
   }
 
   // Parse and apply the separated configuration options


### PR DESCRIPTION
In Unified Logging options can be specified up to four (`-Xlog[:[selections][:[output][:[decorators][:output-options]]]]`).
But it’s possible to specify options with more colons like `java -Xlog:::::`.
It’s better to show a message when more options are specified than maximum number.

By this PR a warning message is outputted when options are specified more than the max number.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257872](https://bugs.openjdk.java.net/browse/JDK-8257872): UL: -Xlog does not check number of options


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1685/head:pull/1685`
`$ git checkout pull/1685`
