### PR TITLE
8245446: vmTestbase/nsk/jvmti/RedefineClasses/StressRedefine/TestDescription.java crash intermittently

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/StressRedefine/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/StressRedefine/TestDescription.java
@@ -36,5 +36,6 @@
  *      -agentlib:stressRedefine
  *      nsk.jvmti.RedefineClasses.StressRedefine
  *      ./bin
+ *      -redefiningThreadsNumber 4
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/StressRedefineWithoutBytecodeCorruption/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/StressRedefineWithoutBytecodeCorruption/TestDescription.java
@@ -28,6 +28,7 @@
  * @key randomness
  * @summary converted from VM Testbase nsk/jvmti/RedefineClasses/StressRedefineWithoutBytecodeCorruption.
  * VM Testbase keywords: [quick, jpda, jvmti, noras, redefine, javac, jdk]
+ * @requires vm.compMode != "Xcomp"
  *
  * @library /vmTestbase
  *          /test/lib


### PR DESCRIPTION
The StressRedefine.java (base for redefine stress tests) defines 3 important constants:
    private static int staticMethodCallersNumber = 10;
    private static int nonstaticMethodCallersNumber = 10;
    private static int redefiningThreadsNumber = 40;

The 1st is number of threads to call a static method from constantly redefined class.
The 2nd is number of threads to call am instance method from constantly redefined class.
The 3rd is number of threads to redefine the target class.
The redefiningThreadsNumber=40 is unreasonably big for the StressRedefine test, and there is no chance with -Xcomp  for one of the methods above to get resolved without a class redefinition. So, after 100 of non-successfull attempts we hit the guarantee in the open/src/hotspot/share/interpreter/interpreterRuntime.cpp:879
  guarantee((retry_count++ < 100)) failed: Could not resolve to latest version of redefined method 
To avoid it, the test StressRedefine/TestDescription.java is tweaked to have redefiningThreadsNumber=4.

The test StressRedefineWithoutBytecodeCorruption is worse as it fails even with redefiningThreadsNumber=1. So, a require is added to exclude the test with the -Xcomp flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * ⚠️ Failed to retrieve information on issue `8245446`.


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1692/head:pull/1692`
`$ git checkout pull/1692`
