### PR TITLE
8196093: javax/swing/JComboBox/8072767/bug8072767.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -738,7 +738,6 @@ javax/swing/JSplitPane/4201995/bug4201995.java 8079127 generic-all
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
-javax/swing/JComboBox/8072767/bug8072767.java 8196093 windows-all,macosx-all
 javax/swing/JFileChooser/4524490/bug4524490.java 8042380 generic-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8193942 generic-all

--- a/test/jdk/javax/swing/JComboBox/8057893/bug8057893.java
+++ b/test/jdk/javax/swing/JComboBox/8057893/bug8057893.java
@@ -35,7 +35,6 @@ import javax.swing.WindowConstants;
  * @test
  * @key headful
  * @bug 8057893
- * @author Alexander Scherbatiy
  * @summary JComboBox actionListener never receives "comboBoxEdited"
  *   from getActionCommand
  * @run main bug8057893
@@ -47,7 +46,7 @@ public class bug8057893 {
 
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
 
         EventQueue.invokeAndWait(() -> {
             frame = new JFrame();
@@ -66,10 +65,12 @@ public class bug8057893 {
             frame.add(comboBox);
             frame.pack();
             frame.setVisible(true);
+            frame.setLocationRelativeTo(null);
             comboBox.requestFocusInWindow();
         });
 
         robot.waitForIdle();
+        robot.delay(1000);
 
         robot.keyPress(KeyEvent.VK_A);
         robot.keyRelease(KeyEvent.VK_A);

--- a/test/jdk/javax/swing/JComboBox/8072767/bug8072767.java
+++ b/test/jdk/javax/swing/JComboBox/8072767/bug8072767.java
@@ -39,7 +39,6 @@ import javax.swing.SwingUtilities;
  * @test
  * @key headful
  * @bug 8072767
- * @author Alexander Scherbatiy
  * @summary DefaultCellEditor for comboBox creates ActionEvent with wrong source
  *          object
  * @run main bug8072767
@@ -52,22 +51,23 @@ public class bug8072767 {
 
     private static JFrame frame;
     private static JTable table;
-    private static Point point;
+    private static volatile Point point;
     private static boolean testPass;
 
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
         SwingUtilities.invokeAndWait(bug8072767::createAndShowGUI);
         robot.waitForIdle();
+        robot.delay(1000);
         SwingUtilities.invokeAndWait(() -> {
             point = table.getLocationOnScreen();
             Rectangle rect = table.getCellRect(0, 0, true);
             point.translate(rect.width / 2, rect.height / 2);
         });
         robot.mouseMove(point.x, point.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
 
         robot.keyPress(KeyEvent.VK_1);
@@ -80,8 +80,8 @@ public class bug8072767 {
         });
 
         robot.mouseMove(point.x, point.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
 
         SwingUtilities.invokeAndWait(() -> {
@@ -98,7 +98,6 @@ public class bug8072767 {
         frame = new JFrame();
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setSize(200, 200);
-        frame.setLocation(100, 100);
 
         table = new JTable(
                 new String[][]{{TEST1}}, new String[]{"Header"});
@@ -108,5 +107,6 @@ public class bug8072767 {
                 new DefaultCellEditor(comboBox));
         frame.getContentPane().add(table);
         frame.setVisible(true);
+        frame.setLocationRelativeTo(null);
     }
 }


### PR DESCRIPTION
Test was failing if JComboBox tests was run in group in nightly mach5 testing.
Modified test to move frame to centre of screen, add delays before frame show. Also updated the test that ran just before this test move frame to center of screen.
Resultant modified test ran fine in JComboBox group and also in standalone, several iterations of which are ran in mach5. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8196093](https://bugs.openjdk.java.net/browse/JDK-8196093): javax/swing/JComboBox/8072767/bug8072767.java fails


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1778/head:pull/1778`
`$ git checkout pull/1778`
