### PR TITLE
8248383: Clarify java.io.Reader.read(char[], ...) behavior for full array

### DIFF
--- a/src/hotspot/share/aot/aotCodeHeap.cpp
+++ b/src/hotspot/share/aot/aotCodeHeap.cpp
@@ -27,6 +27,7 @@
 #include "aot/aotLoader.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "classfile/javaAssertions.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
 #include "gc/shared/gcConfig.hpp"

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -32,6 +32,7 @@
 #include "ci/ciField.hpp"
 #include "ci/ciKlass.hpp"
 #include "ci/ciMemberName.hpp"
+#include "ci/ciSymbols.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
@@ -1477,7 +1478,7 @@ void GraphBuilder::method_return(Value x, bool ignore_return) {
 
   // The conditions for a memory barrier are described in Parse::do_exits().
   bool need_mem_bar = false;
-  if (method()->name() == ciSymbol::object_initializer_name() &&
+  if (method()->name() == ciSymbols::object_initializer_name() &&
        (scope()->wrote_final() ||
          (AlwaysSafeConstructors && scope()->wrote_fields()) ||
          (support_IRIW_for_not_multiple_copy_atomic_cpu && scope()->wrote_volatile()))) {
@@ -3820,7 +3821,7 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
     }
 
     // don't inline throwable methods unless the inlining tree is rooted in a throwable class
-    if (callee->name() == ciSymbol::object_initializer_name() &&
+    if (callee->name() == ciSymbols::object_initializer_name() &&
         callee->holder()->is_subclass_of(ciEnv::current()->Throwable_klass())) {
       // Throwable constructor call
       IRScope* top = scope();

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "c1/c1_InstructionPrinter.hpp"
 #include "c1/c1_ValueStack.hpp"
 #include "ci/ciArray.hpp"

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/vmIntrinsics.hpp"
 #include "ci/bcEscapeAnalyzer.hpp"
 #include "ci/ciConstant.hpp"
 #include "ci/ciField.hpp"
@@ -1204,8 +1205,8 @@ void BCEscapeAnalyzer::do_analysis() {
   iterate_blocks(arena);
 }
 
-vmIntrinsics::ID BCEscapeAnalyzer::known_intrinsic() {
-  vmIntrinsics::ID iid = method()->intrinsic_id();
+vmIntrinsicID BCEscapeAnalyzer::known_intrinsic() {
+  vmIntrinsicID iid = method()->intrinsic_id();
   if (iid == vmIntrinsics::_getClass ||
       iid == vmIntrinsics::_hashCode) {
     return iid;
@@ -1214,7 +1215,7 @@ vmIntrinsics::ID BCEscapeAnalyzer::known_intrinsic() {
   }
 }
 
-void BCEscapeAnalyzer::compute_escape_for_intrinsic(vmIntrinsics::ID iid) {
+void BCEscapeAnalyzer::compute_escape_for_intrinsic(vmIntrinsicID iid) {
   switch (iid) {
     case vmIntrinsics::_getClass:
       _return_local = false;
@@ -1293,7 +1294,7 @@ void BCEscapeAnalyzer::compute_escape_info() {
   int i;
   assert(!methodData()->has_escape_info(), "do not overwrite escape info");
 
-  vmIntrinsics::ID iid = known_intrinsic();
+  vmIntrinsicID iid = known_intrinsic();
 
   // check if method can be analyzed
   if (iid == vmIntrinsics::_none && (method()->is_abstract() || method()->is_native() || !method()->holder()->is_initialized()

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
@@ -98,8 +98,8 @@ class BCEscapeAnalyzer : public ResourceObj {
   void initialize();
   void clear_escape_info();
   void compute_escape_info();
-  vmIntrinsics::ID known_intrinsic();
-  void compute_escape_for_intrinsic(vmIntrinsics::ID iid);
+  vmIntrinsicID known_intrinsic();
+  void compute_escape_for_intrinsic(vmIntrinsicID iid);
   void do_analysis();
 
   void read_escape_info();

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -32,6 +32,7 @@
 #include "ci/ciMethod.hpp"
 #include "ci/ciNullObject.hpp"
 #include "ci/ciReplay.hpp"
+#include "ci/ciSymbols.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/symbolTable.hpp"
@@ -798,7 +799,7 @@ ciMethod* ciEnv::get_method_by_index_impl(const constantPoolHandle& cpool,
 
     // Fake a method that is equivalent to a declared method.
     ciInstanceKlass* holder    = get_instance_klass(SystemDictionary::MethodHandle_klass());
-    ciSymbol*        name      = ciSymbol::invokeBasic_name();
+    ciSymbol*        name      = ciSymbols::invokeBasic_name();
     ciSymbol*        signature = get_symbol(cpool->signature_ref_at(index));
     return get_unloaded_method(holder, name, signature, accessor);
   } else {

--- a/src/hotspot/share/ci/ciField.cpp
+++ b/src/hotspot/share/ci/ciField.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "ci/ciField.hpp"
 #include "ci/ciInstanceKlass.hpp"
+#include "ci/ciSymbols.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "classfile/javaClasses.hpp"
 #include "classfile/systemDictionary.hpp"
@@ -218,7 +219,7 @@ ciField::ciField(fieldDescriptor *fd) :
 static bool trust_final_non_static_fields(ciInstanceKlass* holder) {
   if (holder == NULL)
     return false;
-  if (holder->name() == ciSymbol::java_lang_System())
+  if (holder->name() == ciSymbols::java_lang_System())
     // Never trust strangely unstable finals:  System.out, etc.
     return false;
   // Even if general trusting is disabled, trust system-built closures in these packages.
@@ -239,14 +240,14 @@ static bool trust_final_non_static_fields(ciInstanceKlass* holder) {
   if (holder->is_record())
     return true;
   // Trust final fields in String
-  if (holder->name() == ciSymbol::java_lang_String())
+  if (holder->name() == ciSymbols::java_lang_String())
     return true;
   // Trust Atomic*FieldUpdaters: they are very important for performance, and make up one
   // more reason not to use Unsafe, if their final fields are trusted. See more in JDK-8140483.
-  if (holder->name() == ciSymbol::java_util_concurrent_atomic_AtomicIntegerFieldUpdater_Impl() ||
-      holder->name() == ciSymbol::java_util_concurrent_atomic_AtomicLongFieldUpdater_CASUpdater() ||
-      holder->name() == ciSymbol::java_util_concurrent_atomic_AtomicLongFieldUpdater_LockedUpdater() ||
-      holder->name() == ciSymbol::java_util_concurrent_atomic_AtomicReferenceFieldUpdater_Impl()) {
+  if (holder->name() == ciSymbols::java_util_concurrent_atomic_AtomicIntegerFieldUpdater_Impl() ||
+      holder->name() == ciSymbols::java_util_concurrent_atomic_AtomicLongFieldUpdater_CASUpdater() ||
+      holder->name() == ciSymbols::java_util_concurrent_atomic_AtomicLongFieldUpdater_LockedUpdater() ||
+      holder->name() == ciSymbols::java_util_concurrent_atomic_AtomicReferenceFieldUpdater_Impl()) {
     return true;
   }
   return TrustFinalNonStaticFields;
@@ -415,6 +416,24 @@ bool ciField::will_link(ciMethod* accessing_method,
   }
 
   return true;
+}
+
+bool ciField::is_call_site_target() {
+  ciInstanceKlass* callsite_klass = CURRENT_ENV->CallSite_klass();
+  if (callsite_klass == NULL)
+    return false;
+  return (holder()->is_subclass_of(callsite_klass) && (name() == ciSymbols::target_name()));
+}
+
+bool ciField::is_autobox_cache() {
+  ciSymbol* klass_name = holder()->name();
+  return (name() == ciSymbols::cache_field_name() &&
+          holder()->uses_default_loader() &&
+          (klass_name == ciSymbols::java_lang_Character_CharacterCache() ||
+            klass_name == ciSymbols::java_lang_Byte_ByteCache() ||
+            klass_name == ciSymbols::java_lang_Short_ShortCache() ||
+            klass_name == ciSymbols::java_lang_Integer_IntegerCache() ||
+            klass_name == ciSymbols::java_lang_Long_LongCache()));
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciField.hpp
+++ b/src/hotspot/share/ci/ciField.hpp
@@ -178,23 +178,9 @@ public:
   // (or class/initializer methods if the field is static).
   bool has_initialized_final_update() const { return flags().has_initialized_final_update(); }
 
-  bool is_call_site_target() {
-    ciInstanceKlass* callsite_klass = CURRENT_ENV->CallSite_klass();
-    if (callsite_klass == NULL)
-      return false;
-    return (holder()->is_subclass_of(callsite_klass) && (name() == ciSymbol::target_name()));
-  }
+  bool is_call_site_target();
 
-  bool is_autobox_cache() {
-    ciSymbol* klass_name = holder()->name();
-    return (name() == ciSymbol::cache_field_name() &&
-            holder()->uses_default_loader() &&
-            (klass_name == ciSymbol::java_lang_Character_CharacterCache() ||
-             klass_name == ciSymbol::java_lang_Byte_ByteCache() ||
-             klass_name == ciSymbol::java_lang_Short_ShortCache() ||
-             klass_name == ciSymbol::java_lang_Integer_IntegerCache() ||
-             klass_name == ciSymbol::java_lang_Long_LongCache()));
-  }
+  bool is_autobox_cache();
 
   // Debugging output
   void print();

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -32,6 +32,7 @@
 #include "ci/ciStreams.hpp"
 #include "ci/ciSymbol.hpp"
 #include "ci/ciReplay.hpp"
+#include "ci/ciSymbols.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "compiler/abstractCompiler.hpp"
@@ -946,7 +947,7 @@ bool ciMethod::is_compiled_lambda_form() const {
 // ciMethod::is_object_initializer
 //
 bool ciMethod::is_object_initializer() const {
-   return name() == ciSymbol::object_initializer_name();
+   return name() == ciSymbols::object_initializer_name();
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -29,6 +29,7 @@
 #include "ci/ciInstanceKlass.hpp"
 #include "ci/ciObject.hpp"
 #include "ci/ciSignature.hpp"
+#include "classfile/vmIntrinsics.hpp"
 #include "compiler/methodLiveness.hpp"
 #include "runtime/handles.hpp"
 #include "utilities/bitMap.hpp"
@@ -75,7 +76,7 @@ class ciMethod : public ciMetadata {
   int _code_size;
   int _max_stack;
   int _max_locals;
-  vmIntrinsics::ID _intrinsic_id;
+  vmIntrinsicID _intrinsic_id;
   int _handler_count;
   int _nmethod_age;
   int _interpreter_invocation_count;
@@ -181,7 +182,7 @@ class ciMethod : public ciMetadata {
   int code_size() const                          { check_is_loaded(); return _code_size; }
   int max_stack() const                          { check_is_loaded(); return _max_stack; }
   int max_locals() const                         { check_is_loaded(); return _max_locals; }
-  vmIntrinsics::ID intrinsic_id() const          { check_is_loaded(); return _intrinsic_id; }
+  vmIntrinsicID intrinsic_id() const             { check_is_loaded(); return _intrinsic_id; }
   bool has_exception_handlers() const            { check_is_loaded(); return _handler_count > 0; }
   int exception_table_length() const             { check_is_loaded(); return _handler_count; }
   int interpreter_invocation_count() const       { check_is_loaded(); return _interpreter_invocation_count; }

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -38,6 +38,7 @@
 #include "ci/ciObject.hpp"
 #include "ci/ciObjectFactory.hpp"
 #include "ci/ciSymbol.hpp"
+#include "ci/ciSymbols.hpp"
 #include "ci/ciTypeArray.hpp"
 #include "ci/ciTypeArrayKlass.hpp"
 #include "ci/ciUtilities.inline.hpp"
@@ -136,7 +137,7 @@ void ciObjectFactory::init_shared_objects() {
       ciSymbol* sym = vm_symbol_at(index);
       assert(sym->get_symbol() == vmsym, "oop must match");
     }
-    assert(ciSymbol::void_class_signature()->get_symbol() == vmSymbols::void_class_signature(), "spot check");
+    assert(ciSymbols::void_class_signature()->get_symbol() == vmSymbols::void_class_signature(), "spot check");
 #endif
   }
 

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -122,8 +122,7 @@ void ciObjectFactory::init_shared_objects() {
 
   {
     // Create the shared symbols, but not in _shared_ci_metadata.
-    for (vmSymbolsIterator it = vmSymbolsRange.begin(); it != vmSymbolsRange.end(); ++it) {
-      vmSymbolID index = *it;
+    for (vmSymbolID index : EnumRange<vmSymbolID>{}) {
       Symbol* vmsym = vmSymbols::symbol_at(index);
       assert(vmSymbols::find_sid(vmsym) == index, "1-1 mapping");
       ciSymbol* sym = new (_arena) ciSymbol(vmsym, index);
@@ -131,8 +130,7 @@ void ciObjectFactory::init_shared_objects() {
       _shared_ci_symbols[vmSymbols::as_int(index)] = sym;
     }
 #ifdef ASSERT
-    for (vmSymbolsIterator it = vmSymbolsRange.begin(); it != vmSymbolsRange.end(); ++it) {
-      vmSymbolID index = *it;
+    for (vmSymbolID index : EnumRange<vmSymbolID>{}) {
       Symbol* vmsym = vmSymbols::symbol_at(index);
       ciSymbol* sym = vm_symbol_at(index);
       assert(sym->get_symbol() == vmsym, "oop must match");

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -27,6 +27,7 @@
 #include "ci/ciConstant.hpp"
 #include "ci/ciField.hpp"
 #include "ci/ciStreams.hpp"
+#include "ci/ciSymbols.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "runtime/handles.inline.hpp"
 
@@ -476,7 +477,7 @@ ciKlass* ciBytecodeStream::get_declared_method_holder() {
   bool ignore;
   // report as MethodHandle for invokedynamic, which is syntactically classless
   if (cur_bc() == Bytecodes::_invokedynamic)
-    return CURRENT_ENV->get_klass_by_name(_holder, ciSymbol::java_lang_invoke_MethodHandle(), false);
+    return CURRENT_ENV->get_klass_by_name(_holder, ciSymbols::java_lang_invoke_MethodHandle(), false);
   return CURRENT_ENV->get_klass_by_index(cpool, get_method_holder_index(), ignore, _holder);
 }
 

--- a/src/hotspot/share/ci/ciSymbol.cpp
+++ b/src/hotspot/share/ci/ciSymbol.cpp
@@ -24,8 +24,10 @@
 
 #include "precompiled.hpp"
 #include "ci/ciSymbol.hpp"
+#include "ci/ciSymbols.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "classfile/symbolTable.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "memory/oopFactory.hpp"
 #include "prims/methodHandles.hpp"
 
@@ -38,6 +40,8 @@ ciSymbol::ciSymbol(Symbol* s, vmSymbolID sid)
   _symbol->increment_refcount();  // increment ref count
   assert(sid_ok(), "sid must be consistent with vmSymbols");
 }
+
+DEBUG_ONLY(bool ciSymbol::sid_ok() { return vmSymbols::find_sid(get_symbol()) == _sid; })
 
 // ciSymbol
 //

--- a/src/hotspot/share/ci/ciSymbol.hpp
+++ b/src/hotspot/share/ci/ciSymbol.hpp
@@ -27,8 +27,6 @@
 
 #include "ci/ciBaseObject.hpp"
 #include "ci/ciObject.hpp"
-#include "ci/ciObjectFactory.hpp"
-#include "classfile/vmSymbols.hpp"
 #include "oops/symbol.hpp"
 #include "utilities/vmEnums.hpp"
 
@@ -50,9 +48,10 @@ class ciSymbol : public ciBaseObject {
 
 private:
   const vmSymbolID _sid;
-  DEBUG_ONLY( bool sid_ok() { return vmSymbols::find_sid(get_symbol()) == _sid; } )
 
-  ciSymbol(Symbol* s, vmSymbolID sid = vmSymbolID::NO_SID);
+  ciSymbol(Symbol* s, vmSymbolID sid);
+
+  DEBUG_ONLY(bool sid_ok();)
 
   Symbol* get_symbol() const { return _symbol; }
 
@@ -67,7 +66,7 @@ private:
   static ciSymbol* make_impl(const char* s);
 
 public:
-  // The enumeration ID from vmSymbols, or vmSymbols::NO_SID if none.
+  // The enumeration ID from vmSymbols, or vmSymbolID::NO_SID if none.
   vmSymbolID sid() const { return _sid; }
 
   // The text of the symbol as a null-terminated utf8 string.
@@ -96,11 +95,6 @@ public:
   // Consider adding to vmSymbols.hpp instead of using this constructor.
   // (Your code will be less subject to typographical bugs.)
   static ciSymbol* make(const char* s);
-
-#define CI_SYMBOL_DECLARE(name, ignore_def) \
-  static ciSymbol* name() { return ciObjectFactory::vm_symbol_at(VM_SYMBOL_ENUM_NAME(name)); }
-  VM_SYMBOLS_DO(CI_SYMBOL_DECLARE, CI_SYMBOL_DECLARE)
-#undef CI_SYMBOL_DECLARE
 
   void print() {
     _symbol->print();

--- a/src/hotspot/share/ci/ciSymbols.hpp
+++ b/src/hotspot/share/ci/ciSymbols.hpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_CI_CISYMBOLS_HPP
+#define SHARE_CI_CISYMBOLS_HPP
+
+#include "ci/ciObjectFactory.hpp"
+#include "ci/ciSymbol.hpp"
+#include "classfile/vmSymbols.hpp"
+#include "oops/symbol.hpp"
+
+class ciSymbols {
+ public:
+#define CI_SYMBOL_DECLARE(name, ignore_def) \
+  static ciSymbol* name() { return ciObjectFactory::vm_symbol_at(VM_SYMBOL_ENUM_NAME(name)); }
+
+  VM_SYMBOLS_DO(CI_SYMBOL_DECLARE, CI_SYMBOL_DECLARE)
+#undef CI_SYMBOL_DECLARE
+
+};
+
+#endif // SHARE_CI_CISYMBOLS_HPP

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5302,8 +5302,7 @@ static void check_methods_for_intrinsics(const InstanceKlass* ik,
       // The check is potentially expensive, therefore it is available
       // only in debug builds.
 
-      for (vmIntrinsicsIterator it = vmIntrinsicsRange.begin(); it != vmIntrinsicsRange.end(); ++it) {
-        vmIntrinsicID id = *it;
+      for (vmIntrinsicID id : EnumRange<vmIntrinsicID>{}) {
         if (vmIntrinsics::_compiledLambdaForm == id) {
           // The _compiledLamdbdaForm intrinsic is a special marker for bytecode
           // generated for the JVM from a LambdaForm and therefore no method

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -574,8 +574,7 @@ void vmIntrinsics::init_vm_intrinsic_name_table() {
   const char** nt = &vm_intrinsic_name_table[0];
   char* string = (char*) &vm_intrinsic_name_bodies[0];
 
-  for (vmIntrinsicsIterator it = vmIntrinsicsRange.begin(); it != vmIntrinsicsRange.end(); ++it) {
-    vmIntrinsicID index = *it;
+  for (vmIntrinsicID index : EnumRange<vmIntrinsicID>{}) {
     nt[as_int(index)] = string;
     string += strlen(string); // skip string body
     string += 1;              // skip trailing null
@@ -602,8 +601,7 @@ vmIntrinsics::ID vmIntrinsics::find_id(const char* name) {
     init_vm_intrinsic_name_table();
   }
 
-  for (vmIntrinsicsIterator it = vmIntrinsicsRange.begin(); it != vmIntrinsicsRange.end(); ++it) {
-    vmIntrinsicID index = *it;
+  for (vmIntrinsicID index : EnumRange<vmIntrinsicID>{}) {
     if (0 == strcmp(name, nt[as_int(index)])) {
       return index;
     }

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -1044,8 +1044,6 @@ enum class vmIntrinsicID : int {
 };
 
 ENUMERATOR_RANGE(vmIntrinsicID, vmIntrinsicID::FIRST_ID, vmIntrinsicID::LAST_ID)
-constexpr EnumRange<vmIntrinsicID> vmIntrinsicsRange; // the default range of all valid vmIntrinsicIDs
-using vmIntrinsicsIterator = EnumIterator<vmIntrinsicID>; // convenience
 
 class vmIntrinsics : AllStatic {
   friend class vmSymbols;

--- a/src/hotspot/share/classfile/vmSymbols.cpp
+++ b/src/hotspot/share/classfile/vmSymbols.cpp
@@ -83,8 +83,7 @@ void vmSymbols::initialize(TRAPS) {
 
   if (!UseSharedSpaces) {
     const char* string = &vm_symbol_bodies[0];
-    for (vmSymbolsIterator it = vmSymbolsRange.begin(); it != vmSymbolsRange.end(); ++it) {
-      vmSymbolID index = *it;
+    for (vmSymbolID index : EnumRange<vmSymbolID>{}) {
       Symbol* sym = SymbolTable::new_permanent_symbol(string);
       Symbol::_vm_symbols[as_int(index)] = sym;
       string += strlen(string); // skip string body
@@ -113,12 +112,11 @@ void vmSymbols::initialize(TRAPS) {
 
 #ifdef ASSERT
   // Check for duplicates:
-  for (vmSymbolsIterator it1 = vmSymbolsRange.begin(); it1 != vmSymbolsRange.end(); ++it1) {
-    vmSymbolID i1 = *it1;
+
+  for (vmSymbolID i1 : EnumRange<vmSymbolID>{}) {
     Symbol* sym = symbol_at(i1);
-    for (vmSymbolsIterator it2 = vmSymbolsRange.begin(); it2 != it1; ++it2) {
-      vmSymbolID i2 = *it2;
-      if (symbol_at(i2) == sym) {
+    for (vmSymbolID i2 : EnumRange<vmSymbolID>{vmSymbolID::FIRST_SID, i1}) {
+      if (i2 != i1 && symbol_at(i2) == sym) {
         tty->print("*** Duplicate VM symbol SIDs %s(%d) and %s(%d): \"",
                    vm_symbol_enum_name(i2), as_int(i2),
                    vm_symbol_enum_name(i1), as_int(i1));
@@ -131,8 +129,7 @@ void vmSymbols::initialize(TRAPS) {
 
   // Create an index for find_id:
   {
-    for (vmSymbolsIterator it = vmSymbolsRange.begin(); it != vmSymbolsRange.end(); ++it) {
-      vmSymbolID index = *it;
+    for (vmSymbolID index : EnumRange<vmSymbolID>{}) {
       vm_symbol_index[as_int(index)] = index;
     }
     int num_sids = SID_LIMIT-FIRST_SID;
@@ -153,8 +150,7 @@ void vmSymbols::initialize(TRAPS) {
     assert(symbol_at(sid) == jlo, "");
 
     // Make sure find_sid produces the right answer in each case.
-    for (vmSymbolsIterator it = vmSymbolsRange.begin(); it != vmSymbolsRange.end(); ++it) {
-      vmSymbolID index = *it;
+    for (vmSymbolID index : EnumRange<vmSymbolID>{}) {
       Symbol* sym = symbol_at(index);
       sid = find_sid(sym);
       assert(sid == index, "symbol index works");
@@ -178,8 +174,7 @@ const char* vmSymbols::name_for(vmSymbolID sid) {
   if (sid == vmSymbolID::NO_SID)
     return "NO_SID";
   const char* string = &vm_symbol_bodies[0];
-  for (vmSymbolsIterator it = vmSymbolsRange.begin(); it != vmSymbolsRange.end(); ++it) {
-    vmSymbolID index = *it;
+  for (vmSymbolID index : EnumRange<vmSymbolID>{}) {
     if (index == sid)
       return string;
     string += strlen(string); // skip string body
@@ -192,8 +187,7 @@ const char* vmSymbols::name_for(vmSymbolID sid) {
 
 
 void vmSymbols::symbols_do(SymbolClosure* f) {
-  for (vmSymbolsIterator it = vmSymbolsRange.begin(); it != vmSymbolsRange.end(); ++it) {
-    vmSymbolID index = *it;
+  for (vmSymbolID index : EnumRange<vmSymbolID>{}) {
     f->do_symbol(&Symbol::_vm_symbols[as_int(index)]);
   }
   for (int i = 0; i < T_VOID+1; i++) {
@@ -202,8 +196,7 @@ void vmSymbols::symbols_do(SymbolClosure* f) {
 }
 
 void vmSymbols::metaspace_pointers_do(MetaspaceClosure *closure) {
-  for (vmSymbolsIterator it = vmSymbolsRange.begin(); it != vmSymbolsRange.end(); ++it) {
-    vmSymbolID index = *it;
+  for (vmSymbolID index : EnumRange<vmSymbolID>{}) {
     closure->push(&Symbol::_vm_symbols[as_int(index)]);
   }
   for (int i = 0; i < T_VOID+1; i++) {
@@ -281,8 +274,7 @@ vmSymbolID vmSymbols::find_sid(const Symbol* symbol) {
     // Make sure this is the right answer, using linear search.
     // (We have already proven that there are no duplicates in the list.)
     vmSymbolID sid2 = vmSymbolID::NO_SID;
-    for (vmSymbolsIterator it = vmSymbolsRange.begin(); it != vmSymbolsRange.end(); ++it) {
-      vmSymbolID index = *it;
+    for (vmSymbolID index : EnumRange<vmSymbolID>{}) {
       Symbol* sym2 = symbol_at(index);
       if (sym2 == symbol) {
         sid2 = index;

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -722,8 +722,6 @@ enum class vmSymbolID : int {
 };
 
 ENUMERATOR_RANGE(vmSymbolID, vmSymbolID::FIRST_SID, vmSymbolID::LAST_SID)
-constexpr EnumRange<vmSymbolID> vmSymbolsRange; // the default range of all valid vmSymbolIDs
-using vmSymbolsIterator = EnumIterator<vmSymbolID>; // convenience
 
 class vmSymbols: AllStatic {
   friend class vmIntrinsics;

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_COMPILER_COMPILERDIRECTIVES_HPP
 #define SHARE_COMPILER_COMPILERDIRECTIVES_HPP
 
+#include "classfile/vmIntrinsics.hpp"
 #include "ci/ciMetadata.hpp"
 #include "ci/ciMethod.hpp"
 #include "compiler/methodMatcher.hpp"

--- a/src/hotspot/share/compiler/methodLiveness.cpp
+++ b/src/hotspot/share/compiler/methodLiveness.cpp
@@ -26,6 +26,7 @@
 #include "ci/ciMethod.hpp"
 #include "ci/ciMethodBlocks.hpp"
 #include "ci/ciStreams.hpp"
+#include "classfile/vmIntrinsics.hpp"
 #include "compiler/methodLiveness.hpp"
 #include "interpreter/bytecode.hpp"
 #include "interpreter/bytecodes.hpp"

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrType.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrType.cpp
@@ -138,11 +138,10 @@ static const char* flag_value_origin_to_string(JVMFlagOrigin origin) {
 }
 
 void FlagValueOriginConstant::serialize(JfrCheckpointWriter& writer) {
-  constexpr EnumRange<JVMFlagOrigin> range;
+  constexpr EnumRange<JVMFlagOrigin> range{};
   writer.write_count(static_cast<u4>(range.size()));
 
-  for (EnumIterator<JVMFlagOrigin> it = range.begin(); it != range.end(); ++it) {
-    JVMFlagOrigin origin = *it;
+  for (JVMFlagOrigin origin : range) {
     writer.write_key(static_cast<u4>(origin));
     writer.write(flag_value_origin_to_string(origin));
   }

--- a/src/hotspot/share/jvmci/compilerRuntime.cpp
+++ b/src/hotspot/share/jvmci/compilerRuntime.cpp
@@ -25,6 +25,7 @@
 #include "aot/aotLoader.hpp"
 #include "classfile/stringTable.hpp"
 #include "classfile/symbolTable.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "interpreter/linkResolver.hpp"
 #include "jvmci/compilerRuntime.hpp"

--- a/src/hotspot/share/jvmci/jvmciCompiler.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompiler.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "compiler/compileBroker.hpp"
 #include "classfile/moduleEntry.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "jvmci/jvmciEnv.hpp"
 #include "jvmci/jvmciRuntime.hpp"
 #include "oops/objArrayOop.inline.hpp"
@@ -40,6 +41,16 @@ JVMCICompiler::JVMCICompiler() : AbstractCompiler(compiler_jvmci) {
   _global_compilation_ticks = 0;
   assert(_instance == NULL, "only one instance allowed");
   _instance = this;
+}
+
+JVMCICompiler* JVMCICompiler::instance(bool require_non_null, TRAPS) {
+  if (!EnableJVMCI) {
+    THROW_MSG_NULL(vmSymbols::java_lang_InternalError(), "JVMCI is not enabled")
+  }
+  if (_instance == NULL && require_non_null) {
+    THROW_MSG_NULL(vmSymbols::java_lang_InternalError(), "The JVMCI compiler instance has not been created");
+  }
+  return _instance;
 }
 
 // Initialization

--- a/src/hotspot/share/jvmci/jvmciCompiler.hpp
+++ b/src/hotspot/share/jvmci/jvmciCompiler.hpp
@@ -58,15 +58,7 @@ private:
 public:
   JVMCICompiler();
 
-  static JVMCICompiler* instance(bool require_non_null, TRAPS) {
-    if (!EnableJVMCI) {
-      THROW_MSG_NULL(vmSymbols::java_lang_InternalError(), "JVMCI is not enabled")
-    }
-    if (_instance == NULL && require_non_null) {
-      THROW_MSG_NULL(vmSymbols::java_lang_InternalError(), "The JVMCI compiler instance has not been created");
-    }
-    return _instance;
-  }
+  static JVMCICompiler* instance(bool require_non_null, TRAPS);
 
   virtual const char* name() { return UseJVMCINativeLibrary ? "JVMCI-native" : "JVMCI"; }
 

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "ci/ciMethodData.hpp"
 #include "classfile/systemDictionary.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compilerOracle.hpp"
 #include "interpreter/bytecode.hpp"

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -234,8 +234,7 @@ void Compile::print_intrinsic_statistics() {
   if (total == 0)  total = 1;  // avoid div0 in case of no successes
   #define PRINT_STAT_LINE(name, c, f) \
     tty->print_cr("  %4d (%4.1f%%) %s (%s)", (int)(c), ((c) * 100.0) / total, name, f);
-  for (vmIntrinsicsIterator it = vmIntrinsicsRange.begin(); it != vmIntrinsicsRange.end(); ++it) {
-    vmIntrinsicID id = *it;
+  for (vmIntrinsicID id : EnumRange<vmIntrinsicID>{}) {
     int   flags = _intrinsic_hist_flags[as_int(id)];
     juint count = _intrinsic_hist_count[as_int(id)];
     if ((flags | count) != 0) {

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "ci/ciCallSite.hpp"
 #include "ci/ciMethodHandle.hpp"
+#include "ci/ciSymbols.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compileLog.hpp"
@@ -1120,7 +1121,7 @@ ciMethod* Compile::optimize_inlining(ciMethod* caller, ciInstanceKlass* klass,
     // finalize() call on array is not allowed.
     if (receiver_type->isa_aryptr() &&
         callee->holder() == env()->Object_klass() &&
-        callee->name() != ciSymbol::finalize_method_name()) {
+        callee->name() != ciSymbols::finalize_method_name()) {
       return callee;
     }
 

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -26,7 +26,7 @@
 #include "asm/macroAssembler.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "classfile/systemDictionary.hpp"
-#include "classfile/vmSymbols.hpp"
+#include "classfile/vmIntrinsics.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/compileLog.hpp"
 #include "gc/shared/barrierSet.hpp"
@@ -60,7 +60,7 @@
 
 //---------------------------make_vm_intrinsic----------------------------
 CallGenerator* Compile::make_vm_intrinsic(ciMethod* m, bool is_virtual) {
-  vmIntrinsics::ID id = m->intrinsic_id();
+  vmIntrinsicID id = m->intrinsic_id();
   assert(id != vmIntrinsics::_none, "must be a VM intrinsic");
 
   if (!m->is_loaded()) {
@@ -89,7 +89,7 @@ CallGenerator* Compile::make_vm_intrinsic(ciMethod* m, bool is_virtual) {
     return new LibraryIntrinsic(m, is_virtual,
                                 vmIntrinsics::predicates_needed(id),
                                 vmIntrinsics::does_virtual_dispatch(id),
-                                (vmIntrinsics::ID) id);
+                                id);
   } else {
     return NULL;
   }
@@ -672,7 +672,7 @@ bool LibraryCallKit::try_to_inline(int predicate) {
 
   default:
     // If you get here, it may be that someone has added a new intrinsic
-    // to the list in vmSymbols.hpp without implementing it here.
+    // to the list in vmIntrinsics.hpp without implementing it here.
 #ifndef PRODUCT
     if ((PrintMiscellaneous && (Verbose || WizardMode)) || PrintOpto) {
       tty->print_cr("*** Warning: Unimplemented intrinsic %s(%d)",
@@ -708,7 +708,7 @@ Node* LibraryCallKit::try_to_predicate(int predicate) {
 
   default:
     // If you get here, it may be that someone has added a new intrinsic
-    // to the list in vmSymbols.hpp without implementing it here.
+    // to the list in vmIntrinsics.hpp without implementing it here.
 #ifndef PRODUCT
     if ((PrintMiscellaneous && (Verbose || WizardMode)) || PrintOpto) {
       tty->print_cr("*** Warning: Unimplemented predicate for intrinsic %s(%d)",

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "ci/ciSymbols.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "compiler/compileLog.hpp"
 #include "oops/objArrayKlass.hpp"
@@ -245,7 +246,7 @@ void Parse::do_new() {
 
   // Should throw an InstantiationError?
   if (klass->is_abstract() || klass->is_interface() ||
-      klass->name() == ciSymbol::java_lang_Class() ||
+      klass->name() == ciSymbols::java_lang_Class() ||
       iter().is_unresolved_klass()) {
     uncommon_trap(Deoptimization::Reason_unhandled,
                   Deoptimization::Action_none,

--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "ci/ciSymbols.hpp"
 #include "classfile/javaClasses.hpp"
 #include "compiler/compileLog.hpp"
 #include "opto/addnode.hpp"
@@ -417,13 +418,13 @@ StringConcat* PhaseStringOpts::build_candidate(CallStaticJavaNode* call) {
   ciSymbol* int_sig;
   ciSymbol* char_sig;
   if (m->holder() == C->env()->StringBuilder_klass()) {
-    string_sig = ciSymbol::String_StringBuilder_signature();
-    int_sig = ciSymbol::int_StringBuilder_signature();
-    char_sig = ciSymbol::char_StringBuilder_signature();
+    string_sig = ciSymbols::String_StringBuilder_signature();
+    int_sig = ciSymbols::int_StringBuilder_signature();
+    char_sig = ciSymbols::char_StringBuilder_signature();
   } else if (m->holder() == C->env()->StringBuffer_klass()) {
-    string_sig = ciSymbol::String_StringBuffer_signature();
-    int_sig = ciSymbol::int_StringBuffer_signature();
-    char_sig = ciSymbol::char_StringBuffer_signature();
+    string_sig = ciSymbols::String_StringBuffer_signature();
+    int_sig = ciSymbols::int_StringBuffer_signature();
+    char_sig = ciSymbols::char_StringBuffer_signature();
   } else {
     return NULL;
   }
@@ -470,14 +471,14 @@ StringConcat* PhaseStringOpts::build_candidate(CallStaticJavaNode* call) {
         if (use != NULL &&
             use->method() != NULL &&
             !use->method()->is_static() &&
-            use->method()->name() == ciSymbol::object_initializer_name() &&
+            use->method()->name() == ciSymbols::object_initializer_name() &&
             use->method()->holder() == m->holder()) {
           // Matched the constructor.
           ciSymbol* sig = use->method()->signature()->as_symbol();
-          if (sig == ciSymbol::void_method_signature() ||
-              sig == ciSymbol::int_void_signature() ||
-              sig == ciSymbol::string_void_signature()) {
-            if (sig == ciSymbol::string_void_signature()) {
+          if (sig == ciSymbols::void_method_signature() ||
+              sig == ciSymbols::int_void_signature() ||
+              sig == ciSymbols::string_void_signature()) {
+            if (sig == ciSymbols::string_void_signature()) {
               // StringBuilder(String) so pick this up as the first argument
               assert(use->in(TypeFunc::Parms + 1) != NULL, "what?");
               const Type* type = _gvn->type(use->in(TypeFunc::Parms + 1));
@@ -534,7 +535,7 @@ StringConcat* PhaseStringOpts::build_candidate(CallStaticJavaNode* call) {
       break;
     } else if (!cnode->method()->is_static() &&
                cnode->method()->holder() == m->holder() &&
-               cnode->method()->name() == ciSymbol::append_name() &&
+               cnode->method()->name() == ciSymbols::append_name() &&
                (cnode->method()->signature()->as_symbol() == string_sig ||
                 cnode->method()->signature()->as_symbol() == char_sig ||
                 cnode->method()->signature()->as_symbol() == int_sig)) {
@@ -599,7 +600,7 @@ PhaseStringOpts::PhaseStringOpts(PhaseGVN* gvn, Unique_Node_List*):
   assert(OptimizeStringConcat, "shouldn't be here");
 
   size_table_field = C->env()->Integer_klass()->get_field_by_name(ciSymbol::make("sizeTable"),
-                                                                  ciSymbol::make("[I"), true);
+                                                                  ciSymbols::int_array_signature(), true);
   if (size_table_field == NULL) {
     // Something wrong so give up.
     assert(false, "why can't we find Integer.sizeTable?");

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "ci/ciSymbols.hpp"
 #include "opto/castnode.hpp"
 #include "opto/graphKit.hpp"
 #include "opto/phaseX.hpp"
@@ -358,8 +359,8 @@ Node* PhaseVector::expand_vbox_alloc_node(VectorBoxAllocateNode* vbox_alloc,
   Node* vec_obj = kit.new_instance(klass_node);
 
   // Store the allocated array into object.
-  ciField* field = ciEnv::current()->vector_VectorPayload_klass()->get_field_by_name(ciSymbol::payload_name(),
-                                                                                     ciSymbol::object_signature(),
+  ciField* field = ciEnv::current()->vector_VectorPayload_klass()->get_field_by_name(ciSymbols::payload_name(),
+                                                                                     ciSymbols::object_signature(),
                                                                                      false);
   assert(field != NULL, "");
   Node* vec_field = kit.basic_plus_adr(vec_obj, field->offset_in_bytes());
@@ -403,8 +404,8 @@ void PhaseVector::expand_vunbox_node(VectorUnboxNode* vec_unbox) {
       bt = T_BYTE;
     }
 
-    ciField* field = ciEnv::current()->vector_VectorPayload_klass()->get_field_by_name(ciSymbol::payload_name(),
-                                                                                       ciSymbol::object_signature(),
+    ciField* field = ciEnv::current()->vector_VectorPayload_klass()->get_field_by_name(ciSymbols::payload_name(),
+                                                                                       ciSymbols::object_signature(),
                                                                                        false);
     assert(field != NULL, "");
     int offset = field->offset_in_bytes();

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "ci/ciSymbols.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "opto/library_call.hpp"
 #include "opto/runtime.hpp"
@@ -40,14 +41,14 @@ static bool check_vbox(const TypeInstPtr* vbox_type) {
   ciInstanceKlass* ik = vbox_type->klass()->as_instance_klass();
   assert(is_vector(ik), "not a vector");
 
-  ciField* fd1 = ik->get_field_by_name(ciSymbol::ETYPE_name(), ciSymbol::class_signature(), /* is_static */ true);
+  ciField* fd1 = ik->get_field_by_name(ciSymbols::ETYPE_name(), ciSymbols::class_signature(), /* is_static */ true);
   assert(fd1 != NULL, "element type info is missing");
 
   ciConstant val1 = fd1->constant_value();
   BasicType elem_bt = val1.as_object()->as_instance()->java_mirror_type()->basic_type();
   assert(is_java_primitive(elem_bt), "element type info is missing");
 
-  ciField* fd2 = ik->get_field_by_name(ciSymbol::VLENGTH_name(), ciSymbol::int_signature(), /* is_static */ true);
+  ciField* fd2 = ik->get_field_by_name(ciSymbols::VLENGTH_name(), ciSymbols::int_signature(), /* is_static */ true);
   assert(fd2 != NULL, "vector length info is missing");
 
   ciConstant val2 = fd2->constant_value();

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -26,6 +26,7 @@
 #include "classfile/javaClasses.inline.hpp"
 #include "classfile/moduleEntry.hpp"
 #include "classfile/systemDictionary.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "code/nmethod.hpp"
 #include "code/pcDesc.hpp"
 #include "code/scopeDesc.hpp"

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -32,6 +32,7 @@
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "classfile/verifier.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "code/codeCache.hpp"
 #include "compiler/compileBroker.hpp"
 #include "interpreter/oopMapCache.hpp"

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -32,6 +32,7 @@
 #include "classfile/protectionDomainCache.hpp"
 #include "classfile/stringTable.hpp"
 #include "classfile/symbolTable.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "code/codeCache.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/methodMatcher.hpp"

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -36,6 +36,7 @@
 #include "classfile/stringTable.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "code/codeBlob.hpp"
 #include "code/codeCache.hpp"
 #include "code/compressedStream.hpp"

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/systemDictionary.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "gc/shared/oopStorageSet.hpp"
 #include "memory/allocation.hpp"
 #include "memory/heapInspection.hpp"

--- a/src/hotspot/share/utilities/enumIterator.hpp
+++ b/src/hotspot/share/utilities/enumIterator.hpp
@@ -57,20 +57,18 @@
 // EnumRange -- defines the range of *one specific* iteration loop.
 // EnumIterator -- the current point in the iteration loop.
 
-// Example (see vmSymbols.hpp/cpp)
+// Example:
 //
-// ENUMERATOR_RANGE(vmSymbolID, vmSymbolID::FIRST_SID, vmSymbolID::LAST_SID)
-// constexpr EnumRange<vmSymbolID> vmSymbolsRange;
-// using vmSymbolsIterator = EnumIterator<vmSymbolID>;
-//
-// /* Without range-based for, allowed */
-// for (vmSymbolsIterator it = vmSymbolsRange.begin(); it != vmSymbolsRange.end(); ++it) {
-//  vmSymbolID index = *it; ....
+// /* With range-base for (recommended) */
+// for (vmSymbolID index : EnumRange<vmSymbolID>{}) {
+//    ....
 // }
 //
-// /* With range-base for, not allowed by HotSpot coding style yet */
-// for (vmSymbolID index : vmSymbolsRange) {
-//    ....
+// /* Without range-based for */
+// constexpr EnumRange<vmSymbolID> vmSymbolsRange{};
+// using vmSymbolsIterator = EnumIterator<vmSymbolID>;
+// for (vmSymbolsIterator it = vmSymbolsRange.begin(); it != vmSymbolsRange.end(); ++it) {
+//  vmSymbolID index = *it; ....
 // }
 
 // EnumeratorRange is a traits type supporting iteration over the enumerators of T.

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -217,6 +217,12 @@ public abstract class Reader implements Readable, Closeable {
      * Reads characters into an array.  This method will block until some input
      * is available, an I/O error occurs, or the end of the stream is reached.
      *
+     * <p> If the length of {@code cbuf} is zero, then no characters are read
+     * and {@code 0} is returned; otherwise, there is an attempt to read at
+     * least one character.  If no character is available because the stream is
+     * at its end, the value {@code -1} is returned; otherwise, at least one
+     * character is read and stored into {@code cbuf}.
+     *
      * @param       cbuf  Destination buffer
      *
      * @return      The number of characters read, or -1
@@ -233,6 +239,12 @@ public abstract class Reader implements Readable, Closeable {
      * Reads characters into a portion of an array.  This method will block
      * until some input is available, an I/O error occurs, or the end of the
      * stream is reached.
+     *
+     * <p> If {@code len} is zero, then no characters are read and {@code 0} is
+     * returned; otherwise, there is an attempt to read at least one character.
+     * If no character is available because the stream is at its end, the value
+     * {@code -1} is returned; otherwise, at least one character is read and
+     * stored into {@code cbuf}.
      *
      * @param      cbuf  Destination buffer
      * @param      off   Offset at which to start storing characters

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -37,12 +37,12 @@ import java.util.Objects;
  *
  *
  * @see BufferedReader
- * @see   LineNumberReader
+ * @see LineNumberReader
  * @see CharArrayReader
  * @see InputStreamReader
- * @see   FileReader
+ * @see FileReader
  * @see FilterReader
- * @see   PushbackReader
+ * @see PushbackReader
  * @see PipedReader
  * @see StringReader
  * @see Writer

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -37,12 +37,12 @@ import java.util.Objects;
  *
  *
  * @see BufferedReader
- * @see LineNumberReader
+ * @see   LineNumberReader
  * @see CharArrayReader
  * @see InputStreamReader
- * @see FileReader
+ * @see   FileReader
  * @see FilterReader
- * @see PushbackReader
+ * @see   PushbackReader
  * @see PipedReader
  * @see StringReader
  * @see Writer

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
@@ -689,9 +689,7 @@ class WindowsPath implements Path {
             throw new IllegalArgumentException();
 
         StringBuilder sb = new StringBuilder();
-        Integer[] nelems = new Integer[endIndex - beginIndex];
         for (int i = beginIndex; i < endIndex; i++) {
-            nelems[i-beginIndex] = sb.length();
             sb.append(elementAsString(i));
             if (i != (endIndex-1))
                 sb.append("\\");

--- a/test/hotspot/gtest/utilities/test_enumIterator.cpp
+++ b/test/hotspot/gtest/utilities/test_enumIterator.cpp
@@ -110,3 +110,71 @@ TEST(TestEnumIterator, implicit_iterator) {
   }
   EXPECT_EQ(it, range.end());
 }
+
+TEST(TestEnumIterator, explict_range_based_for_loop_full) {
+  int i = explicit_start;
+  for (ExplicitTest value : EnumRange<ExplicitTest>{}) {
+    EXPECT_EQ(size_t(i - explicit_start), EnumRange<ExplicitTest>{}.index(value));
+    EXPECT_TRUE(value == ExplicitTest::value1 ||
+                value == ExplicitTest::value2 ||
+                value == ExplicitTest::value3);
+    ++i;
+  }
+}
+
+TEST(TestEnumIterator, explict_range_based_for_loop_start) {
+  constexpr EnumRange<ExplicitTest> range{ExplicitTest::value2};
+  int start = explicit_start + 2;
+  int i = start;
+  for (ExplicitTest value : range) {
+    EXPECT_EQ(size_t(i - start), range.index(value));
+    EXPECT_TRUE(value == ExplicitTest::value2 || value == ExplicitTest::value3);
+    EXPECT_TRUE(value != ExplicitTest::value1);
+    ++i;
+  }
+}
+
+TEST(TestEnumIterator, explict_range_based_for_loop_start_end) {
+  constexpr EnumRange<ExplicitTest> range{ExplicitTest::value1, ExplicitTest::value2};
+  int start = explicit_start + 1;
+  int i = start;
+  for (ExplicitTest value : range) {
+    EXPECT_EQ(size_t(i - start), range.index(value));
+    EXPECT_TRUE(value == ExplicitTest::value1 || value == ExplicitTest::value2);
+    EXPECT_TRUE(value != ExplicitTest::value3);
+    ++i;
+  }
+}
+
+TEST(TestEnumIterator, implicit_range_based_for_loop) {
+  int i = implicit_start;
+  for (ImplicitTest value : EnumRange<ImplicitTest>{}) {
+    EXPECT_EQ(size_t(i - implicit_start), EnumRange<ImplicitTest>{}.index(value));
+    ++i;
+  }
+}
+
+TEST(TestEnumIterator, implicit_range_based_for_loop_start) {
+  int start = implicit_start + 1;
+  EnumRange<ImplicitTest> range{static_cast<ImplicitTest>(start)};
+  int i = start;
+  for (ImplicitTest value : range) {
+    EXPECT_EQ(size_t(i - start), range.index(value));
+    int iv = static_cast<int>(value);
+    EXPECT_TRUE(start <= iv && iv <= implicit_end);
+    ++i;
+  }
+}
+
+TEST(TestEnumIterator, implicit_range_based_for_loop_start_end) {
+  int start = implicit_start + 1;
+  int end = implicit_end - 1;
+  EnumRange<ImplicitTest> range{static_cast<ImplicitTest>(start), static_cast<ImplicitTest>(end)};
+  int i = start;
+  for (ImplicitTest value : range) {
+    EXPECT_EQ(size_t(i - start), range.index(value));
+    int iv = static_cast<int>(value);
+    EXPECT_TRUE(start <= iv && iv <= end);
+    ++i;
+  }
+}

--- a/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclasses.jcod
+++ b/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclasses.jcod
@@ -239,7 +239,7 @@ class NoSubclasses {
 class SubClass {
   0xCAFEBABE;
   65535; // minor version
-  60; // version
+  61; // version
   [13] { // Constant Pool
     ; // first element is empty
     Method #2 #3; // #1     at 0x0A

--- a/test/jdk/java/io/Reader/ReadIntoZeroLengthArray.java
+++ b/test/jdk/java/io/Reader/ReadIntoZeroLengthArray.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.CharArrayReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.LineNumberReader;
+import java.io.PushbackReader;
+import java.io.Reader;
+import java.io.StringReader;
+
+/*
+ * @test
+ * @bug 8248383
+ * @summary Ensure that zero is returned for read into zero length array
+ */
+public class ReadIntoZeroLengthArray {
+    private static char[] cbuf0 = new char[0];
+    private static char[] cbuf1 = new char[1];
+
+    public static void main(String[] args) throws Exception {
+        File file = File.createTempFile("foo", "bar", new File("."));
+        file.deleteOnExit();
+
+        Reader fileReader = new FileReader(file);
+        Reader[] readers = new Reader[] {
+            new LineNumberReader(fileReader),
+            new CharArrayReader(new char[] {27}),
+            new PushbackReader(fileReader),
+            fileReader,
+            new StringReader(new String(new byte[] {(byte)42}))
+        };
+
+        for (Reader reader : readers) {
+            check(reader);
+        }
+
+        System.out.println("Test succeeded");
+    }
+
+    private static void check(Reader r) throws IOException {
+        System.out.printf("Testing %s%n", r.getClass().getName());
+        if (r.read(cbuf0) != 0)
+            throw new RuntimeException();
+        if (r.read(cbuf1, 0, 0) !=  0)
+            throw new RuntimeException();
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
@@ -684,7 +684,7 @@ public class TestHtmlTableTags extends JavadocTester {
         checkOutput("constant-values.html", true,
                 """
                     <div class="col-first even-row-color"><code id="pkg1.C1.CONSTANT1">public&nbsp;s\
-                    tatic&nbsp;final&nbsp;<a href="https://download.java.net/java/early_access/jdk16\
+                    tatic&nbsp;final&nbsp;<a href="https://download.java.net/java/early_access/jdk17\
                     /docs/api/java.base/java/lang/String.html" title="class or interface in java.lan\
                     g" class="external-link">String</a></code></div>
                     <div class="col-second even-row-color"><code><a href="pkg1/C1.html#CONSTANT1">CO\
@@ -815,7 +815,7 @@ public class TestHtmlTableTags extends JavadocTester {
         checkOutput("constant-values.html", true,
                 """
                     <div class="col-first even-row-color"><code id="pkg1.C1.CONSTANT1">public&nbsp;s\
-                    tatic&nbsp;final&nbsp;<a href="https://download.java.net/java/early_access/jdk16\
+                    tatic&nbsp;final&nbsp;<a href="https://download.java.net/java/early_access/jdk17\
                     /docs/api/java.base/java/lang/String.html" title="class or interface in java.lan\
                     g" class="external-link">String</a></code></div>
                     <div class="col-second even-row-color"><code><a href="pkg1/C1.html#CONSTANT1">CO\


### PR DESCRIPTION
Please review this small verbiage change to specify clearly the behavior of `Reader::read(char[] cbuf)` when the length of `cbuf` is zero, and that of `Reader::read(char[] cbuf, int off, int len)` when `len` is zero.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248383](https://bugs.openjdk.java.net/browse/JDK-8248383): Clarify java.io.Reader.read(char[], ...) behavior for full array


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to 0dc2e243f06c94f75db1363c66b4355dad3c6160
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1737/head:pull/1737`
`$ git checkout pull/1737`
