### PR TITLE
8257906: JFR: RecordingStream leaks memory

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
@@ -410,8 +410,8 @@ public final class RecordingStream implements AutoCloseable, EventStream {
     }
 
     private void updateOnCompleteHandler() {
-        if (maxAge != null && maxSize != 0) {
-            // User has set removal policy
+        if (maxAge != null || maxSize != 0) {
+            // User has set a chunk removal policy
             directoryStream.setChunkCompleteHandler(null);
         } else {
             directoryStream.setChunkCompleteHandler(new ChunkConsumer(recording));

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
@@ -45,8 +45,6 @@ import jdk.jfr.internal.PrivateAccess;
 import jdk.jfr.internal.SecuritySupport;
 import jdk.jfr.internal.Utils;
 import jdk.jfr.internal.consumer.EventDirectoryStream;
-import jdk.jfr.internal.consumer.JdkJfrConsumer;
-import jdk.jfr.internal.management.ManagementSupport;
 
 /**
  * A recording stream produces events from the current JVM (Java Virtual

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
@@ -46,6 +46,7 @@ import jdk.jfr.internal.SecuritySupport;
 import jdk.jfr.internal.Utils;
 import jdk.jfr.internal.consumer.EventDirectoryStream;
 import jdk.jfr.internal.consumer.JdkJfrConsumer;
+import jdk.jfr.internal.management.ManagementSupport;
 
 /**
  * A recording stream produces events from the current JVM (Java Virtual
@@ -68,9 +69,27 @@ import jdk.jfr.internal.consumer.JdkJfrConsumer;
  */
 public final class RecordingStream implements AutoCloseable, EventStream {
 
+    final static class ChunkConsumer implements Consumer<Long> {
+
+        private final Recording recording;
+
+        ChunkConsumer(Recording recording) {
+            this.recording = recording;
+        }
+
+        @Override
+        public void accept(Long endNanos) {
+            Instant t = Utils.epochNanosToInstant(endNanos);
+            PlatformRecording p = PrivateAccess.getInstance().getPlatformRecording(recording);
+            p.removeBefore(t);
+        }
+    }
+
     private final Recording recording;
     private final Instant creationTime;
     private final EventDirectoryStream directoryStream;
+    private long maxSize;
+    private Duration maxAge;
 
     /**
      * Creates an event stream for the current JVM (Java Virtual Machine).
@@ -247,7 +266,11 @@ public final class RecordingStream implements AutoCloseable, EventStream {
      *         state
      */
     public void setMaxAge(Duration maxAge) {
-        recording.setMaxAge(maxAge);
+        synchronized (directoryStream) {
+            recording.setMaxAge(maxAge);
+            this.maxAge = maxAge;
+            updateOnCompleteHandler();
+        }
     }
 
     /**
@@ -270,7 +293,11 @@ public final class RecordingStream implements AutoCloseable, EventStream {
      * @throws IllegalStateException if the recording is in {@code CLOSED} state
      */
     public void setMaxSize(long maxSize) {
-        recording.setMaxSize(maxSize);
+        synchronized (directoryStream) {
+            recording.setMaxSize(maxSize);
+            this.maxSize = maxSize;
+            updateOnCompleteHandler();
+        }
     }
 
     @Override
@@ -320,6 +347,7 @@ public final class RecordingStream implements AutoCloseable, EventStream {
 
     @Override
     public void close() {
+        directoryStream.setChunkCompleteHandler(null);
         recording.close();
         directoryStream.close();
     }
@@ -333,6 +361,7 @@ public final class RecordingStream implements AutoCloseable, EventStream {
     public void start() {
         PlatformRecording pr = PrivateAccess.getInstance().getPlatformRecording(recording);
         long startNanos = pr.start();
+        updateOnCompleteHandler();
         directoryStream.start(startNanos);
     }
 
@@ -363,6 +392,7 @@ public final class RecordingStream implements AutoCloseable, EventStream {
     public void startAsync() {
         PlatformRecording pr = PrivateAccess.getInstance().getPlatformRecording(recording);
         long startNanos = pr.start();
+        updateOnCompleteHandler();
         directoryStream.startAsync(startNanos);
     }
 
@@ -379,5 +409,14 @@ public final class RecordingStream implements AutoCloseable, EventStream {
     @Override
     public void onMetadata(Consumer<MetadataEvent> action) {
         directoryStream.onMetadata(action);
+    }
+
+    private void updateOnCompleteHandler() {
+        if (maxAge != null && maxSize != 0) {
+            // User has set removal policy
+            directoryStream.setChunkCompleteHandler(null);
+        } else {
+            directoryStream.setChunkCompleteHandler(new ChunkConsumer(recording));
+        }
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -469,7 +469,6 @@ public final class ChunkParser {
 
     public void close() {
         this.closed = true;
-        this.parsers = null; // Will drop reference to caches
         try {
             input.close();
         } catch(IOException e) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -469,6 +469,7 @@ public final class ChunkParser {
 
     public void close() {
         this.closed = true;
+        this.parsers = null; // Will drop reference to caches
         try {
             input.close();
         } catch(IOException e) {
@@ -487,5 +488,17 @@ public final class ChunkParser {
 
     public boolean hasStaleMetadata() {
         return staleMetadata;
+    }
+
+    public void resetCache() {
+        LongMap<Parser> ps = this.parsers;
+        if (ps != null) {
+            ps.forEach(p -> {
+                if (p instanceof EventParser) {
+                    EventParser ep = (EventParser) p;
+                    ep.resetCache();
+                }
+            });
+        }
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
@@ -119,6 +119,8 @@ public class EventDirectoryStream extends AbstractEventStream {
             } else {
                 jvm.include(t);
             }
+            sortedCache = null;
+            currentParser = null;
         }
     }
 
@@ -156,6 +158,7 @@ public class EventDirectoryStream extends AbstractEventStream {
                     }
                     if (disp.parserConfiguration.isOrdered()) {
                         processOrdered(disp);
+                        currentParser.resetCache();
                     } else {
                         processUnordered(disp);
                     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
@@ -119,8 +119,6 @@ public class EventDirectoryStream extends AbstractEventStream {
             } else {
                 jvm.include(t);
             }
-            sortedCache = null;
-            currentParser = null;
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventDirectoryStream.java
@@ -156,10 +156,10 @@ public class EventDirectoryStream extends AbstractEventStream {
                     }
                     if (disp.parserConfiguration.isOrdered()) {
                         processOrdered(disp);
-                        currentParser.resetCache();
                     } else {
                         processUnordered(disp);
                     }
+                    currentParser.resetCache();
                     if (currentParser.getStartNanos() + currentParser.getChunkDuration() > filterEnd) {
                         close();
                         return;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
@@ -99,6 +99,7 @@ public final class EventFileStream extends AbstractEventStream {
             currentParser.setFlushOperation(getFlushOperation());
             if (disp.parserConfiguration.isOrdered()) {
                 processOrdered(disp);
+                currentParser.resetCache();
             } else {
                 processUnordered(disp);
             }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/EventFileStream.java
@@ -99,10 +99,10 @@ public final class EventFileStream extends AbstractEventStream {
             currentParser.setFlushOperation(getFlushOperation());
             if (disp.parserConfiguration.isOrdered()) {
                 processOrdered(disp);
-                currentParser.resetCache();
             } else {
                 processUnordered(disp);
             }
+            currentParser.resetCache();
             if (isClosed() || currentParser.isLastChunk()) {
                 return;
             }


### PR DESCRIPTION
Hi,

This fix takes care of two memory-leaks that happen when using the RecordingStream in its default configuration.

The first leak happens due to a cache being filled up, but not reset after a chunk segment has been parsed. The second leak is more subtle and happens because objects are created on the heap to track an increased number of chunk files in the disk repository.

Testing:  jdk/jdk/jfr

Emitted and parsed about 3 000 chunks and checked the heap usage after GC. A slight increase (10 kb) could be seen over time, resulting in on average 1-2 bytes per million events, but could be due to compressed integers using more space in byte arrays during loading. More time could be spent investigating this, but I like to get these fixes in as soon as possible.

Heap histogram is stable for the important data structures.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257906](https://bugs.openjdk.java.net/browse/JDK-8257906): JFR: RecordingStream leaks memory


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1774/head:pull/1774`
`$ git checkout pull/1774`
