### PR TITLE
8257917: [JVMCI] crash when materializing boxed values under -Xcomp

### DIFF
--- a/src/hotspot/share/aot/aotLoader.cpp
+++ b/src/hotspot/share/aot/aotLoader.cpp
@@ -26,6 +26,7 @@
 #include "aot/aotLoader.inline.hpp"
 #include "classfile/javaClasses.hpp"
 #include "jvm.h"
+#include "jvmci/jvmci.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/compressedOops.hpp"
@@ -329,15 +330,5 @@ void AOTLoader::initialize_box_caches(TRAPS) {
     return;
   }
   TraceTime timer("AOT initialization of box caches", TRACETIME_LOG(Info, aot, startuptime));
-  Symbol* box_classes[] = { java_lang_Boolean::symbol(), java_lang_Byte_ByteCache::symbol(),
-    java_lang_Short_ShortCache::symbol(), java_lang_Character_CharacterCache::symbol(),
-    java_lang_Integer_IntegerCache::symbol(), java_lang_Long_LongCache::symbol() };
-
-  for (unsigned i = 0; i < sizeof(box_classes) / sizeof(Symbol*); i++) {
-    Klass* k = SystemDictionary::resolve_or_fail(box_classes[i], true, CHECK);
-    InstanceKlass* ik = InstanceKlass::cast(k);
-    if (ik->is_not_initialized()) {
-      ik->initialize(CHECK);
-    }
-  }
+  JVMCI::ensure_box_caches_initialized(CHECK);
 }

--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -37,6 +37,7 @@
 JVMCIRuntime* JVMCI::_compiler_runtime = NULL;
 JVMCIRuntime* JVMCI::_java_runtime = NULL;
 volatile bool JVMCI::_is_initialized = false;
+volatile bool JVMCI::_box_caches_initialized = false;
 void* JVMCI::_shared_library_handle = NULL;
 char* JVMCI::_shared_library_path = NULL;
 volatile bool JVMCI::_in_shutdown = false;
@@ -123,6 +124,35 @@ void JVMCI::initialize_globals() {
     // There is only a single runtime
     _java_runtime = _compiler_runtime = new JVMCIRuntime(0);
   }
+}
+
+void JVMCI::ensure_box_caches_initialized(TRAPS) {
+  if (_box_caches_initialized) {
+    return;
+  }
+  MutexLocker locker(JVMCI_lock);
+  // Check again after locking
+  if (_box_caches_initialized) {
+    return;
+  }
+
+  Symbol* box_classes[] = {
+    java_lang_Boolean::symbol(),
+    java_lang_Byte_ByteCache::symbol(),
+    java_lang_Short_ShortCache::symbol(),
+    java_lang_Character_CharacterCache::symbol(),
+    java_lang_Integer_IntegerCache::symbol(),
+    java_lang_Long_LongCache::symbol()
+  };
+
+  for (unsigned i = 0; i < sizeof(box_classes) / sizeof(Symbol*); i++) {
+    Klass* k = SystemDictionary::resolve_or_fail(box_classes[i], true, CHECK);
+    InstanceKlass* ik = InstanceKlass::cast(k);
+    if (ik->is_not_initialized()) {
+      ik->initialize(CHECK);
+    }
+  }
+  _box_caches_initialized = true;
 }
 
 JavaThread* JVMCI::compilation_tick(JavaThread* thread) {

--- a/src/hotspot/share/jvmci/jvmci.hpp
+++ b/src/hotspot/share/jvmci/jvmci.hpp
@@ -53,6 +53,9 @@ class JVMCI : public AllStatic {
   // execution has completed successfully.
   static volatile bool _is_initialized;
 
+  // used to synchronize lazy initialization of boxing cache classes.
+  static volatile bool _box_caches_initialized;
+
   // Handle created when loading the JVMCI shared library with os::dll_load.
   // Must hold JVMCI_lock when initializing.
   static void* _shared_library_handle;
@@ -109,6 +112,9 @@ class JVMCI : public AllStatic {
   static void initialize_globals();
 
   static void initialize_compiler(TRAPS);
+
+  // Ensures the boxing cache classes (e.g., java.lang.Integer.IntegerCache) are initialized.
+  static void ensure_box_caches_initialized(TRAPS);
 
   // Increments a value indicating some JVMCI compilation activity
   // happened on `thread` if it is a CompilerThread.


### PR DESCRIPTION
The following crash can occur under `-Xcomp` when JVMCI compiled code tries to materialize a virtual box (e.g. `java.lang.Character` object):
```
# Internal Error (deoptimization.cpp:798), pid=26877, tid=8195
# guarantee(ik->is_initialized()) failed: java/lang/Character$CharacterCache must be initialized
```
The problem occurs when the caching class (`java/lang/Character$CharacterCache` in this case) has not been initialized. Normally, the caching class will be initialized when interpreting code that does autoboxing. However, with `-XX:-TieredCompilation -Xcomp` it's possible for class initialization to not be interpreted. When JVMCI compiled code containing virtual boxes is about to be installed, the VM must ensure the box caching classes are initialized. This PR does exactly that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257917](https://bugs.openjdk.java.net/browse/JDK-8257917): [JVMCI] crash when materializing boxed values under -Xcomp


### Reviewers
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1705/head:pull/1705`
`$ git checkout pull/1705`
