### PR TITLE
8258584: java/util/HexFormat/HexFormatTest.java fails on x86_32

### DIFF
--- a/test/jdk/java/util/HexFormat/HexFormatTest.java
+++ b/test/jdk/java/util/HexFormat/HexFormatTest.java
@@ -42,7 +42,7 @@ import static org.testng.Assert.expectThrows;
 /*
  * @test
  * @summary Check HexFormat formatting and parsing
- * @run testng/othervm -Xmx4G HexFormatTest
+ * @run testng/othervm HexFormatTest
  */
 
 @Test
@@ -640,12 +640,7 @@ public class HexFormatTest {
             Throwable ex = expectThrows(OutOfMemoryError.class,
                     () -> hex.formatHex(bytes));
             System.out.println("ex: " + ex);
-        } catch (OutOfMemoryError oome) {
-            System.out.printf("OOME: total mem: %08x, free mem: %08x, max mem: %08x%n",
-                    Runtime.getRuntime().totalMemory(),
-                    Runtime.getRuntime().freeMemory(),
-                    Runtime.getRuntime().maxMemory());
-            throw oome;
+        } catch (OutOfMemoryError ignored) {
         }
 
     }

--- a/test/jdk/java/util/HexFormat/HexFormatTest.java
+++ b/test/jdk/java/util/HexFormat/HexFormatTest.java
@@ -23,6 +23,7 @@
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.testng.SkipException;
 
 import java.io.CharArrayWriter;
 import java.io.IOException;
@@ -640,7 +641,12 @@ public class HexFormatTest {
             Throwable ex = expectThrows(OutOfMemoryError.class,
                     () -> hex.formatHex(bytes));
             System.out.println("ex: " + ex);
-        } catch (OutOfMemoryError ignored) {
+        } catch (OutOfMemoryError oome) {
+            System.out.printf("OOME: total mem: %08x, free mem: %08x, max mem: %08x%n",
+                    Runtime.getRuntime().totalMemory(),
+                    Runtime.getRuntime().freeMemory(),
+                    Runtime.getRuntime().maxMemory());
+            throw new SkipException("Insufficient Memory to test OOME");
         }
 
     }

--- a/test/jdk/java/util/HexFormat/HexFormatTest.java
+++ b/test/jdk/java/util/HexFormat/HexFormatTest.java
@@ -42,6 +42,7 @@ import static org.testng.Assert.expectThrows;
 /*
  * @test
  * @summary Check HexFormat formatting and parsing
+ * @requires vm.bits == 64
  * @run testng/othervm -Xmx4G HexFormatTest
  */
 

--- a/test/jdk/java/util/HexFormat/HexFormatTest.java
+++ b/test/jdk/java/util/HexFormat/HexFormatTest.java
@@ -42,7 +42,6 @@ import static org.testng.Assert.expectThrows;
 /*
  * @test
  * @summary Check HexFormat formatting and parsing
- * @requires vm.bits == 64
  * @run testng/othervm -Xmx4G HexFormatTest
  */
 


### PR DESCRIPTION
Hi all,

java/util/HexFormat/HexFormatTest.java fails on x86_32 due to '-Xmx4G'.
The reason is that -Xmx4G is invalid maximum heap size for 32-bit platforms.
The current implementation only supports maximum 3800M on 32-bit systems [1].

I've tried to reduce the -Xmx size, but it still fails even with -Xmx2G.
So this test seems to be brittle on 32-bit platforms since 2G is already larger than 3800M/2=1900M.
The fix just skips the test for 32-bit systems.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/os/posix/os_posix.cpp#L567

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258584](https://bugs.openjdk.java.net/browse/JDK-8258584): java/util/HexFormat/HexFormatTest.java fails on x86_32


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1817/head:pull/1817`
`$ git checkout pull/1817`
