### PR TITLE
Epsilon: clean up unused includes

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
@@ -28,7 +28,6 @@
 #include "gc/shared/gcArguments.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
-#include "utilities/macros.hpp"
 
 size_t EpsilonArguments::conservative_max_heap_alignment() {
   return UseLargePages ? os::large_page_size() : os::vm_page_size();

--- a/src/hotspot/share/gc/epsilon/epsilonBarrierSet.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonBarrierSet.cpp
@@ -28,7 +28,6 @@
 #include "gc/epsilon/epsilonThreadLocalData.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
-#include "utilities/macros.hpp"
 #ifdef COMPILER1
 #include "gc/shared/c1/barrierSetC1.hpp"
 #endif


### PR DESCRIPTION
Hi all,

CLion IDE shows two warnings of unused includes(`#include "utilities/macros.hpp"`) in epsilon gc code. these maybe can be removed.

Testing: macosx-x86_64-server-{release,fastdebug,slowdebug}

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1744/head:pull/1744`
`$ git checkout pull/1744`
