### PR TITLE
8257726: Make -XX:+StressLdcRewrite option a diagnostic option

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -876,11 +876,11 @@ const intx ObjectAlignmentInBytes = 8;
   product(ccstr, TraceJVMTI, NULL,                                          \
           "Trace flags for JVMTI functions and events")                     \
                                                                             \
-  /* This option can change an EMCP method into an obsolete method. */      \
-  /* This can affect tests that except specific methods to be EMCP. */      \
-  /* This option should be used with caution.                       */      \
-  product(bool, StressLdcRewrite, false,                                    \
-          "Force ldc -> ldc_w rewrite during RedefineClasses")              \
+  product(bool, StressLdcRewrite, false, DIAGNOSTIC,                        \
+          "Force ldc -> ldc_w rewrite during RedefineClasses. "             \
+          "This option can change an EMCP method into an obsolete method "  \
+          "and can affect tests that expect specific methods to be EMCP. "  \
+          "This option should be used with caution.")                       \
                                                                             \
   product(bool, AllowRedefinitionToAddDeleteMethods, false,                 \
           "(Deprecated) Allow redefinition to add and delete private "      \

--- a/test/jdk/java/lang/instrument/RedefineMethodWithAnnotations.sh
+++ b/test/jdk/java/lang/instrument/RedefineMethodWithAnnotations.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ cp "${TESTSRC}"/RedefineMethodWithAnnotationsAnnotations.java \
     RedefineMethodWithAnnotationsAnnotations.java
 
 "${JAVA}" ${TESTVMOPTS} -javaagent:RedefineMethodWithAnnotationsAgent.jar \
-    -XX:+StressLdcRewrite -XX:+IgnoreUnrecognizedVMOptions \
+    -XX:+UnlockDiagnosticVMOptions -XX:+StressLdcRewrite -XX:+IgnoreUnrecognizedVMOptions \
     -cp "${TESTCLASSES}" RedefineMethodWithAnnotationsApp > output.log 2>&1
 cat output.log
 


### PR DESCRIPTION
See bug for details.  Tested:

$ java -XX:+StressLdcRewrite -version
Error: VM option 'StressLdcRewrite' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.
Error: The unlock option must precede 'StressLdcRewrite'.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
$ java -XX:+UnlockDiagnosticVMOptions -XX:+StressLdcRewrite -version
openjdk version "16-internal" 2021-03-16
OpenJDK Runtime Environment (build 16-internal+0-2020-12-15-1356558.coleen...)
OpenJDK 64-Bit Server VM (build 16-internal+0-2020-12-15-1356558.coleen..., mixed mode, sharing)

Also, java/lang/instrument which has a test using StressLdcRewrite and tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257726](https://bugs.openjdk.java.net/browse/JDK-8257726): Make -XX:+StressLdcRewrite option a diagnostic option


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1783/head:pull/1783`
`$ git checkout pull/1783`
