### PR TITLE
8257905: Make fixpath.sh more liberal in accepting paths embedded in arguments

### DIFF
--- a/make/scripts/fixpath.sh
+++ b/make/scripts/fixpath.sh
@@ -293,7 +293,7 @@ function convert_path() {
   winpath=""
   # Start looking for drive prefix. Also allow /xxxx prefixes (typically options
   # for Visual Studio tools), and embedded file:// URIs.
-  if [[ $arg =~ ^([^/]*|.*file://|/[a-zA-Z:]{1,3}:?)($DRIVEPREFIX/)([a-z])(/[^/]+.*$) ]] ; then
+  if [[ $arg =~ ^([^/]*|-[^:=]*[:=]|.*file://|/[a-zA-Z:]{1,3}:?)($DRIVEPREFIX/)([a-z])(/[^/]+.*$) ]] ; then
     prefix="${BASH_REMATCH[1]}"
     winpath="${BASH_REMATCH[3]}:${BASH_REMATCH[4]}"
     # Change slash to backslash (or vice versa if mixed mode)

--- a/make/scripts/fixpath.sh
+++ b/make/scripts/fixpath.sh
@@ -302,7 +302,7 @@ function convert_path() {
     else
       winpath="${winpath//'\'/'/'}"
     fi
-  elif [[ $arg =~ ^([^/]*|(.*file://))(/([-_.a-zA-Z0-9]+)(/[-_.a-zA-Z0-9]+)+)(.*)?$ ]] ; then
+  elif [[ $arg =~ ^([^/]*|-[^:=]*[:=]|(.*file://))(/([-_.+a-zA-Z0-9]+)(/[-_.+a-zA-Z0-9]+)+)(.*)?$ ]] ; then
     # This looks like a unix path, like /foo/bar. Also embedded file:// URIs.
     prefix="${BASH_REMATCH[1]}"
     pathmatch="${BASH_REMATCH[3]}"


### PR DESCRIPTION
When calling a Windows tool that needs an argument on the form `-option/a:/home/ihse/myjdk/...`, fixpath gets confused and thinks `/a:/home/ihse/myjdk` is a unix path, notices that it does not exists, and stops trying to convert the path. 

Instead it needs to recheck for paths after a separator such as `:` or `=`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257905](https://bugs.openjdk.java.net/browse/JDK-8257905): Make fixpath.sh more liberal in accepting paths embedded in arguments


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1698/head:pull/1698`
`$ git checkout pull/1698`
