### PR TITLE
8257802: LogCompilation throws couldn't find bytecode on JDK 8 log

### DIFF
--- a/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/UncommonTrapEvent.java
+++ b/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/UncommonTrapEvent.java
@@ -118,6 +118,12 @@ class UncommonTrapEvent extends BasicLogEvent {
      */
     public void setCompilation(Compilation compilation) {
         super.setCompilation(compilation);
+
+        if (compilation.getSpecial() != null) {
+          assert compilation.getLevel() == 0 : "Should be 0";
+          return;
+        }
+
         // Attempt to associate a bytecode with with this trap
         CallSite site = compilation.getCall();
         int i = 0;


### PR DESCRIPTION
JBS: https://bugs.openjdk.java.net/browse/JDK-8257802

The problem is that there is a call/inline_fail sequence in the optimizer phase after the parse phase. It looks like this has never been handled well the tool. My solution here is to skip these in the optimizer phase because there is not enough context to know the call site.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257802](https://bugs.openjdk.java.net/browse/JDK-8257802): LogCompilation throws couldn't find bytecode on JDK 8 log


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1725/head:pull/1725`
`$ git checkout pull/1725`
