### PR TITLE
8258233: Reenable another fixed problemlisted test

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -757,7 +757,6 @@ javax/swing/JFileChooser/8062561/bug8062561.java 8196466 linux-all,macosx-all
 javax/swing/JInternalFrame/Test6325652.java 8224977 macosx-all
 javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java 8225045 linux-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
-javax/swing/JFileChooser/6868611/bug6868611.java 7059834 windows-all
 javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java 8065099,8208565 macosx-all,linux-all
 javax/swing/UIDefaults/6302464/bug6302464.java 8199079 macosx-all
 javax/swing/PopupFactory/8048506/bug8048506.java 8202660 windows-all


### PR DESCRIPTION
javax/swing/JFileChooser/6868611/bug6868611.java was failing in windows in mach5 testing but was fixed in JDK-8198004 later on, but this test was not removed from problemList. We can remove it from problemlist now.
Tested for several iteration in mach5. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258233](https://bugs.openjdk.java.net/browse/JDK-8258233): Reenable another fixed problemlisted test


### Reviewers
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Committer)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1766/head:pull/1766`
`$ git checkout pull/1766`
