### PR TITLE
8258144: suppress messages from AdapterHandlerLibrary::create_native_wrapper if -XX:CompileCommand=quiet is set

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -37,6 +37,7 @@
 #include "code/vtableStubs.hpp"
 #include "compiler/abstractCompiler.hpp"
 #include "compiler/compileBroker.hpp"
+#include "compiler/compilerOracle.hpp"
 #include "compiler/disassembler.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/gcLocker.inline.hpp"
@@ -2924,7 +2925,7 @@ void AdapterHandlerLibrary::create_native_wrapper(const methodHandle& method) {
   if (nm != NULL) {
     const char *msg = method->is_static() ? "(static)" : "";
     CompileTask::print_ul(nm, msg);
-    if (PrintCompilation) {
+    if (PrintCompilation && !CompilerOracle::be_quiet()) {
       ttyLocker ttyl;
       CompileTask::print(tty, nm, msg);
     }


### PR DESCRIPTION
suppress messages from AdapterHandlerLibrary::create_native_wrapper if -XX:CompileCommand=quiet is set

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258144](https://bugs.openjdk.java.net/browse/JDK-8258144): suppress messages from AdapterHandlerLibrary::create_native_wrapper if -XX:CompileCommand=quiet is set


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1756/head:pull/1756`
`$ git checkout pull/1756`
