### PR TITLE
8254850: Update terminology in java.awt.GridBagLayout source code comments

### DIFF
--- a/src/java.desktop/share/classes/java/awt/GridBagLayout.java
+++ b/src/java.desktop/share/classes/java/awt/GridBagLayout.java
@@ -1104,7 +1104,7 @@ java.io.Serializable {
                 }
 
 
-                /* Cache the current slave's size. */
+                /* Cache the current child's size. */
                 if (sizeflag == PREFERREDSIZE)
                     d = comp.getPreferredSize();
                 else
@@ -1245,7 +1245,7 @@ java.io.Serializable {
                 else if (constraints.gridwidth == 0 && curCol < 0)
                     curRow = curY + curHeight;
 
-                /* Assign the new values to the gridbag slave */
+                /* Assign the new values to the gridbag child */
                 constraints.tempX = curX;
                 constraints.tempY = curY;
                 constraints.tempWidth = curWidth;
@@ -1364,7 +1364,7 @@ java.io.Serializable {
                         px = constraints.tempX + constraints.tempWidth; /* right column */
 
                         /*
-                         * Figure out if we should use this slave\'s weight.  If the weight
+                         * Figure out if we should use this child\'s weight.  If the weight
                          * is less than the total weight spanned by the width of the cell,
                          * then discard the weight.  Otherwise split the difference
                          * according to the existing weights.
@@ -1390,7 +1390,7 @@ java.io.Serializable {
 
                         /*
                          * Calculate the minWidth array values.
-                         * First, figure out how wide the current slave needs to be.
+                         * First, figure out how wide the current child needs to be.
                          * Then, see if it will fit within the current minWidth values.
                          * If it will not fit, add the difference according to the
                          * weightX array.
@@ -1425,7 +1425,7 @@ java.io.Serializable {
                         py = constraints.tempY + constraints.tempHeight; /* bottom row */
 
                         /*
-                         * Figure out if we should use this slave's weight.  If the weight
+                         * Figure out if we should use this child's weight.  If the weight
                          * is less than the total weight spanned by the height of the cell,
                          * then discard the weight.  Otherwise split it the difference
                          * according to the existing weights.
@@ -1451,7 +1451,7 @@ java.io.Serializable {
 
                         /*
                          * Calculate the minHeight array values.
-                         * First, figure out how tall the current slave needs to be.
+                         * First, figure out how tall the current child needs to be.
                          * Then, see if it will fit within the current minHeight values.
                          * If it will not fit, add the difference according to the
                          * weightY array.
@@ -1975,7 +1975,7 @@ java.io.Serializable {
 
     /**
      * Figures out the minimum size of the
-     * master based on the information from {@code getLayoutInfo}.
+     * parent based on the information from {@code getLayoutInfo}.
      * This method should only be used internally by
      * {@code GridBagLayout}.
      *
@@ -2055,7 +2055,7 @@ java.io.Serializable {
         rightToLeft = !parent.getComponentOrientation().isLeftToRight();
 
         /*
-         * If the parent has no slaves anymore, then don't do anything
+         * If the parent has no children anymore, then don't do anything
          * at all:  just leave the parent's size as-is.
          */
         if (components.length == 0 &&
@@ -2065,7 +2065,7 @@ java.io.Serializable {
         }
 
         /*
-         * Pass #1: scan all the slaves to figure out the total amount
+         * Pass #1: scan all the children to figure out the total amount
          * of space needed.
          */
 
@@ -2155,7 +2155,7 @@ java.io.Serializable {
          */
 
         /*
-         * Now do the actual layout of the slaves using the layout information
+         * Now do the actual layout of the children using the layout information
          * that has been collected.
          */
 

--- a/src/java.desktop/share/classes/java/awt/GridBagLayout.java
+++ b/src/java.desktop/share/classes/java/awt/GridBagLayout.java
@@ -1364,7 +1364,7 @@ java.io.Serializable {
                         px = constraints.tempX + constraints.tempWidth; /* right column */
 
                         /*
-                         * Figure out if we should use this child\'s weight.  If the weight
+                         * Figure out if we should use this child's weight.  If the weight
                          * is less than the total weight spanned by the width of the cell,
                          * then discard the weight.  Otherwise split the difference
                          * according to the existing weights.


### PR DESCRIPTION
This is part of an effort in the JDK to replace archaic/non-inclusive words with more neutral terms.
See JDK-8253315 for details.
 
This updates a few comments in GridBagLayout to use the terms parent and child which are
sufficiently descriptive and consistent with lots of other usages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254850](https://bugs.openjdk.java.net/browse/JDK-8254850): Update terminology in java.awt.GridBagLayout source code comments


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author) ⚠️ Review applies to 60eeff0555302515f4f393ffb43e3aa9005e9b79
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to 60eeff0555302515f4f393ffb43e3aa9005e9b79


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1784/head:pull/1784`
`$ git checkout pull/1784`
