### PR TITLE
JDK-8185734: [Windows] Structured Exception Catcher missing around gtest execution

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -608,6 +608,7 @@ define SetupRunGtestTestBody
 	    $$(FIXPATH) $$(TEST_IMAGE_DIR)/hotspot/gtest/$$($1_VARIANT)/gtestLauncher \
 	        -jdk $(JDK_UNDER_TEST) $$($1_GTEST_FILTER) \
 	        --gtest_output=xml:$$($1_TEST_RESULTS_DIR)/gtest.xml \
+	        --gtest_catch_exceptions=0 \
 	        $$($1_GTEST_REPEAT) $$(GTEST_OPTIONS) $$(GTEST_VM_OPTIONS) \
 	        $$(GTEST_JAVA_OPTIONS) $$($1_AOT_OPTIONS) \
 	        > >($(TEE) $$($1_TEST_RESULTS_DIR)/gtest.txt) \

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -512,6 +512,7 @@ struct tm* os::gmtime_pd(const time_t* clock, struct tm* res) {
   return NULL;
 }
 
+JNIEXPORT
 LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo);
 
 // Thread start routine for all newly created threads
@@ -2446,6 +2447,7 @@ static inline void report_error(Thread* t, DWORD exception_code,
 }
 
 //-----------------------------------------------------------------------------
+JNIEXPORT
 LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
   if (InterceptOSException) return EXCEPTION_CONTINUE_SEARCH;
   PEXCEPTION_RECORD exception_record = exceptionInfo->ExceptionRecord;

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -68,6 +68,7 @@
 #define REG_PC Eip
 #endif // AMD64
 
+JNIEXPORT
 extern LONG WINAPI topLevelExceptionFilter(_EXCEPTION_POINTERS* );
 
 // Install a win32 structured exception handler around thread.

--- a/test/hotspot/gtest/gtestLauncher.cpp
+++ b/test/hotspot/gtest/gtestLauncher.cpp
@@ -23,11 +23,23 @@
 
 #include "jni.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#include <excpt.h>
+extern LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo);
+#endif
+
 extern "C" {
   JNIIMPORT void JNICALL runUnitTests(int argv, char** argc);
 }
 
 int main(int argc, char** argv) {
+#ifdef _WIN32
+  __try {
+#endif
   runUnitTests(argc, argv);
+#ifdef _WIN32
+  } __except(topLevelExceptionFilter(GetExceptionInformation())) {}
+#endif
   return 0;
 }

--- a/test/hotspot/jtreg/gtest/GTestWrapper.java
+++ b/test/hotspot/jtreg/gtest/GTestWrapper.java
@@ -82,6 +82,7 @@ public class GTestWrapper {
         command.add("-jdk");
         command.add(Utils.TEST_JDK);
         command.add("--gtest_output=xml:" + resultFile);
+        command.add("--gtest_catch_exceptions=0" + resultFile);
         for (String a : args) {
             command.add(a);
         }


### PR DESCRIPTION
Hi,

May I have reviews please for the following patch.

At the moment, if a crash happens on Windows in gtests, the gtest SEH handler may be invoked instead of our error handler, and we just see a one-line-warning "SEH happened blabala". No hs-err file.

Even worse, if a crash happens inside the VM as part of the gtests, if our SEH handler does not get involved, this may interfere with VM functionality - e.g. SafeFetch.

Whether or not our SEH handler gets involved currently depends on arbitrary factors: 
- whether the fault happens in a VM or Java thread - which have a __try/__except around their start function - or whether the fault happens directly in the thread running the test
- Faults in generated code are not handled on x86 but are okay x64 (where a SEH handler is registered for the code cache region) or on aarch64 (which uses VEH).

This patch consists of two parts

A) It surrounds the gtestlauncher main function with a SEH catcher. For that to work I also need to export the SEH handler from the hotspot. Note: It is difficult to place the SEH catcher: SEH is mutually exclusive with C++ exceptions, and since googletest uses C++ exceptions to communicate test conditions, the only place to put those __try/__except is really up here, at the entry of the gtestlauncher main() function.

B) This is unfortunately not sufficient since googletest uses its own SEH catcher to wrap each test (see gtest.cc). Since that catcher sits below our catcher on the stack, it superimposes ours. 

In JBS, @kimbarrett suggested to build gtests with GTEST_HAS_SEH switched off to prevent gtest from using SEH. Unfortunately that won't work since the use of death tests means we need SEH. If we switch GTEST_HAS_SEH off, the death tests don't build. I also do not like this suggestion since this configuration may have a higher chance of bitrotting upstream.

The solution I found is to switch off exception catching from user code as described in [3] using `--gtest_catch_exceptions=0` or the environment variable `GTEST_CATCH_EXCEPTIONS=0`. Since we do not use C++ exceptions in the hotspot, this is fine. 

The only drawback is that this cannot be done from within the gtestlauncher itself. Setting the environment variable in the main function - or even during dynamic initialization - does not work because the gtestlauncher itself parses all arguments as part of dynamic initialization. So I did the next best thing and specified `--gtest_catch_exceptions=0` at the places where we run the gtests. This is not perfect, but better than nothing.

Testing: manually on Windows x64, x86, GH actions (Linux errors seem unrelated to this patch).

----

Notes:
- If we owned the googletest code - forked it off like we did before - (B) would be very simple to solve by changing the default for `gtest_catch_exceptions` to 1. I still believe maintaining a fork of googletest would have many benefits.

- Using VEH would have saved us from using __try/__except here, so we would have not needed (A). ATM we use VEH on aarch, SEH on x64+x32. Uniformly switching to VEH has been discussed several times in the past, the last attempt has been by @luhenry (see [1], [2]), but this has not yet materialized. 

[1] https://mail.openjdk.java.net/pipermail/hotspot-runtime-dev/2020-June/040228.html
[2] https://mail.openjdk.java.net/pipermail/hotspot-runtime-dev/2020-August/040967.html
[3] https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#disabling-catching-test-thrown-exceptions

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8185734](https://bugs.openjdk.java.net/browse/JDK-8185734): [Windows] Structured Exception Catcher missing around gtest execution


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1757/head:pull/1757`
`$ git checkout pull/1757`
