### PR TITLE
8257973: UTIL_LOOKUP_PROGS should only find executable files

### DIFF
--- a/make/autoconf/util_paths.m4
+++ b/make/autoconf/util_paths.m4
@@ -391,7 +391,7 @@ AC_DEFUN([UTIL_LOOKUP_PROGS],
             # Try again with .exe
             full_path="$elem/$name.exe"
           fi
-          if test -e "$full_path"; then
+          if test -x "$full_path" && test ! -d "$full_path" ; then
             $1="$full_path"
             UTIL_FIXUP_EXECUTABLE($1, $3, $4)
             result="[$]$1"


### PR DESCRIPTION
It turns out that UTIL_LOOKUP_PROGS does not verify that when it find a file in the PATH that matches the given tool name, it accept it straight away. Even if the file is a directory, or is not executable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257973](https://bugs.openjdk.java.net/browse/JDK-8257973): UTIL_LOOKUP_PROGS should only find executable files


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1715/head:pull/1715`
`$ git checkout pull/1715`
