### PR TITLE
8257457: Update --release 16 symbol information for JDK 16 build 28

### DIFF
--- a/make/data/symbols/java.base-G.sym.txt
+++ b/make/data/symbols/java.base-G.sym.txt
@@ -36,24 +36,40 @@ innerclass innerClass java/util/Spliterator$OfInt outerClass java/util/Spliterat
 innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
 
 class name java/lang/Boolean
+header extends java/lang/Object implements java/io/Serializable,java/lang/Comparable,java/lang/constant/Constable flags 31 signature Ljava/lang/Object;Ljava/io/Serializable;Ljava/lang/Comparable<Ljava/lang/Boolean;>;Ljava/lang/constant/Constable; runtimeAnnotations @Ljdk/internal/ValueBased;
+-method name <init> descriptor (Z)V
+-method name <init> descriptor (Ljava/lang/String;)V
 -method name booleanValue descriptor ()Z
 -method name valueOf descriptor (Z)Ljava/lang/Boolean;
 method name booleanValue descriptor ()Z flags 1 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name valueOf descriptor (Z)Ljava/lang/Boolean; flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
+method name <init> descriptor (Z)V flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
+method name <init> descriptor (Ljava/lang/String;)V flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
 
 class name java/lang/Byte
+header extends java/lang/Number implements java/lang/Comparable,java/lang/constant/Constable flags 31 signature Ljava/lang/Number;Ljava/lang/Comparable<Ljava/lang/Byte;>;Ljava/lang/constant/Constable; runtimeAnnotations @Ljdk/internal/ValueBased;
 -method name valueOf descriptor (B)Ljava/lang/Byte;
+-method name <init> descriptor (B)V
+-method name <init> descriptor (Ljava/lang/String;)V
 -method name byteValue descriptor ()B
 method name valueOf descriptor (B)Ljava/lang/Byte; flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name byteValue descriptor ()B flags 1 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
+method name <init> descriptor (B)V flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
+method name <init> descriptor (Ljava/lang/String;)V thrownTypes java/lang/NumberFormatException flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
 
 class name java/lang/Character
+header extends java/lang/Object implements java/io/Serializable,java/lang/Comparable,java/lang/constant/Constable nestMembers java/lang/Character$UnicodeScript,java/lang/Character$UnicodeBlock,java/lang/Character$Subset flags 31 signature Ljava/lang/Object;Ljava/io/Serializable;Ljava/lang/Comparable<Ljava/lang/Character;>;Ljava/lang/constant/Constable; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/Character$UnicodeBlock outerClass java/lang/Character innerClassName UnicodeBlock flags 19
+innerclass innerClass java/lang/Character$UnicodeScript outerClass java/lang/Character innerClassName UnicodeScript flags 4019
+innerclass innerClass java/lang/Character$Subset outerClass java/lang/Character innerClassName Subset flags 9
+-method name <init> descriptor (C)V
 -method name valueOf descriptor (C)Ljava/lang/Character;
 -method name charValue descriptor ()C
 -method name reverseBytes descriptor (C)C
 method name valueOf descriptor (C)Ljava/lang/Character; flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name charValue descriptor ()C flags 1 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name reverseBytes descriptor (C)C flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
+method name <init> descriptor (C)V flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
 
 class name java/lang/Class
 -method name isInstance descriptor (Ljava/lang/Object;)Z
@@ -67,6 +83,7 @@ class name java/lang/Class
 -method name getRecordComponents descriptor ()[Ljava/lang/reflect/RecordComponent;
 -method name isRecord descriptor ()Z
 -method name isHidden descriptor ()Z
+-method name permittedSubclasses descriptor ()[Ljava/lang/constant/ClassDesc;
 method name isInstance descriptor (Ljava/lang/Object;)Z flags 101 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name isAssignableFrom descriptor (Ljava/lang/Class;)Z flags 101 signature (Ljava/lang/Class<*>;)Z runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name isInterface descriptor ()Z flags 101 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
@@ -78,6 +95,7 @@ method name getRecordComponents descriptor ()[Ljava/lang/reflect/RecordComponent
 method name isRecord descriptor ()Z flags 1
 method name cast descriptor (Ljava/lang/Object;)Ljava/lang/Object; flags 1 signature (Ljava/lang/Object;)TT; runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name isHidden descriptor ()Z flags 101 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
+method name getPermittedSubclasses descriptor ()[Ljava/lang/Class; flags 1 signature ()[Ljava/lang/Class<*>; classAnnotations @Ljdk/internal/PreviewFeature;(feature=eLjdk/internal/PreviewFeature$Feature;SEALED_CLASSES;,essentialAPI=Zfalse) runtimeAnnotations @Ljdk/internal/reflect/CallerSensitive;
 
 class name java/lang/Compiler
 header extends java/lang/Object flags 31 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
@@ -86,7 +104,11 @@ class name java/lang/Deprecated
 header extends java/lang/Object implements java/lang/annotation/Annotation flags 2601 runtimeAnnotations @Ljava/lang/annotation/Documented;@Ljava/lang/annotation/Retention;(value=eLjava/lang/annotation/RetentionPolicy;RUNTIME;)@Ljava/lang/annotation/Target;(value={eLjava/lang/annotation/ElementType;CONSTRUCTOR;eLjava/lang/annotation/ElementType;FIELD;eLjava/lang/annotation/ElementType;LOCAL_VARIABLE;eLjava/lang/annotation/ElementType;METHOD;eLjava/lang/annotation/ElementType;PACKAGE;eLjava/lang/annotation/ElementType;MODULE;eLjava/lang/annotation/ElementType;PARAMETER;eLjava/lang/annotation/ElementType;TYPE;})
 
 class name java/lang/Double
+header extends java/lang/Number implements java/lang/Comparable,java/lang/constant/Constable,java/lang/constant/ConstantDesc flags 31 signature Ljava/lang/Number;Ljava/lang/Comparable<Ljava/lang/Double;>;Ljava/lang/constant/Constable;Ljava/lang/constant/ConstantDesc; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
 -method name valueOf descriptor (D)Ljava/lang/Double;
+-method name <init> descriptor (D)V
+-method name <init> descriptor (Ljava/lang/String;)V
 -method name doubleValue descriptor ()D
 -method name doubleToLongBits descriptor (D)J
 -method name doubleToRawLongBits descriptor (D)J
@@ -96,9 +118,16 @@ method name doubleValue descriptor ()D flags 1 runtimeAnnotations @Ljdk/internal
 method name doubleToLongBits descriptor (D)J flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name doubleToRawLongBits descriptor (D)J flags 109 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name longBitsToDouble descriptor (J)D flags 109 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
+method name <init> descriptor (D)V flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
+method name <init> descriptor (Ljava/lang/String;)V thrownTypes java/lang/NumberFormatException flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
 
 class name java/lang/Float
+header extends java/lang/Number implements java/lang/Comparable,java/lang/constant/Constable,java/lang/constant/ConstantDesc flags 31 signature Ljava/lang/Number;Ljava/lang/Comparable<Ljava/lang/Float;>;Ljava/lang/constant/Constable;Ljava/lang/constant/ConstantDesc; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
 -method name valueOf descriptor (F)Ljava/lang/Float;
+-method name <init> descriptor (F)V
+-method name <init> descriptor (D)V
+-method name <init> descriptor (Ljava/lang/String;)V
 -method name floatValue descriptor ()F
 -method name floatToIntBits descriptor (F)I
 -method name floatToRawIntBits descriptor (F)I
@@ -108,6 +137,9 @@ method name floatValue descriptor ()F flags 1 runtimeAnnotations @Ljdk/internal/
 method name floatToIntBits descriptor (F)I flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name floatToRawIntBits descriptor (F)I flags 109 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name intBitsToFloat descriptor (I)F flags 109 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
+method name <init> descriptor (F)V flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
+method name <init> descriptor (D)V flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
+method name <init> descriptor (Ljava/lang/String;)V thrownTypes java/lang/NumberFormatException flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
 
 class name java/lang/IllegalCallerException
 header extends java/lang/RuntimeException flags 21
@@ -116,8 +148,12 @@ class name java/lang/IndexOutOfBoundsException
 method name <init> descriptor (J)V flags 1
 
 class name java/lang/Integer
+header extends java/lang/Number implements java/lang/Comparable,java/lang/constant/Constable,java/lang/constant/ConstantDesc flags 31 signature Ljava/lang/Number;Ljava/lang/Comparable<Ljava/lang/Integer;>;Ljava/lang/constant/Constable;Ljava/lang/constant/ConstantDesc; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
 -method name toString descriptor (I)Ljava/lang/String;
 -method name valueOf descriptor (I)Ljava/lang/Integer;
+-method name <init> descriptor (I)V
+-method name <init> descriptor (Ljava/lang/String;)V
 -method name intValue descriptor ()I
 -method name numberOfLeadingZeros descriptor (I)I
 -method name numberOfTrailingZeros descriptor (I)I
@@ -130,12 +166,18 @@ method name numberOfLeadingZeros descriptor (I)I flags 9 runtimeAnnotations @Ljd
 method name numberOfTrailingZeros descriptor (I)I flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name bitCount descriptor (I)I flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name reverseBytes descriptor (I)I flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
+method name <init> descriptor (I)V flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
+method name <init> descriptor (Ljava/lang/String;)V thrownTypes java/lang/NumberFormatException flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
 
 class name java/lang/LayerInstantiationException
 header extends java/lang/RuntimeException flags 21
 
 class name java/lang/Long
+header extends java/lang/Number implements java/lang/Comparable,java/lang/constant/Constable,java/lang/constant/ConstantDesc flags 31 signature Ljava/lang/Number;Ljava/lang/Comparable<Ljava/lang/Long;>;Ljava/lang/constant/Constable;Ljava/lang/constant/ConstantDesc; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
 -method name valueOf descriptor (J)Ljava/lang/Long;
+-method name <init> descriptor (J)V
+-method name <init> descriptor (Ljava/lang/String;)V
 -method name longValue descriptor ()J
 -method name numberOfLeadingZeros descriptor (J)I
 -method name numberOfTrailingZeros descriptor (J)I
@@ -147,6 +189,8 @@ method name numberOfLeadingZeros descriptor (J)I flags 9 runtimeAnnotations @Ljd
 method name numberOfTrailingZeros descriptor (J)I flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name bitCount descriptor (J)I flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name reverseBytes descriptor (J)J flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
+method name <init> descriptor (J)V flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
+method name <init> descriptor (Ljava/lang/String;)V thrownTypes java/lang/NumberFormatException flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
 
 class name java/lang/Math
 -method name signum descriptor (D)D
@@ -249,16 +293,30 @@ method name clone descriptor ()Ljava/lang/Object; thrownTypes java/lang/CloneNot
 method name notify descriptor ()V flags 111 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name notifyAll descriptor ()V flags 111 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 
+class name java/lang/ProcessHandle
+header extends java/lang/Object implements java/lang/Comparable nestMembers java/lang/ProcessHandle$Info flags 601 signature Ljava/lang/Object;Ljava/lang/Comparable<Ljava/lang/ProcessHandle;>; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/ProcessHandle$Info outerClass java/lang/ProcessHandle innerClassName Info flags 609
+
 class name java/lang/Record
 header extends java/lang/Object flags 421
 
+class name java/lang/Runtime$Version
+header extends java/lang/Object implements java/lang/Comparable nestHost java/lang/Runtime flags 31 signature Ljava/lang/Object;Ljava/lang/Comparable<Ljava/lang/Runtime$Version;>; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/Runtime$Version outerClass java/lang/Runtime innerClassName Version flags 19
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
 class name java/lang/Short
+header extends java/lang/Number implements java/lang/Comparable,java/lang/constant/Constable flags 31 signature Ljava/lang/Number;Ljava/lang/Comparable<Ljava/lang/Short;>;Ljava/lang/constant/Constable; runtimeAnnotations @Ljdk/internal/ValueBased;
 -method name valueOf descriptor (S)Ljava/lang/Short;
+-method name <init> descriptor (S)V
+-method name <init> descriptor (Ljava/lang/String;)V
 -method name shortValue descriptor ()S
 -method name reverseBytes descriptor (S)S
 method name valueOf descriptor (S)Ljava/lang/Short; flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name shortValue descriptor ()S flags 1 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name reverseBytes descriptor (S)S flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
+method name <init> descriptor (S)V flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
+method name <init> descriptor (Ljava/lang/String;)V thrownTypes java/lang/NumberFormatException flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="9")
 
 class name java/lang/StrictMath
 -method name sqrt descriptor (D)D
@@ -480,9 +538,11 @@ class name java/lang/module/ResolvedModule
 header extends java/lang/Object flags 31
 
 class name java/lang/ref/Reference
+-method name isEnqueued descriptor ()Z
 -method name get descriptor ()Ljava/lang/Object;
 method name get descriptor ()Ljava/lang/Object; flags 1 signature ()TT; runtimeAnnotations @Ljdk/internal/vm/annotation/IntrinsicCandidate;
 method name refersTo descriptor (Ljava/lang/Object;)Z flags 11 signature (TT;)Z
+method name isEnqueued descriptor ()Z flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(since="16")
 
 class name java/lang/reflect/AccessibleObject
 header extends java/lang/Object implements java/lang/reflect/AnnotatedElement flags 21
@@ -655,6 +715,59 @@ class name java/text/RuleBasedCollator
 header extends java/text/Collator flags 21
 innerclass innerClass java/text/Normalizer$Form outerClass java/text/Normalizer innerClassName Form flags 4019
 
+class name java/time/Duration
+header extends java/lang/Object implements java/time/temporal/TemporalAmount,java/lang/Comparable,java/io/Serializable flags 31 signature Ljava/lang/Object;Ljava/time/temporal/TemporalAmount;Ljava/lang/Comparable<Ljava/time/Duration;>;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+
+class name java/time/Instant
+header extends java/lang/Object implements java/time/temporal/Temporal,java/time/temporal/TemporalAdjuster,java/lang/Comparable,java/io/Serializable flags 31 signature Ljava/lang/Object;Ljava/time/temporal/Temporal;Ljava/time/temporal/TemporalAdjuster;Ljava/lang/Comparable<Ljava/time/Instant;>;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
+class name java/time/LocalDate
+header extends java/lang/Object implements java/time/temporal/Temporal,java/time/temporal/TemporalAdjuster,java/time/chrono/ChronoLocalDate,java/io/Serializable flags 31 runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
+class name java/time/LocalDateTime
+header extends java/lang/Object implements java/time/temporal/Temporal,java/time/temporal/TemporalAdjuster,java/time/chrono/ChronoLocalDateTime,java/io/Serializable flags 31 signature Ljava/lang/Object;Ljava/time/temporal/Temporal;Ljava/time/temporal/TemporalAdjuster;Ljava/time/chrono/ChronoLocalDateTime<Ljava/time/LocalDate;>;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
+class name java/time/LocalTime
+header extends java/lang/Object implements java/time/temporal/Temporal,java/time/temporal/TemporalAdjuster,java/lang/Comparable,java/io/Serializable flags 31 signature Ljava/lang/Object;Ljava/time/temporal/Temporal;Ljava/time/temporal/TemporalAdjuster;Ljava/lang/Comparable<Ljava/time/LocalTime;>;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
+class name java/time/MonthDay
+header extends java/lang/Object implements java/time/temporal/TemporalAccessor,java/time/temporal/TemporalAdjuster,java/lang/Comparable,java/io/Serializable flags 31 signature Ljava/lang/Object;Ljava/time/temporal/TemporalAccessor;Ljava/time/temporal/TemporalAdjuster;Ljava/lang/Comparable<Ljava/time/MonthDay;>;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
+class name java/time/OffsetDateTime
+header extends java/lang/Object implements java/time/temporal/Temporal,java/time/temporal/TemporalAdjuster,java/lang/Comparable,java/io/Serializable flags 31 signature Ljava/lang/Object;Ljava/time/temporal/Temporal;Ljava/time/temporal/TemporalAdjuster;Ljava/lang/Comparable<Ljava/time/OffsetDateTime;>;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
+class name java/time/OffsetTime
+header extends java/lang/Object implements java/time/temporal/Temporal,java/time/temporal/TemporalAdjuster,java/lang/Comparable,java/io/Serializable flags 31 signature Ljava/lang/Object;Ljava/time/temporal/Temporal;Ljava/time/temporal/TemporalAdjuster;Ljava/lang/Comparable<Ljava/time/OffsetTime;>;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
+class name java/time/Period
+header extends java/lang/Object implements java/time/chrono/ChronoPeriod,java/io/Serializable flags 31 runtimeAnnotations @Ljdk/internal/ValueBased;
+
+class name java/time/Year
+header extends java/lang/Object implements java/time/temporal/Temporal,java/time/temporal/TemporalAdjuster,java/lang/Comparable,java/io/Serializable flags 31 signature Ljava/lang/Object;Ljava/time/temporal/Temporal;Ljava/time/temporal/TemporalAdjuster;Ljava/lang/Comparable<Ljava/time/Year;>;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
+class name java/time/YearMonth
+header extends java/lang/Object implements java/time/temporal/Temporal,java/time/temporal/TemporalAdjuster,java/lang/Comparable,java/io/Serializable flags 31 signature Ljava/lang/Object;Ljava/time/temporal/Temporal;Ljava/time/temporal/TemporalAdjuster;Ljava/lang/Comparable<Ljava/time/YearMonth;>;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
+class name java/time/ZoneId
+header extends java/lang/Object implements java/io/Serializable flags 421 runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/util/Map$Entry outerClass java/util/Map innerClassName Entry flags 609
+
+class name java/time/ZoneOffset
+header extends java/time/ZoneId implements java/time/temporal/TemporalAccessor,java/time/temporal/TemporalAdjuster,java/lang/Comparable,java/io/Serializable flags 31 signature Ljava/time/ZoneId;Ljava/time/temporal/TemporalAccessor;Ljava/time/temporal/TemporalAdjuster;Ljava/lang/Comparable<Ljava/time/ZoneOffset;>;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+
+class name java/time/ZonedDateTime
+header extends java/lang/Object implements java/time/temporal/Temporal,java/time/chrono/ChronoZonedDateTime,java/io/Serializable flags 31 signature Ljava/lang/Object;Ljava/time/temporal/Temporal;Ljava/time/chrono/ChronoZonedDateTime<Ljava/time/LocalDate;>;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
 class name java/time/chrono/ChronoLocalDate
 header extends java/lang/Object implements java/time/temporal/Temporal,java/time/temporal/TemporalAdjuster,java/lang/Comparable flags 601 signature Ljava/lang/Object;Ljava/time/temporal/Temporal;Ljava/time/temporal/TemporalAdjuster;Ljava/lang/Comparable<Ljava/time/chrono/ChronoLocalDate;>;
 innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
@@ -662,6 +775,18 @@ innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang
 class name java/time/chrono/ChronoLocalDateTime
 header extends java/lang/Object implements java/time/temporal/Temporal,java/time/temporal/TemporalAdjuster,java/lang/Comparable flags 601 signature <D::Ljava/time/chrono/ChronoLocalDate;>Ljava/lang/Object;Ljava/time/temporal/Temporal;Ljava/time/temporal/TemporalAdjuster;Ljava/lang/Comparable<Ljava/time/chrono/ChronoLocalDateTime<*>;>;
 innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
+
+class name java/time/chrono/HijrahDate
+header extends java/time/chrono/ChronoLocalDateImpl implements java/time/chrono/ChronoLocalDate,java/io/Serializable flags 31 signature Ljava/time/chrono/ChronoLocalDateImpl<Ljava/time/chrono/HijrahDate;>;Ljava/time/chrono/ChronoLocalDate;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+
+class name java/time/chrono/JapaneseDate
+header extends java/time/chrono/ChronoLocalDateImpl implements java/time/chrono/ChronoLocalDate,java/io/Serializable flags 31 signature Ljava/time/chrono/ChronoLocalDateImpl<Ljava/time/chrono/JapaneseDate;>;Ljava/time/chrono/ChronoLocalDate;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+
+class name java/time/chrono/MinguoDate
+header extends java/time/chrono/ChronoLocalDateImpl implements java/time/chrono/ChronoLocalDate,java/io/Serializable flags 31 signature Ljava/time/chrono/ChronoLocalDateImpl<Ljava/time/chrono/MinguoDate;>;Ljava/time/chrono/ChronoLocalDate;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
+
+class name java/time/chrono/ThaiBuddhistDate
+header extends java/time/chrono/ChronoLocalDateImpl implements java/time/chrono/ChronoLocalDate,java/io/Serializable flags 31 signature Ljava/time/chrono/ChronoLocalDateImpl<Ljava/time/chrono/ThaiBuddhistDate;>;Ljava/time/chrono/ChronoLocalDate;Ljava/io/Serializable; runtimeAnnotations @Ljdk/internal/ValueBased;
 
 class name java/time/format/DateTimeFormatterBuilder
 method name appendDayPeriodText descriptor (Ljava/time/format/TextStyle;)Ljava/time/format/DateTimeFormatterBuilder; flags 1
@@ -710,6 +835,18 @@ header extends java/lang/Object flags 21 deprecated true runtimeAnnotations @Lja
 
 class name java/util/Observer
 header extends java/lang/Object flags 601 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(since="9")
+
+class name java/util/Optional
+header extends java/lang/Object flags 31 signature <T:Ljava/lang/Object;>Ljava/lang/Object; runtimeAnnotations @Ljdk/internal/ValueBased;
+
+class name java/util/OptionalDouble
+header extends java/lang/Object flags 31 runtimeAnnotations @Ljdk/internal/ValueBased;
+
+class name java/util/OptionalInt
+header extends java/lang/Object flags 31 runtimeAnnotations @Ljdk/internal/ValueBased;
+
+class name java/util/OptionalLong
+header extends java/lang/Object flags 31 runtimeAnnotations @Ljdk/internal/ValueBased;
 
 class name java/util/TimeZone
 header extends java/lang/Object implements java/io/Serializable,java/lang/Cloneable flags 421

--- a/make/data/symbols/jdk.compiler-G.sym.txt
+++ b/make/data/symbols/jdk.compiler-G.sym.txt
@@ -93,7 +93,8 @@ class name com/sun/source/doctree/ReferenceTree
 header extends java/lang/Object implements com/sun/source/doctree/DocTree flags 601
 
 class name com/sun/source/doctree/ReturnTree
-header extends java/lang/Object implements com/sun/source/doctree/BlockTagTree flags 601
+header extends java/lang/Object implements com/sun/source/doctree/BlockTagTree,com/sun/source/doctree/InlineTagTree flags 601
+method name isInline descriptor ()Z flags 1
 
 class name com/sun/source/doctree/SeeTree
 header extends java/lang/Object implements com/sun/source/doctree/BlockTagTree flags 601
@@ -335,6 +336,7 @@ header extends java/lang/Object implements com/sun/source/util/SourcePositions f
 class name com/sun/source/util/DocTreeFactory
 header extends java/lang/Object flags 601
 innerclass innerClass com/sun/source/doctree/AttributeTree$ValueKind outerClass com/sun/source/doctree/AttributeTree innerClassName ValueKind flags 4019
+method name newReturnTree descriptor (ZLjava/util/List;)Lcom/sun/source/doctree/ReturnTree; flags 1 signature (ZLjava/util/List<+Lcom/sun/source/doctree/DocTree;>;)Lcom/sun/source/doctree/ReturnTree;
 
 class name com/sun/source/util/DocTreePathScanner
 header extends com/sun/source/util/DocTreeScanner flags 21 signature <R:Ljava/lang/Object;P:Ljava/lang/Object;>Lcom/sun/source/util/DocTreeScanner<TR;TP;>;

--- a/make/data/symbols/jdk.incubator.foreign-G.sym.txt
+++ b/make/data/symbols/jdk.incubator.foreign-G.sym.txt
@@ -155,88 +155,88 @@ method name force descriptor (Ljdk/incubator/foreign/MemorySegment;)V flags 9
 class name jdk/incubator/foreign/MemoryAccess
 header extends java/lang/Object flags 31
 innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
-method name getByteAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)B flags 9
-method name setByteAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JB)V flags 9
-method name getCharAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)C flags 9
-method name setCharAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JC)V flags 9
-method name getShortAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)S flags 9
-method name setShortAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JS)V flags 9
-method name getIntAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)I flags 9
-method name setIntAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JI)V flags 9
-method name getFloatAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)F flags 9
-method name setFloatAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JF)V flags 9
-method name getLongAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)J flags 9
-method name setLongAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JJ)V flags 9
-method name getDoubleAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)D flags 9
-method name setDoubleAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JD)V flags 9
-method name getAddressAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)Ljdk/incubator/foreign/MemoryAddress; flags 9
-method name setAddressAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjdk/incubator/foreign/Addressable;)V flags 9
-method name getCharAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)C flags 9
-method name setCharAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;C)V flags 9
-method name getShortAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)S flags 9
-method name setShortAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;S)V flags 9
-method name getIntAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)I flags 9
-method name setIntAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;I)V flags 9
-method name getFloatAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)F flags 9
-method name setFloatAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;F)V flags 9
-method name getLongAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)J flags 9
-method name setLongAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;J)V flags 9
-method name getDoubleAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)D flags 9
-method name setDoubleAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;D)V flags 9
-method name getByte descriptor (Ljdk/incubator/foreign/MemorySegment;)B flags 9
-method name setByte descriptor (Ljdk/incubator/foreign/MemorySegment;B)V flags 9
-method name getChar descriptor (Ljdk/incubator/foreign/MemorySegment;)C flags 9
-method name setChar descriptor (Ljdk/incubator/foreign/MemorySegment;C)V flags 9
-method name getShort descriptor (Ljdk/incubator/foreign/MemorySegment;)S flags 9
-method name setShort descriptor (Ljdk/incubator/foreign/MemorySegment;S)V flags 9
-method name getInt descriptor (Ljdk/incubator/foreign/MemorySegment;)I flags 9
-method name setInt descriptor (Ljdk/incubator/foreign/MemorySegment;I)V flags 9
-method name getFloat descriptor (Ljdk/incubator/foreign/MemorySegment;)F flags 9
-method name setFloat descriptor (Ljdk/incubator/foreign/MemorySegment;F)V flags 9
-method name getLong descriptor (Ljdk/incubator/foreign/MemorySegment;)J flags 9
-method name setLong descriptor (Ljdk/incubator/foreign/MemorySegment;J)V flags 9
-method name getDouble descriptor (Ljdk/incubator/foreign/MemorySegment;)D flags 9
-method name setDouble descriptor (Ljdk/incubator/foreign/MemorySegment;D)V flags 9
-method name getAddress descriptor (Ljdk/incubator/foreign/MemorySegment;)Ljdk/incubator/foreign/MemoryAddress; flags 9
-method name setAddress descriptor (Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/Addressable;)V flags 9
-method name getChar descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;)C flags 9
-method name setChar descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;C)V flags 9
-method name getShort descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;)S flags 9
-method name setShort descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;S)V flags 9
-method name getInt descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;)I flags 9
-method name setInt descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;I)V flags 9
-method name getFloat descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;)F flags 9
-method name setFloat descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;F)V flags 9
-method name getLong descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;)J flags 9
-method name setLong descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;J)V flags 9
-method name getDouble descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;)D flags 9
-method name setDouble descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;D)V flags 9
-method name getCharAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)C flags 9
-method name setCharAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JC)V flags 9
-method name getShortAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)S flags 9
-method name setShortAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JS)V flags 9
-method name getIntAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)I flags 9
-method name setIntAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JI)V flags 9
-method name getFloatAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)F flags 9
-method name setFloatAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JF)V flags 9
-method name getLongAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)J flags 9
-method name setLongAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JJ)V flags 9
-method name getDoubleAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)D flags 9
-method name setDoubleAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JD)V flags 9
-method name getAddressAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)Ljdk/incubator/foreign/MemoryAddress; flags 9
-method name setAddressAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjdk/incubator/foreign/Addressable;)V flags 9
-method name getCharAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)C flags 9
-method name setCharAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;C)V flags 9
-method name getShortAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)S flags 9
-method name setShortAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;S)V flags 9
-method name getIntAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)I flags 9
-method name setIntAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;I)V flags 9
-method name getFloatAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)F flags 9
-method name setFloatAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;F)V flags 9
-method name getLongAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)J flags 9
-method name setLongAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;J)V flags 9
-method name getDoubleAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)D flags 9
-method name setDoubleAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;D)V flags 9
+method name getByteAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)B flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setByteAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JB)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getCharAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)C flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setCharAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JC)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getShortAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)S flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setShortAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JS)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getIntAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)I flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setIntAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JI)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getFloatAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)F flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setFloatAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JF)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getLongAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)J flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setLongAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JJ)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getDoubleAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)D flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setDoubleAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JD)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getAddressAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;J)Ljdk/incubator/foreign/MemoryAddress; flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setAddressAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjdk/incubator/foreign/Addressable;)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getCharAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)C flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setCharAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;C)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getShortAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)S flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setShortAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;S)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getIntAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)I flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setIntAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;I)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getFloatAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)F flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setFloatAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;F)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getLongAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)J flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setLongAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;J)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getDoubleAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)D flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setDoubleAtOffset descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;D)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getByte descriptor (Ljdk/incubator/foreign/MemorySegment;)B flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setByte descriptor (Ljdk/incubator/foreign/MemorySegment;B)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getChar descriptor (Ljdk/incubator/foreign/MemorySegment;)C flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setChar descriptor (Ljdk/incubator/foreign/MemorySegment;C)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getShort descriptor (Ljdk/incubator/foreign/MemorySegment;)S flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setShort descriptor (Ljdk/incubator/foreign/MemorySegment;S)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getInt descriptor (Ljdk/incubator/foreign/MemorySegment;)I flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setInt descriptor (Ljdk/incubator/foreign/MemorySegment;I)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getFloat descriptor (Ljdk/incubator/foreign/MemorySegment;)F flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setFloat descriptor (Ljdk/incubator/foreign/MemorySegment;F)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getLong descriptor (Ljdk/incubator/foreign/MemorySegment;)J flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setLong descriptor (Ljdk/incubator/foreign/MemorySegment;J)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getDouble descriptor (Ljdk/incubator/foreign/MemorySegment;)D flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setDouble descriptor (Ljdk/incubator/foreign/MemorySegment;D)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getAddress descriptor (Ljdk/incubator/foreign/MemorySegment;)Ljdk/incubator/foreign/MemoryAddress; flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setAddress descriptor (Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/Addressable;)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getChar descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;)C flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setChar descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;C)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getShort descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;)S flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setShort descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;S)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getInt descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;)I flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setInt descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;I)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getFloat descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;)F flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setFloat descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;F)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getLong descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;)J flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setLong descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;J)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getDouble descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;)D flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setDouble descriptor (Ljdk/incubator/foreign/MemorySegment;Ljava/nio/ByteOrder;D)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getCharAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)C flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setCharAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JC)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getShortAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)S flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setShortAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JS)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getIntAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)I flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setIntAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JI)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getFloatAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)F flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setFloatAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JF)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getLongAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)J flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setLongAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JJ)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getDoubleAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)D flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setDoubleAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JD)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getAddressAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;J)Ljdk/incubator/foreign/MemoryAddress; flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setAddressAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjdk/incubator/foreign/Addressable;)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getCharAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)C flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setCharAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;C)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getShortAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)S flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setShortAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;S)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getIntAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)I flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setIntAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;I)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getFloatAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)F flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setFloatAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;F)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getLongAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)J flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setLongAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;J)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name getDoubleAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;)D flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
+method name setDoubleAtIndex descriptor (Ljdk/incubator/foreign/MemorySegment;JLjava/nio/ByteOrder;D)V flags 9 runtimeAnnotations @Ljdk/internal/vm/annotation/ForceInline;
 
 class name jdk/incubator/foreign/MemoryAddress
 header extends java/lang/Object implements jdk/incubator/foreign/Addressable flags 601
@@ -251,6 +251,10 @@ method name asSegmentRestricted descriptor (JLjava/lang/Runnable;Ljava/lang/Obje
 class name jdk/incubator/foreign/MemoryHandles
 -method name withOffset descriptor (Ljava/lang/invoke/VarHandle;J)Ljava/lang/invoke/VarHandle;
 -method name withStride descriptor (Ljava/lang/invoke/VarHandle;J)Ljava/lang/invoke/VarHandle;
+
+class name jdk/incubator/foreign/MemoryLayout
+method name bitOffsetHandle descriptor ([Ljdk/incubator/foreign/MemoryLayout$PathElement;)Ljava/lang/invoke/MethodHandle; flags 81
+method name byteOffsetHandle descriptor ([Ljdk/incubator/foreign/MemoryLayout$PathElement;)Ljava/lang/invoke/MethodHandle; flags 81
 
 class name jdk/incubator/foreign/MemoryLayouts
 field name ADDRESS descriptor Ljdk/incubator/foreign/ValueLayout; flags 19

--- a/make/data/symbols/jdk.net-G.sym.txt
+++ b/make/data/symbols/jdk.net-G.sym.txt
@@ -51,10 +51,14 @@ method name getOption descriptor (Ljava/net/DatagramSocket;Ljava/net/SocketOptio
 method name supportedOptions descriptor (Ljava/lang/Class;)Ljava/util/Set; flags 9 deprecated true signature (Ljava/lang/Class<*>;)Ljava/util/Set<Ljava/net/SocketOption<*>;>; runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="16")
 
 class name jdk/net/UnixDomainPrincipal
-header extends java/lang/Object flags 31
+header extends java/lang/Record record true flags 31
+recordcomponent name user descriptor Ljava/nio/file/attribute/UserPrincipal;
+recordcomponent name group descriptor Ljava/nio/file/attribute/GroupPrincipal;
+innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
 method name <init> descriptor (Ljava/nio/file/attribute/UserPrincipal;Ljava/nio/file/attribute/GroupPrincipal;)V flags 1
-method name equals descriptor (Ljava/lang/Object;)Z flags 1
-method name hashCode descriptor ()I flags 1
 method name user descriptor ()Ljava/nio/file/attribute/UserPrincipal; flags 1
 method name group descriptor ()Ljava/nio/file/attribute/GroupPrincipal; flags 1
+method name toString descriptor ()Ljava/lang/String; flags 11
+method name hashCode descriptor ()I flags 11
+method name equals descriptor (Ljava/lang/Object;)Z flags 11
 


### PR DESCRIPTION
Update symbol information for --release 16 to JDK 16 b28, includes updates for JEP 390.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257457](https://bugs.openjdk.java.net/browse/JDK-8257457): Update --release 16 symbol information for JDK 16 build 28


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1754/head:pull/1754`
`$ git checkout pull/1754`
