### PR TITLE
8257913: Enable cross-compilation with only sysroot specified

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -534,10 +534,6 @@ jobs:
           echo "cross_flags=
           --openjdk-target=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}
           --with-sysroot=${HOME}/sysroot-${{ matrix.debian-arch }}/
-          --with-toolchain-path=${HOME}/sysroot-${{ matrix.debian-arch }}/
-          --with-freetype-lib=${HOME}/sysroot-${{ matrix.debian-arch }}/usr/lib/${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}/
-          --with-freetype-include=${HOME}/sysroot-${{ matrix.debian-arch }}/usr/include/freetype2/
-          --x-libraries=${HOME}/sysroot-${{ matrix.debian-arch }}/usr/lib/${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}/
           " >> $GITHUB_ENV
         if: matrix.debian-arch != ''
 

--- a/make/autoconf/lib-x11.m4
+++ b/make/autoconf/lib-x11.m4
@@ -68,6 +68,8 @@ AC_DEFUN_ONCE([LIB_SETUP_X11],
             x_libraries="$SYSROOT/usr/lib64"
           elif test -f "$SYSROOT/usr/lib/libX11.so"; then
             x_libraries="$SYSROOT/usr/lib"
+          elif test -f "$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-linux-gnu/libX11.so"; then
+            x_libraries="$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-linux-gnu/libX11.so"
           fi
         fi
       fi

--- a/make/autoconf/lib-x11.m4
+++ b/make/autoconf/lib-x11.m4
@@ -70,6 +70,8 @@ AC_DEFUN_ONCE([LIB_SETUP_X11],
             x_libraries="$SYSROOT/usr/lib"
           elif test -f "$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-linux-gnu/libX11.so"; then
             x_libraries="$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-linux-gnu/libX11.so"
+          elif test -f "$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-linux-gnueabihf/libX11.so"; then
+            x_libraries="$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-linux-gnueabihf/libX11.so"
           fi
         fi
       fi


### PR DESCRIPTION
Current cross-compilation targets add the whole lot of configure options to make it compile. See if we can specify just the `--with-sysroot`, and everything else gets autodetected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8257913](https://bugs.openjdk.java.net/browse/JDK-8257913): Enable cross-compilation with only sysroot specified


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1702/head:pull/1702`
`$ git checkout pull/1702`
