### PR TITLE
8258142: Simplify G1RedirtyCardsQueue

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -199,6 +199,7 @@ class RemoveSelfForwardPtrHRClosure: public HeapRegionClosure {
   G1CollectedHeap* _g1h;
   uint _worker_id;
 
+  G1RedirtyCardsLocalQueueSet _rdclqs;
   G1RedirtyCardsQueue _rdcq;
   UpdateLogBuffersDeferred _log_buffer_cl;
 
@@ -206,8 +207,14 @@ public:
   RemoveSelfForwardPtrHRClosure(G1RedirtyCardsQueueSet* rdcqs, uint worker_id) :
     _g1h(G1CollectedHeap::heap()),
     _worker_id(worker_id),
-    _rdcq(rdcqs),
+    _rdclqs(rdcqs),
+    _rdcq(&_rdclqs),
     _log_buffer_cl(&_rdcq) {
+  }
+
+  ~RemoveSelfForwardPtrHRClosure() {
+    _rdcq.flush();
+    _rdclqs.flush();
   }
 
   size_t remove_self_forward_ptr_by_walking_hr(HeapRegion* hr,

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -199,7 +199,7 @@ class RemoveSelfForwardPtrHRClosure: public HeapRegionClosure {
   G1CollectedHeap* _g1h;
   uint _worker_id;
 
-  G1RedirtyCardsLocalQueueSet _rdclqs;
+  G1RedirtyCardsLocalQueueSet _rdc_local_qset;
   G1RedirtyCardsQueue _rdcq;
   UpdateLogBuffersDeferred _log_buffer_cl;
 
@@ -207,14 +207,14 @@ public:
   RemoveSelfForwardPtrHRClosure(G1RedirtyCardsQueueSet* rdcqs, uint worker_id) :
     _g1h(G1CollectedHeap::heap()),
     _worker_id(worker_id),
-    _rdclqs(rdcqs),
-    _rdcq(&_rdclqs),
+    _rdc_local_qset(rdcqs),
+    _rdcq(&_rdc_local_qset),
     _log_buffer_cl(&_rdcq) {
   }
 
   ~RemoveSelfForwardPtrHRClosure() {
     _rdcq.flush();
-    _rdclqs.flush();
+    _rdc_local_qset.flush();
   }
 
   size_t remove_self_forward_ptr_by_walking_hr(HeapRegion* hr,

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -58,8 +58,8 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
                                            size_t optional_cset_length)
   : _g1h(g1h),
     _task_queue(g1h->task_queue(worker_id)),
-    _rdclqs(rdcqs),
-    _rdcq(&_rdclqs),
+    _rdc_local_qset(rdcqs),
+    _rdcq(&_rdc_local_qset),
     _ct(g1h->card_table()),
     _closures(NULL),
     _plab_allocator(NULL),
@@ -115,7 +115,7 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
 
 size_t G1ParScanThreadState::flush(size_t* surviving_young_words) {
   _rdcq.flush();
-  _rdclqs.flush();
+  _rdc_local_qset.flush();
   flush_numa_stats();
   // Update allocation statistics.
   _plab_allocator->flush_and_retire_stats();

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -58,7 +58,8 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
                                            size_t optional_cset_length)
   : _g1h(g1h),
     _task_queue(g1h->task_queue(worker_id)),
-    _rdcq(rdcqs),
+    _rdclqs(rdcqs),
+    _rdcq(&_rdclqs),
     _ct(g1h->card_table()),
     _closures(NULL),
     _plab_allocator(NULL),
@@ -114,6 +115,7 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
 
 size_t G1ParScanThreadState::flush(size_t* surviving_young_words) {
   _rdcq.flush();
+  _rdclqs.flush();
   flush_numa_stats();
   // Update allocation statistics.
   _plab_allocator->flush_and_retire_stats();

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -48,6 +48,7 @@ class outputStream;
 class G1ParScanThreadState : public CHeapObj<mtGC> {
   G1CollectedHeap* _g1h;
   G1ScannerTasksQueue* _task_queue;
+  G1RedirtyCardsLocalQueueSet _rdclqs;
   G1RedirtyCardsQueue _rdcq;
   G1CardTable* _ct;
   G1EvacuationRootClosures* _closures;

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -48,7 +48,7 @@ class outputStream;
 class G1ParScanThreadState : public CHeapObj<mtGC> {
   G1CollectedHeap* _g1h;
   G1ScannerTasksQueue* _task_queue;
-  G1RedirtyCardsLocalQueueSet _rdclqs;
+  G1RedirtyCardsLocalQueueSet _rdc_local_qset;
   G1RedirtyCardsQueue _rdcq;
   G1CardTable* _ct;
   G1EvacuationRootClosures* _closures;

--- a/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.cpp
+++ b/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,19 +30,21 @@
 
 // G1RedirtyCardsQueueBase::LocalQSet
 
-G1RedirtyCardsQueueBase::LocalQSet::LocalQSet(G1RedirtyCardsQueueSet* shared_qset) :
+G1RedirtyCardsLocalQueueSet::G1RedirtyCardsLocalQueueSet(G1RedirtyCardsQueueSet* shared_qset) :
   PtrQueueSet(shared_qset->allocator()),
   _shared_qset(shared_qset),
   _buffers()
 {}
 
-G1RedirtyCardsQueueBase::LocalQSet::~LocalQSet() {
+#ifdef ASSERT
+G1RedirtyCardsLocalQueueSet::~G1RedirtyCardsLocalQueueSet() {
   assert(_buffers._head == NULL, "unflushed qset");
   assert(_buffers._tail == NULL, "invariant");
   assert(_buffers._entry_count == 0, "invariant");
 }
+#endif // ASSERT
 
-void G1RedirtyCardsQueueBase::LocalQSet::enqueue_completed_buffer(BufferNode* node) {
+void G1RedirtyCardsLocalQueueSet::enqueue_completed_buffer(BufferNode* node) {
   _buffers._entry_count += buffer_size() - node->index();
   node->set_next(_buffers._head);
   _buffers._head = node;
@@ -51,26 +53,22 @@ void G1RedirtyCardsQueueBase::LocalQSet::enqueue_completed_buffer(BufferNode* no
   }
 }
 
-G1BufferNodeList G1RedirtyCardsQueueBase::LocalQSet::take_all_completed_buffers() {
-  G1BufferNodeList result = _buffers;
+void G1RedirtyCardsLocalQueueSet::flush() {
+  _shared_qset->add_bufferlist(_buffers);
   _buffers = G1BufferNodeList();
-  return result;
-}
-
-void G1RedirtyCardsQueueBase::LocalQSet::flush() {
-  _shared_qset->merge_bufferlist(this);
 }
 
 // G1RedirtyCardsQueue
 
-G1RedirtyCardsQueue::G1RedirtyCardsQueue(G1RedirtyCardsQueueSet* qset) :
-  G1RedirtyCardsQueueBase(qset), // Init _local_qset before passing to PtrQueue.
-  PtrQueue(&_local_qset, true /* active (always) */)
+G1RedirtyCardsQueue::G1RedirtyCardsQueue(G1RedirtyCardsLocalQueueSet* qset) :
+  PtrQueue(qset, true /* always active */)
 {}
 
+#ifdef ASSERT
 G1RedirtyCardsQueue::~G1RedirtyCardsQueue() {
-  flush();
+  assert(is_empty(), "unflushed queue");
 }
+#endif // ASSERT
 
 void G1RedirtyCardsQueue::handle_completed_buffer() {
   enqueue_completed_buffer();
@@ -78,7 +76,6 @@ void G1RedirtyCardsQueue::handle_completed_buffer() {
 
 void G1RedirtyCardsQueue::flush() {
   flush_impl();
-  _local_qset.flush();
 }
 
 // G1RedirtyCardsQueueSet
@@ -134,13 +131,12 @@ void G1RedirtyCardsQueueSet::enqueue_completed_buffer(BufferNode* node) {
   update_tail(node);
 }
 
-void G1RedirtyCardsQueueSet::merge_bufferlist(LocalQSet* src) {
+void G1RedirtyCardsQueueSet::add_bufferlist(const G1BufferNodeList& buffers) {
   assert(_collecting, "precondition");
-  const G1BufferNodeList from = src->take_all_completed_buffers();
-  if (from._head != NULL) {
-    assert(from._tail != NULL, "invariant");
-    Atomic::add(&_entry_count, from._entry_count);
-    _list.prepend(*from._head, *from._tail);
-    update_tail(from._tail);
+  if (buffers._head != NULL) {
+    assert(buffers._tail != NULL, "invariant");
+    Atomic::add(&_entry_count, buffers._entry_count);
+    _list.prepend(*buffers._head, *buffers._tail);
+    update_tail(buffers._tail);
   }
 }


### PR DESCRIPTION
Please review this change to G1RedirtyCardsQueue to separate the local qset
from the queue. This simplifies the implementation, though requires clients
to deal with the local qset explicitly. This is an enabling step toward
desired simplifications of the PtrQueue hierarchy. This change also
simplifies the interaction between the local qset and the global qset.

Testing:
mach5 tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258142](https://bugs.openjdk.java.net/browse/JDK-8258142): Simplify G1RedirtyCardsQueue


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 6a48914fc3c48294c55180886c99c309df556b58
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer) ⚠️ Review applies to 6a48914fc3c48294c55180886c99c309df556b58


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1755/head:pull/1755`
`$ git checkout pull/1755`
