### PR TITLE
8258554: javax/swing/JTable/4235420/bug4235420.java fails in GTK L&F

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -733,7 +733,6 @@ javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 802462
 # The next test below is an intermittent failure
 javax/swing/JComboBox/8033069/bug8033069ScrollBar.java 8163367 generic-all
 javax/swing/JColorChooser/Test6827032.java 8197825 windows-all
-javax/swing/JTable/4235420/bug4235420.java     8079127 generic-all
 javax/swing/JSplitPane/4201995/bug4201995.java 8079127 generic-all
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all

--- a/test/jdk/javax/swing/JTable/4235420/bug4235420.java
+++ b/test/jdk/javax/swing/JTable/4235420/bug4235420.java
@@ -37,20 +37,34 @@ import java.util.Map;
 public class bug4235420 {
 
     public static void main(String[] argv) throws Exception {
-        if ("Nimbus".equals(UIManager.getLookAndFeel().getName())) {
-            System.out.println("The test is skipped for Nimbus");
-
-            return;
-        }
-
-        SwingUtilities.invokeAndWait(new Runnable() {
-            @Override
-            public void run() {
-                Table table = new Table();
-
-                table.test();
+        for (UIManager.LookAndFeelInfo LF :
+                UIManager.getInstalledLookAndFeels()) {
+            try {
+                UIManager.setLookAndFeel(LF.getClassName());
+            } catch (UnsupportedLookAndFeelException ignored) {
+                System.out.println("Unsupported L&F: " + LF.getClassName());
+            } catch (ClassNotFoundException | InstantiationException
+                     | IllegalAccessException e) {
+                throw new RuntimeException(e);
             }
-        });
+	    System.out.println("Testing L&F: " + LF.getClassName());
+
+            if ("Nimbus".equals(UIManager.getLookAndFeel().getName()) ||
+	        "GTK".equals(UIManager.getLookAndFeel().getName())) {
+                System.out.println("The test is skipped for Nimbus and GTK");
+
+                continue;
+            }
+
+            SwingUtilities.invokeAndWait(new Runnable() {
+                @Override
+                public void run() {
+                    Table table = new Table();
+
+                    table.test();
+                }
+            });
+        }
     }
 
     private static class Table extends JTable {

--- a/test/jdk/javax/swing/JTable/4235420/bug4235420.java
+++ b/test/jdk/javax/swing/JTable/4235420/bug4235420.java
@@ -47,10 +47,10 @@ public class bug4235420 {
                      | IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
-	    System.out.println("Testing L&F: " + LF.getClassName());
+            System.out.println("Testing L&F: " + LF.getClassName());
 
             if ("Nimbus".equals(UIManager.getLookAndFeel().getName()) ||
-	        "GTK".equals(UIManager.getLookAndFeel().getName())) {
+                "GTK".equals(UIManager.getLookAndFeel().getName())) {
                 System.out.println("The test is skipped for Nimbus and GTK");
 
                 continue;


### PR DESCRIPTION
This test tests whether creation of Renderers and Editors are delayed but in nimbus and subseqeuently in GTK L&F the renderers are created in installDefaults() [1] itself so it fails in GTKL&F.
As nimbus is already skipped in the test, it is modified to skip GTK L&F too. Along with this modification, the test is also updated to test all installed L&Fs.
Mach5 job running for several iterations for all platform is ok. Link in JBS.

[1] https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTableUI.java#L118

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258554](https://bugs.openjdk.java.net/browse/JDK-8258554): javax/swing/JTable/4235420/bug4235420.java fails in GTK L&F


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1813/head:pull/1813`
`$ git checkout pull/1813`
