### PR TITLE
8258380: [JVMCI] don't clear InstalledCode reference when unloading JVMCI nmethods

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1270,7 +1270,6 @@ void nmethod::make_unloaded() {
   JVMCINMethodData* nmethod_data = jvmci_nmethod_data();
   if (nmethod_data != NULL) {
     nmethod_data->invalidate_nmethod_mirror(this);
-    nmethod_data->clear_nmethod_mirror(this);
   }
 #endif
 }

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -714,6 +714,12 @@ void JVMCINMethodData::invalidate_nmethod_mirror(nmethod* nm) {
       HotSpotJVMCI::InstalledCode::set_entryPoint(jvmciEnv, nmethod_mirror, 0);
     }
   }
+
+  if (_nmethod_mirror_index != -1 && nm->is_unloaded()) {
+    // Drop the reference to the nmethod mirror object but don't clear the actual oop reference.  Otherwise
+    // it would appear that the nmethod didn't need to be unloaded in the first place.
+    _nmethod_mirror_index = -1;
+  }
 }
 
 JVMCIRuntime::JVMCIRuntime(int id) {


### PR DESCRIPTION
We have been getting crashes running our unit tests in our gates with JDK15. The crashes are mostly in nmethod::is_unloaded because IsUnloadingBehaviour::current() is null. It seemed like there was some inconsistency in the notion of is_unloading for JVMCI nmethods that was leading to the crashes. I noticed that the is_unloading path rescans the nmethod using a closure to determine if it's unloading and since make_unloaded will clear the InstalledCode reference at the end if you ran the closure again it might return false since the oop is now null instead of being an unmarked oop. There's no point in the clearly the oop in this path anyway since the nmethod is dead and leaving the oop around seem to solve this crash. We're only see this crash in 15 but I don't see why it couldn't occur in 11 or later.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258380](https://bugs.openjdk.java.net/browse/JDK-8258380): [JVMCI] don't clear InstalledCode reference when unloading JVMCI nmethods


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1777/head:pull/1777`
`$ git checkout pull/1777`
