### PR TITLE
8258415: gtest for committed memory leaks reservation

### DIFF
--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -202,6 +202,8 @@ public:
     ASSERT_TRUE(result);
     ASSERT_EQ(2 * page_sz, committed_size);
     ASSERT_EQ(committed_start, (address)(base + page_sz));
+
+    os::release_memory(base, size);
   }
 };
 


### PR DESCRIPTION
Add a call to os::release_memory() in the gtest.
Tested with gtest on linux-x64-debug.  tier1 testing in progress to run on other platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258415](https://bugs.openjdk.java.net/browse/JDK-8258415): gtest for committed memory leaks reservation


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1809/head:pull/1809`
`$ git checkout pull/1809`
