### PR TITLE
8258239: Shenandoah: Used wrong closure to mark concurrent roots

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -420,7 +420,7 @@ ShenandoahMarkConcurrentRootsTask::ShenandoahMarkConcurrentRootsTask(ShenandoahO
 void ShenandoahMarkConcurrentRootsTask::work(uint worker_id) {
   ShenandoahConcurrentWorkerSession worker_session(worker_id);
   ShenandoahObjToScanQueue* q = _queue_set->queue(worker_id);
-  ShenandoahMarkResolveRefsClosure cl(q, _rp);
+  ShenandoahMarkRefsClosure cl(q, _rp);
   _rs.oops_do(&cl, worker_id);
 }
 


### PR DESCRIPTION
During concurrent mark phase, there should not have forwarded objects in roots. Therefore, it should use ShenandoahMarkRefsClosure to mark concurrent roots, instead of ShenandoahMarkResolveRefsClosure.

Note: this is *not* a correctness bug, but performance one, as ShenandoahMarkResolveRefsClosure closure unnecessarily resolves forwarding pointers, where always resolved to themselves.

- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258239](https://bugs.openjdk.java.net/browse/JDK-8258239): Shenandoah: Used wrong closure to mark concurrent roots


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1768/head:pull/1768`
`$ git checkout pull/1768`
