### PR TITLE
8257964: Broken Calendar#getMinimalDaysInFirstWeek with java.locale.providers=HOST

### DIFF
--- a/src/java.base/windows/classes/sun/util/locale/provider/HostLocaleProviderAdapterImpl.java
+++ b/src/java.base/windows/classes/sun/util/locale/provider/HostLocaleProviderAdapterImpl.java
@@ -369,10 +369,11 @@ public class HostLocaleProviderAdapterImpl {
                 int firstWeek = getCalendarDataValue(
                         removeExtensions(locale).toLanguageTag(),
                         CD_FIRSTWEEKOFYEAR);
+                // Interpret the value from Windows LOCALE_IFIRSTWEEKOFYEAR setting
                 return switch (firstWeek) {
-                    case 1 -> 7;
-                    case 2 -> 4;
-                    default -> 1;
+                    case 1 -> 7; // First full week following 1/1 is the first week of the year.
+                    case 2 -> 4; // First week containing at least four days is the first week of the year.
+                    default -> 1; // First week can be a single day, if 1/1 falls on the last day of the week.
                 };
             }
         };

--- a/src/java.base/windows/classes/sun/util/locale/provider/HostLocaleProviderAdapterImpl.java
+++ b/src/java.base/windows/classes/sun/util/locale/provider/HostLocaleProviderAdapterImpl.java
@@ -75,7 +75,7 @@ public class HostLocaleProviderAdapterImpl {
 
     // CalendarData value types
     private static final int CD_FIRSTDAYOFWEEK = 0;
-    private static final int CD_MINIMALDAYSINFIRSTWEEK = 1;
+    private static final int CD_FIRSTWEEKOFYEAR = 1;
 
     // Currency/Locale display name types
     private static final int DN_CURRENCY_NAME   = 0;
@@ -366,7 +366,14 @@ public class HostLocaleProviderAdapterImpl {
 
             @Override
             public int getMinimalDaysInFirstWeek(Locale locale) {
-                return 0;
+                int firstWeek = getCalendarDataValue(
+                        removeExtensions(locale).toLanguageTag(),
+                        CD_FIRSTWEEKOFYEAR);
+                return switch (firstWeek) {
+                    case 1 -> 7;
+                    case 2 -> 4;
+                    default -> 1;
+                };
             }
         };
     }

--- a/src/java.base/windows/native/libjava/HostLocaleProviderAdapter_md.c
+++ b/src/java.base/windows/native/libjava/HostLocaleProviderAdapter_md.c
@@ -647,6 +647,11 @@ JNIEXPORT jint JNICALL Java_sun_util_locale_provider_HostLocaleProviderAdapterIm
             LOCALE_IFIRSTDAYOFWEEK | LOCALE_RETURN_NUMBER,
             (LPWSTR)&num, sizeof(num));
         break;
+    case sun_util_locale_provider_HostLocaleProviderAdapterImpl_CD_FIRSTWEEKOFYEAR:
+        got = getLocaleInfoWrapper(langtag,
+            LOCALE_IFIRSTWEEKOFYEAR | LOCALE_RETURN_NUMBER,
+            (LPWSTR)&num, sizeof(num));
+        break;
     }
 
     (*env)->ReleaseStringChars(env, jlangtag, langtag);

--- a/test/jdk/java/util/Locale/LocaleProvidersRun.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersRun.java
@@ -26,7 +26,7 @@
  * @bug 6336885 7196799 7197573 7198834 8000245 8000615 8001440 8008577
  *      8010666 8013086 8013233 8013903 8015960 8028771 8054482 8062006
  *      8150432 8215913 8220227 8228465 8232871 8232860 8236495 8245241
- *      8246721 8248695
+ *      8246721 8248695 8257964
  * @summary tests for "java.locale.providers" system property
  * @library /test/lib
  * @build LocaleProviders
@@ -172,6 +172,9 @@ public class LocaleProvidersRun {
 
         //testing 8248695 fix.
         testRun("HOST", "bug8248695Test", "", "", "");
+
+        //testing 8257964 fix. (macOS/Windows only)
+        testRun("HOST", "bug8257964Test", "", "", "");
     }
 
     private static void testRun(String prefList, String methodName,


### PR DESCRIPTION
Hello,

Please review the changes to the subject issue. getMinimalDaysInFirstWeek() for Windows has been implemented to suffice the bug claim.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257964](https://bugs.openjdk.java.net/browse/JDK-8257964): Broken Calendar#getMinimalDaysInFirstWeek with java.locale.providers=HOST


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to a9ea9f16bf18c07a083a6e56be4663a21ad85aa3


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1741/head:pull/1741`
`$ git checkout pull/1741`
