### PR TITLE
8258015: [JVMCI] JVMCI_lock shouldn't be held while initializing box classes

### DIFF
--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -130,11 +130,6 @@ void JVMCI::ensure_box_caches_initialized(TRAPS) {
   if (_box_caches_initialized) {
     return;
   }
-  MutexLocker locker(JVMCI_lock);
-  // Check again after locking
-  if (_box_caches_initialized) {
-    return;
-  }
 
   Symbol* box_classes[] = {
     java_lang_Boolean::symbol(),


### PR DESCRIPTION
Hi all,

Plenty of AOT tests failed after JDK-8257917.
The reason is that JVMCI_lock [1] was held during box classes initilization.
However, this assert [2] doesn't allow a lock (except tty_lock [3]) to be held in that case.
So JVMCI_lock here [1] should be removed.

Testing:
  compiler/aot and compiler/jvmci on Linux/x64

Thanks.
Best regards,
Jie


[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/jvmci/jvmci.cpp#L133
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/runtime/thread.cpp#L795
[3] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/runtime/mutex.cpp#L440

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258015](https://bugs.openjdk.java.net/browse/JDK-8258015): [JVMCI] JVMCI_lock shouldn't be held while initializing box classes


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1727/head:pull/1727`
`$ git checkout pull/1727`
