### PR TITLE
8257970: Remove julong types in os::limit_heap_by_allocatable_memory

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -546,7 +546,7 @@ bool os::get_host_name(char* buf, size_t buflen) {
   return true;
 }
 
-bool os::has_allocatable_memory_limit(julong* limit) {
+bool os::has_allocatable_memory_limit(size_t* limit) {
   struct rlimit rlim;
   int getrlimit_res = getrlimit(RLIMIT_AS, &rlim);
   // if there was an error when calling getrlimit, assume that there is no limitation
@@ -555,7 +555,7 @@ bool os::has_allocatable_memory_limit(julong* limit) {
   if ((getrlimit_res != 0) || (rlim.rlim_cur == RLIM_INFINITY)) {
     result = false;
   } else {
-    *limit = (julong)rlim.rlim_cur;
+    *limit = (size_t)rlim.rlim_cur;
     result = true;
   }
 #ifdef _LP64
@@ -564,7 +564,7 @@ bool os::has_allocatable_memory_limit(julong* limit) {
   // arbitrary virtual space limit for 32 bit Unices found by testing. If
   // getrlimit above returned a limit, bound it with this limit. Otherwise
   // directly use it.
-  const julong max_virtual_limit = (julong)3800*M;
+  const size_t max_virtual_limit = 3800*M;
   if (result) {
     *limit = MIN2(*limit, max_virtual_limit);
   } else {
@@ -581,9 +581,9 @@ bool os::has_allocatable_memory_limit(julong* limit) {
   // until the difference between these limits is "small".
 
   // the minimum amount of memory we care about allocating.
-  const julong min_allocation_size = M;
+  const size_t min_allocation_size = M;
 
-  julong upper_limit = *limit;
+  size_t upper_limit = *limit;
 
   // first check a few trivial cases
   if (is_allocatable(upper_limit) || (upper_limit <= min_allocation_size)) {
@@ -594,9 +594,9 @@ bool os::has_allocatable_memory_limit(julong* limit) {
     *limit = min_allocation_size;
   } else {
     // perform the binary search.
-    julong lower_limit = min_allocation_size;
+    size_t lower_limit = min_allocation_size;
     while ((upper_limit - lower_limit) > min_allocation_size) {
-      julong temp_limit = ((upper_limit - lower_limit) / 2) + lower_limit;
+      size_t temp_limit = ((upper_limit - lower_limit) / 2) + lower_limit;
       temp_limit = align_down(temp_limit, min_allocation_size);
       if (is_allocatable(temp_limit)) {
         lower_limit = temp_limit;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -852,16 +852,16 @@ julong os::physical_memory() {
   return win32::physical_memory();
 }
 
-bool os::has_allocatable_memory_limit(julong* limit) {
+bool os::has_allocatable_memory_limit(size_t* limit) {
   MEMORYSTATUSEX ms;
   ms.dwLength = sizeof(ms);
   GlobalMemoryStatusEx(&ms);
 #ifdef _LP64
-  *limit = (julong)ms.ullAvailVirtual;
+  *limit = (size_t)ms.ullAvailVirtual;
   return true;
 #else
   // Limit to 1400m because of the 2gb address space wall
-  *limit = MIN2((julong)1400*M, (julong)ms.ullAvailVirtual);
+  *limit = MIN2((size_t)1400*M, (size_t)ms.ullAvailVirtual);
   return true;
 #endif
 }

--- a/src/hotspot/share/gc/z/zAddressSpaceLimit.cpp
+++ b/src/hotspot/share/gc/z/zAddressSpaceLimit.cpp
@@ -29,10 +29,10 @@
 #include "utilities/align.hpp"
 
 static size_t address_space_limit() {
-  julong limit = 0;
+  size_t limit = 0;
 
   if (os::has_allocatable_memory_limit(&limit)) {
-    return (size_t)limit;
+    return limit;
   }
 
   // No limit

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1655,17 +1655,17 @@ jint Arguments::set_ergonomics_flags() {
   return JNI_OK;
 }
 
-julong Arguments::limit_heap_by_allocatable_memory(julong limit) {
-  julong max_allocatable;
-  julong result = limit;
+size_t Arguments::limit_heap_by_allocatable_memory(size_t limit) {
+  size_t max_allocatable;
+  size_t result = limit;
   if (os::has_allocatable_memory_limit(&max_allocatable)) {
     // The AggressiveHeap check is a temporary workaround to avoid calling
     // GCarguments::heap_virtual_to_physical_ratio() before a GC has been
     // selected. This works because AggressiveHeap implies UseParallelGC
     // where we know the ratio will be 1. Once the AggressiveHeap option is
     // removed, this can be cleaned up.
-    julong heap_virtual_to_physical_ratio = (AggressiveHeap ? 1 : GCConfig::arguments()->heap_virtual_to_physical_ratio());
-    julong fraction = MaxVirtMemFraction * heap_virtual_to_physical_ratio;
+    size_t heap_virtual_to_physical_ratio = (AggressiveHeap ? 1 : GCConfig::arguments()->heap_virtual_to_physical_ratio());
+    size_t fraction = MaxVirtMemFraction * heap_virtual_to_physical_ratio;
     result = MIN2(result, max_allocatable / fraction);
   }
   return result;

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -366,7 +366,7 @@ class Arguments : AllStatic {
   // Limits the given heap size by the maximum amount of virtual
   // memory this process is currently allowed to use. It also takes
   // the virtual-to-physical ratio of the current GC into account.
-  static julong limit_heap_by_allocatable_memory(julong size);
+  static size_t limit_heap_by_allocatable_memory(size_t size);
   // Setup heap size
   static void set_heap_size();
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -237,7 +237,7 @@ class os: AllStatic {
 
   static julong available_memory();
   static julong physical_memory();
-  static bool has_allocatable_memory_limit(julong* limit);
+  static bool has_allocatable_memory_limit(size_t* limit);
   static bool is_server_class_machine();
 
   // Returns the id of the processor on which the calling thread is currently executing.


### PR DESCRIPTION
Please review this cleanup. In the review of JDK-8257901, the request came up to change the `julong` types (return value, arguments) in `os::limit_heap_by_allocatable_memory()` to `size_t`. This change of types also propagates to `os::has_allocatable_memory_limit()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257970](https://bugs.openjdk.java.net/browse/JDK-8257970): Remove julong types in os::limit_heap_by_allocatable_memory


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1736/head:pull/1736`
`$ git checkout pull/1736`
