### PR TITLE
8257993: vmTestbase/nsk/jvmti/RedefineClasses/StressRedefine/TestDescription.java crash intermittently

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -821,24 +821,17 @@ void InterpreterRuntime::resolve_invoke(JavaThread* thread, Bytecodes::Code byte
   CallInfo info;
   constantPoolHandle pool(thread, last_frame.method()->constants());
 
+  methodHandle resolved_method;
+
   {
     JvmtiHideSingleStepping jhss(thread);
     LinkResolver::resolve_invoke(info, receiver, pool,
                                  last_frame.get_index_u2_cpcache(bytecode), bytecode,
                                  CHECK);
-    if (JvmtiExport::can_hotswap_or_post_breakpoint()) {
-      int retry_count = 0;
-      while (info.resolved_method()->is_old()) {
-        // It is very unlikely that method is redefined more than 100 times
-        // in the middle of resolve. If it is looping here more than 100 times
-        // means then there could be a bug here.
-        guarantee((retry_count++ < 100),
-                  "Could not resolve to latest version of redefined method");
-        // method is redefined in the middle of resolve so re-try.
-        LinkResolver::resolve_invoke(info, receiver, pool,
-                                     last_frame.get_index_u2_cpcache(bytecode), bytecode,
-                                     CHECK);
-      }
+    if (JvmtiExport::can_hotswap_or_post_breakpoint() && info.resolved_method()->is_old()) {
+      resolved_method = methodHandle(THREAD, info.resolved_method()->get_new_method());
+    } else {
+      resolved_method = methodHandle(THREAD, info.resolved_method());
     }
   } // end JvmtiHideSingleStepping
 
@@ -848,22 +841,20 @@ void InterpreterRuntime::resolve_invoke(JavaThread* thread, Bytecodes::Code byte
 
 #ifdef ASSERT
   if (bytecode == Bytecodes::_invokeinterface) {
-    if (info.resolved_method()->method_holder() ==
-                                            SystemDictionary::Object_klass()) {
+    if (resolved_method->method_holder() == SystemDictionary::Object_klass()) {
       // NOTE: THIS IS A FIX FOR A CORNER CASE in the JVM spec
       // (see also CallInfo::set_interface for details)
       assert(info.call_kind() == CallInfo::vtable_call ||
              info.call_kind() == CallInfo::direct_call, "");
-      Method* rm = info.resolved_method();
-      assert(rm->is_final() || info.has_vtable_index(),
+      assert(resolved_method->is_final() || info.has_vtable_index(),
              "should have been set already");
-    } else if (!info.resolved_method()->has_itable_index()) {
+    } else if (!resolved_method->has_itable_index()) {
       // Resolved something like CharSequence.toString.  Use vtable not itable.
       assert(info.call_kind() != CallInfo::itable_call, "");
     } else {
       // Setup itable entry
       assert(info.call_kind() == CallInfo::itable_call, "");
-      int index = info.resolved_method()->itable_index();
+      int index = resolved_method->itable_index();
       assert(info.itable_index() == index, "");
     }
   } else if (bytecode == Bytecodes::_invokespecial) {
@@ -878,7 +869,6 @@ void InterpreterRuntime::resolve_invoke(JavaThread* thread, Bytecodes::Code byte
   // methods must be checked for every call.
   InstanceKlass* sender = pool->pool_holder();
   sender = sender->is_unsafe_anonymous() ? sender->unsafe_anonymous_host() : sender;
-  methodHandle resolved_method(THREAD, info.resolved_method());
 
   switch (info.call_kind()) {
   case CallInfo::direct_call:


### PR DESCRIPTION
This change handles redefinition during method resolution, by returning the new method.  It's not needed to reresolve the invocation. See the bug for more information.

Tested with tier1-3 and tier8 on linux-x64-debug and macos-x64-debug, and running the failing tests 100x without failure.  Thank you to Serguei for confirming the testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257993](https://bugs.openjdk.java.net/browse/JDK-8257993): vmTestbase/nsk/jvmti/RedefineClasses/StressRedefine/TestDescription.java crash intermittently


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1717/head:pull/1717`
`$ git checkout pull/1717`
