### PR TITLE
8257885: [TESTBUG] java/foreign/TestSegments.java fails on x86_32

### DIFF
--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @run testng/othervm -Xmx4G -XX:MaxDirectMemorySize=1M TestSegments
+ * @run testng/othervm -Xmx3500M -XX:MaxDirectMemorySize=1M TestSegments
  */
 
 import jdk.incubator.foreign.MappedMemorySegments;


### PR DESCRIPTION
Hi all,

java/foreign/TestSegments.java fails on x86_32 due to '-Xmx4G'.
The reason is that -Xmx4G is invalid maximum heap size for 32-bit platforms.
The current implimentation only supports maximum 3800M on 32-bit systems [1].

The fix just change '-Xmx4G' to '-Xmx3500M'.

Testing:
  - java/foreign/TestSegments.java on Linux/x86_{32,64}  

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/os/posix/os_posix.cpp#L567

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8257885](https://bugs.openjdk.java.net/browse/JDK-8257885): [TESTBUG] java/foreign/TestSegments.java fails on x86_32


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1689/head:pull/1689`
`$ git checkout pull/1689`
