### PR TITLE
JDK-8257539: tools/jpackage/windows/WinL10nTest.java unpack.bat failed with Exit code: 1618

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -63,7 +63,7 @@ public class WindowsHelper {
 
     private static void runMsiexecWithRetries(Executor misexec) {
         Executor.Result result = null;
-        for (int attempt = 0; attempt != 3; ++attempt) {
+        for (int attempt = 0; attempt < 8; ++attempt) {
             result = misexec.executeWithoutExitCodeCheck();
 
             // The given Executor may either be of an msiexe command or an
@@ -72,7 +72,8 @@ public class WindowsHelper {
             if ((result.exitCode == 1618) || (result.exitCode == 1603)) {
                 // Another installation is already in progress.
                 // Wait a little and try again.
-                ThrowingRunnable.toRunnable(() -> Thread.sleep(3000)).run();
+                Long timeout = 1000L * (attempt + 3); // from 3 to 10 seconds
+                ThrowingRunnable.toRunnable(() -> Thread.sleep(timeout)).run();
                 continue;
             }
             break;


### PR DESCRIPTION
Same code change as https://github.com/openjdk/jdk/pull/1676 that got messed up with merge

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257539](https://bugs.openjdk.java.net/browse/JDK-8257539): tools/jpackage/windows/WinL10nTest.java unpack.bat failed with Exit code: 1618


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - Committer)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1720/head:pull/1720`
`$ git checkout pull/1720`
