### PR TITLE
JDK-8223322: Improve concurrency in jpackage instances

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppStoreBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppStoreBundler.java
@@ -106,6 +106,7 @@ public class MacAppStoreBundler extends MacBaseInstallerBundler {
 
     public Path bundle(Map<String, ? super Object> params,
             Path outdir) throws PackagerException {
+        List<String> keyChains = new ArrayList<>();
         Log.verbose(MessageFormat.format(I18N.getString(
                 "message.building-bundle"), APP_NAME.fetchFrom(params)));
 
@@ -121,7 +122,7 @@ public class MacAppStoreBundler extends MacBaseInstallerBundler {
             Files.createDirectories(appImageDir);
 
             try {
-                MacAppImageBuilder.addNewKeychain(params);
+                MacAppImageBuilder.addNewKeychain(keyChains, params);
             } catch (InterruptedException e) {
                 Log.error(e.getMessage());
             }
@@ -138,7 +139,7 @@ public class MacAppStoreBundler extends MacBaseInstallerBundler {
             MacAppImageBuilder.signAppBundle(params, appLocation,
                     signingIdentity, identifierPrefix,
                     MacAppImageBuilder.getConfig_Entitlements(params));
-            MacAppImageBuilder.restoreKeychainList(params);
+            MacAppImageBuilder.restoreKeychainList(keyChains, params);
 
             ProcessBuilder pb;
 

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
@@ -100,12 +100,12 @@ public class Arguments {
     private String buildRoot = null;
     private String mainJarPath = null;
 
-    private static boolean runtimeInstaller = false;
+    private boolean runtimeInstaller = false;
 
     private List<AddLauncherArguments> addLaunchers = null;
 
-    private static Map<String, CLIOptions> argIds = new HashMap<>();
-    private static Map<String, CLIOptions> argShortIds = new HashMap<>();
+    private static final Map<String, CLIOptions> argIds = new HashMap<>();
+    private static final Map<String, CLIOptions> argShortIds = new HashMap<>();
 
     static {
         // init maps for parsing arguments
@@ -117,7 +117,12 @@ public class Arguments {
         });
     }
 
+    private static final InheritableThreadLocal<Arguments> instance =
+            new InheritableThreadLocal<Arguments>();
+
     public Arguments(String[] args) {
+        instance.set(this);
+
         argList = new ArrayList<String>(args.length);
         for (String arg : args) {
             argList.add(arg);
@@ -392,16 +397,8 @@ public class Arguments {
             this.category = category;
         }
 
-        static void setContext(Arguments context) {
-            argContext = context;
-        }
-
         public static Arguments context() {
-            if (argContext != null) {
-                return argContext;
-            } else {
-                throw new RuntimeException("Argument context is not set.");
-            }
+            return instance.get();
         }
 
         public String getId() {
@@ -462,10 +459,6 @@ public class Arguments {
 
     public boolean processArguments() {
         try {
-
-            // init context of arguments
-            CLIOptions.setContext(this);
-
             // parse cmd line
             String arg;
             CLIOptions option;

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
@@ -173,7 +173,7 @@ public class IOUtils {
         exec(pb, testForPresenceOnly, consumer, false, Executor.INFINITE_TIMEOUT);
     }
 
-    static void exec(ProcessBuilder pb, boolean testForPresenceOnly,
+    static synchronized void exec(ProcessBuilder pb, boolean testForPresenceOnly,
             PrintStream consumer, boolean writeOutputToFile, long timeout)
             throws IOException {
         List<String> output = new ArrayList<>();

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JLinkBundlerHelper.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JLinkBundlerHelper.java
@@ -154,7 +154,7 @@ final class JLinkBundlerHelper {
         return modules;
     }
 
-    private static void runJLink(Path output, List<Path> modulePath,
+    private static synchronized void runJLink(Path output, List<Path> modulePath,
             Set<String> modules, Set<String> limitModules,
             List<String> options)
             throws PackagerException, IOException {

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JPackageToolProvider.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JPackageToolProvider.java
@@ -40,8 +40,7 @@ public class JPackageToolProvider implements ToolProvider {
         return "jpackage";
     }
 
-    public synchronized int run(
-            PrintWriter out, PrintWriter err, String... args) {
+    public int run(PrintWriter out, PrintWriter err, String... args) {
         try {
             return new jdk.jpackage.main.Main().execute(out, err, args);
         } catch (RuntimeException re) {

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Log.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Log.java
@@ -75,16 +75,12 @@ public class Log {
         public void info(String msg) {
             if (out != null) {
                 out.println(msg);
-            } else {
-                System.out.println(msg);
             }
         }
 
         public void fatalError(String msg) {
             if (err != null) {
                 err.println(msg);
-            } else {
-                System.err.println(msg);
             }
         }
 
@@ -92,8 +88,6 @@ public class Log {
             msg = addTimestamp(msg);
             if (err != null) {
                 err.println(msg);
-            } else {
-                System.err.println(msg);
             }
         }
 
@@ -101,9 +95,6 @@ public class Log {
             if (out != null && verbose) {
                 out.print(addTimestamp(""));
                 t.printStackTrace(out);
-            } else if (verbose) {
-                System.out.print(addTimestamp(""));
-                t.printStackTrace(System.out);
             }
         }
 
@@ -111,8 +102,6 @@ public class Log {
             msg = addTimestamp(msg);
             if (out != null && verbose) {
                 out.println(msg);
-            } else if (verbose) {
-                System.out.println(msg);
             }
         }
 
@@ -142,62 +131,50 @@ public class Log {
         }
     }
 
-    private static Logger delegate = null;
+    private static final InheritableThreadLocal<Logger> instance =
+            new InheritableThreadLocal<Logger>() {
+                @Override protected Logger initialValue() {
+                    return new Logger();
+                }
+            };
 
-    public static void setLogger(Logger logger) {
-        delegate = (logger != null) ? logger : new Logger();
+    public static void setPrintWriter (PrintWriter out, PrintWriter err) {
+        instance.get().setPrintWriter(out, err);
     }
 
     public static void flush() {
-        if (delegate != null) {
-            delegate.flush();
-        }
+        instance.get().flush();
     }
 
     public static void info(String msg) {
-        if (delegate != null) {
-           delegate.info(msg);
-        }
+        instance.get().info(msg);
     }
 
     public static void fatalError(String msg) {
-        if (delegate != null) {
-            delegate.fatalError(msg);
-        }
+        instance.get().fatalError(msg);
     }
 
     public static void error(String msg) {
-        if (delegate != null) {
-            delegate.error(msg);
-        }
+        instance.get().error(msg);
     }
 
     public static void setVerbose() {
-        if (delegate != null) {
-            delegate.setVerbose();
-        }
+        instance.get().setVerbose();
     }
 
     public static boolean isVerbose() {
-        return (delegate != null) ? delegate.isVerbose() : false;
+        return instance.get().isVerbose();
     }
 
     public static void verbose(String msg) {
-        if (delegate != null) {
-           delegate.verbose(msg);
-        }
+       instance.get().verbose(msg);
     }
 
     public static void verbose(Throwable t) {
-        if (delegate != null) {
-           delegate.verbose(t);
-        }
+       instance.get().verbose(t);
     }
 
     public static void verbose(List<String> strings, List<String> out, int ret) {
-        if (delegate != null) {
-           delegate.verbose(strings, out, ret);
-        }
+       instance.get().verbose(strings, out, ret);
     }
-
 }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/main/Main.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/main/Main.java
@@ -46,10 +46,10 @@ public class Main {
      * @param args command line arguments
      */
     public static void main(String... args) throws Exception {
-        // Create logger with default system.out and system.err
-        Log.setLogger(null);
 
-        int status = new jdk.jpackage.main.Main().execute(args);
+        PrintWriter out = new PrintWriter(System.out);
+        PrintWriter err = new PrintWriter(System.err);
+        int status = new jdk.jpackage.main.Main().execute(out, err, args);
         System.exit(status);
     }
 
@@ -62,15 +62,8 @@ public class Main {
      * @return an exit code. 0 means success, non-zero means an error occurred.
      */
     public int execute(PrintWriter out, PrintWriter err, String... args) {
-        // Create logger with provided streams
-        Log.Logger logger = new Log.Logger();
-        logger.setPrintWriter(out, err);
-        Log.setLogger(logger);
+        Log.setPrintWriter(out, err);
 
-        return execute(args);
-    }
-
-    private int execute(String... args) {
         try {
             String[] newArgs;
             try {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageType.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageType.java
@@ -60,6 +60,21 @@ public enum PackageType {
         }
     }
 
+    public static PackageType getDefault() {
+        if (TKit.isWindows()) {
+            return WIN_EXE;
+        } else if (TKit.isOSX()) {
+            return MAC_DMG;
+        } else if (TKit.isLinux()) {
+            if (LINUX_DEB.isSupported()) {
+                return LINUX_DEB;
+            } else if (LINUX_RPM.isSupported()) {
+                return LINUX_RPM;
+            }
+        }
+        throw new RuntimeException("Failed to determine default package type");
+    }
+
     PackageType(String bundleSuffix, String bundlerClass) {
         this(bundleSuffix.substring(1), bundleSuffix, bundlerClass);
     }

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageType.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageType.java
@@ -60,21 +60,6 @@ public enum PackageType {
         }
     }
 
-    public static PackageType getDefault() {
-        if (TKit.isWindows()) {
-            return WIN_EXE;
-        } else if (TKit.isOSX()) {
-            return MAC_DMG;
-        } else if (TKit.isLinux()) {
-            if (LINUX_DEB.isSupported()) {
-                return LINUX_DEB;
-            } else if (LINUX_RPM.isSupported()) {
-                return LINUX_RPM;
-            }
-        }
-        throw new RuntimeException("Failed to determine default package type");
-    }
-
     PackageType(String bundleSuffix, String bundlerClass) {
         this(bundleSuffix.substring(1), bundleSuffix, bundlerClass);
     }

--- a/test/jdk/tools/jpackage/share/ConcurrentTest.java
+++ b/test/jdk/tools/jpackage/share/ConcurrentTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.Date;
+import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.PackageType;
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.Annotations.Test;
+
+/**
+ * Concurrent test.  Using ToolProvider, run several jpackage test concurrently
+ */
+
+/*
+ * @test
+ * @summary Concurrent jpackage command runs using ToolProvider
+ * @library ../helpers
+ * @key jpackagePlatformPackage
+ * @build jdk.jpackage.test.*
+ * @modules jdk.jpackage/jdk.jpackage.internal
+ * @compile ConcurrentTest.java
+ * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=ConcurrentTest
+ */
+public class ConcurrentTest {
+
+    @Test
+    public static void test() {
+
+        final JPackageCommand cmd1 =
+                JPackageCommand.helloAppImage("com.other/com.other.Hello")
+        .useToolProvider(true)
+        .setPackageType(PackageType.getDefault())
+        .setArgumentValue("--name", "ConcurrentOtherInstaller");
+
+        final JPackageCommand cmd2 =
+                JPackageCommand.helloAppImage("Hello")
+        .useToolProvider(true)
+        .setPackageType(PackageType.IMAGE)
+        .setArgumentValue("--name", "ConcurrentAppImage");
+
+        Date[] times = race(cmd1, cmd2);
+        TKit.assertTrue(times[0].after(times[1]),
+                "We expected app-image command to finish first, but times[0] is "
+                + times[0] + " and times[1] is" + times[1]);
+
+        cmd1.useToolProvider(false);
+        cmd1.useToolProvider(false);
+
+        times = race(cmd1, cmd2);
+        TKit.assertTrue(times[0].after(times[1]),
+                "We expected app-image command to finish first, but times[0] is "
+                + times[0] + " and times[1] is" + times[1]);
+    }
+
+    private static Date[] race(JPackageCommand cmd1, JPackageCommand cmd2) {
+        final Date[] times = new Date[2];
+
+        Thread t1 = new Thread(new Runnable() {
+            public void run() {
+                cmd1.execute();
+                times[0] = new Date();
+            }
+        });
+
+        Thread t2 = new Thread(new Runnable() {
+            public void run() {
+                cmd2.execute();
+                times[1] = new Date();
+            }
+        });
+        try {
+            t1.start();
+            t2.start();
+
+            t1.join();
+            t2.join();
+            return times;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Remove all non final static variables in jpackage java code (using InheritableThreadLocal for Logger and Argument instances) and remove sychronization in JPackageToolProvider.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8223322](https://bugs.openjdk.java.net/browse/JDK-8223322): Improve concurrency in jpackage instances


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1829/head:pull/1829`
`$ git checkout pull/1829`
