### PR TITLE
8257837: Performance regression in heap byte buffer views

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -495,6 +495,7 @@ class methodHandle;
   /* support for Unsafe */                                                                                              \
   do_class(jdk_internal_misc_Unsafe,               "jdk/internal/misc/Unsafe")                                          \
   do_class(sun_misc_Unsafe,                        "sun/misc/Unsafe")                                                   \
+  do_class(jdk_internal_misc_ScopedMemoryAccess,   "jdk/internal/misc/ScopedMemoryAccess")                              \
                                                                                                                         \
   do_intrinsic(_writeback0,               jdk_internal_misc_Unsafe,     writeback0_name, long_void_signature , F_RN)             \
    do_name(     writeback0_name,                                        "writeback0")                                            \

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1586,7 +1586,8 @@ bool MethodData::profile_unsafe(const methodHandle& m, int bci) {
   Bytecode_invoke inv(m , bci);
   if (inv.is_invokevirtual()) {
     if (inv.klass() == vmSymbols::jdk_internal_misc_Unsafe() ||
-        inv.klass() == vmSymbols::sun_misc_Unsafe()) {
+        inv.klass() == vmSymbols::sun_misc_Unsafe() ||
+        inv.klass() == vmSymbols::jdk_internal_misc_ScopedMemoryAccess()) {
       ResourceMark rm;
       char* name = inv.name()->as_C_string();
       if (!strncmp(name, "get", 3) || !strncmp(name, "put", 3)) {

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverPollutedBuffer.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverPollutedBuffer.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.incubator.foreign;
+
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import sun.misc.Unsafe;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.incubator.foreign.MemoryLayouts.JAVA_INT;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 3, jvmArgsAppend = { "--add-modules=jdk.incubator.foreign" })
+public class LoopOverPollutedBuffer {
+
+    static final int ELEM_SIZE = 1_000_000;
+    static final int CARRIER_SIZE = (int) JAVA_INT.byteSize();
+    static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
+
+    static final Unsafe unsafe = Utils.unsafe;
+
+    ByteBuffer dbb = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
+    byte[] arr = new byte[ALLOC_SIZE];
+    ByteBuffer hbb = ByteBuffer.wrap(arr).order(ByteOrder.nativeOrder());
+    FloatBuffer hfb = hbb.asFloatBuffer();
+
+
+    @Setup
+    public void setup() {
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            dbb.putFloat(i * 4, i);
+            hbb.putFloat(i * 4, i);
+        }
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            hfb.put(i, i);
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        unsafe.invokeCleaner(dbb);
+        arr = null;
+        hbb = null;
+        hfb = null;
+    }
+
+    @Benchmark
+    public int direct_byte_buffer_get_float() {
+        int sum = 0;
+        for (int k = 0; k < ELEM_SIZE; k++) {
+            dbb.putFloat(k, (float)k + 1);
+            float v = dbb.getFloat(k * 4);
+            sum += (int)v;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int heap_byte_buffer_get_int() {
+        int sum = 0;
+        for (int k = 0; k < ELEM_SIZE; k++) {
+            hbb.putInt(k, k + 1);
+            int v = hbb.getInt(k * 4);
+            sum += v;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int unsafe_get_float() {
+        int sum = 0;
+        for (int k = 0; k < ALLOC_SIZE; k += 4) {
+            unsafe.putFloat(arr, k + Unsafe.ARRAY_BYTE_BASE_OFFSET, k + 1);
+            float v = unsafe.getFloat(arr, k + Unsafe.ARRAY_BYTE_BASE_OFFSET);
+            sum += (int)v;
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
As a result of the recent integration of the foreign memory access API, some of the buffer implementations now use `ScopedMemoryAccess` instead of `Unsafe`. While this works generally well, there are situations where profile pollution arises, which result in a considerable slowdown. The profile pollution occurs because the same ScopedMemoryAccess method (e.g. `getIntUnaligned`) is called with two different buffer kinds (e.g. an off heap buffer where base == null, and an on-heap buffer where base == byte[]). Because of that, unsafe access cannot be optimized, since C2 can't guess what the unsafe base access is.

In reality, this problem was already known (and solved) elsewhere: the sun.misc.Unsafe wrapper does basically the same thing that ScopedMemoryAccess does. To make sure that profile pollution does not occur in those cases, argument profiling is enabled for sun.misc.Unsafe as well. This patch adds yet another case for ScopedMemoryAccess.

Here are the benchmark results:

Before:

```
Benchmark                                            Mode  Cnt  Score   Error  Units
LoopOverPollutedBuffer.direct_byte_buffer_get_float  avgt   30  0.612 ? 0.005  ms/op
LoopOverPollutedBuffer.heap_byte_buffer_get_int      avgt   30  2.740 ? 0.039  ms/op
LoopOverPollutedBuffer.unsafe_get_float              avgt   30  0.504 ? 0.020  ms/op
```

After

```
Benchmark                                            Mode  Cnt  Score   Error  Units
LoopOverPollutedBuffer.direct_byte_buffer_get_float  avgt   30  0.613 ? 0.007  ms/op
LoopOverPollutedBuffer.heap_byte_buffer_get_int      avgt   30  0.304 ? 0.002  ms/op
LoopOverPollutedBuffer.unsafe_get_float              avgt   30  0.491 ? 0.004  ms/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257837](https://bugs.openjdk.java.net/browse/JDK-8257837): Performance regression in heap byte buffer views


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1733/head:pull/1733`
`$ git checkout pull/1733`
