### PR TITLE
8258514: Replace Collections.unmodifiableList with List.of

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/AlpnExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/AlpnExtension.java
@@ -85,8 +85,7 @@ final class AlpnExtension {
         final List<String> applicationProtocols;
 
         private AlpnSpec(String[] applicationProtocols) {
-            this.applicationProtocols = Collections.unmodifiableList(
-                    Arrays.asList(applicationProtocols));
+            this.applicationProtocols = List.of(applicationProtocols);
         }
 
         private AlpnSpec(HandshakeContext hc,

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -198,8 +198,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
                 Collections.unmodifiableCollection(
                         new ArrayList<>(hc.localSupportedSignAlgs));
         this.serverNameIndication = hc.negotiatedServerName;
-        this.requestedServerNames = Collections.unmodifiableList(
-                new ArrayList<>(hc.getRequestedServerNames()));
+        this.requestedServerNames = List.copyOf(hc.getRequestedServerNames());
         if (hc.sslConfig.isClientMode) {
             this.useExtendedMasterSecret =
                 (hc.handshakeExtensions.get(

--- a/src/java.base/share/classes/sun/security/ssl/ServerNameExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/ServerNameExtension.java
@@ -89,8 +89,7 @@ final class ServerNameExtension {
          * (see JDK-6323374).
          */
         private CHServerNamesSpec(List<SNIServerName> serverNames) {
-            this.serverNames = Collections.<SNIServerName>unmodifiableList(
-                    new ArrayList<>(serverNames));
+            this.serverNames = List.copyOf(serverNames);
         }
 
         private CHServerNamesSpec(HandshakeContext hc,


### PR DESCRIPTION
The Collections.unmodifiableList() method could be recurring copy on itself and have potential problems. The List.of() method is solid, and could be used instead.

Code cleanup, no new regression text.

Bug: https://bugs.openjdk.java.net/browse/JDK-8258514

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258514](https://bugs.openjdk.java.net/browse/JDK-8258514): Replace Collections.unmodifiableList with List.of


### Reviewers
 * [Jamil Nimeh](https://openjdk.java.net/census#jnimeh) (@jnimeh - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1804/head:pull/1804`
`$ git checkout pull/1804`
