### PR TITLE
8255959: Timeouts in VectorConversion tests

### DIFF
--- a/test/jdk/jdk/incubator/vector/Vector64ConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/Vector64ConversionTests.java
@@ -31,7 +31,7 @@ import java.util.function.IntFunction;
 
 /**
  * @test
- * @requires (os.arch !="ppc64") & (os.arch != "ppc64le")
+ * @requires (os.arch != "ppc64") & (os.arch != "ppc64le")
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
  * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
@@ -40,7 +40,7 @@ import java.util.function.IntFunction;
 
 /**
  * @test VectorConversionHighTimeout
- * @requires os.arch =="ppc64" | os.arch == "ppc64le"
+ * @requires os.arch == "ppc64" | os.arch == "ppc64le"
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
  * @run testng/othervm/timeout=1800  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
@@ -50,7 +50,7 @@ import java.util.function.IntFunction;
 /*
  * @test VectorConversionPPC64
  * @bug 8256479
- * @requires os.arch =="ppc64" | os.arch == "ppc64le"
+ * @requires os.arch == "ppc64" | os.arch == "ppc64le"
  * @summary VectorConversion on PPC64 without Vector Register usage
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation

--- a/test/jdk/jdk/incubator/vector/Vector64ConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/Vector64ConversionTests.java
@@ -31,9 +31,19 @@ import java.util.function.IntFunction;
 
 /**
  * @test
+ * @requires (os.arch !="ppc64") & (os.arch != "ppc64le")
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
  * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ *      Vector64ConversionTests
+ */
+
+/**
+ * @test VectorConversionHighTimeout
+ * @requires os.arch =="ppc64" | os.arch == "ppc64le"
+ * @modules jdk.incubator.vector
+ * @modules java.base/jdk.internal.vm.annotation
+ * @run testng/othervm/timeout=1800  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      Vector64ConversionTests
  */
 
@@ -44,7 +54,7 @@ import java.util.function.IntFunction;
  * @summary VectorConversion on PPC64 without Vector Register usage
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
- * @run testng/othervm  -XX:-SuperwordUseVSX -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ * @run testng/othervm/timeout=1800  -XX:-SuperwordUseVSX -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  * Vector64ConversionTests
  */
 


### PR DESCRIPTION
I'd like to address the remaining timeouts on PPC64. Other ones were resolved by JDK-8256581.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255959](https://bugs.openjdk.java.net/browse/JDK-8255959): Timeouts in VectorConversion tests


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to b2af9056c8812e4a0440eab1a78adabb1be8a7fd
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to b2af9056c8812e4a0440eab1a78adabb1be8a7fd


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1704/head:pull/1704`
`$ git checkout pull/1704`
