### PR TITLE
JDK-8257989: Error in gtest os_page_size_for_region_unaligned after 8257588

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -102,7 +102,7 @@ TEST_VM(os, page_size_for_region_unaligned) {
     for (size_t s = os::page_sizes().largest(); s != 0; s = os::page_sizes().next_smaller(s)) {
       const size_t expected = os::page_sizes().next_smaller(s);
       if (expected != 0) {
-        size_t actual = os::page_size_for_region_unaligned(expected - 17, 1);
+        size_t actual = os::page_size_for_region_unaligned(s - 17, 1);
         ASSERT_EQ(actual, expected);
       }
     }


### PR DESCRIPTION
There appears to be a bug at ln105 of test/hotspot/gtest/runtime/test_os.cpp

https://github.com/openjdk/jdk/pull/1522/files/163b308b97c07d567c48f100475481cdc5e75740#diff-6d3fc66964a0fccf7f85c284fffec5dffa62be8497423a7684cee83d55338884R104

`   // Given a slightly smaller size than a page size,
   // return the next smaller page size.
    if (os::_page_sizes[1] > os::_page_sizes[0]) {
      size_t expected = os::_page_sizes[0];
      size_t actual = os::page_size_for_region_unaligned(os::_page_sizes[1] - 17, 1);
      ASSERT_EQ(actual, expected);
    for (size_t s = os::page_sizes().largest(); s != 0; s = os::page_sizes().next_smaller(s)) {
      const size_t expected = os::page_sizes().next_smaller(s);
      if (expected != 0) {
        size_t actual = os::page_size_for_region_unaligned(expected - 17, 1);
        ASSERT_EQ(actual, expected);
      }
    }`

On ln104 we are trying to compare the next smaller page size of 's', with a page size returned for slightly smaller size of the size 's -17'.

Instead we compare next smaller page size of 's' to 'expected - 17'. I believe this should be 's - 17':
`os::page_size_for_region_unaligned(expected - 17, 1);`
vs.
`os::page_size_for_region_unaligned(s - 17, 1);`

Running gtest tests with 2 largepage sizes (3 total sizes) fails, however default of 2 page_sizes passes (4k and 2m or 1g):
(./hotspot/variant-server/libjvm/gtest/gtestLauncher -jdk:./images/jdk -Xms2G -Xmx2G -XX:+UseLargePages -XX:LargePageSizeInBytes=2M)
> [----------] 17 tests from os                                                                                                                                                                          [ RUN      ] os.page_size_for_region_vm                                                                                                                                                                [       OK ] os.page_size_for_region_vm (0 ms)                                                                                                                                                         [ RUN      ] os.page_size_for_region_aligned_vm                                                                                                                                                        [       OK ] os.page_size_for_region_aligned_vm (0 ms)                                                                                                                                                 [ RUN      ] os.page_size_for_region_alignment_vm                                                                                                                                                      [       OK ] os.page_size_for_region_alignment_vm (0 ms)                                                                                                                                               [ RUN      ] os.page_size_for_region_unaligned_vm                                                                                                                                                      test/hotspot/gtest/runtime/test_os.cpp:106: Failure                                                                                                                                                    Expected equality of these values:                                                                                                                                                                       actual                                                                                                                                                                                                   Which is: 4096                                                                                                                                                                                       expected                                                                                                                                                                                                 Which is: 2097152                                                                                                                                                                                  [  FAILED  ] os.page_size_for_region_unaligned_vm (0 ms) 

This only happen when https://github.com/openjdk/jdk/pull/1153 is present in code, because otherwise you will only have two page_sizes, but still this should return the correct results.

Signed-off-by: Marcus G K Williams <marcus.williams@intel.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257989](https://bugs.openjdk.java.net/browse/JDK-8257989): Error in gtest os_page_size_for_region_unaligned after 8257588


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1719/head:pull/1719`
`$ git checkout pull/1719`
