### PR TITLE
8259231: Epsilon: improve performance under contention during virtual space expansion

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -113,7 +113,9 @@ HeapWord* EpsilonHeap::allocate_work(size_t size) {
     {
       MutexLocker ml(Heap_lock);
 
-      // check to prevent overallocation
+      // two reason:
+      //   1. reduce the chance of expand fail when another thread expand success and with enough space
+      //   2. prevent overallocation
       res = _space->par_allocate(size);
       if (res != NULL) {
         break;

--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -113,7 +113,7 @@ HeapWord* EpsilonHeap::allocate_work(size_t size) {
     if (res != NULL) {
       break;
     }
-    
+
     // Allocation failed, attempt expansion, and retry:
     {
       MutexLocker ml(Heap_lock);

--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -110,26 +110,34 @@ HeapWord* EpsilonHeap::allocate_work(size_t size) {
 
   while (res == NULL) {
     // Allocation failed, attempt expansion, and retry:
-    MutexLocker ml(Heap_lock);
+    {
+      MutexLocker ml(Heap_lock);
 
-    size_t space_left = max_capacity() - capacity();
-    size_t want_space = MAX2(size, EpsilonMinHeapExpand);
+      // check to prevent overallocation
+      res = _space->par_allocate(size);
+      if (res != NULL) {
+        break;
+      }
 
-    if (want_space < space_left) {
-      // Enough space to expand in bulk:
-      bool expand = _virtual_space.expand_by(want_space);
-      assert(expand, "Should be able to expand");
-    } else if (size < space_left) {
-      // No space to expand in bulk, and this allocation is still possible,
-      // take all the remaining space:
-      bool expand = _virtual_space.expand_by(space_left);
-      assert(expand, "Should be able to expand");
-    } else {
-      // No space left:
-      return NULL;
+      size_t space_left = max_capacity() - capacity();
+      size_t want_space = MAX2(size, EpsilonMinHeapExpand);
+
+      if (want_space < space_left) {
+        // Enough space to expand in bulk:
+        bool expand = _virtual_space.expand_by(want_space);
+        assert(expand, "Should be able to expand");
+      } else if (size < space_left) {
+        // No space to expand in bulk, and this allocation is still possible,
+        // take all the remaining space:
+        bool expand = _virtual_space.expand_by(space_left);
+        assert(expand, "Should be able to expand");
+      } else {
+        // No space left:
+        return NULL;
+      }
+
+      _space->set_end((HeapWord *) _virtual_space.high());
     }
-
-    _space->set_end((HeapWord *) _virtual_space.high());
     res = _space->par_allocate(size);
   }
 

--- a/src/hotspot/share/gc/epsilon/epsilon_globals.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilon_globals.hpp
@@ -64,7 +64,7 @@
           "smaller TLABs until policy catches up.")                         \
                                                                             \
   product(bool, EpsilonElasticTLABDecay, true, EXPERIMENTAL,                \
-          "Use timed decays to shrik TLAB sizes. This conserves memory "    \
+          "Use timed decays to shrink TLAB sizes. This conserves memory "   \
           "for the threads that allocate in bursts of different sizes, "    \
           "for example the small/rare allocations coming after the initial "\
           "large burst.")                                                   \

--- a/src/hotspot/share/gc/epsilon/epsilon_globals.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilon_globals.hpp
@@ -64,7 +64,7 @@
           "smaller TLABs until policy catches up.")                         \
                                                                             \
   product(bool, EpsilonElasticTLABDecay, true, EXPERIMENTAL,                \
-          "Use timed decays to shrink TLAB sizes. This conserves memory "   \
+          "Use timed decays to shrik TLAB sizes. This conserves memory "    \
           "for the threads that allocate in bursts of different sizes, "    \
           "for example the small/rare allocations coming after the initial "\
           "large burst.")                                                   \


### PR DESCRIPTION
Hi all,

The `EpsilonHeap::allocate_work` method maybe can be fixed and improved by this:
1. it can prevent allocate failure by retry `_space->par_allocate` before expanding virtual space,  when there not enough virtual space but another thread expanding succeeded just and has enough space.
2. it can reduce the lock time by move `res = _space->par_allocate(size);` out of lock scope.

Test on macosx-x86_64-server-{release, fastdebug, slowdebug} with current test case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259231](https://bugs.openjdk.java.net/browse/JDK-8259231): Epsilon: improve performance under contention during virtual space expansion


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1794/head:pull/1794`
`$ git checkout pull/1794`
