### PR TITLE
8258593: remove redundant codes in HeapObjectDumper

### DIFF
--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1408,15 +1408,12 @@ class VM_HeapDumper;
 
 class HeapObjectDumper : public ObjectClosure {
  private:
-  VM_HeapDumper* _dumper;
   DumpWriter* _writer;
 
-  VM_HeapDumper* dumper()               { return _dumper; }
   DumpWriter* writer()                  { return _writer; }
 
  public:
-  HeapObjectDumper(VM_HeapDumper* dumper, DumpWriter* writer) {
-    _dumper = dumper;
+  HeapObjectDumper(DumpWriter* writer) {
     _writer = writer;
   }
 
@@ -1826,7 +1823,7 @@ void VM_HeapDumper::work(uint worker_id) {
   // segment is started.
   // The HPROF_GC_CLASS_DUMP and HPROF_GC_INSTANCE_DUMP are the vast bulk
   // of the heap dump.
-  HeapObjectDumper obj_dumper(this, writer());
+  HeapObjectDumper obj_dumper(writer());
   Universe::heap()->object_iterate(&obj_dumper);
 
   // HPROF_GC_ROOT_THREAD_OBJ + frames + jni locals


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258593](https://bugs.openjdk.java.net/browse/JDK-8258593): remove redundant codes in HeapObjectDumper


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1819/head:pull/1819`
`$ git checkout pull/1819`
