### PR TITLE
8257887: java/foreign/TestSegments.java test fails on 32-bit after JDK-8257186

### DIFF
--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @run testng/othervm -Xmx4G -XX:MaxDirectMemorySize=1M TestSegments
  */
 


### PR DESCRIPTION
See here:
 https://github.com/mcimadamore/jdk/runs/1460615378

```
$ CONF=linux-x86-server-fastdebug make images run-test TEST=java/foreign/TestSegments.java

STDERR:
Invalid maximum heap size: -Xmx4G
The specified size exceeds the maximum representable size.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

Adding `@requires` in the same form other `java/foreign` tests have it skips the test on 32-bit platforms.

Additional testing: 
 - [x] Affected test on Linux x86_32 (skipped now)
 - [x] Affected test on Linux x86_64 (still passes)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257887](https://bugs.openjdk.java.net/browse/JDK-8257887): java/foreign/TestSegments.java test fails on 32-bit after JDK-8257186


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer)
 * [Aditya Mandaleeka](https://openjdk.java.net/census#adityam) (@adityamandaleeka - Author)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1688/head:pull/1688`
`$ git checkout pull/1688`
