### PR TITLE
8258582: HttpClient: the HttpClient doesn't explicitly shutdown its default executor when stopping.

### DIFF
--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -19,6 +19,7 @@ grant codeBase "jrt:/java.net.http" {
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.util";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.www";
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.misc";
+    permission java.lang.RuntimePermission "modifyThread";
     permission java.net.SocketPermission "*","connect,resolve";
     permission java.net.URLPermission "http:*","*:*";
     permission java.net.URLPermission "https:*","*:*";


### PR DESCRIPTION
Hi,

Please find an almost trivial fix for:
8258582: HttpClient: the HttpClient doesn't explicitly shutdown its default executor when stopping.

The HttpClient should shutdown his executor when stopping, when the executor was created by the HttpClient itself.

best regards,

-- daniel

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258582](https://bugs.openjdk.java.net/browse/JDK-8258582): HttpClient: the HttpClient doesn't explicitly shutdown its default executor when stopping.


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1822/head:pull/1822`
`$ git checkout pull/1822`
