### PR TITLE
8256843: [PPC64] runtime/logging/RedefineClasses.java fails with assert: registers not saved on stack

### DIFF
--- a/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
+++ b/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
@@ -490,7 +490,7 @@ void trace_method_handle_stub(const char* adaptername,
 
   bool has_mh = (strstr(adaptername, "/static") == NULL &&
                  strstr(adaptername, "linkTo") == NULL);    // static linkers don't have MH
-  const char* mh_reg_name = has_mh ? "R23_method_handle" : "G23";
+  const char* mh_reg_name = has_mh ? "R23_method_handle" : "R23";
   log_info(methodhandles)("MH %s %s=" INTPTR_FORMAT " sp=" INTPTR_FORMAT,
                 adaptername, mh_reg_name, p2i(mh), p2i(entry_sp));
 
@@ -528,7 +528,9 @@ void trace_method_handle_stub(const char* adaptername,
       // => carefully detect that frame when doing the stack walking
 
       // Current C frame
-      frame cur_frame = os::current_frame();
+      intptr_t* csp = (intptr_t*) *((intptr_t*) os::current_stack_pointer());
+      // hack.
+      frame cur_frame(csp, (address)0x8);
 
       // Robust search of trace_calling_frame (independant of inlining).
       assert(cur_frame.sp() <= saved_regs, "registers not saved on stack ?");

--- a/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
+++ b/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
@@ -528,9 +528,7 @@ void trace_method_handle_stub(const char* adaptername,
       // => carefully detect that frame when doing the stack walking
 
       // Current C frame
-      intptr_t* csp = (intptr_t*) *((intptr_t*) os::current_stack_pointer());
-      // hack.
-      frame cur_frame(csp, (address)0x8);
+      frame cur_frame = os::current_frame();
 
       // Robust search of trace_calling_frame (independant of inlining).
       assert(cur_frame.sp() <= saved_regs, "registers not saved on stack ?");

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -164,8 +164,12 @@ frame os::current_frame() {
   frame topframe(csp, (address)0x8);
   // Return sender of sender of current topframe which hopefully
   // both have pc != NULL.
+#ifdef _NMT_NOINLINE_
   frame tmp = os::get_sender_for_C_frame(&topframe);
   return os::get_sender_for_C_frame(&tmp);
+#else
+  return os::get_sender_for_C_frame(&topframe);
+#endif
 }
 
 bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -184,8 +184,12 @@ frame os::current_frame() {
   frame topframe(csp, (address)0x8);
   // Return sender of sender of current topframe which hopefully
   // both have pc != NULL.
+#ifdef _NMT_NOINLINE_
   frame tmp = os::get_sender_for_C_frame(&topframe);
   return os::get_sender_for_C_frame(&tmp);
+#else
+  return os::get_sender_for_C_frame(&topframe);
+#endif
 }
 
 bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,

--- a/src/hotspot/share/utilities/nativeCallStack.cpp
+++ b/src/hotspot/share/utilities/nativeCallStack.cpp
@@ -36,7 +36,7 @@ NativeCallStack::NativeCallStack(int toSkip, bool fillStack) :
     // to call os::get_native_stack. A tail call is used if _NMT_NOINLINE_ is not defined
     // (which means this is not a slowdebug build), and we are on 64-bit (except Windows).
     // This is not necessarily a rule, but what has been obvserved to date.
-#if (defined(_NMT_NOINLINE_) || defined(_WINDOWS) || !defined(_LP64))
+#if (defined(_NMT_NOINLINE_) || defined(_WINDOWS) || !defined(_LP64) || defined(PPC64))
     // Not a tail call.
     toSkip++;
 #if (defined(_NMT_NOINLINE_) && defined(BSD) && defined(_LP64))


### PR DESCRIPTION
Method handle logging is broken in fastdebug builds. Problem is that os::current_frame() doesn't return the right frame in fastdebug builds.
Unfortunately, fixing os::current_frame() would break NMT stack traces (runtime/NMT/CheckForProperDetailStackTrace.java).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8256843](https://bugs.openjdk.java.net/browse/JDK-8256843): [PPC64] runtime/logging/RedefineClasses.java fails with assert: registers not saved on stack


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1724/head:pull/1724`
`$ git checkout pull/1724`
