### PR TITLE
8257901: ZGC: Take virtual memory usage into account when sizing heap

### DIFF
--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -174,7 +174,5 @@ void GCArguments::initialize_heap_flags_and_sizes() {
 }
 
 size_t GCArguments::heap_virtual_to_physical_ratio() {
-  // Used by heap size heuristics to determine max amount
-  // of address space to use for the heap.
   return 1;
 }

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -172,3 +172,7 @@ void GCArguments::initialize_heap_flags_and_sizes() {
 
   DEBUG_ONLY(assert_flags();)
 }
+
+size_t GCArguments::max_virtual_memory_fraction() {
+  return MaxVirtMemFraction;
+}

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -173,6 +173,8 @@ void GCArguments::initialize_heap_flags_and_sizes() {
   DEBUG_ONLY(assert_flags();)
 }
 
-size_t GCArguments::max_virtual_memory_fraction() {
-  return MaxVirtMemFraction;
+size_t GCArguments::heap_virtual_to_physical_ratio() {
+  // Used by heap size heuristics to determine max amount
+  // of address space to use for the heap.
+  return 1;
 }

--- a/src/hotspot/share/gc/shared/gcArguments.hpp
+++ b/src/hotspot/share/gc/shared/gcArguments.hpp
@@ -46,7 +46,11 @@ protected:
 public:
   virtual void initialize();
   virtual size_t conservative_max_heap_alignment() = 0;
+
+  // Used by heap size heuristics to determine max
+  // amount of address space to use for the heap.
   virtual size_t heap_virtual_to_physical_ratio();
+
   virtual CollectedHeap* create_heap() = 0;
 
   // Allows GCs to tell external code if it's supported or not in the current setup.

--- a/src/hotspot/share/gc/shared/gcArguments.hpp
+++ b/src/hotspot/share/gc/shared/gcArguments.hpp
@@ -46,6 +46,7 @@ protected:
 public:
   virtual void initialize();
   virtual size_t conservative_max_heap_alignment() = 0;
+  virtual size_t max_virtual_memory_fraction();
   virtual CollectedHeap* create_heap() = 0;
 
   // Allows GCs to tell external code if it's supported or not in the current setup.

--- a/src/hotspot/share/gc/shared/gcArguments.hpp
+++ b/src/hotspot/share/gc/shared/gcArguments.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, Red Hat, Inc. and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -46,7 +46,7 @@ protected:
 public:
   virtual void initialize();
   virtual size_t conservative_max_heap_alignment() = 0;
-  virtual size_t max_virtual_memory_fraction();
+  virtual size_t heap_virtual_to_physical_ratio();
   virtual CollectedHeap* create_heap() = 0;
 
   // Allows GCs to tell external code if it's supported or not in the current setup.

--- a/src/hotspot/share/gc/z/zAddressSpaceLimit.cpp
+++ b/src/hotspot/share/gc/z/zAddressSpaceLimit.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zAddressSpaceLimit.cpp
+++ b/src/hotspot/share/gc/z/zAddressSpaceLimit.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "gc/z/zAddressSpaceLimit.hpp"
 #include "gc/z/zGlobals.hpp"
+#include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 #include "utilities/align.hpp"
 
@@ -46,6 +47,6 @@ size_t ZAddressSpaceLimit::mark_stack() {
 
 size_t ZAddressSpaceLimit::heap_view() {
   // Allow all heap views to occupy 50% of the address space
-  const size_t limit = address_space_limit() / 2 / ZHeapViews;
+  const size_t limit = address_space_limit() / MaxVirtMemFraction / ZHeapViews;
   return align_up(limit, ZGranuleSize);
 }

--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -95,11 +95,8 @@ void ZArguments::initialize() {
   }
 }
 
-size_t ZArguments::max_virtual_memory_fraction() {
-  // Used by heap size heuristics to determine max amount of address
-  // space to use. Inflates the default MaxVirtMemFraction to account
-  // for all heap views and the virtual-to-physical ratio.
-  return MaxVirtMemFraction * ZHeapViews * ZVirtualToPhysicalRatio;
+size_t ZArguments::heap_virtual_to_physical_ratio() {
+  return ZHeapViews * ZVirtualToPhysicalRatio;
 }
 
 size_t ZArguments::conservative_max_heap_alignment() {

--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -25,6 +25,7 @@
 #include "gc/z/zAddressSpaceLimit.hpp"
 #include "gc/z/zArguments.hpp"
 #include "gc/z/zCollectedHeap.hpp"
+#include "gc/z/zGlobals.hpp"
 #include "gc/z/zHeuristics.hpp"
 #include "gc/shared/gcArguments.hpp"
 #include "runtime/globals.hpp"
@@ -92,6 +93,13 @@ void ZArguments::initialize() {
     FLAG_SET_DEFAULT(ZVerifyRoots, true);
     FLAG_SET_DEFAULT(ZVerifyObjects, true);
   }
+}
+
+size_t ZArguments::max_virtual_memory_fraction() {
+  // Used by heap size heuristics to determine max amount of address
+  // space to use. Inflates the default MaxVirtMemFraction to account
+  // for all heap views and the virtual-to-physical ratio.
+  return MaxVirtMemFraction * ZHeapViews * ZVirtualToPhysicalRatio;
 }
 
 size_t ZArguments::conservative_max_heap_alignment() {

--- a/src/hotspot/share/gc/z/zArguments.hpp
+++ b/src/hotspot/share/gc/z/zArguments.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ private:
 
   virtual void initialize();
   virtual size_t conservative_max_heap_alignment();
-  virtual size_t max_virtual_memory_fraction();
+  virtual size_t heap_virtual_to_physical_ratio();
   virtual CollectedHeap* create_heap();
 
   virtual bool is_supported() const;

--- a/src/hotspot/share/gc/z/zArguments.hpp
+++ b/src/hotspot/share/gc/z/zArguments.hpp
@@ -34,6 +34,7 @@ private:
 
   virtual void initialize();
   virtual size_t conservative_max_heap_alignment();
+  virtual size_t max_virtual_memory_fraction();
   virtual CollectedHeap* create_heap();
 
   virtual bool is_supported() const;

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1659,7 +1659,7 @@ julong Arguments::limit_by_allocatable_memory(julong limit) {
   julong max_allocatable;
   julong result = limit;
   if (os::has_allocatable_memory_limit(&max_allocatable)) {
-    result = MIN2(result, max_allocatable / MaxVirtMemFraction);
+    result = MIN2(result, max_allocatable / GCConfig::arguments()->max_virtual_memory_fraction());
   }
   return result;
 }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1659,7 +1659,13 @@ julong Arguments::limit_heap_by_allocatable_memory(julong limit) {
   julong max_allocatable;
   julong result = limit;
   if (os::has_allocatable_memory_limit(&max_allocatable)) {
-    julong fraction = MaxVirtMemFraction * GCConfig::arguments()->heap_virtual_to_physical_ratio();
+    // The AggressiveHeap check is a temporary workaround to avoid calling
+    // GCarguments::heap_virtual_to_physical_ratio() before a GC has been
+    // selected. This works because AggressiveHeap implies UseParallelGC
+    // where we know the ratio will be 1. Once the AggressiveHeap option is
+    // removed, this can be cleaned up.
+    julong heap_virtual_to_physical_ratio = (AggressiveHeap ? 1 : GCConfig::arguments()->heap_virtual_to_physical_ratio());
+    julong fraction = MaxVirtMemFraction * heap_virtual_to_physical_ratio;
     result = MIN2(result, max_allocatable / fraction);
   }
   return result;

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -363,8 +363,9 @@ class Arguments : AllStatic {
   static void set_use_compressed_klass_ptrs();
   static jint set_ergonomics_flags();
   static jint set_shared_spaces_flags_and_archive_paths();
-  // limits the given memory size by the maximum amount of memory this process is
-  // currently allowed to allocate or reserve.
+  // Limits the given heap size by the maximum amount of virtual
+  // memory this process is currently allowed to use. It also takes
+  // the virtual-to-physical ratio of the current GC into account.
   static julong limit_heap_by_allocatable_memory(julong size);
   // Setup heap size
   static void set_heap_size();

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -365,7 +365,7 @@ class Arguments : AllStatic {
   static jint set_shared_spaces_flags_and_archive_paths();
   // limits the given memory size by the maximum amount of memory this process is
   // currently allowed to allocate or reserve.
-  static julong limit_by_allocatable_memory(julong size);
+  static julong limit_heap_by_allocatable_memory(julong size);
   // Setup heap size
   static void set_heap_size();
 


### PR DESCRIPTION
MaxVirtMemFraction limits the amount of address space the GC should use for the heap. This is used by the heuristics in Arguments::set_heap_size() to select an appropriate default max heap size. However, that heuristic can select a max heap size that will not fit with ZGC, since ZGC uses additional address space (for multi-mapping and the virtual-to-physical ratio). As a result, if the address space is limited, and -Xmx is not specified, then ZGC might refuse to start with the error:

"Failed to reserve enough address space for Java heap"

I propose we abstract MaxVirtMemFraction to make it configurable for each GC, so that the heuristics in Arguments::set_heap_size() will pick a default max heap size that also works for ZGC.

Testing: Manual testing using different ulimit -v sizes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257901](https://bugs.openjdk.java.net/browse/JDK-8257901): ZGC: Take virtual memory usage into account when sizing heap


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to 4370e0edc62d24350d76276ea5c90f8674ac6a27
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Author) ⚠️ Review applies to 4370e0edc62d24350d76276ea5c90f8674ac6a27
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to eaaf4f97341229bb487eedf80c820d2998f49d32


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1696/head:pull/1696`
`$ git checkout pull/1696`
