### PR TITLE
8257928: Test image build failure with clang-10 due to -Wmisleading-indentation

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass028/redefclass028.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass028/redefclass028.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -244,7 +244,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
     /* obtain WAITTIME parameter */
-        timeout = nsk_jvmti_getWaitTime() * 60000;
+    timeout = nsk_jvmti_getWaitTime() * 60000;
     NSK_DISPLAY1("waittime=%d msecs\n", (int) timeout);
 
     /* create JVMTI environment */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass029/redefclass029.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass029/redefclass029.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,7 +243,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
     /* obtain WAITTIME parameter */
-        timeout = nsk_jvmti_getWaitTime() * 60000;
+    timeout = nsk_jvmti_getWaitTime() * 60000;
     NSK_DISPLAY1("waittime=%d msecs\n", (int) timeout);
 
     /* create JVMTI environment */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass030/redefclass030.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass030/redefclass030.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -244,7 +244,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
     /* obtain WAITTIME parameter */
-        timeout = nsk_jvmti_getWaitTime() * 60000;
+    timeout = nsk_jvmti_getWaitTime() * 60000;
     NSK_DISPLAY1("waittime=%d msecs\n", (int) timeout);
 
     /* create JVMTI environment */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t003/hs201t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t003/hs201t003.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -293,7 +293,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
     /* obtain WAITTIME parameter */
-        timeout = nsk_jvmti_getWaitTime() * 60000;
+    timeout = nsk_jvmti_getWaitTime() * 60000;
     NSK_DISPLAY1("waittime=%d msecs\n", (int) timeout);
 
     /* create JVMTI environment */


### PR DESCRIPTION
Flag '-Wmisleading-indentation' was introduced since clang-10 [1] and
gcc-6 [2]. Putting the code with proper indentations would suppress this
warning.

The main reason why test image build with gcc succeeds is that, clang
and gcc might behave differently for some corner cases under
'-Wmisleading-indentation'.

The following code snippet is crafted based on this build failure, where
each statement with improper indentation (line A and line B) follows an
if-statement. The key difference between foo() and bar() lies in that
there exists an extra comment, i.e. "/* comment 2 */", between statement
at line A and the if-statement.

    int foo(int num) {
      /* comment 1 */
      if (num > 1)
        return 0;

      /* comment 2 */
        num = num + 1;  // line A
      return num;
    }

    int bar(int val) {
      /* comment 3 */
      if (val > 1)
        return 0;

        val = val + 1;  // line B
      return val;
    }

It's worth noting that foo() is quite similar to the erroneous code in
this build failure. Clang-10 would emit misleading indentation warnings
for both foo() and bar(), whereas gcc-6 or higher considers foo() free
of problems. [3]

This patch is a complement to JDK-8253892. In JDK-8253892, flag
'-Wmisleading-indentation' is disabled for both clang and gcc when
building JRE and JDK images. This patch does not disable the flag for
test image building, but just fixes the code, becasue:
  - only a small number of warnings are produced and it's easy to fix
  them one by one.
  - inconsistent warning behaviors between gcc and clang are triggered
  by this case and simply disabling the flag does not work.

Note that AArch64 is NOT tested because test image build still fails
after this bug is fixed due to another runtime error (See JDK-8257936),
which is not related to this patch.

[1] https://releases.llvm.org/10.0.0/tools/clang/docs/DiagnosticsReference.html
[2] https://gcc.gnu.org/onlinedocs/gcc-6.5.0/gcc/Warning-Options.html#Warning-Options
[3] https://godbolt.org/z/xs6xWv

---------------------
We have tested with this patch, the test image can be built successfully with clang-10 on Linux X86 machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257928](https://bugs.openjdk.java.net/browse/JDK-8257928): Test image build failure with clang-10 due to -Wmisleading-indentation


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1709/head:pull/1709`
`$ git checkout pull/1709`
