### PR TITLE
8258576: Try to get zerobased CCS if heap is above 32 and CDS is disabled

### DIFF
--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -707,7 +707,7 @@ void Metaspace::global_initialize() {
     //  territory, i.e. its base is under 32G, then we attempt to place ccs
     //  right above the java heap.
     // Otherwise the lower 32G are still free. We try to place ccs at the lowest
-    // allowed mapping address for efficient encoding of compressed class pointers.
+    // allowed mapping address.
     address base = (UseCompressedOops && (uint64_t)CompressedOops::base() < OopEncodingHeapMax) ?
                    CompressedOops::end() : (address)HeapBaseMinAddress;
     base = align_up(base, Metaspace::reserve_alignment());

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -703,13 +703,13 @@ void Metaspace::global_initialize() {
     // case (b)
     ReservedSpace rs;
 
-    // If UseCompressedOops=1, java heap may have been placed in coops-friendly
-    //  territory already (lower address regions), so we attempt to place ccs
+    // If UseCompressedOops=1 and the java heap has been placed in coops-friendly
+    //  territory, i.e. its base is under 32G, then we attempt to place ccs
     //  right above the java heap.
-    // If UseCompressedOops=0, the heap has been placed anywhere - probably in
-    //  high memory regions. In that case, try to place ccs at the lowest allowed
-    //  mapping address.
-    address base = UseCompressedOops ? CompressedOops::end() : (address)HeapBaseMinAddress;
+    // Otherwise the lower 32G are still free. We try to place ccs at the lowest
+    // allowed mapping address for efficient encoding of compressed class pointers.
+    address base = (UseCompressedOops && (uint64_t)CompressedOops::base() < OopEncodingHeapMax) ?
+                   CompressedOops::end() : (address)HeapBaseMinAddress;
     base = align_up(base, Metaspace::reserve_alignment());
 
     const size_t size = align_up(CompressedClassSpaceSize, Metaspace::reserve_alignment());

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -98,13 +98,37 @@ public class CompressedClassPointers {
             "-Xshare:off",
             "-XX:+VerifyBeforeGC", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        if (testNarrowKlassBase() && !Platform.isAix()) {
-            // AIX: the heap cannot be placed below 32g. The first attempt to
-            // place the CCS behind the heap fails (luckily). Subsequently CCS
-            // is successfully placed below 32g. So we get 0x0 as narrow klass
-            // base.
+        if (testNarrowKlassBase() && !Platform.isPPC() && !Platform.isOSX()) {
+            // PPC: in most cases the heap cannot be placed below 32g so there
+            // is room for ccs and narrow klass base will be 0x0. Exception:
+            // Linux 4.1.42 or earlier (see ELF_ET_DYN_BASE in JDK-8244847).
+            // For simplicity we exclude PPC.
+            // OSX: similar.
             output.shouldNotContain("Narrow klass base: 0x0000000000000000");
             output.shouldContain("Narrow klass shift: 0");
+        }
+        output.shouldHaveExitValue(0);
+    }
+
+    // Settings as in largeHeapTest() except for max heap size. We make max heap
+    // size even larger such that it cannot fit into lower 32G but not too large
+    // for compressed oops.
+    // We expect a zerobased ccs.
+    public static void largeHeapAbove32GTest() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-Xmx31g",
+            "-XX:-UseAOT", // AOT explicitly set klass shift to 3.
+            logging_option,
+            "-Xshare:off",
+            "-XX:+VerifyBeforeGC", "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        if (testNarrowKlassBase()) {
+            output.shouldContain("Narrow klass base: 0x0000000000000000");
+            if (!Platform.isAArch64()) {
+                output.shouldContain("Narrow klass shift: 0");
+            }
         }
         output.shouldHaveExitValue(0);
     }
@@ -297,6 +321,7 @@ public class CompressedClassPointers {
         smallHeapTest();
         smallHeapTestWith1G();
         largeHeapTest();
+        largeHeapAbove32GTest();
         largePagesForHeapTest();
         heapBaseMinAddressTest();
         sharingTest();

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -126,7 +126,7 @@ public class CompressedClassPointers {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         if (testNarrowKlassBase()) {
             output.shouldContain("Narrow klass base: 0x0000000000000000");
-            if (!Platform.isAArch64()) {
+            if (!Platform.isAArch64() && !Platform.isOSX()) {
                 output.shouldContain("Narrow klass shift: 0");
             }
         }


### PR DESCRIPTION
Please review this small enhancement if CDS is disabled.

It tries to get a zerobased compressed class space if we have a not-zerobased compressed oops heap, i.e. the heap is above 32g. In this case there is a good chance to locate CCS below 32g.

The fix passed our CI testing: JCK and JTREG, also in Xcomp mode, SPECjvm2008, SPECjbb2015, Renaissance Suite,
SAP specific tests with fastdebug and release builds on all platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258576](https://bugs.openjdk.java.net/browse/JDK-8258576): Try to get zerobased CCS if heap is above 32 and CDS is disabled


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to 1f7195deb67fc276a8a17d539c285267d4dde527
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 1f7195deb67fc276a8a17d539c285267d4dde527


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1815/head:pull/1815`
`$ git checkout pull/1815`
