### PR TITLE
8257700: Add logging for sealed classes in JVM_GetPermittedSubclasses

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2126,7 +2126,8 @@ JVM_ENTRY(jobjectArray, JVM_GetPermittedSubclasses(JNIEnv* env, jclass current))
   Klass* c = java_lang_Class::as_Klass(mirror);
   assert(c->is_instance_klass(), "must be");
   InstanceKlass* ik = InstanceKlass::cast(c);
-  log_trace(class, sealed)("Calling GetPermittedSubclasses for type %s", ik->external_name());
+  log_trace(class, sealed)("Calling GetPermittedSubclasses for %s type %s",
+                           ik->is_sealed() ? "sealed" : "non-sealed", ik->external_name());
   if (ik->is_sealed()) {
     JvmtiVMObjectAllocEventCollector oam;
     Array<u2>* subclasses = ik->permitted_subclasses();
@@ -2176,7 +2177,6 @@ JVM_ENTRY(jobjectArray, JVM_GetPermittedSubclasses(JNIEnv* env, jclass current))
     }
     return (jobjectArray)JNIHandles::make_local(THREAD, result());
   } else {
-    log_trace(class, sealed)("Type %s is not sealed", ik->external_name());
     return NULL;
   }
 }

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2126,6 +2126,7 @@ JVM_ENTRY(jobjectArray, JVM_GetPermittedSubclasses(JNIEnv* env, jclass current))
   Klass* c = java_lang_Class::as_Klass(mirror);
   assert(c->is_instance_klass(), "must be");
   InstanceKlass* ik = InstanceKlass::cast(c);
+  ResourceMark rm(THREAD);
   log_trace(class, sealed)("Calling GetPermittedSubclasses for %s type %s",
                            ik->is_sealed() ? "sealed" : "non-sealed", ik->external_name());
   if (ik->is_sealed()) {
@@ -2164,9 +2165,6 @@ JVM_ENTRY(jobjectArray, JVM_GetPermittedSubclasses(JNIEnv* env, jclass current))
     }
     if (count < length) {
       // we had invalid entries so we need to compact the array
-      log_trace(class, sealed)(" - compacting array from length %d to %d",
-                               length, count);
-
       objArrayOop r2 = oopFactory::new_objArray(SystemDictionary::Class_klass(),
                                                 count, CHECK_NULL);
       objArrayHandle result2(THREAD, r2);


### PR DESCRIPTION
Please review this small fix for JDK-8257700 to add logging to JVM_GetPermittedSubclasses().  The fix was tested with Mach5 tiers 1 and 2 on Linux, MacOS, and WIndows, tiers 3-5 on Linux x64, and by running the hotspot runtime sealed tests with -Xlog:class+sealed=trace and looking at the output.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257700](https://bugs.openjdk.java.net/browse/JDK-8257700): Add logging for sealed classes in JVM_GetPermittedSubclasses


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**) ⚠️ Review applies to 4cb2719d86da255924296d4e693ef9d5890ff06b
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 4cb2719d86da255924296d4e693ef9d5890ff06b


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1780/head:pull/1780`
`$ git checkout pull/1780`
