### PR TITLE
Remove empty finalize() methods from SocketInputStream and SocketOutputStream

### DIFF
--- a/src/java.base/share/classes/java/net/SocketInputStream.java
+++ b/src/java.base/share/classes/java/net/SocketInputStream.java
@@ -46,8 +46,7 @@ class SocketInputStream extends FileInputStream {
     }
 
     private boolean eof;
-    private AbstractPlainSocketImpl impl = null;
-    private byte temp[];
+    private AbstractPlainSocketImpl impl;
 
     /**
      * Creates a new SocketInputStream. Can only be called
@@ -55,7 +54,7 @@ class SocketInputStream extends FileInputStream {
      * that the fd will not be closed.
      * @param impl the implemented socket input stream
      */
-    SocketInputStream(AbstractPlainSocketImpl impl) throws IOException {
+    SocketInputStream(AbstractPlainSocketImpl impl) {
         super(impl.getFileDescriptor());
         this.impl = impl;
     }
@@ -88,7 +87,7 @@ class SocketInputStream extends FileInputStream {
      * @throws    IOException If an I/O error has occurred.
      */
     private native int socketRead0(FileDescriptor fd,
-                                   byte b[], int off, int len,
+                                   byte[] b, int off, int len,
                                    int timeout)
         throws IOException;
 
@@ -106,7 +105,7 @@ class SocketInputStream extends FileInputStream {
      * @throws    IOException If an I/O error has occurred.
      */
     private int socketRead(FileDescriptor fd,
-                           byte b[], int off, int len,
+                           byte[] b, int off, int len,
                            int timeout)
         throws IOException {
         return socketRead0(fd, b, off, len, timeout);
@@ -119,7 +118,7 @@ class SocketInputStream extends FileInputStream {
      *          returned when the end of the stream is reached.
      * @throws    IOException If an I/O error has occurred.
      */
-    public int read(byte b[]) throws IOException {
+    public int read(byte[] b) throws IOException {
         return read(b, 0, b.length);
     }
 
@@ -133,11 +132,11 @@ class SocketInputStream extends FileInputStream {
      *          returned when the end of the stream is reached.
      * @throws    IOException If an I/O error has occurred.
      */
-    public int read(byte b[], int off, int length) throws IOException {
+    public int read(byte[] b, int off, int length) throws IOException {
         return read(b, off, length, impl.getTimeout());
     }
 
-    int read(byte b[], int off, int length, int timeout) throws IOException {
+    int read(byte[] b, int off, int length, int timeout) throws IOException {
         int n;
 
         // EOF already encountered
@@ -193,7 +192,7 @@ class SocketInputStream extends FileInputStream {
         if (eof) {
             return -1;
         }
-        temp = new byte[1];
+        byte[] temp = new byte[1];
         int n = read(temp, 0, 1);
         if (n <= 0) {
             return -1;
@@ -213,9 +212,9 @@ class SocketInputStream extends FileInputStream {
         }
         long n = numbytes;
         int buflen = (int) Math.min(1024, n);
-        byte data[] = new byte[buflen];
+        byte[] data = new byte[buflen];
         while (n > 0) {
-            int r = read(data, 0, (int) Math.min((long) buflen, n));
+            int r = read(data, 0, (int) Math.min(buflen, n));
             if (r < 0) {
                 break;
             }
@@ -242,12 +241,6 @@ class SocketInputStream extends FileInputStream {
         // InputStream which calls Socket.close directly
         assert false;
     }
-
-    /**
-     * Overrides finalize, the fd is closed by the Socket.
-     */
-    @SuppressWarnings({"deprecation", "removal"})
-    protected void finalize() {}
 
     /**
      * Perform class load-time initializations.

--- a/src/java.base/share/classes/java/net/SocketOutputStream.java
+++ b/src/java.base/share/classes/java/net/SocketOutputStream.java
@@ -43,8 +43,7 @@ class SocketOutputStream extends FileOutputStream {
         init();
     }
 
-    private AbstractPlainSocketImpl impl = null;
-    private byte temp[] = new byte[1];
+    private final AbstractPlainSocketImpl impl;
 
     /**
      * Creates a new SocketOutputStream. Can only be called
@@ -52,7 +51,7 @@ class SocketOutputStream extends FileOutputStream {
      * that the fd will not be closed.
      * @param impl the socket output stream implemented
      */
-    SocketOutputStream(AbstractPlainSocketImpl impl) throws IOException {
+    SocketOutputStream(AbstractPlainSocketImpl impl) {
         super(impl.getFileDescriptor());
         this.impl = impl;
     }
@@ -91,7 +90,7 @@ class SocketOutputStream extends FileOutputStream {
      * @param len the number of bytes that are written
      * @throws    IOException If an I/O error has occurred.
      */
-    private void socketWrite(byte b[], int off, int len) throws IOException {
+    private void socketWrite(byte[] b, int off, int len) throws IOException {
 
 
         if (len <= 0 || off < 0 || len > b.length - off) {
@@ -122,6 +121,7 @@ class SocketOutputStream extends FileOutputStream {
      * @throws    IOException If an I/O error has occurred.
      */
     public void write(int b) throws IOException {
+        byte[] temp = new byte[1];
         temp[0] = (byte)b;
         socketWrite(temp, 0, 1);
     }
@@ -131,7 +131,7 @@ class SocketOutputStream extends FileOutputStream {
      * @param b the data to be written
      * @throws    SocketException If an I/O error has occurred.
      */
-    public void write(byte b[]) throws IOException {
+    public void write(byte[] b) throws IOException {
         socketWrite(b, 0, b.length);
     }
 
@@ -143,7 +143,7 @@ class SocketOutputStream extends FileOutputStream {
      * @param len the number of bytes that are written
      * @throws    SocketException If an I/O error has occurred.
      */
-    public void write(byte b[], int off, int len) throws IOException {
+    public void write(byte[] b, int off, int len) throws IOException {
         socketWrite(b, off, len);
     }
 
@@ -152,12 +152,6 @@ class SocketOutputStream extends FileOutputStream {
         // OutputStream which calls Socket.close directly
         assert false;
     }
-
-    /**
-     * Overrides finalize, the fd is closed by the Socket.
-     */
-    @SuppressWarnings({"deprecation", "removal"})
-    protected void finalize() {}
 
     /**
      * Perform class load-time initializations.


### PR DESCRIPTION
Both `SocketInputStream` and `SocketOutputStream` have no inheritors within JDK, both are package-private, so cannot be inherited by users and both override empty `finalize()` from `java.lang.Object`.

I think we can drop `finalize()` from both mentioned classes reducing unreachable objects lifetime. Also some primitive clean-up is possible.

Testing is ok for tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1782/head:pull/1782`
`$ git checkout pull/1782`
