### PR TITLE
8257986: [JVMCI] ProblemList 2 reprofile JVMCI tests

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -44,6 +44,8 @@ compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/codecache/jmx/PoolsIndependenceTest.java 8167015 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
+compiler/jvmci/compilerToVM/IsMatureVsReprofileTest.java 8257919 generic-all
+compiler/jvmci/compilerToVM/ReprofileTest.java 8257919 generic-all
 compiler/tiered/LevelTransitionTest.java 8067651 generic-all
 
 compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all


### PR DESCRIPTION
ProblemList compiler/jvmci/compilerToVM/ReprofileTest.java and compiler/jvmci/compilerToVM/IsMatureVsReprofileTest.java 
to reduce the noise in the JDK16 CI.

I used ProblemList.txt instead of ProblemList-graal.txt because it is caused by Hotspot changes 8252049.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257986](https://bugs.openjdk.java.net/browse/JDK-8257986): [JVMCI] ProblemList 2 reprofile JVMCI tests


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1721/head:pull/1721`
`$ git checkout pull/1721`
