### PR TITLE
8258056: jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java fails against jdk17

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
@@ -684,7 +684,7 @@ public class TestHtmlTableTags extends JavadocTester {
         checkOutput("constant-values.html", true,
                 """
                     <div class="col-first even-row-color"><code id="pkg1.C1.CONSTANT1">public&nbsp;s\
-                    tatic&nbsp;final&nbsp;<a href="https://download.java.net/java/early_access/jdk16\
+                    tatic&nbsp;final&nbsp;<a href="https://download.java.net/java/early_access/jdk17\
                     /docs/api/java.base/java/lang/String.html" title="class or interface in java.lan\
                     g" class="external-link">String</a></code></div>
                     <div class="col-second even-row-color"><code><a href="pkg1/C1.html#CONSTANT1">CO\
@@ -815,7 +815,7 @@ public class TestHtmlTableTags extends JavadocTester {
         checkOutput("constant-values.html", true,
                 """
                     <div class="col-first even-row-color"><code id="pkg1.C1.CONSTANT1">public&nbsp;s\
-                    tatic&nbsp;final&nbsp;<a href="https://download.java.net/java/early_access/jdk16\
+                    tatic&nbsp;final&nbsp;<a href="https://download.java.net/java/early_access/jdk17\
                     /docs/api/java.base/java/lang/String.html" title="class or interface in java.lan\
                     g" class="external-link">String</a></code></div>
                     <div class="col-second even-row-color"><code><a href="pkg1/C1.html#CONSTANT1">CO\


### PR DESCRIPTION
Hi all,

could you pleaes review this small and trivial fix for `jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java` test? the test faled to find "https://download.java.net/java/early_access/jdk16/" string after we switched to jdk17, the patch is basically `s/jdk16/jdk17/g`.

testing: `test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258056](https://bugs.openjdk.java.net/browse/JDK-8258056): jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java fails against jdk17


### Reviewers
 * [Jesper Wilhelmsson](https://openjdk.java.net/census#jwilhelm) (@JesperIRL - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1739/head:pull/1739`
`$ git checkout pull/1739`
