### PR TITLE
8258054: runtime/sealedClasses/GetPermittedSubclassesTest.java fails w/ jdk17

### DIFF
--- a/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclasses.jcod
+++ b/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclasses.jcod
@@ -239,7 +239,7 @@ class NoSubclasses {
 class SubClass {
   0xCAFEBABE;
   65535; // minor version
-  60; // version
+  61; // version
   [13] { // Constant Pool
     ; // first element is empty
     Method #2 #3; // #1     at 0x0A


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch which updates class file version in `test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclasses.jcod`? [8257450](https://bugs.openjdk.java.net/browse/JDK-8257450] has updated only one class defined by `GetPermittedSubclasses.jcod`, this patch updates the 2nd (out of 2).

testing: `runtime/sealedClasses/GetPermittedSubclassesTest.java`

-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258054](https://bugs.openjdk.java.net/browse/JDK-8258054): runtime/sealedClasses/GetPermittedSubclassesTest.java fails w/ jdk17


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1738/head:pull/1738`
`$ git checkout pull/1738`
