### PR TITLE
8257997: sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java again reports leaks after JDK-8257884

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java
@@ -31,20 +31,19 @@ import jdk.test.lib.util.FileUtils;
 
 /*
  * @test
- * @bug 8256818 8257670 8257884
+ * @bug 8256818 8257670 8257884 8257997
  * @summary Test that creating and closing SSL Sockets without bind/connect
  *          will not leave leaking socket file descriptors
  * @library /test/lib
  * @run main/othervm SSLSocketLeak
  */
-// Note: this test is not reliable, run it manually.
 public class SSLSocketLeak {
 
     // number of sockets to open/close
     private static final int NUM_TEST_SOCK = 500;
 
     // percentage of accepted growth of open handles
-    private static final int OPEN_HANDLE_GROWTH_THRESHOLD = Platform.isWindows() ? 25 : 10;
+    private static final int OPEN_HANDLE_GROWTH_THRESHOLD_PERCENTAGE = Platform.isWindows() ? 25 : 10;
 
     public static void main(String[] args) throws IOException {
         long fds_start = FileUtils.getProcessHandleCount();
@@ -58,7 +57,7 @@ public class SSLSocketLeak {
         long fds_end = FileUtils.getProcessHandleCount();
         System.out.println("FDs in the end: " + fds_end);
 
-        if ((fds_end - fds_start) > (NUM_TEST_SOCK / OPEN_HANDLE_GROWTH_THRESHOLD)) {
+        if ((fds_end - fds_start) > ((NUM_TEST_SOCK * OPEN_HANDLE_GROWTH_THRESHOLD_PERCENTAGE)) / 100) {
             throw new RuntimeException("Too many open file descriptors. Looks leaky.");
         }
     }


### PR DESCRIPTION
The fix for [JDK-8257884](https://bugs.openjdk.java.net/browse/JDK-8257884) had a flaw which made the test fail even more often on Windows than before. Here is the correction.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257997](https://bugs.openjdk.java.net/browse/JDK-8257997): sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java again reports leaks after JDK-8257884


### Reviewers
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1729/head:pull/1729`
`$ git checkout pull/1729`
