### PR TITLE
8258471: "search codecache" clhsdb command does not work

### DIFF
--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1401,6 +1401,7 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   declare_type(BufferBlob,               RuntimeBlob)                     \
   declare_type(AdapterBlob,              BufferBlob)                      \
   declare_type(MethodHandlesAdapterBlob, BufferBlob)                      \
+  declare_type(VtableBlob,               BufferBlob)                      \
   declare_type(CompiledMethod,           CodeBlob)                        \
   declare_type(nmethod,                  CompiledMethod)                  \
   declare_type(RuntimeStub,              RuntimeBlob)                     \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeCache.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeCache.java
@@ -64,6 +64,7 @@ public class CodeCache {
     virtualConstructor.addMapping("RuntimeStub", RuntimeStub.class);
     virtualConstructor.addMapping("AdapterBlob", AdapterBlob.class);
     virtualConstructor.addMapping("MethodHandlesAdapterBlob", MethodHandlesAdapterBlob.class);
+    virtualConstructor.addMapping("VtableBlob", VtableBlob.class);
     virtualConstructor.addMapping("SafepointBlob", SafepointBlob.class);
     virtualConstructor.addMapping("DeoptimizationBlob", DeoptimizationBlob.class);
     if (VM.getVM().isServerCompiler()) {
@@ -167,7 +168,7 @@ public class CodeCache {
     }
     catch (Exception e) {
       String message = "Unable to deduce type of CodeBlob from address " + codeBlobAddr +
-                       " (expected type nmethod, RuntimeStub, ";
+                       " (expected type nmethod, RuntimeStub, VtableBlob, ";
       if (VM.getVM().isClientCompiler()) {
         message = message + " or ";
       }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/VtableBlob.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/VtableBlob.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, NTT DATA.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package sun.jvm.hotspot.code;
+
+import sun.jvm.hotspot.debugger.Address;
+
+public class VtableBlob extends BufferBlob {
+
+    public VtableBlob(Address addr) {
+        super(addr);
+    }
+
+    public boolean isVtableBlob() {
+        return true;
+    }
+
+    public String getName() {
+        return "VtableBlob: " + super.getName();
+    }
+
+}


### PR DESCRIPTION
`search codecache` command does not work as following:

```
hsdb> search codecache 0x7fedbd0aec90
java.lang.RuntimeException: Unable to deduce type of CodeBlob from address 0x00007fedbc85e810 (expected type nmethod, RuntimeStub, SafepointBlob, DeoptimizationBlob, or ExceptionBlob)
        at jdk.hotspot.agent/sun.jvm.hotspot.code.CodeCache.createCodeBlobWrapper(CodeCache.java:177)
        at jdk.hotspot.agent/sun.jvm.hotspot.memory.CodeHeap.iterate(CodeHeap.java:111)
        at jdk.hotspot.agent/sun.jvm.hotspot.code.CodeCache.iterate(CodeCache.java:185)
        at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor$40.doit(CommandProcessor.java:1535)
        at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.executeCommand(CommandProcessor.java:2051)
        at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.executeCommand(CommandProcessor.java:2021)
        at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.run(CommandProcessor.java:1901)
        at jdk.hotspot.agent/sun.jvm.hotspot.CLHSDB.run(CLHSDB.java:99)
        at jdk.hotspot.agent/sun.jvm.hotspot.CLHSDB.main(CLHSDB.java:40)
        at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.runCLHSDB(SALauncher.java:280)
        at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.main(SALauncher.java:483)
```

I checked the Object which points 0x7fedbd0aec90, it was `VtableBlob`. It has been introduced in [JDK-8199406](https://bugs.openjdk.java.net/browse/JDK-8199406), but it did not change SA code.

SA should support `VtableBlob`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258471](https://bugs.openjdk.java.net/browse/JDK-8258471): "search codecache" clhsdb command does not work


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1800/head:pull/1800`
`$ git checkout pull/1800`
