### PR TITLE
8258015: [JVMCI] JVMCI_lock shouldn't be held while initializing box classes

### DIFF
--- a/src/hotspot/share/aot/aotLoader.cpp
+++ b/src/hotspot/share/aot/aotLoader.cpp
@@ -330,5 +330,5 @@ void AOTLoader::initialize_box_caches(TRAPS) {
     return;
   }
   TraceTime timer("AOT initialization of box caches", TRACETIME_LOG(Info, aot, startuptime));
-  JVMCI::ensure_box_caches_initialized(NULL, CHECK);
+  JVMCI::ensure_box_caches_initialized(CHECK);
 }

--- a/src/hotspot/share/aot/aotLoader.cpp
+++ b/src/hotspot/share/aot/aotLoader.cpp
@@ -330,5 +330,5 @@ void AOTLoader::initialize_box_caches(TRAPS) {
     return;
   }
   TraceTime timer("AOT initialization of box caches", TRACETIME_LOG(Info, aot, startuptime));
-  JVMCI::ensure_box_caches_initialized(CHECK);
+  JVMCI::ensure_box_caches_initialized(NULL, CHECK);
 }

--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -126,13 +126,13 @@ void JVMCI::initialize_globals() {
   }
 }
 
-void JVMCI::ensure_box_caches_initialized(Mutex* lock, TRAPS) {
-  MutexLocker locker(lock);
-  // Check again after locking
+void JVMCI::ensure_box_caches_initialized(TRAPS) {
   if (_box_caches_initialized) {
     return;
   }
 
+  // While multiple threads may reach here, that's fine
+  // since class initialization is synchronized.
   Symbol* box_classes[] = {
     java_lang_Boolean::symbol(),
     java_lang_Byte_ByteCache::symbol(),

--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -37,7 +37,7 @@
 JVMCIRuntime* JVMCI::_compiler_runtime = NULL;
 JVMCIRuntime* JVMCI::_java_runtime = NULL;
 volatile bool JVMCI::_is_initialized = false;
-volatile bool JVMCI::_box_caches_initialized = false;
+bool JVMCI::_box_caches_initialized = false;
 void* JVMCI::_shared_library_handle = NULL;
 char* JVMCI::_shared_library_path = NULL;
 volatile bool JVMCI::_in_shutdown = false;
@@ -126,11 +126,8 @@ void JVMCI::initialize_globals() {
   }
 }
 
-void JVMCI::ensure_box_caches_initialized(TRAPS) {
-  if (_box_caches_initialized) {
-    return;
-  }
-  MutexLocker locker(JVMCI_lock);
+void JVMCI::ensure_box_caches_initialized(Mutex* lock, TRAPS) {
+  MutexLocker locker(lock);
   // Check again after locking
   if (_box_caches_initialized) {
     return;

--- a/src/hotspot/share/jvmci/jvmci.hpp
+++ b/src/hotspot/share/jvmci/jvmci.hpp
@@ -114,8 +114,7 @@ class JVMCI : public AllStatic {
   static void initialize_compiler(TRAPS);
 
   // Ensures the boxing cache classes (e.g., java.lang.Integer.IntegerCache) are initialized.
-  // If non-null, `lock` is acquired to synchronize this operation.
-  static void ensure_box_caches_initialized(Mutex* lock, TRAPS);
+  static void ensure_box_caches_initialized(TRAPS);
 
   // Increments a value indicating some JVMCI compilation activity
   // happened on `thread` if it is a CompilerThread.

--- a/src/hotspot/share/jvmci/jvmci.hpp
+++ b/src/hotspot/share/jvmci/jvmci.hpp
@@ -53,8 +53,8 @@ class JVMCI : public AllStatic {
   // execution has completed successfully.
   static volatile bool _is_initialized;
 
-  // used to synchronize lazy initialization of boxing cache classes.
-  static volatile bool _box_caches_initialized;
+  // True once boxing cache classes are guaranteed to be initialized.
+  static bool _box_caches_initialized;
 
   // Handle created when loading the JVMCI shared library with os::dll_load.
   // Must hold JVMCI_lock when initializing.
@@ -114,7 +114,8 @@ class JVMCI : public AllStatic {
   static void initialize_compiler(TRAPS);
 
   // Ensures the boxing cache classes (e.g., java.lang.Integer.IntegerCache) are initialized.
-  static void ensure_box_caches_initialized(TRAPS);
+  // If non-null, `lock` is acquired to synchronize this operation.
+  static void ensure_box_caches_initialized(Mutex* lock, TRAPS);
 
   // Increments a value indicating some JVMCI compilation activity
   // happened on `thread` if it is a CompilerThread.

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -945,6 +945,10 @@ JVMCI::CodeInstallResult CodeInstaller::initialize_buffer(CodeBuffer& buffer, bo
     }
   }
 #endif
+  if (_has_auto_box) {
+    JavaThread* THREAD = JavaThread::current();
+    JVMCI::ensure_box_caches_initialized(JVMCI_lock, CHECK_(JVMCI::ok));
+  }
   return JVMCI::ok;
 }
 
@@ -1022,7 +1026,6 @@ GrowableArray<ScopeValue*>* CodeInstaller::record_virtual_objects(JVMCIObject de
   }
   GrowableArray<ScopeValue*>* objects = new GrowableArray<ScopeValue*>(JVMCIENV->get_length(virtualObjects), JVMCIENV->get_length(virtualObjects), NULL);
   // Create the unique ObjectValues
-  bool has_auto_box = false;
   for (int i = 0; i < JVMCIENV->get_length(virtualObjects); i++) {
     // HandleMark hm(THREAD);
     JVMCIObject value = JVMCIENV->get_object_at(virtualObjects, i);
@@ -1030,7 +1033,7 @@ GrowableArray<ScopeValue*>* CodeInstaller::record_virtual_objects(JVMCIObject de
     JVMCIObject type = jvmci_env()->get_VirtualObject_type(value);
     bool is_auto_box = jvmci_env()->get_VirtualObject_isAutoBox(value);
     if (is_auto_box) {
-      has_auto_box = true;
+      _has_auto_box = true;
     }
     Klass* klass = jvmci_env()->asKlass(type);
     oop javaMirror = klass->java_mirror();
@@ -1054,10 +1057,6 @@ GrowableArray<ScopeValue*>* CodeInstaller::record_virtual_objects(JVMCIObject de
   }
   _debug_recorder->dump_object_pool(objects);
 
-  if (has_auto_box) {
-    JavaThread* THREAD = JavaThread::current();
-    JVMCI::ensure_box_caches_initialized(CHECK_NULL);
-  }
   return objects;
 }
 

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -947,7 +947,7 @@ JVMCI::CodeInstallResult CodeInstaller::initialize_buffer(CodeBuffer& buffer, bo
 #endif
   if (_has_auto_box) {
     JavaThread* THREAD = JavaThread::current();
-    JVMCI::ensure_box_caches_initialized(JVMCI_lock, CHECK_(JVMCI::ok));
+    JVMCI::ensure_box_caches_initialized(CHECK_(JVMCI::ok));
   }
   return JVMCI::ok;
 }

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.hpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.hpp
@@ -200,6 +200,7 @@ private:
   Dependencies*             _dependencies;
   ExceptionHandlerTable     _exception_handler_table;
   ImplicitExceptionTable    _implicit_exception_table;
+  bool                      _has_auto_box;
 
   bool _immutable_pic_compilation;  // Installer is called for Immutable PIC compilation.
 
@@ -230,7 +231,11 @@ private:
 
 public:
 
-  CodeInstaller(JVMCIEnv* jvmci_env, bool immutable_pic_compilation) : _arena(mtJVMCI), _jvmci_env(jvmci_env), _immutable_pic_compilation(immutable_pic_compilation) {}
+  CodeInstaller(JVMCIEnv* jvmci_env, bool immutable_pic_compilation) :
+    _arena(mtJVMCI),
+    _jvmci_env(jvmci_env),
+    _has_auto_box(false),
+    _immutable_pic_compilation(immutable_pic_compilation) {}
 
 #if INCLUDE_AOT
   JVMCI::CodeInstallResult gather_metadata(JVMCIObject target, JVMCIObject compiled_code, CodeMetadata& metadata, JVMCI_TRAPS);


### PR DESCRIPTION
This PR fixes a regression caused by JDK-8257917 by not locking JVMCI_lock when initializing the boxing cache classes.

It also reduces the calls to `JVMCI::ensure_box_caches_initialized` to be at most one per JVMCI code installation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258015](https://bugs.openjdk.java.net/browse/JDK-8258015): [JVMCI] JVMCI_lock shouldn't be held while initializing box classes


### Reviewers
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1730/head:pull/1730`
`$ git checkout pull/1730`
