### PR TITLE
8258477: Pre-submit testing using GitHub Actions should merge changes from target branch

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,9 +1,18 @@
+#
+# The pre-submit tests will only runs for forks of the TARGET_PROJECT defined below. This is set to "jdk" by default,
+# and can be changed by downstream projects if they also want to run pre-submit tests.
+#
+# The tests will attempt to merge the latest commits from TARGET_BRANCH before executing, to ensure that what is tested
+# is as close as possible to what the final integration result will be. This is set to "master" by default, and can
+# be changed by downstream projects that utilize multiple branches in order to select the correct one.
+#
 name: Pre-submit tests
 
 on:
   push:
     branches-ignore:
       - master
+      - pr/*
   workflow_dispatch:
     inputs:
       platforms:
@@ -15,6 +24,9 @@ jobs:
   prerequisites:
     name: Prerequisites
     runs-on: "ubuntu-20.04"
+    env:
+      TARGET_PROJECT: jdk
+      TARGET_BRANCH: master
     outputs:
       should_run: ${{ steps.check_submit.outputs.should_run }}
       bundle_id: ${{ steps.check_bundle_id.outputs.bundle_id }}
@@ -25,11 +37,20 @@ jobs:
       platform_windows_x64: ${{ steps.check_platforms.outputs.platform_windows_x64 }}
       platform_macos_x64: ${{ steps.check_platforms.outputs.platform_macos_x64 }}
       dependencies: ${{ steps.check_deps.outputs.dependencies }}
+      fetch_target_command: ${{ steps.merge_target.outputs.command }}
+      merge_target_command: ${{ steps.try_merge_target.outputs.command }}
 
     steps:
+      - name: Determine target project name (fork source)
+        id: upstream_repo
+        uses: actions/github-script@v3
+        with:
+          result-encoding: string
+          script: "return (await github.repos.get( {owner: context.repo.owner, repo: context.repo.repo })).data.source.name"
+
       - name: Check if submit tests should actually run depending on secrets and manual triggering
         id: check_submit
-        run: echo "::set-output name=should_run::${{ github.event.inputs.platforms != '' || (!secrets.JDK_SUBMIT_FILTER || startsWith(github.ref, 'refs/heads/submit/')) }}"
+        run: echo "::set-output name=should_run::${{ env.TARGET_PROJECT == steps.upstream_repo.outputs.result }} && (${{ github.event.inputs.platforms != '' || (!secrets.JDK_SUBMIT_FILTER || startsWith(github.ref, 'refs/heads/submit/')) }})"
 
       - name: Check which platforms should be included
         id: check_platforms
@@ -51,6 +72,27 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: jdk
+          fetch-depth: 1000
+        if: steps.check_submit.outputs.should_run != 'false'
+
+      - name: Determine merge target hash
+        id: merge_target
+        run: |
+          git fetch https://github.com/openjdk/${{ steps.upstream_repo.outputs.result }} ${TARGET_BRANCH}
+          echo "::set-output name=hash::`git rev-parse FETCH_HEAD`"
+          echo "::set-output name=command::git fetch https://github.com/openjdk/${{ steps.upstream_repo.outputs.result }} ${TARGET_BRANCH}"
+        working-directory: jdk
+        if: steps.check_submit.outputs.should_run != 'false'
+
+      - name: Determine merge strategy
+        id: try_merge_target
+        run: >
+          (git -c user.name="presubmit" -c user.email="presubmit@github.actions" merge --no-edit ${{ steps.merge_target.outputs.hash }} &&
+            echo "::set-output name=command::git -c user.name="presubmit" -c user.email="presubmit@github.actions" merge --no-edit ${{ steps.merge_target.outputs.hash }}") ||
+          (git merge --abort && git -c user.name="presubmit" -c user.email="presubmit@github.actions" rebase ${{ steps.merge_target.outputs.hash }} &&
+            echo "::set-output name=command::git -c user.name="presubmit" -c user.email="presubmit@github.actions" rebase ${{ steps.merge_target.outputs.hash }}") ||
+          echo "::set-output name=command::echo There are merge conflicts with the target that will have to be resolved before integration"
+        working-directory: jdk
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Determine versions and locations to be used for dependencies
@@ -129,6 +171,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: jdk
+          fetch-depth: 1000
+
+      - name: Merge latest changes from target branch
+        run: |
+          ${{ needs.prerequisites.outputs.fetch_target_command }}
+          ${{ needs.prerequisites.outputs.merge_target_command }}
+        working-directory: jdk
 
       - name: Restore boot JDK from cache
         id: bootjdk
@@ -256,6 +305,13 @@ jobs:
     steps:
       - name: Checkout the source
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 1000
+
+      - name: Merge latest changes from target branch
+        run: |
+          ${{ needs.prerequisites.outputs.fetch_target_command }}
+          ${{ needs.prerequisites.outputs.merge_target_command }}
 
       - name: Restore boot JDK from cache
         id: bootjdk
@@ -439,6 +495,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: jdk
+          fetch-depth: 1000
+
+      - name: Merge latest changes from target branch
+        run: |
+          ${{ needs.prerequisites.outputs.fetch_target_command }}
+          ${{ needs.prerequisites.outputs.merge_target_command }}
+        working-directory: jdk
 
       - name: Restore boot JDK from cache
         id: bootjdk
@@ -591,6 +654,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: jdk
+          fetch-depth: 1000
+
+      - name: Merge latest changes from target branch
+        run: |
+          ${{ needs.prerequisites.outputs.fetch_target_command }}
+          ${{ needs.prerequisites.outputs.merge_target_command }}
+        working-directory: jdk
 
       - name: Restore boot JDK from cache
         id: bootjdk
@@ -724,6 +794,13 @@ jobs:
     steps:
       - name: Checkout the source
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 1000
+
+      - name: Merge latest changes from target branch
+        run: |
+          ${{ needs.prerequisites.outputs.fetch_target_command }}
+          ${{ needs.prerequisites.outputs.merge_target_command }}
 
       - name: Restore boot JDK from cache
         id: bootjdk
@@ -889,6 +966,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: jdk
+          fetch-depth: 1000
+
+      - name: Merge latest changes from target branch
+        run: |
+          ${{ needs.prerequisites.outputs.fetch_target_command }}
+          ${{ needs.prerequisites.outputs.merge_target_command }}
+        working-directory: jdk
 
       - name: Restore boot JDK from cache
         id: bootjdk
@@ -978,6 +1062,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: jdk
+          fetch-depth: 1000
+
+      - name: Merge latest changes from target branch
+        run: |
+          ${{ needs.prerequisites.outputs.fetch_target_command }}
+          ${{ needs.prerequisites.outputs.merge_target_command }}
+        working-directory: jdk
 
       - name: Restore boot JDK from cache
         id: bootjdk
@@ -1115,6 +1206,13 @@ jobs:
     steps:
       - name: Checkout the source
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 1000
+
+      - name: Merge latest changes from target branch
+        run: |
+          ${{ needs.prerequisites.outputs.fetch_target_command }}
+          ${{ needs.prerequisites.outputs.merge_target_command }}
 
       - name: Restore boot JDK from cache
         id: bootjdk
@@ -1291,6 +1389,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: jdk
+          fetch-depth: 1000
+
+      - name: Merge latest changes from target branch
+        run: |
+          ${{ needs.prerequisites.outputs.fetch_target_command }}
+          ${{ needs.prerequisites.outputs.merge_target_command }}
+        working-directory: jdk
 
       - name: Restore boot JDK from cache
         id: bootjdk
@@ -1418,6 +1523,13 @@ jobs:
     steps:
       - name: Checkout the source
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 1000
+
+      - name: Merge latest changes from target branch
+        run: |
+          ${{ needs.prerequisites.outputs.fetch_target_command }}
+          ${{ needs.prerequisites.outputs.merge_target_command }}
 
       - name: Restore boot JDK from cache
         id: bootjdk

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -19,6 +19,10 @@ on:
         description: "Platform(s) to execute on"
         required: true
         default: "Linux additional (hotspot only), Linux x64, Linux x86, Windows aarch64, Windows x64, macOS x64"
+      merge:
+        description: "Merge latest changes from target branch"
+        required: true
+        default: true
 
 jobs:
   prerequisites:
@@ -82,7 +86,7 @@ jobs:
           echo "::set-output name=hash::`git rev-parse FETCH_HEAD`"
           echo "::set-output name=command::git fetch https://github.com/openjdk/${{ steps.upstream_repo.outputs.result }} ${TARGET_BRANCH}"
         working-directory: jdk
-        if: steps.check_submit.outputs.should_run != 'false'
+        if: steps.check_submit.outputs.should_run != 'false' && (github.event.inputs.platforms == '' || github.event.inputs.merge == 'true')
 
       - name: Determine merge strategy
         id: try_merge_target
@@ -93,7 +97,7 @@ jobs:
             echo "::set-output name=command::git -c user.name="presubmit" -c user.email="presubmit@github.actions" rebase ${{ steps.merge_target.outputs.hash }}") ||
           echo "::set-output name=command::echo There are merge conflicts with the target that will have to be resolved before integration"
         working-directory: jdk
-        if: steps.check_submit.outputs.should_run != 'false'
+        if: steps.check_submit.outputs.should_run != 'false' && (github.event.inputs.platforms == '' || github.event.inputs.merge == 'true')
 
       - name: Determine versions and locations to be used for dependencies
         id: check_deps


### PR DESCRIPTION
Normally when running GitHub Actions on a pull request, what is checked out is the merge of the pull request with the latest changes on the target branch. This ensure that what is tested is as close as possible to what will actually be the result of integrating said pull request. 

In our use of GitHub Actions, we don't run directly on pull requests but instead allow contributors to run them in their own personal forks. In that context, there is no notion of a target branch. However, we can infer the target project and branch by encoding this in the workflow file. This allows us to perform the same merge manually, and achieve the same behaviour. 

The change also adds an option to disable this automated merge when launching the workflow manually, which could be useful when investigating unexpected test failures.

Note that downstream projects picking up this change will have to adapt the workflow file to keep using these actions for pre-submit testing. This has been a common request from downstream projects, but could also be done in a separate change (or not at all).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258477](https://bugs.openjdk.java.net/browse/JDK-8258477): Pre-submit testing using GitHub Actions should merge changes from target branch


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1801/head:pull/1801`
`$ git checkout pull/1801`
