### PR TITLE
8196092: javax/swing/JComboBox/8032878/bug8032878.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -738,7 +738,6 @@ javax/swing/JSplitPane/4201995/bug4201995.java 8079127 generic-all
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
-javax/swing/JComboBox/8032878/bug8032878.java 8196092,8196439 windows-all,macosx-all,linux-all
 javax/swing/JComboBox/8072767/bug8072767.java 8196093 windows-all,macosx-all
 javax/swing/JFileChooser/4524490/bug4524490.java 8042380 generic-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all

--- a/test/jdk/javax/swing/JComboBox/8032878/bug8032878.java
+++ b/test/jdk/javax/swing/JComboBox/8032878/bug8032878.java
@@ -28,9 +28,6 @@
  * @summary Checks that JComboBox as JTable cell editor processes key events
  *          even where setSurrendersFocusOnKeystroke flag in JTable is false and
  *          that it does not lose the first key press where the flag is true.
- * @library ../../regtesthelpers
- * @build Util
- * @author Alexey Ivanov
  * @run main bug8032878
  */
 
@@ -86,6 +83,7 @@ public class bug8032878 implements Runnable {
 
         frame.pack();
         frame.setVisible(true);
+        frame.setLocationRelativeTo(null);
     }
 
     private void test(final boolean flag) throws Exception {
@@ -93,11 +91,13 @@ public class bug8032878 implements Runnable {
             surrender = flag;
             SwingUtilities.invokeAndWait(this);
 
+            robot.waitForIdle();
+            robot.delay(1000);
             runTest();
             checkResult();
         } finally {
             if (frame != null) {
-                frame.dispose();
+                SwingUtilities.invokeAndWait(() -> frame.dispose());
             }
         }
     }
@@ -105,12 +105,20 @@ public class bug8032878 implements Runnable {
     private void runTest() throws Exception {
         robot.waitForIdle();
         // Select 'one'
-        Util.hitKeys(robot, KeyEvent.VK_TAB);
+        robot.keyPress(KeyEvent.VK_TAB);
+        robot.keyRelease(KeyEvent.VK_TAB);
         robot.waitForIdle();
-        Util.hitKeys(robot, KeyEvent.VK_1);
-        Util.hitKeys(robot, KeyEvent.VK_2);
-        Util.hitKeys(robot, KeyEvent.VK_3);
-        Util.hitKeys(robot, KeyEvent.VK_ENTER);
+        robot.keyPress(KeyEvent.VK_1);
+        robot.keyRelease(KeyEvent.VK_1);
+        robot.waitForIdle();
+        robot.keyPress(KeyEvent.VK_2);
+        robot.keyRelease(KeyEvent.VK_2);
+        robot.waitForIdle();
+        robot.keyPress(KeyEvent.VK_3);
+        robot.keyRelease(KeyEvent.VK_3);
+        robot.waitForIdle();
+        robot.keyPress(KeyEvent.VK_ENTER);
+        robot.keyRelease(KeyEvent.VK_ENTER);
         robot.waitForIdle();
     }
 


### PR DESCRIPTION
Test was failing if JComboBox tests was run in group in nightly mach5 testing.
Modified test to remove dependancy from Util class, added delay before frame show and move frame to centre of screen.
Resultant modified test ran fine in JComboBox group and also in standalone, several iterations of which are ran in mach5. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8196092](https://bugs.openjdk.java.net/browse/JDK-8196092): javax/swing/JComboBox/8032878/bug8032878.java fails


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1762/head:pull/1762`
`$ git checkout pull/1762`
