### PR TITLE
8257530: vmTestbase/metaspace/stressDictionary/StressDictionary.java timed out

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressDictionary/StressDictionary.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressDictionary/StressDictionary.java
@@ -29,7 +29,7 @@
  * VM Testbase keywords: [nonconcurrent, javac]
  *
  * @library /vmTestbase /test/lib
- * @run main/othervm/timeout=420 metaspace.stressDictionary.StressDictionary -stressTime 30
+ * @run main/othervm/timeout=600 metaspace.stressDictionary.StressDictionary -stressTime 30
  */
 
 package metaspace.stressDictionary;


### PR DESCRIPTION
Increase the timeout for this test a bit.  The bug didn't show any deadlocks or other indications that the test was stuck.
Tested with 100x on linux, macosx and windows platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257530](https://bugs.openjdk.java.net/browse/JDK-8257530): vmTestbase/metaspace/stressDictionary/StressDictionary.java timed out


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1810/head:pull/1810`
`$ git checkout pull/1810`
