### PR TITLE
8251267: CDS tests should use CDSTestUtils.getOutputDir instead of System.getProperty("user.dir")

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/DirClasspathTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/DirClasspathTest.java
@@ -33,6 +33,7 @@
  */
 
 import jdk.test.lib.Platform;
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 import java.io.File;
 import java.nio.file.Files;
@@ -52,7 +53,7 @@ public class DirClasspathTest {
     }
 
     public static void main(String[] args) throws Exception {
-        File dir = new File(System.getProperty("user.dir"));
+        File dir = CDSTestUtils.getOutputDirAsFile();
         File emptydir = new File(dir, "emptydir");
         emptydir.mkdir();
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
@@ -47,7 +47,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class MoveJDKTest {
     public static void main(String[] args) throws Exception {
         String java_home_src = System.getProperty("java.home");
-        String java_home_dst = System.getProperty("user.dir") + File.separator + "moved_jdk";
+        String java_home_dst = CDSTestUtils.getOutputDir() + File.separator + "moved_jdk";
 
         TestCommon.startNewArchiveName();
         String jsaFile = TestCommon.getCurrentArchiveName();

--- a/test/hotspot/jtreg/runtime/cds/appcds/RelativePath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/RelativePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,11 +39,12 @@ import java.nio.file.Paths;
 import static java.nio.file.StandardCopyOption.COPY_ATTRIBUTES;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import java.util.Arrays;
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.Platform;
 
 public class RelativePath {
 
-  private static final Path USER_DIR = Paths.get(System.getProperty("user.dir"));
+  private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
 
   public static void main(String[] args) throws Exception {
     String appJar = JarBuilder.getOrCreateHelloJar();

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -68,7 +68,7 @@ import cdsutils.DynamicDumpHelper;
  *    prefix + opts + suffix
  */
 public class TestCommon extends CDSTestUtils {
-    private static final String JSA_FILE_PREFIX = System.getProperty("user.dir") +
+    private static final String JSA_FILE_PREFIX = CDSTestUtils.getOutputDir() +
         File.separator;
 
     private static final SimpleDateFormat timeStampFormat =
@@ -115,7 +115,7 @@ public class TestCommon extends CDSTestUtils {
     // to the file; in such cases the File.delete() operation will silently fail, w/o
     // throwing an exception, thus allowing testing to continue.
     public static void deletePriorArchives() {
-        File dir = new File(System.getProperty("user.dir"));
+        File dir = CDSTestUtils.getOutputDirAsFile();
         String files[] = dir.list();
         for (String name : files) {
             if (name.startsWith("appcds-") && name.endsWith(".jsa")) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/UnusedCPDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/UnusedCPDuringDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,12 +35,13 @@
  */
 
 import java.io.File;
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class UnusedCPDuringDump {
 
     public static void main(String[] args) throws Exception {
-        File dir = new File(System.getProperty("user.dir"));
+        File dir = CDSTestUtils.getOutputDirAsFile();
         File emptydir = new File(dir, "emptydir");
         emptydir.mkdir();
         String appJar = JarBuilder.getOrCreateHelloJar();

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedIntegerCacheTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedIntegerCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class ArchivedIntegerCacheTest {
@@ -46,7 +47,7 @@ public class ArchivedIntegerCacheTest {
         String use_whitebox_jar = "-Xbootclasspath/a:" + wbJar;
         String appJar = ClassFileInstaller.getJarPath("boxCache.jar");
 
-        Path userDir = Paths.get(System.getProperty("user.dir"));
+        Path userDir = Paths.get(CDSTestUtils.getOutputDir());
         Path moduleDir = Files.createTempDirectory(userDir, "mods");
 
         //

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleComboTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleComboTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.cds.CDSTestUtils;
 import sun.hotspot.WhiteBox;
 
 public class ArchivedModuleComboTest {
@@ -48,7 +49,7 @@ public class ArchivedModuleComboTest {
         String use_whitebox_jar = "-Xbootclasspath/a:" + wbJar;
         String appJar = ClassFileInstaller.getJarPath("app.jar");
 
-        Path userDir = Paths.get(System.getProperty("user.dir"));
+        Path userDir = Paths.get(CDSTestUtils.getOutputDir());
         Path moduleDir = Files.createTempDirectory(userDir, "mods");
 
         //

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicLotsOfClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicLotsOfClasses.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.ArrayList;
+import jdk.test.lib.cds.CDSTestUtils;
 
 /*
  * @test
@@ -58,7 +59,7 @@ public class DynamicLotsOfClasses extends DynamicArchiveTestBase {
         ArrayList<String> list = new ArrayList<>();
         TestCommon.findAllClasses(list);
 
-        String classList = System.getProperty("user.dir") + File.separator +
+        String classList = CDSTestUtils.getOutputDir() + File.separator +
                            "LotsOfClasses.list";
         List<String> lines = list;
         Path file = Paths.get(classList);

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/MainModuleOnly.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/MainModuleOnly.java
@@ -40,13 +40,14 @@ import java.util.Arrays;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Platform;
+import jdk.test.lib.cds.CDSTestUtils;
 
 import jtreg.SkippedException;
 import sun.hotspot.code.Compiler;
 
 public class MainModuleOnly extends DynamicArchiveTestBase {
 
-    private static final Path USER_DIR = Paths.get(System.getProperty("user.dir"));
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
 
     private static final String FS = File.separator;
     private static final String TEST_SRC = System.getProperty("test.src") +

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/UnsupportedBaseArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/UnsupportedBaseArchive.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import jdk.test.lib.cds.CDSTestUtils;
 
 /*
  * @test
@@ -39,7 +40,7 @@ import java.nio.file.Paths;
  */
 
 public class UnsupportedBaseArchive extends DynamicArchiveTestBase {
-    private static final Path USER_DIR = Paths.get(System.getProperty("user.dir"));
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
 
     private static final String FS = File.separator;
     private static final String TEST_SRC = System.getProperty("test.src") +

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/UnusedCPDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/UnusedCPDuringDump.java
@@ -36,6 +36,7 @@
  */
 
 import java.io.File;
+import jdk.test.lib.cds.CDSTestUtils;
 
 public class UnusedCPDuringDump extends DynamicArchiveTestBase {
 
@@ -49,7 +50,7 @@ public class UnusedCPDuringDump extends DynamicArchiveTestBase {
     }
 
     private static void doTest(String topArchiveName) throws Exception {
-        File dir = new File(System.getProperty("user.dir"));
+        File dir = CDSTestUtils.getOutputDirAsFile();
         File emptydir = new File(dir, "emptydir");
         emptydir.mkdir();
         String appJar = JarBuilder.getOrCreateHelloJar();

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCSharedStringsDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCSharedStringsDuringDump.java
@@ -39,6 +39,7 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import jdk.test.lib.cds.CDSOptions;
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
@@ -63,7 +64,7 @@ public class GCSharedStringsDuringDump {
             "-Xlog:gc*=info,gc+region=trace,gc+alloc+region=debug" : "-showversion";
 
         String sharedArchiveCfgFile =
-            System.getProperty("user.dir") + File.separator + "GCSharedStringDuringDump_gen.txt";
+            CDSTestUtils.getOutputDir() + File.separator + "GCSharedStringDuringDump_gen.txt";
         try (FileOutputStream fos = new FileOutputStream(sharedArchiveCfgFile)) {
             PrintWriter out = new PrintWriter(new OutputStreamWriter(fos));
             out.println("VERSION: 1.0");

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/NewModuleFinderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/NewModuleFinderTest.java
@@ -43,7 +43,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class NewModuleFinderTest {
 
-    private static final Path USER_DIR = Paths.get(System.getProperty("user.dir"));
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
     private static final String TEST_SRC = System.getProperty("test.src");
     private static final Path SRC_DIR = Paths.get(TEST_SRC, "modulepath/src");
     private static final Path MODS_DIR = Paths.get("mods");

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/AddModules.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/AddModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,11 +36,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class AddModules {
 
-    private static final Path USER_DIR = Paths.get(System.getProperty("user.dir"));
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
 
     private static final String TEST_SRC = System.getProperty("test.src");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/AddOpens.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/AddOpens.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,11 +35,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class AddOpens {
 
-    private static final Path USER_DIR = Paths.get(System.getProperty("user.dir"));
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
 
     private static final String TEST_SRC = System.getProperty("test.src");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/AddReads.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/AddReads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,12 +35,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Asserts;
 
 public class AddReads {
 
-    private static final Path USER_DIR = Paths.get(System.getProperty("user.dir"));
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
 
     private static final String TEST_SRC = System.getProperty("test.src");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ExportModule.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ExportModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,13 +35,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.compiler.CompilerUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Asserts;
 
 public class ExportModule {
 
-    private static final Path USER_DIR = Paths.get(System.getProperty("user.dir"));
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
 
     private static final String TEST_SRC = System.getProperty("test.src");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/JvmtiAddPath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/JvmtiAddPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 import sun.hotspot.WhiteBox;
 
@@ -50,7 +51,7 @@ public class JvmtiAddPath {
         "[class,load] ExtraClass source: file:"
     };
 
-    private static final Path USER_DIR = Paths.get(System.getProperty("user.dir"));
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
 
     private static final String TEST_SRC = System.getProperty("test.src");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/MainModuleOnly.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/MainModuleOnly.java
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.cds.CDSTestUtils.Result;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Platform;
@@ -47,7 +48,7 @@ import sun.hotspot.code.Compiler;
 
 public class MainModuleOnly {
 
-    private static final Path USER_DIR = Paths.get(System.getProperty("user.dir"));
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
 
     private static final String TEST_SRC = System.getProperty("test.src");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,11 +36,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class ModulePathAndCP {
 
-    private static final Path USER_DIR = Paths.get(System.getProperty("user.dir"));
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
 
     private static final String TEST_SRC = System.getProperty("test.src");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
@@ -37,11 +37,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class OptimizeModuleHandlingTest {
 
-    private static final Path USER_DIR = Paths.get(System.getProperty("user.dir"));
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
 
     private static final String TEST_SRC = System.getProperty("test.src");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsHumongous.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsHumongous.java
@@ -39,12 +39,13 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import sun.hotspot.WhiteBox;
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.Asserts;
 
 public class SharedStringsHumongous {
-    static String sharedArchiveConfigFile = System.getProperty("user.dir") + File.separator + "SharedStringsHumongous_gen.txt";
+    static String sharedArchiveConfigFile = CDSTestUtils.getOutputDir() + File.separator + "SharedStringsHumongous_gen.txt";
 
     public static void main(String[] args) throws Exception {
         WhiteBox wb = WhiteBox.getWhiteBox();

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsStress.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsStress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,11 +34,12 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 public class SharedStringsStress {
-    static String sharedArchiveConfigFile = System.getProperty("user.dir") + File.separator + "SharedStringsStress_gen.txt";
+    static String sharedArchiveConfigFile = CDSTestUtils.getOutputDir() + File.separator + "SharedStringsStress_gen.txt";
 
     public static void main(String[] args) throws Exception {
         try (FileOutputStream fos = new FileOutputStream(sharedArchiveConfigFile)) {

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -494,6 +494,10 @@ public class CDSTestUtils {
         return outputDir;
     }
 
+    public static File getOutputDirAsFile() {
+        return outputDirAsFile;
+    }
+
     // get the file object for the test artifact
     public static File getTestArtifact(String name, boolean checkExistence) {
         File file = new File(outputDirAsFile, name);


### PR DESCRIPTION
Replacing
    `String s = System.getProperty("user.dir");` 
with
    `String s = CDSTestUtils.getOutputDir(); `

Replacing
    `File dir = new File(System.getProperty("user.dir"));`
with
    `File dir = CDSTestUtils.getOutputDirAsFile();`

Passed tier1, hs-tiers 2/3/4 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251267](https://bugs.openjdk.java.net/browse/JDK-8251267): CDS tests should use CDSTestUtils.getOutputDir instead of System.getProperty("user.dir")


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1700/head:pull/1700`
`$ git checkout pull/1700`
