### PR TITLE
8258524: Instrumented EventHandler calls private instance method EventWriter.reset

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
@@ -191,7 +191,7 @@ public final class EventWriter {
         }
     }
 
-    private void reset() {
+    public void reset() {
         currentPosition = startPosition;
         if (flushOnEnd) {
             flushOnEnd = flush();


### PR DESCRIPTION
This resolves the issue by making the method public.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258524](https://bugs.openjdk.java.net/browse/JDK-8258524): Instrumented EventHandler calls private instance method EventWriter.reset 


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1824/head:pull/1824`
`$ git checkout pull/1824`
