### PR TITLE
8258244: Shenandoah: Not expecting forwarded object in roots during mark after JDK-8240868

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -51,7 +51,6 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.inline.hpp"
 
-template<UpdateRefsMode UPDATE_REFS>
 class ShenandoahInitMarkRootsClosure : public OopClosure {
 private:
   ShenandoahObjToScanQueue* _queue;
@@ -60,7 +59,7 @@ private:
 
   template <class T>
   inline void do_oop_work(T* p) {
-    ShenandoahConcurrentMark::mark_through_ref<T, UPDATE_REFS, NO_DEDUP>(p, _heap, _queue, _mark_context, false);
+    ShenandoahConcurrentMark::mark_through_ref<T, NONE, NO_DEDUP>(p, _heap, _queue, _mark_context, false);
   }
 
 public:
@@ -81,7 +80,6 @@ ShenandoahMarkRefsSuperClosure::ShenandoahMarkRefsSuperClosure(ShenandoahObjToSc
   _weak(false)
 { }
 
-template<UpdateRefsMode UPDATE_REFS>
 class ShenandoahInitMarkRootsTask : public AbstractGangTask {
 private:
   ShenandoahRootScanner* _rp;
@@ -101,7 +99,7 @@ public:
 
     ShenandoahObjToScanQueue* q = queues->queue(worker_id);
 
-    ShenandoahInitMarkRootsClosure<UPDATE_REFS> mark_cl(q);
+    ShenandoahInitMarkRootsClosure mark_cl(q);
     do_work(heap, &mark_cl, worker_id);
   }
 
@@ -301,15 +299,8 @@ void ShenandoahConcurrentMark::mark_roots(ShenandoahPhaseTimings::Phase root_pha
   TASKQUEUE_STATS_ONLY(task_queues()->reset_taskqueue_stats());
   task_queues()->reserve(nworkers);
 
-  if (heap->has_forwarded_objects()) {
-    ShenandoahInitMarkRootsTask<RESOLVE> mark_roots(&root_proc);
-    workers->run_task(&mark_roots);
-  } else {
-    // No need to update references, which means the heap is stable.
-    // Can save time not walking through forwarding pointers.
-    ShenandoahInitMarkRootsTask<NONE> mark_roots(&root_proc);
-    workers->run_task(&mark_roots);
-  }
+  ShenandoahInitMarkRootsTask mark_roots(&root_proc);
+  workers->run_task(&mark_roots);
 }
 
 void ShenandoahConcurrentMark::update_roots(ShenandoahPhaseTimings::Phase root_phase) {
@@ -463,13 +454,8 @@ void ShenandoahConcurrentMark::finish_mark_from_roots(bool full_gc) {
                                             ShenandoahPhaseTimings::full_gc_scan_conc_roots :
                                             ShenandoahPhaseTimings::degen_gc_scan_conc_roots;
       ShenandoahGCPhase gc_phase(phase);
-      if (_heap->has_forwarded_objects()) {
-        ShenandoahProcessConcurrentRootsTask<ShenandoahMarkResolveRefsClosure> task(this, phase, nworkers);
-        _heap->workers()->run_task(&task);
-      } else {
-        ShenandoahProcessConcurrentRootsTask<ShenandoahMarkRefsClosure> task(this, phase, nworkers);
-        _heap->workers()->run_task(&task);
-      }
+      ShenandoahProcessConcurrentRootsTask<ShenandoahMarkRefsClosure> task(this, phase, nworkers);
+      _heap->workers()->run_task(&task);
     }
 
     // Finally mark everything else we've got in our queues during the previous steps.

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -420,7 +420,7 @@ ShenandoahMarkConcurrentRootsTask::ShenandoahMarkConcurrentRootsTask(ShenandoahO
 void ShenandoahMarkConcurrentRootsTask::work(uint worker_id) {
   ShenandoahConcurrentWorkerSession worker_session(worker_id);
   ShenandoahObjToScanQueue* q = _queue_set->queue(worker_id);
-  ShenandoahMarkResolveRefsClosure cl(q, _rp);
+  ShenandoahMarkRefsClosure cl(q, _rp);
   _rs.oops_do(&cl, worker_id);
 }
 


### PR DESCRIPTION
This is a cleanup, no forwarded objects are expected in roots during mark phase after JDK-8240868.

There may be forwarded objects during full gc marking, if it is upgraded from degenerated GC, but roots are fixed before full gc marking happens.

- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258244](https://bugs.openjdk.java.net/browse/JDK-8258244): Shenandoah: Not expecting forwarded object in roots during mark after JDK-8240868


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1772/head:pull/1772`
`$ git checkout pull/1772`
