### PR TITLE
8257924: Use full path when running external executable from jpackage

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppBundler.java
@@ -127,7 +127,7 @@ public class MacAppBundler extends AppImageBundler {
 
             // Signing will not work without Xcode with command line developer tools
             try {
-                ProcessBuilder pb = new ProcessBuilder("xcrun", "--help");
+                ProcessBuilder pb = new ProcessBuilder("/usr/bin/xcrun", "--help");
                 Process p = pb.start();
                 int code = p.waitFor();
                 if (code != 0) {

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppImageBuilder.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppImageBuilder.java
@@ -582,7 +582,7 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
         });
 
         List<String> args = new ArrayList<>();
-        args.add("security");
+        args.add("/usr/bin/security");
         args.add("list-keychains");
         args.add("-s");
 
@@ -607,7 +607,7 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
         }
 
         List<String> args = new ArrayList<>();
-        args.add("security");
+        args.add("/usr/bin/security");
         args.add("list-keychains");
         args.add("-s");
 
@@ -658,7 +658,7 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
                             "message.already.signed"), p.toString()));
                 } else {
                     List<String> args = new ArrayList<>();
-                    args.addAll(Arrays.asList("codesign",
+                    args.addAll(Arrays.asList("/usr/bin/codesign",
                             "--timestamp",
                             "--options", "runtime",
                             "-s", signingIdentity,
@@ -706,7 +706,7 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
 
             try {
                 List<String> args = new ArrayList<>();
-                args.addAll(Arrays.asList("codesign",
+                args.addAll(Arrays.asList("/usr/bin/codesign",
                         "--timestamp",
                         "--options", "runtime",
                         "--force",
@@ -751,7 +751,7 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
 
         // sign the app itself
         List<String> args = new ArrayList<>();
-        args.addAll(Arrays.asList("codesign",
+        args.addAll(Arrays.asList("/usr/bin/codesign",
                 "--timestamp",
                 "--options", "runtime",
                 "--force",
@@ -778,7 +778,8 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
 
     private static boolean isFileSigned(Path file) {
         ProcessBuilder pb =
-                new ProcessBuilder("codesign", "--verify", file.toString());
+                new ProcessBuilder("/usr/bin/codesign",
+                        "--verify", file.toString());
 
         try {
             IOUtils.exec(pb);

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppStoreBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppStoreBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,7 +152,7 @@ public class MacAppStoreBundler extends MacBaseInstallerBundler {
                     MAC_APP_STORE_PKG_SIGNING_KEY.fetchFrom(params);
 
             List<String> buildOptions = new ArrayList<>();
-            buildOptions.add("productbuild");
+            buildOptions.add("/usr/bin/productbuild");
             buildOptions.add("--component");
             buildOptions.add(appLocation.toString());
             buildOptions.add("/Applications");

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacBaseInstallerBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacBaseInstallerBundler.java
@@ -164,7 +164,7 @@ public abstract class MacBaseInstallerBundler extends AbstractBundler {
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 PrintStream ps = new PrintStream(baos)) {
             List<String> searchOptions = new ArrayList<>();
-            searchOptions.add("security");
+            searchOptions.add("/usr/bin/security");
             searchOptions.add("find-certificate");
             searchOptions.add("-c");
             searchOptions.add(key);

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacCertificate.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacCertificate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public final class MacCertificate {
         Path result = null;
 
         List<String> args = new ArrayList<>();
-        args.add("security");
+        args.add("/usr/bin/security");
         args.add("find-certificate");
         args.add("-c");
         args.add(certificate);

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacDmgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacDmgBundler.java
@@ -245,7 +245,7 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
 
         // generic find attempt
         try {
-            ProcessBuilder pb = new ProcessBuilder("xcrun", "-find", "SetFile");
+            ProcessBuilder pb = new ProcessBuilder("/usr/bin/xcrun", "-find", "SetFile");
             Process p = pb.start();
             InputStreamReader isr = new InputStreamReader(p.getInputStream());
             BufferedReader br = new BufferedReader(isr);
@@ -387,7 +387,7 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
             // to install-dir in DMG as critical error, since it can fail in
             // headless enviroment.
             try {
-                pb = new ProcessBuilder("osascript",
+                pb = new ProcessBuilder("/usr/bin/osascript",
                         getConfig_VolumeScript(params).toAbsolutePath().toString());
                 IOUtils.exec(pb, 180); // Wait 3 minutes. See JDK-8248248.
             } catch (IOException ex) {

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
@@ -418,7 +418,7 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
 
             // Generate default CPL file
             Path cpl = CONFIG_ROOT.fetchFrom(params).resolve("cpl.plist");
-            ProcessBuilder pb = new ProcessBuilder("pkgbuild",
+            ProcessBuilder pb = new ProcessBuilder("/usr/bin/pkgbuild",
                     "--root",
                     root,
                     "--install-location",
@@ -433,7 +433,7 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
             preparePackageScripts(params);
 
             // build application package
-            pb = new ProcessBuilder("pkgbuild",
+            pb = new ProcessBuilder("/usr/bin/pkgbuild",
                     "--root",
                     root,
                     "--install-location",
@@ -454,7 +454,7 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
             Files.createDirectories(outdir);
 
             List<String> commandLine = new ArrayList<>();
-            commandLine.add("productbuild");
+            commandLine.add("/usr/bin/productbuild");
 
             commandLine.add("--resources");
             commandLine.add(CONFIG_ROOT.fetchFrom(params).toAbsolutePath().toString());

--- a/test/jdk/tools/jpackage/macosx/base/SigningBase.java
+++ b/test/jdk/tools/jpackage/macosx/base/SigningBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class SigningBase {
     private static List<String> codesignResult(Path target, boolean signed) {
         int exitCode = signed ? 0 : 1;
         List<String> result = new Executor()
-                .setExecutable("codesign")
+                .setExecutable("/usr/bin/codesign")
                 .addArguments("--verify", "--deep", "--strict", "--verbose=2",
                         target.toString())
                 .saveOutput()

--- a/test/jdk/tools/jpackage/macosx/base/SigningCheck.java
+++ b/test/jdk/tools/jpackage/macosx/base/SigningCheck.java
@@ -47,7 +47,7 @@ public class SigningCheck {
 
     private static List<String> findCertificate(String name, String keyChain) {
         List<String> result = new Executor()
-                .setExecutable("security")
+                .setExecutable("/usr/bin/security")
                 .addArguments("find-certificate", "-c", name, "-a", keyChain)
                 .executeAndGetOutput();
 
@@ -89,7 +89,7 @@ public class SigningCheck {
         // will not be listed as trusted by dump-trust-settings
         if (SigningBase.DEV_NAME.equals("jpackage.openjdk.java.net")) {
             List<String> result = new Executor()
-                    .setExecutable("security")
+                    .setExecutable("/usr/bin/security")
                     .addArguments("dump-trust-settings")
                     .executeWithoutExitCodeCheckAndGetOutput();
             result.stream().forEachOrdered(TKit::trace);


### PR DESCRIPTION
Changed all external executables to run via full path to avoid potential issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257924](https://bugs.openjdk.java.net/browse/JDK-8257924): Use full path when running external executable from jpackage


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1710/head:pull/1710`
`$ git checkout pull/1710`
