### PR TITLE
8252055: Use java.util.HexFormat in java.security

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/AbstractDrbg.java
+++ b/src/java.base/share/classes/sun/security/provider/AbstractDrbg.java
@@ -730,19 +730,6 @@ public abstract class AbstractDrbg {
 
     // Misc
 
-    /** A handy method returning hexdump string with no colon or new line.
-     *
-     * @param in input byte array
-     * @return the hexdump string
-     */
-    protected static String hex(byte[] in) {
-        StringBuilder sb = new StringBuilder();
-        for (byte b : in) {
-            sb.append(String.format("%02x", b&0xff));
-        }
-        return sb.toString();
-    }
-
     /**
      * Returns the smallest standard strength (112, 128, 192, 256) that is
      * greater or equal to the input.

--- a/src/java.base/share/classes/sun/security/provider/AbstractHashDrbg.java
+++ b/src/java.base/share/classes/sun/security/provider/AbstractHashDrbg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/provider/CtrDrbg.java
+++ b/src/java.base/share/classes/sun/security/provider/CtrDrbg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/provider/CtrDrbg.java
+++ b/src/java.base/share/classes/sun/security/provider/CtrDrbg.java
@@ -30,6 +30,7 @@ import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.*;
 import java.util.Arrays;
+import java.util.HexFormat;
 import java.util.Locale;
 
 public class CtrDrbg extends AbstractDrbg {
@@ -181,8 +182,8 @@ public class CtrDrbg extends AbstractDrbg {
 
     private void status() {
         if (debug != null) {
-            debug.println(this, "Key = " + hex(k));
-            debug.println(this, "V   = " + hex(v));
+            debug.println(this, "Key = " + HexFormat.of().formatHex(k));
+            debug.println(this, "V   = " + HexFormat.of().formatHex(v));
             debug.println(this, "reseed counter = " + reseedCounter);
         }
     }

--- a/src/java.base/share/classes/sun/security/provider/HashDrbg.java
+++ b/src/java.base/share/classes/sun/security/provider/HashDrbg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/provider/HashDrbg.java
+++ b/src/java.base/share/classes/sun/security/provider/HashDrbg.java
@@ -33,6 +33,7 @@ import java.security.NoSuchProviderException;
 import java.security.SecureRandomParameters;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HexFormat;
 import java.util.List;
 
 public class HashDrbg extends AbstractHashDrbg {
@@ -161,8 +162,8 @@ public class HashDrbg extends AbstractHashDrbg {
 
     private void status() {
         if (debug != null) {
-            debug.println(this, "V = " + hex(v));
-            debug.println(this, "C = " + hex(c));
+            debug.println(this, "V = " + HexFormat.of().formatHex(v));
+            debug.println(this, "C = " + HexFormat.of().formatHex(c));
             debug.println(this, "reseed counter = " + reseedCounter);
         }
     }

--- a/src/java.base/share/classes/sun/security/provider/HmacDrbg.java
+++ b/src/java.base/share/classes/sun/security/provider/HmacDrbg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/provider/HmacDrbg.java
+++ b/src/java.base/share/classes/sun/security/provider/HmacDrbg.java
@@ -33,6 +33,7 @@ import java.security.NoSuchProviderException;
 import java.security.SecureRandomParameters;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HexFormat;
 import java.util.List;
 
 public class HmacDrbg extends AbstractHashDrbg {
@@ -51,8 +52,8 @@ public class HmacDrbg extends AbstractHashDrbg {
 
     private void status() {
         if (debug != null) {
-            debug.println(this, "V = " + hex(v));
-            debug.println(this, "Key = " + hex(k));
+            debug.println(this, "V = " + HexFormat.of().formatHex(v));
+            debug.println(this, "Key = " + HexFormat.of().formatHex(k));
             debug.println(this, "reseed counter = " + reseedCounter);
         }
     }

--- a/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
@@ -774,12 +774,12 @@ class RevocationChecker extends PKIXRevocationChecker {
     /*
      * Removes any non-hexadecimal characters from a string.
      */
-    private static final String HEX_DIGITS = "0123456789ABCDEFabcdef";
     private static String stripOutSeparators(String value) {
+        HexFormat hex = HexFormat.of();
         char[] chars = value.toCharArray();
         StringBuilder hexNumber = new StringBuilder();
         for (int i = 0; i < chars.length; i++) {
-            if (HEX_DIGITS.indexOf(chars[i]) != -1) {
+            if (hex.isHexDigit(chars[i])) {
                 hexNumber.append(chars[i]);
             }
         }

--- a/src/java.base/share/classes/sun/security/ssl/SSLLogger.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLLogger.java
@@ -39,6 +39,7 @@ import java.text.MessageFormat;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.HexFormat;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -580,7 +581,7 @@ public final class SSLLogger {
                     Utilities.toHexString((byte[])value) + "\"";
             } else if (value instanceof Byte) {
                 formatted = "\"" + key + "\": \"" +
-                    Utilities.toHexString((byte)value) + "\"";
+                        HexFormat.of().toHexDigits((byte)value) + "\"";
             } else {
                 formatted = "\"" + key + "\": " +
                     "\"" + value.toString() + "\"";

--- a/src/java.base/share/classes/sun/security/ssl/ServerHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ServerHello.java
@@ -33,6 +33,7 @@ import java.security.GeneralSecurityException;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.HexFormat;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -237,9 +238,8 @@ final class ServerHello {
                 serverVersion.name,
                 Utilities.toHexString(serverRandom.randomBytes),
                 sessionId.toString(),
-                cipherSuite.name + "(" +
-                        Utilities.byte16HexString(cipherSuite.id) + ")",
-                Utilities.toHexString(compressionMethod),
+                cipherSuite.name + "(" + Utilities.byte16HexString(cipherSuite.id) + ")",
+                HexFormat.of().toHexDigits(compressionMethod),
                 Utilities.indent(extensions.toString(), "    ")
             };
 

--- a/src/java.base/share/classes/sun/security/ssl/Utilities.java
+++ b/src/java.base/share/classes/sun/security/ssl/Utilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/ssl/Utilities.java
+++ b/src/java.base/share/classes/sun/security/ssl/Utilities.java
@@ -36,10 +36,11 @@ import sun.security.action.GetPropertyAction;
  * A utility class to share the static methods.
  */
 final class Utilities {
-    static final char[] hexDigits = "0123456789ABCDEF".toCharArray();
     private static final String indent = "  ";
     private static final Pattern lineBreakPatern =
                 Pattern.compile("\\r\\n|\\n|\\r");
+    private static final HexFormat HEX_FORMATTER =
+            HexFormat.of().withUpperCase();
 
     /**
      * Puts {@code hostname} into the {@code serverNames} list.
@@ -164,15 +165,8 @@ final class Utilities {
         return builder.toString();
     }
 
-    static String toHexString(byte b) {
-        return String.valueOf(hexDigits[(b >> 4) & 0x0F]) +
-                String.valueOf(hexDigits[b & 0x0F]);
-    }
-
     static String byte16HexString(int id) {
-        return "0x" +
-                hexDigits[(id >> 12) & 0x0F] + hexDigits[(id >> 8) & 0x0F] +
-                hexDigits[(id >> 4) & 0x0F] + hexDigits[id & 0x0F];
+        return "0x" + HEX_FORMATTER.toHexDigits((short)id);
     }
 
     static String toHexString(byte[] bytes) {
@@ -180,19 +174,7 @@ final class Utilities {
             return "";
         }
 
-        StringBuilder builder = new StringBuilder(bytes.length * 3);
-        boolean isFirst = true;
-        for (byte b : bytes) {
-            if (isFirst) {
-                isFirst = false;
-            } else {
-                builder.append(' ');
-            }
-
-            builder.append(hexDigits[(b >> 4) & 0x0F]);
-            builder.append(hexDigits[b & 0x0F]);
-        }
-        return builder.toString();
+        return HEX_FORMATTER.formatHex(bytes);
     }
 
     static String toHexString(long lv) {
@@ -206,10 +188,8 @@ final class Utilities {
                 builder.append(' ');
             }
 
-            builder.append(hexDigits[(int)(lv & 0x0F)]);
-            lv >>>= 4;
-            builder.append(hexDigits[(int)(lv & 0x0F)]);
-            lv >>>= 4;
+            HEX_FORMATTER.toHexDigits(builder, (byte)lv);
+            lv >>>= 8;
         } while (lv != 0);
         builder.reverse();
 

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1445,7 +1445,7 @@ public final class Main {
 
         BufferedReader reader = new BufferedReader(new InputStreamReader(in));
         boolean canRead = false;
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (true) {
             String s = reader.readLine();
             if (s == null) break;
@@ -2597,7 +2597,7 @@ public final class Main {
             throws Exception {
 
         BufferedReader reader = new BufferedReader(new InputStreamReader(in));
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         boolean started = false;
         while (true) {
             String s = reader.readLine();
@@ -3508,33 +3508,6 @@ public final class Main {
     }
 
     /**
-     * Converts a byte to hex digit and writes to the supplied buffer
-     */
-    private void byte2hex(byte b, StringBuffer buf) {
-        char[] hexChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8',
-                            '9', 'A', 'B', 'C', 'D', 'E', 'F' };
-        int high = ((b & 0xf0) >> 4);
-        int low = (b & 0x0f);
-        buf.append(hexChars[high]);
-        buf.append(hexChars[low]);
-    }
-
-    /**
-     * Converts a byte array to hex string
-     */
-    private String toHexString(byte[] block) {
-        StringBuffer buf = new StringBuffer();
-        int len = block.length;
-        for (int i = 0; i < len; i++) {
-             byte2hex(block[i], buf);
-             if (i < len-1) {
-                 buf.append(":");
-             }
-        }
-        return buf.toString();
-    }
-
-    /**
      * Recovers (private) key associated with given alias.
      *
      * @return an array of objects, where the 1st element in the array is the
@@ -3663,7 +3636,7 @@ public final class Main {
         byte[] encCertInfo = cert.getEncoded();
         MessageDigest md = MessageDigest.getInstance(mdAlg);
         byte[] digest = md.digest(encCertInfo);
-        return toHexString(digest);
+        return HexFormat.ofDelimiter(":").withUpperCase().formatHex(digest);
     }
 
     /**
@@ -4571,21 +4544,16 @@ public final class Main {
                         break;
                     case -1:
                         ObjectIdentifier oid = ObjectIdentifier.of(name);
+                        HexFormat hexFmt = HexFormat.of();
                         byte[] data = null;
                         if (value != null) {
                             data = new byte[value.length() / 2 + 1];
                             int pos = 0;
                             for (char c: value.toCharArray()) {
-                                int hex;
-                                if (c >= '0' && c <= '9') {
-                                    hex = c - '0' ;
-                                } else if (c >= 'A' && c <= 'F') {
-                                    hex = c - 'A' + 10;
-                                } else if (c >= 'a' && c <= 'f') {
-                                    hex = c - 'a' + 10;
-                                } else {
+                                if (!hexFmt.isHexDigit(c)) {
                                     continue;
                                 }
+                                int hex = hexFmt.fromHexDigit(c);
                                 if (pos % 2 == 0) {
                                     data[pos/2] = (byte)(hex << 4);
                                 } else {

--- a/src/java.base/share/classes/sun/security/util/Debug.java
+++ b/src/java.base/share/classes/sun/security/util/Debug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/util/Debug.java
+++ b/src/java.base/share/classes/sun/security/util/Debug.java
@@ -27,6 +27,7 @@ package sun.security.util;
 
 import java.io.PrintStream;
 import java.math.BigInteger;
+import java.util.HexFormat;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import java.util.Locale;
@@ -318,22 +319,11 @@ public class Debug {
         return null;
     }
 
-    private static final char[] hexDigits = "0123456789abcdef".toCharArray();
-
     public static String toString(byte[] b) {
         if (b == null) {
             return "(null)";
         }
-        StringBuilder sb = new StringBuilder(b.length * 3);
-        for (int i = 0; i < b.length; i++) {
-            int k = b[i] & 0xff;
-            if (i != 0) {
-                sb.append(':');
-            }
-            sb.append(hexDigits[k >>> 4]);
-            sb.append(hexDigits[k & 0xf]);
-        }
-        return sb.toString();
+        return HexFormat.ofDelimiter(":").formatHex(b);
     }
 
 }

--- a/src/java.base/share/classes/sun/security/util/ManifestEntryVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/ManifestEntryVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/util/ManifestEntryVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/ManifestEntryVerifier.java
@@ -214,8 +214,8 @@ public class ManifestEntryVerifier {
             if (debug != null) {
                 debug.println("Manifest Entry: " +
                                    name + " digest=" + digest.getAlgorithm());
-                debug.println("  manifest " + toHex(manHash));
-                debug.println("  computed " + toHex(theHash));
+                debug.println("  manifest " + HexFormat.of().formatHex(manHash));
+                debug.println("  computed " + HexFormat.of().formatHex(theHash));
                 debug.println();
             }
 
@@ -231,25 +231,4 @@ public class ManifestEntryVerifier {
         }
         return signers;
     }
-
-    // for the toHex function
-    private static final char[] hexc =
-            {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'};
-    /**
-     * convert a byte array to a hex string for debugging purposes
-     * @param data the binary data to be converted to a hex string
-     * @return an ASCII hex string
-     */
-
-    static String toHex(byte[] data) {
-
-        StringBuilder sb = new StringBuilder(data.length*2);
-
-        for (int i=0; i<data.length; i++) {
-            sb.append(hexc[(data[i] >>4) & 0x0f]);
-            sb.append(hexc[data[i] & 0x0f]);
-        }
-        return sb.toString();
-    }
-
 }

--- a/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.HexFormat;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -497,8 +498,8 @@ public class SignatureFileVerifier {
                     if (debug != null) {
                         debug.println("Signature File: Manifest digest " +
                                 algorithm);
-                        debug.println( "  sigfile  " + toHex(expectedHash));
-                        debug.println( "  computed " + toHex(computedHash));
+                        debug.println( "  sigfile  " + HexFormat.of().formatHex(expectedHash));
+                        debug.println( "  computed " + HexFormat.of().formatHex(computedHash));
                         debug.println();
                     }
 
@@ -568,8 +569,8 @@ public class SignatureFileVerifier {
                      debug.println("Signature File: " +
                                         "Manifest Main Attributes digest " +
                                         digest.getAlgorithm());
-                     debug.println( "  sigfile  " + toHex(expectedHash));
-                     debug.println( "  computed " + toHex(computedHash));
+                     debug.println( "  sigfile  " + HexFormat.of().formatHex(expectedHash));
+                     debug.println( "  computed " + HexFormat.of().formatHex(computedHash));
                      debug.println();
                     }
 
@@ -676,8 +677,8 @@ public class SignatureFileVerifier {
                         if (debug != null) {
                           debug.println("Signature Block File: " +
                                    name + " digest=" + digest.getAlgorithm());
-                          debug.println("  expected " + toHex(expected));
-                          debug.println("  computed " + toHex(computed));
+                          debug.println("  expected " + HexFormat.of().formatHex(expected));
+                          debug.println("  computed " + HexFormat.of().formatHex(computed));
                           debug.println();
                         }
 
@@ -690,7 +691,7 @@ public class SignatureFileVerifier {
                                computed = mde.digestWorkaround(digest);
                                if (MessageDigest.isEqual(computed, expected)) {
                                    if (debug != null) {
-                                       debug.println("  re-computed " + toHex(computed));
+                                       debug.println("  re-computed " + HexFormat.of().formatHex(computed));
                                        debug.println();
                                    }
                                    workaround = true;
@@ -761,26 +762,6 @@ public class SignatureFileVerifier {
         } else {
             return null;
         }
-    }
-
-    // for the toHex function
-    private static final char[] hexc =
-            {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'};
-    /**
-     * convert a byte array to a hex string for debugging purposes
-     * @param data the binary data to be converted to a hex string
-     * @return an ASCII hex string
-     */
-
-    static String toHex(byte[] data) {
-
-        StringBuilder sb = new StringBuilder(data.length*2);
-
-        for (int i=0; i<data.length; i++) {
-            sb.append(hexc[(data[i] >>4) & 0x0f]);
-            sb.append(hexc[data[i] & 0x0f]);
-        }
-        return sb.toString();
     }
 
     // returns true if set contains signer

--- a/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
@@ -1932,26 +1932,10 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
             byte[] encCertInfo = cert.getEncoded();
             MessageDigest md = MessageDigest.getInstance(algorithm);
             byte[] digest = md.digest(encCertInfo);
-            StringBuilder sb = new StringBuilder(digest.length * 2);
-            for (int i = 0; i < digest.length; i++) {
-                byte2hex(digest[i], sb);
-            }
-            return sb.toString();
+            return HexFormat.of().withUpperCase().formatHex(digest);
         } catch (NoSuchAlgorithmException | CertificateEncodingException e) {
             // ignored
         }
         return "";
-    }
-
-    /**
-     * Converts a byte to hex digit and writes to the supplied builder
-     */
-    private static void byte2hex(byte b, StringBuilder buf) {
-        char[] hexChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8',
-                '9', 'A', 'B', 'C', 'D', 'E', 'F' };
-        int high = ((b & 0xf0) >> 4);
-        int low = (b & 0x0f);
-        buf.append(hexChars[high])
-            .append(hexChars[low]);
     }
 }


### PR DESCRIPTION
The java.util.HexFormat methods for formatting and parsing replace a number of adhoc hex parsing and formatting methods in sun.security implementation classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252055](https://bugs.openjdk.java.net/browse/JDK-8252055): Use java.util.HexFormat in java.security


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1828/head:pull/1828`
`$ git checkout pull/1828`
