### PR TITLE
8256459: java/net/httpclient/ManyRequests.java and java/net/httpclient/LineBodyHandlerTest.java fail infrequently with java.net.ConnectException: Connection timed out: no further information

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/MultiExchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/MultiExchange.java
@@ -471,7 +471,7 @@ class MultiExchange<T> implements Cancelable {
     /** True if ALL ( even non-idempotent ) requests can be automatic retried. */
     private static final boolean RETRY_ALWAYS = retryPostValue();
     /** True if ConnectException should cause a retry. Enabled by default */
-    private static final boolean RETRY_CONNECT = !disableRetryConnect();
+    static final boolean RETRY_CONNECT = !disableRetryConnect();
 
     /** Returns true is given request has an idempotent method. */
     private static boolean isIdempotentRequest(HttpRequest request) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/PlainHttpConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/PlainHttpConnection.java
@@ -36,7 +36,10 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
 import jdk.internal.net.http.common.FlowTube;
 import jdk.internal.net.http.common.Log;
 import jdk.internal.net.http.common.MinimalFuture;
@@ -56,15 +59,19 @@ class PlainHttpConnection extends HttpConnection {
     private volatile boolean connected;
     private boolean closed;
     private volatile ConnectTimerEvent connectTimerEvent;  // may be null
+    private volatile int unsuccessfulAttempts;
 
-    // should be volatile to provide proper synchronization(visibility) action
+    private enum ConnectState {
+        SUCCESS, RETRY
+    }
+
 
     /**
      * Returns a ConnectTimerEvent iff there is a connect timeout duration,
      * otherwise null.
      */
     private ConnectTimerEvent newConnectTimer(Exchange<?> exchange,
-                                              CompletableFuture<Void> cf) {
+                                              CompletableFuture<?> cf) {
         Duration duration = exchange.remainingConnectTimeout().orElse(null);
         if (duration != null) {
             ConnectTimerEvent cte = new ConnectTimerEvent(duration, exchange, cf);
@@ -74,12 +81,12 @@ class PlainHttpConnection extends HttpConnection {
     }
 
     final class ConnectTimerEvent extends TimeoutEvent {
-        private final CompletableFuture<Void> cf;
+        private final CompletableFuture<?> cf;
         private final Exchange<?> exchange;
 
         ConnectTimerEvent(Duration duration,
                           Exchange<?> exchange,
-                          CompletableFuture<Void> cf) {
+                          CompletableFuture<?> cf) {
             super(duration);
             this.exchange = exchange;
             this.cf = cf;
@@ -102,10 +109,10 @@ class PlainHttpConnection extends HttpConnection {
     }
 
     final class ConnectEvent extends AsyncEvent {
-        private final CompletableFuture<Void> cf;
+        private final CompletableFuture<ConnectState> cf;
         private final Exchange<?> exchange;
 
-        ConnectEvent(CompletableFuture<Void> cf, Exchange<?> exchange) {
+        ConnectEvent(CompletableFuture<ConnectState> cf, Exchange<?> exchange) {
             this.cf = cf;
             this.exchange = exchange;
         }
@@ -133,8 +140,13 @@ class PlainHttpConnection extends HttpConnection {
                               finished, exchange.multi.requestCancelled(), chan.getLocalAddress());
                 assert finished || exchange.multi.requestCancelled() : "Expected channel to be connected";
                 // complete async since the event runs on the SelectorManager thread
-                cf.completeAsync(() -> null, client().theExecutor());
+                cf.completeAsync(() -> ConnectState.SUCCESS, client().theExecutor());
             } catch (Throwable e) {
+                if (canRetryConnect(e)) {
+                    unsuccessfulAttempts++;
+                    cf.completeAsync(() -> ConnectState.RETRY, client().theExecutor());
+                    return;
+                }
                 Throwable t = Utils.toConnectException(e);
                 client().theExecutor().execute( () -> cf.completeExceptionally(t));
                 close();
@@ -150,17 +162,19 @@ class PlainHttpConnection extends HttpConnection {
 
     @Override
     public CompletableFuture<Void> connectAsync(Exchange<?> exchange) {
-        CompletableFuture<Void> cf = new MinimalFuture<>();
+        CompletableFuture<ConnectState> cf = new MinimalFuture<>();
         try {
             assert !connected : "Already connected";
             assert !chan.isBlocking() : "Unexpected blocking channel";
             boolean finished;
 
-            connectTimerEvent = newConnectTimer(exchange, cf);
-            if (connectTimerEvent != null) {
-                if (debug.on())
-                    debug.log("registering connect timer: " + connectTimerEvent);
-                client().registerTimer(connectTimerEvent);
+            if (connectTimerEvent == null) {
+                connectTimerEvent = newConnectTimer(exchange, cf);
+                if (connectTimerEvent != null) {
+                    if (debug.on())
+                        debug.log("registering connect timer: " + connectTimerEvent);
+                    client().registerTimer(connectTimerEvent);
+                }
             }
 
             PrivilegedExceptionAction<Boolean> pa =
@@ -172,7 +186,7 @@ class PlainHttpConnection extends HttpConnection {
             }
             if (finished) {
                 if (debug.on()) debug.log("connect finished without blocking");
-                cf.complete(null);
+                cf.complete(ConnectState.SUCCESS);
             } else {
                 if (debug.on()) debug.log("registering connect event");
                 client().registerEvent(new ConnectEvent(cf, exchange));
@@ -187,7 +201,43 @@ class PlainHttpConnection extends HttpConnection {
                     debug.log("Failed to close channel after unsuccessful connect");
             }
         }
-        return cf;
+        return cf.handle((r,t) -> checkRetryConnect(r, t,exchange))
+                .thenCompose(Function.identity());
+    }
+
+    /**
+     * On some platforms, a ConnectEvent may be raised and a ConnectionException
+     * may occur with the message "Connection timed out: no further information"
+     * before our actual connection timeout has expired. In this case, this
+     * method will be called with a {@code connect} state of {@code ConnectState.RETRY)
+     * and we will retry once again.
+     * @param connect indicates whether the connection was successful or should be retried
+     * @param failed the failure if the connection failed
+     * @param exchange the exchange
+     * @return a completable future that will take care of retrying the connection if needed.
+     */
+    private CompletableFuture<Void> checkRetryConnect(ConnectState connect, Throwable failed, Exchange<?> exchange) {
+        // first check if the connection failed
+        if (failed != null) return MinimalFuture.failedFuture(failed);
+        // then check if the connection should be retried
+        if (connect == ConnectState.RETRY) {
+            int attempts = unsuccessfulAttempts;
+            assert attempts <= 1;
+            if (debug.on())
+                debug.log("Retrying connect after %d attempts", attempts);
+            return connectAsync(exchange);
+        }
+        // Otherwise, the connection was successful;
+        assert connect == ConnectState.SUCCESS;
+        return MinimalFuture.completedFuture(null);
+    }
+
+    private boolean canRetryConnect(Throwable e) {
+        if (!(e instanceof ConnectException)) return false;
+        if (unsuccessfulAttempts > 0) return false;
+        ConnectTimerEvent timer = connectTimerEvent;
+        if (timer == null) return true;
+        return timer.deadline().isAfter(Instant.now());
     }
 
     @Override

--- a/src/java.net.http/share/classes/jdk/internal/net/http/PlainHttpConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/PlainHttpConnection.java
@@ -61,9 +61,10 @@ class PlainHttpConnection extends HttpConnection {
     private volatile ConnectTimerEvent connectTimerEvent;  // may be null
     private volatile int unsuccessfulAttempts;
 
-    private enum ConnectState {
-        SUCCESS, RETRY
-    }
+    // Indicates whether a connection attempt has succeeded or should be retried.
+    // If the attempt failed, and shouldn't be retried, there will be an exception
+    // instead.
+    private enum ConnectState { SUCCESS, RETRY }
 
 
     /**
@@ -233,6 +234,7 @@ class PlainHttpConnection extends HttpConnection {
     }
 
     private boolean canRetryConnect(Throwable e) {
+        if (!MultiExchange.RETRY_CONNECT) return false;
         if (!(e instanceof ConnectException)) return false;
         if (unsuccessfulAttempts > 0) return false;
         ConnectTimerEvent timer = connectTimerEvent;

--- a/test/jdk/java/net/httpclient/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/HttpServerAdapters.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -505,13 +506,23 @@ public interface HttpServerAdapters {
             return new Http1TestServer(server);
         }
 
+        public static HttpTestServer of(HttpServer server, ExecutorService executor) {
+            return new Http1TestServer(server, executor);
+        }
+
         public static HttpTestServer of(Http2TestServer server) {
             return new Http2TestServerImpl(server);
         }
 
         private static class Http1TestServer extends  HttpTestServer {
             private final HttpServer impl;
+            private final ExecutorService executor;
             Http1TestServer(HttpServer server) {
+                this(server, null);
+            }
+            Http1TestServer(HttpServer server, ExecutorService executor) {
+                if (executor != null) server.setExecutor(executor);
+                this.executor = executor;
                 this.impl = server;
             }
             @Override
@@ -522,7 +533,13 @@ public interface HttpServerAdapters {
             @Override
             public void stop() {
                 System.out.println("Http1TestServer: stop");
-                impl.stop(0);
+                try {
+                    impl.stop(0);
+                } finally {
+                    if (executor != null) {
+                        executor.shutdownNow();
+                    }
+                }
             }
             @Override
             public HttpTestContext addHandler(HttpTestHandler handler, String path) {

--- a/test/jdk/java/net/httpclient/LineBodyHandlerTest.java
+++ b/test/jdk/java/net/httpclient/LineBodyHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,6 +76,7 @@ import static org.testng.Assert.assertTrue;
  * @summary Basic tests for line adapter subscribers as created by
  *          the BodyHandlers returned by BodyHandler::fromLineSubscriber
  *          and BodyHandler::asLines
+ * @bug 8256459
  * @modules java.base/sun.net.www.http
  *          java.net.http/jdk.internal.net.http.common
  *          java.net.http/jdk.internal.net.http.frame

--- a/test/jdk/java/net/httpclient/ManyRequests.java
+++ b/test/jdk/java/net/httpclient/ManyRequests.java
@@ -51,14 +51,20 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpClient.Builder;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Formatter;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 import java.util.concurrent.CompletableFuture;
@@ -81,16 +87,21 @@ public class ManyRequests {
 
         InetSocketAddress addr = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
         HttpsServer server = HttpsServer.create(addr, 0);
+        ExecutorService executor = executorFor("HTTPS/1.1 Server Thread");
         server.setHttpsConfigurator(new Configurator(ctx));
+        server.setExecutor(executor);
 
         HttpClient client = HttpClient.newBuilder()
+                                      .proxy(Builder.NO_PROXY)
                                       .sslContext(ctx)
+                                      .connectTimeout(Duration.ofMillis(120_000)) // 2mins
                                       .build();
         try {
             test(server, client);
             System.out.println("OK");
         } finally {
             server.stop(0);
+            executor.shutdownNow();
         }
     }
 
@@ -102,7 +113,7 @@ public class ManyRequests {
     static final boolean XFIXED = Boolean.getBoolean("test.XFixed");
 
     static class TestEchoHandler extends EchoHandler {
-        final Random rand = new Random();
+        final Random rand = jdk.test.lib.RandomFactory.getRandom();
         @Override
         public void handle(HttpExchange e) throws IOException {
             System.out.println("Server: received " + e.getRequestURI());
@@ -279,4 +290,18 @@ public class ManyRequests {
             params.setSSLParameters(getSSLContext().getSupportedSSLParameters());
         }
     }
+
+    private static ExecutorService executorFor(String serverThreadName) {
+        ThreadFactory factory = new ThreadFactory() {
+            final AtomicInteger counter = new AtomicInteger();
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r);
+                thread.setName(serverThreadName + "#" + counter.incrementAndGet());
+                return thread;
+            }
+        };
+        return Executors.newCachedThreadPool(factory);
+    }
+
 }

--- a/test/jdk/java/net/httpclient/ManyRequests.java
+++ b/test/jdk/java/net/httpclient/ManyRequests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8087112 8180044
+ * @bug 8087112 8180044 8256459
  * @modules java.net.http
  *          java.logging
  *          jdk.httpserver

--- a/test/jdk/java/net/httpclient/ManyRequests2.java
+++ b/test/jdk/java/net/httpclient/ManyRequests2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8087112 8180044
+ * @bug 8087112 8180044 8256459
  * @modules java.net.http
  *          java.logging
  *          jdk.httpserver


### PR DESCRIPTION
Hi, 

Please find here a changeset that fixes the infrequent (but annoying) test failures
caused by unexpected ConnectionException "Connection timed out: no further information"
which have been observed to occur on some platforms.

Tests are updated to allow the test server to handle requests concurrently.
PlainHttpConnection is updated to retry connection once if chan::finishConnect fails
early with ConnectionException and the connection timeout has not expired.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256459](https://bugs.openjdk.java.net/browse/JDK-8256459): java/net/httpclient/ManyRequests.java and java/net/httpclient/LineBodyHandlerTest.java fail infrequently with java.net.ConnectException: Connection timed out: no further information


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1716/head:pull/1716`
`$ git checkout pull/1716`
