### PR TITLE
8258057: serviceability/attach/RemovingUnixDomainSocketTest.java doesn't ignore VM warnings

### DIFF
--- a/test/hotspot/jtreg/serviceability/attach/RemovingUnixDomainSocketTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/RemovingUnixDomainSocketTest.java
@@ -51,7 +51,8 @@ public class RemovingUnixDomainSocketTest {
         jcmd.addToolArg(Long.toString(pid));
         jcmd.addToolArg("VM.version");
 
-        Process jcmdProc = ProcessTools.startProcess("jcmd", new ProcessBuilder(jcmd.getCommand()));
+        ProcessBuilder pb = new ProcessBuilder(jcmd.getCommand());
+        Process jcmdProc = pb.start();
 
         OutputAnalyzer out = new OutputAnalyzer(jcmdProc);
 
@@ -66,7 +67,7 @@ public class RemovingUnixDomainSocketTest {
             "jcmd  exitValue = " + out.getExitValue());
 
         out.shouldHaveExitValue(0);
-        out.stderrShouldBeEmptyIgnoreVMWarnings();
+        out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
     }
 
     public static void main(String... args) throws Exception {

--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -40,7 +40,7 @@ public final class OutputAnalyzer {
 
     private static final String jvmwarningmsg = ".* VM warning:.*";
 
-    private static final String deprecatedmsg = ".* deprecated.*";
+    private static final String deprecatedmsg = ".* VM warning:.* deprecated.*";
 
     private final OutputBuffer buffer;
     /**

--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -40,6 +40,8 @@ public final class OutputAnalyzer {
 
     private static final String jvmwarningmsg = ".* VM warning:.*";
 
+    private static final String deprecatedmsg = ".* deprecated.*";
+
     private final OutputBuffer buffer;
     /**
      * Create an OutputAnalyzer, a utility class for verifying output and exit
@@ -141,6 +143,21 @@ public final class OutputAnalyzer {
      */
     public OutputAnalyzer stderrShouldBeEmptyIgnoreVMWarnings() {
         if (!getStderr().replaceAll(jvmwarningmsg + "\\R", "").isEmpty()) {
+            reportDiagnosticSummary();
+            throw new RuntimeException("stderr was not empty");
+        }
+        return this;
+    }
+
+    /**
+     * Verify that the stderr contents of output buffer is empty,
+     * after filtering out the Hotspot deprecation warning messages
+     *
+     * @throws RuntimeException
+     *             If stderr was not empty
+     */
+    public OutputAnalyzer stderrShouldBeEmptyIgnoreDeprecatedWarnings() {
+        if (!getStderr().replaceAll(deprecatedmsg + "\\R", "").isEmpty()) {
             reportDiagnosticSummary();
             throw new RuntimeException("stderr was not empty");
         }


### PR DESCRIPTION
Hi,

Please review the following small fix for test RemovingUnixDomainSocketTest.java. As explained in the bug comments, the issue is due to having two different StreamPumper objects consuming from the same stderr, one created by ProcessTools.startProcess() and another by OutputAnalyzer(). In the failing cases the StreamPumper processing thread created in ProcessTools.startProcess() consumes the first part of the deprecation message while the one created in OutputAnalyzer consumes the rest. Since out.getStderr() is not empty and does not contain the string "VM warning:", the test fails.

I simply replaced the ProcessTools.startProcess() call by a call to start() on the ProcessBuilder object, which doesn't use StreamPumper. I added stderrShouldBeEmptyIgnoreDeprecatedWarnings(), since as mentioned in 8248162 we might not want to hide all warning messages.

Without the patch I can consistently reproduce the issue. With the patch the test always passes.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258057](https://bugs.openjdk.java.net/browse/JDK-8258057): serviceability/attach/RemovingUnixDomainSocketTest.java doesn't ignore VM warnings


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to 6e03341b915ec7b75c3fc551022d4f79b2dfe7c1
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to 6e03341b915ec7b75c3fc551022d4f79b2dfe7c1
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1749/head:pull/1749`
`$ git checkout pull/1749`
