### PR TITLE
8257229: gtest death tests fail with unrecognized stderr output

### DIFF
--- a/test/hotspot/gtest/unittest.hpp
+++ b/test/hotspot/gtest/unittest.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,7 +135,7 @@
   TEST(category, CONCAT(name, _vm_assert)) {                        \
     ASSERT_EXIT(child_ ## category ## _ ## name ## _(),             \
                 ::testing::ExitedWithCode(1),                       \
-                "^assert failed: " msg);                            \
+                "assert failed: " msg);                             \
   }                                                                 \
                                                                     \
   void test_ ## category ## _ ## name ## _()


### PR DESCRIPTION
The regexp used by the TEST_VM_ASSERT_MSG macro is too restrictive. It shouldn't require that "assert failed" to be the very beginning of the VM output. Note that the other macro, TEST_VM_ASSERT, does not have the "^" in its regexp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257229](https://bugs.openjdk.java.net/browse/JDK-8257229): gtest death tests fail with unrecognized stderr output


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1748/head:pull/1748`
`$ git checkout pull/1748`
