### PR TITLE
8258134: assert(size == calc_size) failed: incorrect size calculation on x86_32 with AVX512 machines

### DIFF
--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -951,35 +951,10 @@ static int vec_mov_helper(CodeBuffer *cbuf, bool do_size, int src_lo, int dst_lo
 static int vec_spill_helper(CodeBuffer *cbuf, bool do_size, bool is_load,
                             int stack_offset, int reg, uint ireg, outputStream* st);
 
-static int vec_stack_to_stack_helper(CodeBuffer *cbuf, bool do_size, int src_offset,
+static void vec_stack_to_stack_helper(CodeBuffer *cbuf, int src_offset,
                                      int dst_offset, uint ireg, outputStream* st) {
-  int calc_size = 0;
-  int src_offset_size = (src_offset == 0) ? 0 : ((src_offset < 0x80) ? 1 : 4);
-  int dst_offset_size = (dst_offset == 0) ? 0 : ((dst_offset < 0x80) ? 1 : 4);
-  switch (ireg) {
-  case Op_VecS:
-    calc_size = 3+src_offset_size + 3+dst_offset_size;
-    break;
-  case Op_VecD: {
-    calc_size = 3+src_offset_size + 3+dst_offset_size;
-    int tmp_src_offset = src_offset + 4;
-    int tmp_dst_offset = dst_offset + 4;
-    src_offset_size = (tmp_src_offset == 0) ? 0 : ((tmp_src_offset < 0x80) ? 1 : 4);
-    dst_offset_size = (tmp_dst_offset == 0) ? 0 : ((tmp_dst_offset < 0x80) ? 1 : 4);
-    calc_size += 3+src_offset_size + 3+dst_offset_size;
-    break;
-  }
-  case Op_VecX:
-  case Op_VecY:
-  case Op_VecZ:
-    calc_size = 6 + 6 + 5+src_offset_size + 5+dst_offset_size;
-    break;
-  default:
-    ShouldNotReachHere();
-  }
   if (cbuf) {
     MacroAssembler _masm(cbuf);
-    int offset = __ offset();
     switch (ireg) {
     case Op_VecS:
       __ pushl(Address(rsp, src_offset));
@@ -1012,11 +987,8 @@ static int vec_stack_to_stack_helper(CodeBuffer *cbuf, bool do_size, int src_off
     default:
       ShouldNotReachHere();
     }
-    int size = __ offset() - offset;
-    assert(size == calc_size, "incorrect size calculation");
-    return size;
 #ifndef PRODUCT
-  } else if (!do_size) {
+  } else {
     switch (ireg) {
     case Op_VecS:
       st->print("pushl   [rsp + #%d]\t# 32-bit mem-mem spill\n\t"
@@ -1056,7 +1028,6 @@ static int vec_stack_to_stack_helper(CodeBuffer *cbuf, bool do_size, int src_off
     }
 #endif
   }
-  return calc_size;
 }
 
 uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bool do_size, outputStream* st ) const {
@@ -1088,18 +1059,19 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
       // mem -> mem
       int src_offset = ra_->reg2offset(src_first);
       int dst_offset = ra_->reg2offset(dst_first);
-      return vec_stack_to_stack_helper(cbuf, do_size, src_offset, dst_offset, ireg, st);
+      vec_stack_to_stack_helper(cbuf, src_offset, dst_offset, ireg, st);
     } else if (src_first_rc == rc_xmm && dst_first_rc == rc_xmm ) {
-      return vec_mov_helper(cbuf, do_size, src_first, dst_first, src_second, dst_second, ireg, st);
+      vec_mov_helper(cbuf, do_size, src_first, dst_first, src_second, dst_second, ireg, st);
     } else if (src_first_rc == rc_xmm && dst_first_rc == rc_stack ) {
       int stack_offset = ra_->reg2offset(dst_first);
-      return vec_spill_helper(cbuf, do_size, false, stack_offset, src_first, ireg, st);
+      vec_spill_helper(cbuf, do_size, false, stack_offset, src_first, ireg, st);
     } else if (src_first_rc == rc_stack && dst_first_rc == rc_xmm ) {
       int stack_offset = ra_->reg2offset(src_first);
-      return vec_spill_helper(cbuf, do_size, true,  stack_offset, dst_first, ireg, st);
+      vec_spill_helper(cbuf, do_size, true,  stack_offset, dst_first, ireg, st);
     } else {
       ShouldNotReachHere();
     }
+    return 0;
   }
 
   // --------------------------------------


### PR DESCRIPTION
Hi all,

Two vector api tests crashed on x86_32 with AVX512 machines due to this assert [1].
The reason is that 'calc_size' is incorrect.

But there is no need to calculate 'calc_size' manually at all since the result [2] is actually never used by the VM.
Also, it is really hard to maintain the calculation logic for various hardwares and configurations.
And it may be easily broken again in the future with more and more complicated instructions & configurations.

So it would be better to remove the calculation and the assert, which is safe and already done for x86_64 [3].
The fix just follows what is done for x86_64.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/x86_32.ad#L1016
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/x86_32.ad#L1059
[3] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/x86_64.ad#L1042

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258134](https://bugs.openjdk.java.net/browse/JDK-8258134): assert(size == calc_size) failed: incorrect size calculation on x86_32 with AVX512 machines


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1753/head:pull/1753`
`$ git checkout pull/1753`
