### PR TITLE
8256213: Remove os::split_reserved_memory

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -366,20 +366,6 @@ char* os::map_memory_to_file_aligned(size_t size, size_t alignment, int file_des
   return aligned_base;
 }
 
-// On Posix platforms, reservations are done using mmap which can be released in parts. So splitting is a no-op.
-void os::split_reserved_memory(char *base, size_t size, size_t split) {
-  char* const split_address = base + split;
-  assert(size > 0, "Sanity");
-  assert(size > split, "Sanity");
-  assert(split > 0, "Sanity");
-  assert(is_aligned(base, os::vm_allocation_granularity()), "Sanity");
-  assert(is_aligned(split_address, os::vm_allocation_granularity()), "Sanity");
-
-  // NMT: tell NMT to track both parts individually from now on.
-  MemTracker::record_virtual_memory_split_reserved(base, size, split);
-
-}
-
 int os::vsnprintf(char* buf, size_t len, const char* fmt, va_list args) {
   // All supported POSIX platforms provide C99 semantics.
   int result = ::vsnprintf(buf, len, fmt, args);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3193,34 +3193,6 @@ char* os::replace_existing_mapping_with_file_mapping(char* base, size_t size, in
   return map_memory_to_file(base, size, fd);
 }
 
-// On win32, one cannot release just a part of reserved memory, it's an
-// all or nothing deal.  When we split a reservation, we must break the
-// reservation into two reservations.
-void os::split_reserved_memory(char *base, size_t size, size_t split) {
-
-  char* const split_address = base + split;
-  assert(size > 0, "Sanity");
-  assert(size > split, "Sanity");
-  assert(split > 0, "Sanity");
-  assert(is_aligned(base, os::vm_allocation_granularity()), "Sanity");
-  assert(is_aligned(split_address, os::vm_allocation_granularity()), "Sanity");
-
-  const bool rc = release_memory(base, size) &&
-                  (attempt_reserve_memory_at(base, split) != NULL) &&
-                  (attempt_reserve_memory_at(split_address, size - split) != NULL);
-  if (!rc) {
-    log_warning(os)("os::split_reserved_memory failed for " RANGE_FORMAT,
-                    RANGE_FORMAT_ARGS(base, size));
-    os::print_memory_mappings(base, size, tty);
-    assert(false, "os::split_reserved_memory failed for " RANGE_FORMAT,
-                    RANGE_FORMAT_ARGS(base, size));
-  }
-
-  // NMT: nothing to do here. Since Windows implements the split by
-  //  releasing and re-reserving memory, the parts are already registered
-  //  as individual mappings with NMT.
-}
-
 // Multiple threads can race in this code but it's not possible to unmap small sections of
 // virtual space to get requested alignment, like posix-like os's.
 // Windows prevents multiple thread from remapping over each other so this loop is thread-safe.

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -1668,8 +1668,7 @@ char* MetaspaceShared::reserve_address_space_for_archives(FileMapInfo* static_ma
     // Now split up the space into ccs and cds archive. For simplicity, just leave
     //  the gap reserved at the end of the archive space. Do not do real splitting.
     archive_space_rs = total_space_rs.first_part(ccs_begin_offset,
-                                                 (size_t)os::vm_allocation_granularity(),
-                                                 /*split=*/false);
+                                                 (size_t)os::vm_allocation_granularity());
     class_space_rs = total_space_rs.last_part(ccs_begin_offset);
     MemTracker::record_virtual_memory_split_reserved(total_space_rs.base(), total_space_rs.size(),
                                                      ccs_begin_offset);

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -252,13 +252,9 @@ void ReservedSpace::initialize(size_t size, size_t alignment, bool large,
   }
 }
 
-ReservedSpace ReservedSpace::first_part(size_t partition_size, size_t alignment, bool split) {
+ReservedSpace ReservedSpace::first_part(size_t partition_size, size_t alignment) {
   assert(partition_size <= size(), "partition failed");
-  if (split && partition_size > 0 && partition_size < size()) {
-    os::split_reserved_memory(base(), size(), partition_size);
-  }
-  ReservedSpace result(base(), partition_size, alignment, special(),
-                       executable());
+  ReservedSpace result(base(), partition_size, alignment, special(), executable());
   return result;
 }
 

--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -80,7 +80,7 @@ class ReservedSpace {
   ReservedSpace last_part (size_t partition_size, size_t alignment);
 
   // These simply call the above using the default alignment.
-  inline ReservedSpace first_part(size_t partition_size/*, bool split = false*/);
+  inline ReservedSpace first_part(size_t partition_size);
   inline ReservedSpace last_part (size_t partition_size);
 
   // Alignment

--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -76,17 +76,11 @@ class ReservedSpace {
 
   // Splitting
   // This splits the space into two spaces, the first part of which will be returned.
-  // If split==true, the resulting two spaces can be released independently from each other.
-  //  This may cause the original space to loose its content.
-  //  They also will be tracked individually by NMT and can be tagged with different flags.
-  //  Note that this may cause the original space to loose its content.
-  // If split==false, the resulting space will be just a hotspot-internal representation
-  //  of a sub section of the underlying mapping.
-  ReservedSpace first_part(size_t partition_size, size_t alignment, bool split = false);
+  ReservedSpace first_part(size_t partition_size, size_t alignment);
   ReservedSpace last_part (size_t partition_size, size_t alignment);
 
   // These simply call the above using the default alignment.
-  inline ReservedSpace first_part(size_t partition_size, bool split = false);
+  inline ReservedSpace first_part(size_t partition_size/*, bool split = false*/);
   inline ReservedSpace last_part (size_t partition_size);
 
   // Alignment
@@ -101,9 +95,9 @@ class ReservedSpace {
 };
 
 ReservedSpace
-ReservedSpace::first_part(size_t partition_size, bool split)
+ReservedSpace::first_part(size_t partition_size)
 {
-  return first_part(partition_size, alignment(), split);
+  return first_part(partition_size, alignment());
 }
 
 ReservedSpace ReservedSpace::last_part(size_t partition_size)

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -336,16 +336,6 @@ class os: AllStatic {
   // Does not overwrite existing mappings.
   static char*  attempt_reserve_memory_at(char* addr, size_t bytes, bool executable = false);
 
-  // Split a reserved memory region [base, base+size) into two regions [base, base+split) and
-  //  [base+split, base+size).
-  //  This may remove the original mapping, so its content may be lost.
-  // Both base and split point must be aligned to allocation granularity; split point shall
-  //  be >0 and <size.
-  // Splitting guarantees that the resulting two memory regions can be released independently
-  //  from each other using os::release_memory(). It also means NMT will track these regions
-  //  individually, allowing different tags to be set.
-  static void   split_reserved_memory(char *base, size_t size, size_t split);
-
   static bool   commit_memory(char* addr, size_t bytes, bool executable);
   static bool   commit_memory(char* addr, size_t size, size_t alignment_hint,
                               bool executable);


### PR DESCRIPTION
Hi, Please review 
  This is the second step for removing problematic os::split_reserved_memory on Windows. The first step has been accomplished under bug 8255917 (https://bugs.openjdk.java.net/browse/JDK-8255917).
  This step remove the function split_reserved_memory which no longer be called after first step.

Tests: tier1-4

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256213](https://bugs.openjdk.java.net/browse/JDK-8256213): Remove os::split_reserved_memory


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to 4318c9a3678c7a6b89bd221e323b387b4ebc767c
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1825/head:pull/1825`
`$ git checkout pull/1825`
