### PR TITLE
JDK-8258469: Cleanup remaining safefetch test coding

### DIFF
--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -34,7 +34,6 @@
 #include "runtime/stubRoutines.hpp"
 #include "utilities/align.hpp"
 #include "utilities/copy.hpp"
-#include "utilities/vmError.hpp"
 #ifdef COMPILER2
 #include "opto/runtime.hpp"
 #endif
@@ -268,40 +267,7 @@ static void test_arraycopy_func(address func, int alignment) {
     assert(fbuffer[i] == v && fbuffer2[i] == v2, "shouldn't have copied anything");
   }
 }
-
-// simple test for SafeFetch32
-static void test_safefetch32() {
-  if (CanUseSafeFetch32()) {
-    int dummy = 17;
-    int* const p_invalid = (int*) VMError::get_segfault_address();
-    int* const p_valid = &dummy;
-    int result_invalid = SafeFetch32(p_invalid, 0xABC);
-    assert(result_invalid == 0xABC, "SafeFetch32 error");
-    int result_valid = SafeFetch32(p_valid, 0xABC);
-    assert(result_valid == 17, "SafeFetch32 error");
-  }
-}
-
-// simple test for SafeFetchN
-static void test_safefetchN() {
-  if (CanUseSafeFetchN()) {
-#ifdef _LP64
-    const intptr_t v1 = UCONST64(0xABCD00000000ABCD);
-    const intptr_t v2 = UCONST64(0xDEFD00000000DEFD);
-#else
-    const intptr_t v1 = 0xABCDABCD;
-    const intptr_t v2 = 0xDEFDDEFD;
-#endif
-    intptr_t dummy = v1;
-    intptr_t* const p_invalid = (intptr_t*) VMError::get_segfault_address();
-    intptr_t* const p_valid = &dummy;
-    intptr_t result_invalid = SafeFetchN(p_invalid, v2);
-    assert(result_invalid == v2, "SafeFetchN error");
-    intptr_t result_valid = SafeFetchN(p_valid, v2);
-    assert(result_valid == v1, "SafeFetchN error");
-  }
-}
-#endif
+#endif // ASSERT
 
 void StubRoutines::initialize2() {
   if (_code2 == NULL) {
@@ -392,13 +358,6 @@ void StubRoutines::initialize2() {
   // Aligned to BytesPerLong
   test_arraycopy_func(CAST_FROM_FN_PTR(address, Copy::aligned_conjoint_words), sizeof(jlong));
   test_arraycopy_func(CAST_FROM_FN_PTR(address, Copy::aligned_disjoint_words), sizeof(jlong));
-
-  // test safefetch routines
-  // Not on Windows 32bit until 8074860 is fixed
-#if ! (defined(_WIN32) && defined(_M_IX86))
-  test_safefetch32();
-  test_safefetchN();
-#endif
 
 #endif
 }

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -68,17 +68,6 @@ bool VMError::_error_reported = false;
 // call this when the VM is dying--it might loosen some asserts
 bool VMError::is_error_reported() { return _error_reported; }
 
-// returns an address which is guaranteed to generate a SIGSEGV on read,
-// for test purposes, which is not NULL and contains bits in every word
-void* VMError::get_segfault_address() {
-  return (void*)
-#ifdef _LP64
-    0xABC0000000000ABCULL;
-#else
-    0x00000ABC;
-#endif
-}
-
 // List of environment variables that should be reported in error log file.
 const char *env_list[] = {
   // All platforms
@@ -490,7 +479,7 @@ void VMError::report(outputStream* st, bool _verbose) {
     if (_verbose && TestSafeFetchInErrorHandler) {
       st->print_cr("Will test SafeFetch...");
       if (CanUseSafeFetch32()) {
-        int* const invalid_pointer = (int*) get_segfault_address();
+        int* const invalid_pointer = (int*)segfault_address;
         const int x = 0x76543210;
         int i1 = SafeFetch32(invalid_pointer, x);
         int i2 = SafeFetch32(invalid_pointer, x);
@@ -1760,7 +1749,7 @@ static void crash_with_sigfpe() {
 // crash with sigsegv at non-null address.
 static void crash_with_segfault() {
 
-  char* const crash_addr = (char*) VMError::get_segfault_address();
+  char* const crash_addr = (char*)VMError::segfault_address;
   *crash_addr = 'X';
 
 } // end: crash_with_segfault

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -185,8 +185,9 @@ public:
 
   DEBUG_ONLY(static void controlled_crash(int how);)
 
-  // returns an address which is guaranteed to generate a SIGSEGV on read,
-  // for test purposes, which is not NULL and contains bits in every word
-  static void* get_segfault_address();
+  // Address which is guaranteed to generate a fault on read, for test purposes,
+  // which is not NULL and contains bits in every word.
+  static const intptr_t segfault_address = LP64_ONLY(0xABC0000000000ABCULL) NOT_LP64(0x00000ABC);
+
 };
 #endif // SHARE_UTILITIES_VMERROR_HPP


### PR DESCRIPTION
JDK-8257828 fixed SafeFetch for non-java-thread situations on all platforms. It also introduced gtests.
JDK-8185734 fixed the problem that gtests were running without SEH catcher on Windows, preventing us from testing Windows x86 at least.

Since we have now gtests to test SafeFetch, and since all these issues are fixed, we can remove the related test coding in stubRoutines.cpp.

Testing: manual gtests and GH actions (the Linux x86 error can be ignored, see https://bugs.openjdk.java.net/browse/JDK-8258481).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258469](https://bugs.openjdk.java.net/browse/JDK-8258469): Cleanup remaining safefetch test coding


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1799/head:pull/1799`
`$ git checkout pull/1799`
