### PR TITLE
8257596: Clarify trusted final fields for record classes

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -739,6 +739,12 @@ void InstanceKlass::deallocate_contents(ClassLoaderData* loader_data) {
   }
 }
 
+bool InstanceKlass::is_record() const {
+  return _record_components != NULL &&
+         is_final() &&
+         java_super() == SystemDictionary::Record_klass();
+}
+
 bool InstanceKlass::is_sealed() const {
   return _permitted_subclasses != NULL &&
          _permitted_subclasses != Universe::the_empty_short_array() &&

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -473,7 +473,7 @@ class InstanceKlass: public Klass {
   void set_record_components(Array<RecordComponent*>* record_components) {
     _record_components = record_components;
   }
-  bool is_record() const { return _record_components != NULL; }
+  bool is_record() const;
 
   // permitted subclasses
   Array<u2>* permitted_subclasses() const     { return _permitted_subclasses; }

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -1851,6 +1851,11 @@ JVM_ENTRY(jobjectArray, JVM_GetClassDeclaredFields(JNIEnv *env, jclass ofClass, 
 }
 JVM_END
 
+/*
+ * A class is a record if and only if it is final and a direct subclass
+ * of java.lang.Record and the presence of `RecordComponents` attributes;
+ * otherwise, it is not a record.
+ */
 JVM_ENTRY(jboolean, JVM_IsRecord(JNIEnv *env, jclass cls))
 {
   JVMWrapper("JVM_IsRecord");
@@ -1864,6 +1869,14 @@ JVM_ENTRY(jboolean, JVM_IsRecord(JNIEnv *env, jclass cls))
 }
 JVM_END
 
+/*
+ * Returns an array representing the RecordComponents attribute, or
+ * NULL if the attribute is not present.
+ *
+ * Note that this function returns the content of the RecordComponents
+ * attribute if present.  A non-record class with the RecordComponents attribute
+ * is not record but this function returns non-null.
+ */
 JVM_ENTRY(jobjectArray, JVM_GetRecordComponents(JNIEnv* env, jclass ofClass))
 {
   JVMWrapper("JVM_GetRecordComponents");
@@ -1871,31 +1884,26 @@ JVM_ENTRY(jobjectArray, JVM_GetRecordComponents(JNIEnv* env, jclass ofClass))
   assert(c->is_instance_klass(), "must be");
   InstanceKlass* ik = InstanceKlass::cast(c);
 
-  if (ik->is_record()) {
-    Array<RecordComponent*>* components = ik->record_components();
-    assert(components != NULL, "components should not be NULL");
-    {
-      JvmtiVMObjectAllocEventCollector oam;
-      constantPoolHandle cp(THREAD, ik->constants());
-      int length = components->length();
-      assert(length >= 0, "unexpected record_components length");
-      objArrayOop record_components =
-        oopFactory::new_objArray(SystemDictionary::RecordComponent_klass(), length, CHECK_NULL);
-      objArrayHandle components_h (THREAD, record_components);
+  Array<RecordComponent*>* components = ik->record_components();
+  if (components != NULL) {
+    JvmtiVMObjectAllocEventCollector oam;
+    constantPoolHandle cp(THREAD, ik->constants());
+    int length = components->length();
+    assert(length >= 0, "unexpected record_components length");
+    objArrayOop record_components =
+      oopFactory::new_objArray(SystemDictionary::RecordComponent_klass(), length, CHECK_NULL);
+    objArrayHandle components_h (THREAD, record_components);
 
-      for (int x = 0; x < length; x++) {
-        RecordComponent* component = components->at(x);
-        assert(component != NULL, "unexpected NULL record component");
-        oop component_oop = java_lang_reflect_RecordComponent::create(ik, component, CHECK_NULL);
-        components_h->obj_at_put(x, component_oop);
-      }
-      return (jobjectArray)JNIHandles::make_local(THREAD, components_h());
+    for (int x = 0; x < length; x++) {
+      RecordComponent* component = components->at(x);
+      assert(component != NULL, "unexpected NULL record component");
+      oop component_oop = java_lang_reflect_RecordComponent::create(ik, component, CHECK_NULL);
+      components_h->obj_at_put(x, component_oop);
     }
+    return (jobjectArray)JNIHandles::make_local(THREAD, components_h());
   }
 
-  // Return empty array if ofClass is not a record.
-  objArrayOop result = oopFactory::new_objArray(SystemDictionary::RecordComponent_klass(), 0, CHECK_NULL);
-  return (jobjectArray)JNIHandles::make_local(THREAD, result);
+  return NULL;
 }
 JVM_END
 

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -2383,11 +2383,7 @@ public final class Class<T> implements java.io.Serializable,
         if (!isRecord()) {
             return null;
         }
-        RecordComponent[] recordComponents = getRecordComponents0();
-        if (recordComponents == null) {
-            return new RecordComponent[0];
-        }
-        return recordComponents;
+        return getRecordComponents0();
     }
 
     /**
@@ -3577,9 +3573,17 @@ public final class Class<T> implements java.io.Serializable,
     private native Field[]       getDeclaredFields0(boolean publicOnly);
     private native Method[]      getDeclaredMethods0(boolean publicOnly);
     private native Constructor<T>[] getDeclaredConstructors0(boolean publicOnly);
-    private native Class<?>[]   getDeclaredClasses0();
+    private native Class<?>[]    getDeclaredClasses0();
+
+    /*
+     * Returns an array representing the RecordComponents attribute, or
+     * null if not present.
+     *
+     * Note that this method may return non-null array on a non-record class
+     * if the RecordComponents attribute is present.
+     */
     private native RecordComponent[] getRecordComponents0();
-    private native boolean      isRecord0();
+    private native boolean       isRecord0();
 
     /**
      * Helper method to get the method name from arguments.
@@ -3706,6 +3710,8 @@ public final class Class<T> implements java.io.Serializable,
      * @since 16
      */
     public boolean isRecord() {
+        // this superclass and final modifier check is not strictly necessary
+        // they are intrinsified and serve as a fast-path check
         return getSuperclass() == java.lang.Record.class &&
                 (this.getModifiers() & Modifier.FINAL) != 0 &&
                 isRecord0();


### PR DESCRIPTION
This is a follow-up on JDK-8255342 that removes non-specified JVM checks on classes with `RecordComponents` attributes.  That introduces a regression in `InstanceKlass::is_record` that returns true on a non-record class which has `RecordComponents` attribute present.   This causes unexpected semantics in `JVM_IsRecord` and `JVM_GetRecordComponents` and also a regression to trust final fields for non-record classes.

I propose to change `InstanceKlass::is_record` to match the JLS semantic of a record class, i.e. final direct subclass of `java.lang.Record` with the presence of `RecordComponents` attribute.  There is no change to JVM class file validation.   Also I propose clearly define:
    - `JVM_IsRecord` returns true if the given class is a record i.e. final and direct subclass of `java.lang.Record` with `RecordComponents` attribute
    - `JVM_GetRecordComponents` returns an `RecordComponents` array  if `RecordComponents` attribute is present; otherwise, returns NULL.  This does not check if it's a record class or not.  So it may return non-null on a non-record class if it has `RecordComponents` attribute.  So `JVM_GetRecordComponents` returns the content of the classfile.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257596](https://bugs.openjdk.java.net/browse/JDK-8257596): Clarify trusted final fields for record classes


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1706/head:pull/1706`
`$ git checkout pull/1706`
