### PR TITLE
8253497: Core Libs Terminology Refresh

### DIFF
--- a/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -132,7 +132,7 @@ public class EquivMapsGenerator {
                     + " A region/variant subtag \"" + preferred
                     + "\" is registered for more than one subtags.");
             }
-        } else { // language, extlang, grandfathered, and redundant
+        } else { // language, extlang, legacy, and redundant
             if (!initialLanguageMap.containsKey(preferred)) {
                 sb = new StringBuilder(preferred);
                 sb.append(',');

--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ import jdk.internal.util.StaticProperty;
  * {@link Status#UNDECIDED UNDECIDED}.
  * Filters should be designed for the specific use case and expected types.
  * A filter designed for a particular use may be passed a class that is outside
- * of the scope of the filter. If the purpose of the filter is to black-list classes
+ * of the scope of the filter. If the purpose of the filter is to reject classes
  * then it can reject a candidate class that matches and report UNDECIDED for others.
  * A filter may be called with class equals {@code null}, {@code arrayLength} equal -1,
  * the depth, number of references, and stream size and return a status

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1645,18 +1645,19 @@ public final class Locale implements Cloneable, Serializable {
      * </pre></ul>
      *
      * <p>This implements the 'Language-Tag' production of BCP47, and
-     * so supports grandfathered (regular and irregular) as well as
+     * so supports legacy (regular and irregular, referred to as
+     * {@code Type: grandfathered} in BCP47) as well as
      * private use language tags.  Stand alone private use tags are
      * represented as empty language and extension 'x-whatever',
-     * and grandfathered tags are converted to their canonical replacements
+     * and legacy tags are converted to their canonical replacements
      * where they exist.
      *
-     * <p>Grandfathered tags with canonical replacements are as follows:
+     * <p>Legacy tags with canonical replacements are as follows:
      *
      * <table class="striped">
-     * <caption style="display:none">Grandfathered tags with canonical replacements</caption>
+     * <caption style="display:none">Legacy tags with canonical replacements</caption>
      * <thead style="text-align:center">
-     * <tr><th scope="col" style="padding: 0 2px">grandfathered tag</th><th scope="col" style="padding: 0 2px">modern replacement</th></tr>
+     * <tr><th scope="col" style="padding: 0 2px">legacy tag</th><th scope="col" style="padding: 0 2px">modern replacement</th></tr>
      * </thead>
      * <tbody style="text-align:center">
      * <tr><th scope="row">art-lojban</th><td>jbo</td></tr>
@@ -1682,13 +1683,13 @@ public final class Locale implements Cloneable, Serializable {
      * </tbody>
      * </table>
      *
-     * <p>Grandfathered tags with no modern replacement will be
+     * <p>Legacy tags with no modern replacement will be
      * converted as follows:
      *
      * <table class="striped">
-     * <caption style="display:none">Grandfathered tags with no modern replacement</caption>
+     * <caption style="display:none">Legacy tags with no modern replacement</caption>
      * <thead style="text-align:center">
-     * <tr><th scope="col" style="padding: 0 2px">grandfathered tag</th><th scope="col" style="padding: 0 2px">converts to</th></tr>
+     * <tr><th scope="col" style="padding: 0 2px">legacy tag</th><th scope="col" style="padding: 0 2px">converts to</th></tr>
      * </thead>
      * <tbody style="text-align:center">
      * <tr><th scope="row">cel-gaulish</th><td>xtg-x-cel-gaulish</td></tr>
@@ -1700,7 +1701,7 @@ public final class Locale implements Cloneable, Serializable {
      * </tbody>
      * </table>
      *
-     * <p>For a list of all grandfathered tags, see the
+     * <p>For a list of all legacy tags, see the
      * IANA Language Subtag Registry (search for "Type: grandfathered").
      *
      * <p><b>Note</b>: there is no guarantee that {@code toLanguageTag}
@@ -2586,7 +2587,7 @@ public final class Locale implements Cloneable, Serializable {
          * Resets the Builder to match the provided IETF BCP 47
          * language tag.  Discards the existing state.  Null and the
          * empty string cause the builder to be reset, like {@link
-         * #clear}.  Grandfathered tags (see {@link
+         * #clear}.  Legacy tags (see {@link
          * Locale#forLanguageTag}) are converted to their canonical
          * form before being processed.  Otherwise, the language tag
          * must be well-formed (see {@link Locale}) or an exception is
@@ -2838,7 +2839,7 @@ public final class Locale implements Cloneable, Serializable {
          * on this builder.
          *
          * <p>This applies the conversions listed in {@link Locale#forLanguageTag}
-         * when constructing a Locale. (Grandfathered tags are handled in
+         * when constructing a Locale. (Legacy tags are handled in
          * {@link #setLanguageTag}.)
          *
          * @return A Locale.

--- a/src/java.base/share/classes/jdk/internal/logger/BootstrapLogger.java
+++ b/src/java.base/share/classes/jdk/internal/logger/BootstrapLogger.java
@@ -847,7 +847,7 @@ public final class BootstrapLogger implements Logger, PlatformLogger.Bridge,
         else return VM.isBooted();
     }
 
-    // A bit of black magic. We try to find out the nature of the logging
+    // A bit of magic. We try to find out the nature of the logging
     // backend without actually loading it.
     private static enum LoggingBackend {
         // There is no LoggerFinder and JUL is not present

--- a/src/java.base/share/classes/sun/util/locale/LanguageTag.java
+++ b/src/java.base/share/classes/sun/util/locale/LanguageTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,10 +60,10 @@ public class LanguageTag {
     private List<String> variants = Collections.emptyList();   // variant subtags
     private List<String> extensions = Collections.emptyList(); // extensions
 
-    // Map contains grandfathered tags and its preferred mappings from
+    // Map contains legacy language tags and its preferred mappings from
     // http://www.ietf.org/rfc/rfc5646.txt
     // Keys are lower-case strings.
-    private static final Map<String, String[]> GRANDFATHERED = new HashMap<>();
+    private static final Map<String, String[]> LEGACY = new HashMap<>();
 
     static {
         // grandfathered = irregular           ; non-redundant tags registered
@@ -127,7 +127,7 @@ public class LanguageTag {
             {"zh-xiang",    "hsn"},
         };
         for (String[] e : entries) {
-            GRANDFATHERED.put(LocaleUtils.toLowerString(e[0]), e);
+            LEGACY.put(LocaleUtils.toLowerString(e[0]), e);
         }
     }
 
@@ -188,8 +188,8 @@ public class LanguageTag {
 
         StringTokenIterator itr;
 
-        // Check if the tag is grandfathered
-        String[] gfmap = GRANDFATHERED.get(LocaleUtils.toLowerString(languageTag));
+        // Check if the tag is a legacy language tag
+        String[] gfmap = LEGACY.get(LocaleUtils.toLowerString(languageTag));
         if (gfmap != null) {
             // use preferred mapping
             itr = new StringTokenIterator(gfmap[1], SEP);

--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectorServer.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectorServer.java
@@ -132,7 +132,7 @@ public class RMIConnectorServer extends JMXConnectorServer {
      * the serial form of any deserialized object.
      * The pattern must be in same format as used in
      * {@link java.io.ObjectInputFilter.Config#createFilter}.
-     * It may define a white list of permitted classes, a black list of
+     * It may define an accept-list of permitted classes, a reject-list of
      * rejected classes, a maximum depth for the deserialized objects,
      * etc.
      * <p>
@@ -149,7 +149,7 @@ public class RMIConnectorServer extends JMXConnectorServer {
      * classes they use in their serial form.
      * <p>
      * Care must be taken when defining such a filter, as defining
-     * a white list too restrictive or a too wide a black list may
+     * an accept-list too restrictive or a too-wide reject-list may
      * prevent legitimate clients from interoperating with the
      * {@code JMXConnectorServer}.
      */

--- a/src/java.rmi/share/classes/sun/rmi/registry/RegistryImpl.java
+++ b/src/java.rmi/share/classes/sun/rmi/registry/RegistryImpl.java
@@ -441,7 +441,7 @@ public class RegistryImpl extends java.rmi.server.RemoteServer
         if (registryFilter != null) {
             ObjectInputFilter.Status status = registryFilter.checkInput(filterInfo);
             if (status != ObjectInputFilter.Status.UNDECIDED) {
-                // The Registry filter can override the built-in white-list
+                // The Registry filter can override the built-in allow-list
                 return status;
             }
         }

--- a/src/java.rmi/share/classes/sun/rmi/transport/DGCImpl.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/DGCImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -382,7 +382,7 @@ final class DGCImpl implements DGC {
         if (dgcFilter != null) {
             ObjectInputFilter.Status status = dgcFilter.checkInput(filterInfo);
             if (status != ObjectInputFilter.Status.UNDECIDED) {
-                // The DGC filter can override the built-in white-list
+                // The DGC filter can override the built-in allow-list
                 return status;
             }
         }

--- a/test/jdk/java/lang/ClassLoader/Assert.java
+++ b/test/jdk/java/lang/ClassLoader/Assert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public class Assert {
         int[] switches = new int[7];
 
         int switchSource = 0;
-        if (args.length == 0) { // This is master version
+        if (args.length == 0) { // This is  the coordinator version
 
             // This code is for an exhaustive test
             //while(switchSource < 2187) {
@@ -92,7 +92,7 @@ public class Assert {
                                           new InputStreamReader(p.getInputStream()));
                     String outString = blah.readLine();
                     while (outString != null) {
-                        System.out.println("from slave:"+outString);
+                        System.out.println("from BufferedReader:"+outString);
                         outString = blah.readLine();
                     }
                 }

--- a/test/jdk/java/lang/management/ClassLoadingMXBean/LoadCounts.java
+++ b/test/jdk/java/lang/management/ClassLoadingMXBean/LoadCounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,9 +119,9 @@ class SimpleOne {}
 class SimpleTwo {}
 
 class Chain {
-    Slave slave = new Slave();
+    Worker worker = new Worker();
 }
-class Slave {}
+class Worker {}
 
 class LeftHand extends ClassLoader {
     public LeftHand() {

--- a/test/jdk/java/nio/channels/SocketChannel/CloseRegisteredChannel.java
+++ b/test/jdk/java/nio/channels/SocketChannel/CloseRegisteredChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,8 @@ public class CloseRegisteredChannel {
 
         SocketChannel client = SocketChannel.open ();
         client.connect (new InetSocketAddress (InetAddress.getLoopbackAddress(), port));
-        SocketChannel slave = server.accept ();
-        slave.configureBlocking (true);
+        SocketChannel channel = server.accept ();
+        channel.configureBlocking (true);
 
         Selector selector = Selector.open ();
         client.configureBlocking (false);
@@ -53,7 +53,7 @@ public class CloseRegisteredChannel {
         client.close();
         //System.out.println ("client.isOpen = " + client.isOpen());
         System.out.println ("Will hang here...");
-        int nb = slave.read (ByteBuffer.allocate (1024));
+        int nb = channel.read (ByteBuffer.allocate (1024));
         //System.out.println("read nb=" + nb);
 
         selector.close();

--- a/test/jdk/java/util/Locale/LSRDataTest.java
+++ b/test/jdk/java/util/Locale/LSRDataTest.java
@@ -151,7 +151,7 @@ public class LSRDataTest {
                         + " A region/variant subtag \"" + preferred
                         + "\" is registered for more than one subtags.");
             }
-        } else { // language, extlang, grandfathered, and redundant
+        } else { // language, extlang, legacy, and redundant
             if (!singleLangEquivMap.containsKey(preferred)
                     && !multiLangEquivsMap.containsKey(preferred)) {
                 // new entry add it into single equiv map

--- a/test/jdk/java/util/Locale/LocaleEnhanceTest.java
+++ b/test/jdk/java/util/Locale/LocaleEnhanceTest.java
@@ -504,7 +504,7 @@ public class LocaleEnhanceTest extends IntlTest {
 
     public void testForLanguageTag() {
         // forLanguageTag implements the 'Language-Tag' production of
-        // BCP47, so it handles private use and grandfathered tags,
+        // BCP47, so it handles private use and legacy language tags,
         // unlike locale builder.  Tags listed below (except for the
         // sample private use tags) come from 4646bis Feb 29, 2009.
 
@@ -514,7 +514,7 @@ public class LocaleEnhanceTest extends IntlTest {
             { "x-a-b-c", "x-a-b-c" },
             { "x-a-12345678", "x-a-12345678" },
 
-            // grandfathered tags with preferred mappings
+            // legacy language tags with preferred mappings
             { "i-ami", "ami" },
             { "i-bnn", "bnn" },
             { "i-hak", "hak" },
@@ -536,7 +536,7 @@ public class LocaleEnhanceTest extends IntlTest {
             { "zh-min-nan", "nan" },
             { "zh-xiang", "hsn" },
 
-            // grandfathered irregular tags, no preferred mappings, drop illegal fields
+            // irregular legacy language tags, no preferred mappings, drop illegal fields
             // from end.  If no subtag is mappable, fallback to 'und'
             { "i-default", "en-x-i-default" },
             { "i-enochian", "x-i-enochian" },
@@ -548,7 +548,7 @@ public class LocaleEnhanceTest extends IntlTest {
         for (int i = 0; i < tests.length; ++i) {
             String[] test = tests[i];
             Locale locale = Locale.forLanguageTag(test[0]);
-            assertEquals("grandfathered case " + i, test[1], locale.toLanguageTag());
+            assertEquals("legacy language tag case " + i, test[1], locale.toLanguageTag());
         }
 
         // forLanguageTag ignores everything past the first place it encounters

--- a/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -238,7 +238,7 @@ public class DefaultAgentFilterTest {
         boolean retry = false;
         do {
             try {
-                // blacklist String
+                // filter DefaultAgentFilterTest$MyTestObject
                 testDefaultAgent("mgmt1.properties");
                 System.out.println("----\tTest FAILED !!");
                 throw new RuntimeException("---" + DefaultAgentFilterTest.class.getName() + " - No exception reported");
@@ -264,7 +264,7 @@ public class DefaultAgentFilterTest {
         retry = false;
         do {
             try {
-                // blacklist non-existent class
+                // filter non-existent class
                 testDefaultAgent("mgmt2.properties");
                 System.out.println("----\tTest PASSED !!");
             } catch (Exception ex) {


### PR DESCRIPTION
This is part of an effort in the JDK to replace archaic/non-inclusive words with more neutral terms (see JDK-8253315 for details).

Here are the changes covering core libraries code and tests.  Terms were changed as follows:
1. grandfathered -> legacy
2. blacklist -> filter or reject
3. whitelist -> allow or accept
4. master -> coordinator
5. slave -> worker

Addressing similar issues in upstream 3rd party code is out of scope of this PR.  Such changes will be picked up from their upstream sources.