### PR TITLE
8246005: KeyStoreSpi::engineStore(LoadStoreParameter) spec mismatch to its behavior

### DIFF
--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -1421,6 +1421,7 @@ public class KeyStore {
      *          algorithm could not be found
      * @throws    CertificateException if any of the certificates included in
      *          the keystore data could not be stored
+     * @throws    UnsupportedOperationException if this method is not supported
      *
      * @since 1.5
      */

--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -1421,7 +1421,7 @@ public class KeyStore {
      *          algorithm could not be found
      * @throws    CertificateException if any of the certificates included in
      *          the keystore data could not be stored
-     * @throws    UnsupportedOperationException if this method is not supported
+     * @throws    UnsupportedOperationException if this operation is not supported
      *
      * @since 1.5
      */

--- a/src/java.base/share/classes/java/security/KeyStoreSpi.java
+++ b/src/java.base/share/classes/java/security/KeyStoreSpi.java
@@ -319,7 +319,7 @@ public abstract class KeyStoreSpi {
      *          algorithm could not be found
      * @throws    CertificateException if any of the certificates included in
      *          the keystore data could not be stored
-     * @throws UnsupportedOperationException if the implementation
+     * @throws    UnsupportedOperationException if the implementation
      *          has not overridden this method
      *
      * @since 1.5

--- a/src/java.base/share/classes/java/security/KeyStoreSpi.java
+++ b/src/java.base/share/classes/java/security/KeyStoreSpi.java
@@ -304,6 +304,9 @@ public abstract class KeyStoreSpi {
      * Stores this keystore using the given
      * {@code KeyStore.LoadStoreParmeter}.
      *
+     * @implSpec The default implementation throws
+     *          an {@link UnsupportedOperationException}.
+     *
      * @param param the {@code KeyStore.LoadStoreParmeter}
      *          that specifies how to store the keystore,
      *          which may be {@code null}
@@ -316,7 +319,8 @@ public abstract class KeyStoreSpi {
      *          algorithm could not be found
      * @throws    CertificateException if any of the certificates included in
      *          the keystore data could not be stored
-     * @throws    UnsupportedOperationException if this method is not supported
+     * @throws UnsupportedOperationException if the implementation
+     *          has not overridden this method
      *
      * @since 1.5
      */

--- a/src/java.base/share/classes/java/security/KeyStoreSpi.java
+++ b/src/java.base/share/classes/java/security/KeyStoreSpi.java
@@ -316,6 +316,7 @@ public abstract class KeyStoreSpi {
      *          algorithm could not be found
      * @throws    CertificateException if any of the certificates included in
      *          the keystore data could not be stored
+     * @throws    UnsupportedOperationException if this method is not supported
      *
      * @since 1.5
      */

--- a/src/java.base/share/classes/java/security/KeyStoreSpi.java
+++ b/src/java.base/share/classes/java/security/KeyStoreSpi.java
@@ -302,25 +302,25 @@ public abstract class KeyStoreSpi {
 
     /**
      * Stores this keystore using the given
-     * {@code KeyStore.LoadStoreParmeter}.
+     * {@code KeyStore.LoadStoreParameter}.
      *
      * @implSpec The default implementation throws
      *          an {@link UnsupportedOperationException}.
      *
-     * @param param the {@code KeyStore.LoadStoreParmeter}
+     * @param param the {@code KeyStore.LoadStoreParameter}
      *          that specifies how to store the keystore,
      *          which may be {@code null}
      *
      * @throws    IllegalArgumentException if the given
-     *          {@code KeyStore.LoadStoreParmeter}
+     *          {@code KeyStore.LoadStoreParameter}
      *          input is not recognized
      * @throws    IOException if there was an I/O problem with data
      * @throws    NoSuchAlgorithmException if the appropriate data integrity
      *          algorithm could not be found
      * @throws    CertificateException if any of the certificates included in
      *          the keystore data could not be stored
-     * @throws    UnsupportedOperationException if the implementation
-     *          has not overridden this method
+     * @throws    UnsupportedOperationException if the implementation does
+     *          not support this operation
      *
      * @since 1.5
      */


### PR DESCRIPTION
This is a spec change with noreg-doc label.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246005](https://bugs.openjdk.java.net/browse/JDK-8246005): KeyStoreSpi::engineStore(LoadStoreParameter)  spec mismatch to its behavior


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to a153f4f336c65a9188122e7b795b8346c2b9a0d9


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1701/head:pull/1701`
`$ git checkout pull/1701`
