### PR TITLE
8260861: TrustStoreDescriptor log the same value

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java
+++ b/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java
@@ -161,7 +161,7 @@ final class TrustStoreManager {
                                     SSLLogger.isOn("trustmanager")) {
                                 SSLLogger.fine(
                                         "Inaccessible trust store: " +
-                                        storePropName);
+                                        fileName);
                             }
                         }
                     } else {


### PR DESCRIPTION
If both jssecacerts and cacerts are not defined, the same log is printed twice, talking about the jssecacerts instead of cacerts the second time. 

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260861](https://bugs.openjdk.java.net/browse/JDK-8260861): TrustStoreDescriptor log the same value


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1690/head:pull/1690`
`$ git checkout pull/1690`
