### PR TITLE
8258438: build error in test/hotspot/gtest/runtime/test_os.cpp

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -523,7 +523,7 @@ TEST_VM(os, show_mappings_small_range) {
 TEST_VM(os, show_mappings_full_range) {
   // Reserve a small range and fill it with a marker string, should show up
   // on implementations displaying range snippets
-  char* p = os::reserve_memory(1 * M, mtInternal);
+  char* p = os::reserve_memory(1 * M, false, mtInternal);
   if (p != nullptr) {
     if (os::commit_memory(p, 1 * M, false)) {
       strcpy(p, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");


### PR DESCRIPTION
Please review this trivial fix for mach5 tier1 build failure:

```
test/hotspot/gtest/runtime/test_os.cpp:525:39: error: cannot convert 'const MEMFLAGS' to 'bool'
     char* p = os::reserve_memory(1 * M, mtInternal);
                                         ^^^^^^^^^^
```

It's caused by the following change in [os.hpp](url) in [JDK-8234930](https://bugs.openjdk.java.net/browse/JDK-8234930):

```
- static char*  reserve_memory(size_t bytes, MEMFLAGS flags = mtOther);
+ static char*  reserve_memory(size_t bytes, bool executable = false, MEMFLAGS flags = mtOther);
```

I am running a personal tier1 job to validate this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258438](https://bugs.openjdk.java.net/browse/JDK-8258438): build error in test/hotspot/gtest/runtime/test_os.cpp


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1788/head:pull/1788`
`$ git checkout pull/1788`
