### PR TITLE
JDK-8257959: Add gtest run with -XX:+UseLargePages

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -76,7 +76,8 @@ hotspot_containers = \
 tier1_common = \
   sanity/BasicVMTest.java \
   gtest/GTestWrapper.java \
-  gtest/MetaspaceGtests.java
+  gtest/MetaspaceGtests.java \
+  gtest/LargePageGtests.java
 
 tier1_compiler = \
   :tier1_compiler_1 \

--- a/test/hotspot/jtreg/gtest/LargePageGtests.java
+++ b/test/hotspot/jtreg/gtest/LargePageGtests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * This runs the parts of the gtest which make sense in large-page scenarios
+ *  (mainly os*).
+ * Note that if these tests run on a system whose kernel supports large pages
+ *   but where no huge pages are configured, these tests are still useful. They
+ *   will test correct initialization. Later reserve calls will fail and fall
+ *   back to small pages (while complaining loudly) but this should not affect
+ *   the gtests.
+ */
+
+/* @test id=use-large-pages
+ * @summary Run metaspace-related gtests for reclaim policy none (with verifications)
+ * @requires os.family == "linux" | os.family == "windows"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.xml
+ * @run main/native GTestWrapper --gtest_filter=os* -XX:+UseLargePages
+ */
+
+/* @test id=use-large-pages-1G
+ * @summary Run metaspace-related gtests for reclaim policy none (with verifications)
+ * @requires os.family == "linux"
+ * @requires vm.bits == "64"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.xml
+ * @run main/native GTestWrapper --gtest_filter=os* -XX:+UseLargePages -XX:LargePageSizeInBytes=1G
+ */
+
+/* @test id=use-large-pages-sysV
+ * @summary Run metaspace-related gtests for reclaim policy none (with verifications)
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.xml
+ * @run main/native GTestWrapper --gtest_filter=os* -XX:+UseLargePages -XX:+UseSHM
+ */


### PR DESCRIPTION
Hi,

may I please have reviews for this addition.

To better test changes in large page handling, it makes sense to regularly run gtests with large pages enabled. Not the whole gtest suite needs to be run, but at least the os* part.

Thanks, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257959](https://bugs.openjdk.java.net/browse/JDK-8257959): Add gtest run with -XX:+UseLargePages


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1763/head:pull/1763`
`$ git checkout pull/1763`
