### PR TITLE
8257513: C2: assert((constant_addr - _masm.code()->consts()->start()) == con.offset())

### DIFF
--- a/src/hotspot/share/opto/constantTable.hpp
+++ b/src/hotspot/share/opto/constantTable.hpp
@@ -113,7 +113,7 @@ public:
   void set_table_base_offset(int x)  { assert(_table_base_offset == -1 || x == _table_base_offset, "can't change"); _table_base_offset = x; }
   int      table_base_offset() const { assert(_table_base_offset != -1, "not set yet");                      return _table_base_offset; }
 
-  void emit(CodeBuffer& cb);
+  bool emit(CodeBuffer& cb) const;
 
   // Returns the offset of the last entry (the top) of the constant table.
   int  top_offset() const { assert(_constants.top().offset() != -1, "not bound yet"); return _constants.top().offset(); }

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1425,7 +1425,10 @@ void PhaseOutput::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
 
   // Emit the constant table.
   if (C->has_mach_constant_base_node()) {
-    constant_table().emit(*cb);
+    if (!constant_table().emit(*cb)) {
+      C->record_failure("consts section overflow");
+      return;
+    }
   }
 
   // Create an array of labels, one for each basic block

--- a/test/hotspot/jtreg/compiler/codecache/TestStressCodeBuffers.java
+++ b/test/hotspot/jtreg/compiler/codecache/TestStressCodeBuffers.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8257513
+ * @requires vm.debug == true
  * @summary Stress testing code buffers resulted in an assertion failure due to not taking expand calls into account
  *          which can fail more often with -XX:+StressCodeBuffers. Perform some more sanity flag testing.
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+StressCodeBuffers compiler.codecache.TestStressCodeBuffers

--- a/test/hotspot/jtreg/compiler/codecache/TestStressCodeBuffers.java
+++ b/test/hotspot/jtreg/compiler/codecache/TestStressCodeBuffers.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8257513
+ * @summary Stress testing code buffers resulted in an assertion failure due to not taking expand calls into account
+ *          which can fail more often with -XX:+StressCodeBuffers. Perform some more sanity flag testing.
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+StressCodeBuffers compiler.codecache.TestStressCodeBuffers
+ * @run main/othervm -Xcomp -XX:+StressCodeBuffers compiler.codecache.TestStressCodeBuffers
+ */
+
+package compiler.codecache;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class TestStressCodeBuffers {
+
+    static MethodHandle permh;
+
+    public static void main(String[] args) throws Exception {
+        test();
+    }
+
+    public static void test() throws Exception {
+        MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+        MethodHandle mh = lookup.findStatic(TestStressCodeBuffers.class, "bar",
+                                            MethodType.methodType(void.class, int.class, long.class));
+        permh = MethodHandles.permuteArguments(mh, mh.type(), 0, 1); // Triggers assertion failure
+    }
+
+    public static void bar(int x, long y) {}
+}
+


### PR DESCRIPTION
Running the testcase with `-XX:+StressCodeBuffers` initializes the code buffer with a small size:
https://github.com/openjdk/jdk/blob/0c8cc2cde47bed3d5c3edc203869068a0676812b/src/hotspot/share/opto/output.cpp#L1339-L1340
This leads to more frequent expansions in `ConstantTable::emit()` when calling the `_masm.*_constant()` methods. In the `T_VOID` case, we additionally fill the jump-table with dummy words:
https://github.com/openjdk/jdk/blob/0c8cc2cde47bed3d5c3edc203869068a0676812b/src/hotspot/share/opto/constantTable.cpp#L146-L150

When there is an expansion during this loop, then `constant_addr` is still pointing to an outdated address before expanding the code buffer and relocating the data. This lets the assertion fail when subtracting the new address `_masm.code()->consts()->start()` after the expansion.

I extended this assertion for `T_VOID` to take an expansion into account. 

There is a second issue that is currently not handled correctly. The `_masm.*_constant()` methods could return `NULL` when we failed to allocate new space in an expansion which, however, rarely happens. But when running with `-XX:+StressCodeBuffers`, `NULL` is much more likely to be returned because we intentionally free a blob from time to time:
https://github.com/openjdk/jdk/blob/0c8cc2cde47bed3d5c3edc203869068a0676812b/src/hotspot/share/asm/codeBuffer.cpp#L846-L854

I therefore suggest to also change the associated assertions in `ConstantTable::emit()` into bailout code to handle this case (as also done in the `LIR_Assembler` using the `AbstractAssembler::*_constant()` methods).

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257513](https://bugs.openjdk.java.net/browse/JDK-8257513): C2: assert((constant_addr - _masm.code()->consts()->start()) == con.offset())


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1803/head:pull/1803`
`$ git checkout pull/1803`
