### PR TITLE
8258073: x86_32 build broken after JDK-8257731

### DIFF
--- a/src/hotspot/cpu/x86/jniFastGetField_x86_32.cpp
+++ b/src/hotspot/cpu/x86/jniFastGetField_x86_32.cpp
@@ -29,6 +29,7 @@
 #include "prims/jvm_misc.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "runtime/safepoint.hpp"
+#include "runtime/stubRoutines.hpp"
 
 #define __ masm->
 


### PR DESCRIPTION
Hi all,

Please review the one-line change for x86_32 build fix.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258073](https://bugs.openjdk.java.net/browse/JDK-8258073): x86_32 build broken after JDK-8257731


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1743/head:pull/1743`
`$ git checkout pull/1743`
