### PR TITLE
8225072: Add LuxTrust certificate that is expiring in March 2021 to list of allowed but expired certs

### DIFF
--- a/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
+++ b/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
@@ -27,7 +27,7 @@
  * @bug 8189131 8198240 8191844 8189949 8191031 8196141 8204923 8195774 8199779
  *      8209452 8209506 8210432 8195793 8216577 8222089 8222133 8222137 8222136
  *      8223499 8225392 8232019 8234245 8233223 8225068 8225069 8243321 8243320
- *      8243559
+ *      8243559 8225072 8258630
  * @summary Check root CA entries in cacerts file
  */
 import java.io.ByteArrayInputStream;
@@ -258,6 +258,10 @@ public class VerifyCACerts {
             add("addtrustexternalca [jdk]");
             // Valid until: Sat May 30 10:44:50 GMT 2020
             add("addtrustqualifiedca [jdk]");
+            // Valid until: Wed Mar 17 02:51:37 PDT 2021
+            add("luxtrustglobalrootca [jdk]");
+            // Valid until: Wed Mar 17 11:33:33 PDT 2021
+            add("quovadisrootca [jdk]");
         }
     };
 


### PR DESCRIPTION
… certificates

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8225072](https://bugs.openjdk.java.net/browse/JDK-8225072): Add LuxTrust certificate that is expiring in March 2021 to list of allowed but expired certs
 * [JDK-8258630](https://bugs.openjdk.java.net/browse/JDK-8258630): Add expiry exception for QuoVadis root certificate


### Reviewers
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1826/head:pull/1826`
`$ git checkout pull/1826`
