### PR TITLE
8258420: Move URL configuration from Docs.gmk to conf dir

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -57,14 +57,11 @@ $(eval $(call IncludeCustomExtension, Docs.gmk))
 ################################################################################
 # Javadoc settings
 
+# Include configuration for URLs in generated javadoc
+include $(TOPDIR)/make/conf/javadoc.conf
+
 MODULES_SOURCE_PATH := $(call PathList, $(call GetModuleSrcPath) )
 
-# URLs
-JAVADOC_BASE_URL := https://docs.oracle.com/pls/topic/lookup?ctx=javase$(VERSION_NUMBER)&amp;id=homepage
-BUG_SUBMIT_URL := https://bugreport.java.com/bugreport/
-COPYRIGHT_URL := legal/copyright.html
-LICENSE_URL := https://www.oracle.com/java/javase/terms/license/java$(VERSION_NUMBER)speclicense.html
-REDISTRIBUTION_URL := https://www.oracle.com/technetwork/java/redist-137594.html
 
 # In order to get a specific ordering it's necessary to specify the total
 # ordering of tags as the tags are otherwise ordered in order of definition.

--- a/make/conf/javadoc.conf
+++ b/make/conf/javadoc.conf
@@ -1,0 +1,30 @@
+# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# URLs
+JAVADOC_BASE_URL=https://docs.oracle.com/pls/topic/lookup?ctx=javase$(VERSION_NUMBER)&amp;id=homepage
+BUG_SUBMIT_URL=https://bugreport.java.com/bugreport/
+COPYRIGHT_URL=legal/copyright.html
+LICENSE_URL=https://www.oracle.com/java/javase/terms/license/java$(VERSION_NUMBER)speclicense.html
+REDISTRIBUTION_URL=https://www.oracle.com/technetwork/java/redist-137594.html


### PR DESCRIPTION
In `Docs.gmk` there are some hard-coded links to online URL documentation and bug reporting locations. These should not reside in the make file per se, but instead move to the `make/conf` directory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258420](https://bugs.openjdk.java.net/browse/JDK-8258420): Move URL configuration from Docs.gmk to conf dir


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1785/head:pull/1785`
`$ git checkout pull/1785`
