### PR TITLE
8258077: Using -Xcheck:jni can lead to a double-free after JDK-8193234

### DIFF
--- a/src/hotspot/share/prims/jniCheck.cpp
+++ b/src/hotspot/share/prims/jniCheck.cpp
@@ -424,20 +424,21 @@ static void* check_wrapped_array_release(JavaThread* thr, const char* fn_name,
   size_t sz;
   void* orig_result = check_wrapped_array(thr, fn_name, obj, carray, &sz);
   switch (mode) {
-  // As we never make copies, mode 0 and JNI_COMMIT are the same.
   case 0:
+    memcpy(orig_result, carray, sz);
+    GuardedMemory::free_copy(carray);
+    break;
   case JNI_COMMIT:
     memcpy(orig_result, carray, sz);
     break;
   case JNI_ABORT:
+    GuardedMemory::free_copy(carray);
     break;
   default:
     tty->print_cr("%s: Unrecognized mode %i releasing array "
         PTR_FORMAT " elements " PTR_FORMAT, fn_name, mode, p2i(obj), p2i(carray));
     NativeReportJNIFatalError(thr, "Unrecognized array release mode");
   }
-  // We always need to release the copy we made with GuardedMemory
-  GuardedMemory::free_copy(carray);
   return orig_result;
 }
 


### PR DESCRIPTION
Hello,

I'm a contributor of the [jni-rs](https://github.com/jni-rs/jni-rs/) project. Rust bindings to the JNI. 

When running tests against OpenJDK with the flag "-Xcheck:jni" enabled, we detected the following: the behaviour of the `JNI_COMMIT` mode of `ReleasePrimitiveArrayCritical` seems to be inconsistent, when running with `-Xcheck:jni` enabled, vs. without `-Xcheck:jni`.

If using "-Xcheck:jni", we're hitting a double free calling `ReleasePrimitiveArrayCritical` with `JNI_COMMIT`, when we attempt to release the buffer at the end. It is our understanding that the behaviour of `ReleasePrimitiveArrayCritical` must be consistent, independently of whether the check JNI mode is enabled or not.

You can check [https://github.com/jni-rs/jni-rs/issues/283](https://github.com/jni-rs/jni-rs/issues/283) for details / comments on this.

We've tracked down the issue to this February 2019 commit: [openjdk commit 3e904a4](https://github.com/openjdk/jdk/commit/3e904a4801b2bf2e988ba096e5cb64a17fd5fce7). The related discussion is here: [openjdk bug JDK-8193234](https://bugs.openjdk.java.net/browse/JDK-8193234).

As there are no associated tests or functionality in the OpenJDK code base, I've simply reverted the commit. Just in case, I've also built and tested the JDK, without issues.

Not sure what tests are the ones mentioned in the discussions that led to the introduction of this behaviour. It is our understanding that tests of `JNI_COMMIT` functionality must still make a call to `ReleasePrimitiveArrayCritical` with a proper mode (`0` or `JNI_ABORT`) at the end, to release the buffer. And this, independently of `-Xcheck:jni` being enabled or not.

If there are any issues related to this that we're not aware of, please let us know.

This reverts commit 3e904a4801b2bf2e988ba096e5cb64a17fd5fce7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258077](https://bugs.openjdk.java.net/browse/JDK-8258077): Using -Xcheck:jni can lead to a double-free after JDK-8193234


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1697/head:pull/1697`
`$ git checkout pull/1697`
