### PR TITLE
JDK-8242888: Convert dynamic proxy to hidden classes

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -134,8 +134,10 @@ class DirectMethodHandle extends MethodHandle {
         return make(member.getDeclaringClass(), member);
     }
     private static DirectMethodHandle makeAllocator(MemberName ctor) {
+        return makeAllocator(ctor, ctor.getDeclaringClass());
+    }
+    static DirectMethodHandle makeAllocator(MemberName ctor, Class<?> instanceClass) {
         assert(ctor.isConstructor() && ctor.getName().equals("<init>"));
-        Class<?> instanceClass = ctor.getDeclaringClass();
         ctor = ctor.asConstructor();
         assert(ctor.isConstructor() && ctor.getReferenceKind() == REF_newInvokeSpecial) : ctor;
         MethodType mtype = ctor.getMethodType().changeReturnType(instanceClass);

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -42,6 +42,7 @@ import sun.invoke.util.Wrapper;
 
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,6 +50,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -1799,6 +1801,17 @@ abstract class MethodHandleImpl {
             @Override
             public VarHandle insertCoordinates(VarHandle target, int pos, Object... values) {
                 return VarHandles.insertCoordinates(target, pos, values);
+            }
+
+            @Override
+            public MethodHandle createConstructorForSerialization(Constructor<?> constructor, Class<?> forType) {
+                Objects.nonNull(constructor);
+                Objects.nonNull(forType);
+                if (!constructor.getDeclaringClass().isAssignableFrom(forType)) {
+                    throw newIllegalArgumentException("Constructor is not from a compatible class");
+                }
+                MemberName ctor = new MemberName(constructor);
+                return DirectMethodHandle.makeAllocator(ctor, forType);
             }
         });
     }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
@@ -30,6 +30,7 @@ import jdk.internal.invoke.NativeEntryPoint;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
+import java.lang.reflect.Constructor;
 import java.nio.ByteOrder;
 import java.util.List;
 import java.util.Map;
@@ -132,4 +133,9 @@ public interface JavaLangInvokeAccess {
      * @return the native method handle
      */
     MethodHandle nativeMethodHandle(NativeEntryPoint nep, MethodHandle fallback);
+
+    /**
+     *  Creates a MethodHandle for serialization constructor.
+     */
+    MethodHandle createConstructorForSerialization(Constructor<?> constructor, Class<?> forType);
 }

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleConstructorAccessor.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleConstructorAccessor.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package jdk.internal.reflect;
 
 import java.lang.invoke.MethodHandle;
@@ -15,7 +40,7 @@ class MethodHandleConstructorAccessor extends ConstructorAccessorImpl {
         this.target = target
                 .asSpreader(Object[].class, target.type().parameterCount())
                 .asType(MethodType.methodType(Object.class, Object[].class));
-    }
+    } 
 
     @Override
     public Object newInstance(Object[] args) throws InstantiationException,

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleConstructorAccessor.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleConstructorAccessor.java
@@ -1,28 +1,3 @@
-/*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
- *
- * This code is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
- *
- * This code is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * version 2 for more details (a copy is included in the LICENSE file that
- * accompanied this code).
- *
- * You should have received a copy of the GNU General Public License version
- * 2 along with this work; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
- * or visit www.oracle.com if you need additional information or have any
- * questions.
- */
-
 package jdk.internal.reflect;
 
 import java.lang.invoke.MethodHandle;
@@ -40,7 +15,7 @@ class MethodHandleConstructorAccessor extends ConstructorAccessorImpl {
         this.target = target
                 .asSpreader(Object[].class, target.type().parameterCount())
                 .asType(MethodType.methodType(Object.class, Object[].class));
-    } 
+    }
 
     @Override
     public Object newInstance(Object[] args) throws InstantiationException,

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleConstructorAccessor.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleConstructorAccessor.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package jdk.internal.reflect;
 
 import java.lang.invoke.MethodHandle;

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleConstructorAccessor.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleConstructorAccessor.java
@@ -1,0 +1,30 @@
+package jdk.internal.reflect;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.InvocationTargetException;
+
+import jdk.internal.vm.annotation.Stable;
+
+class MethodHandleConstructorAccessor extends ConstructorAccessorImpl {
+
+    @Stable
+    private final MethodHandle target;
+
+    MethodHandleConstructorAccessor(MethodHandle target) {
+        this.target = target
+                .asSpreader(Object[].class, target.type().parameterCount())
+                .asType(MethodType.methodType(Object.class, Object[].class));
+    }
+
+    @Override
+    public Object newInstance(Object[] args) throws InstantiationException,
+            IllegalArgumentException, InvocationTargetException {
+        try {
+            return target.invokeExact(args);
+        } catch (Throwable t) {
+            throw new InvocationTargetException(t);
+        }
+    }
+
+}

--- a/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
@@ -43,6 +43,7 @@ import java.security.PrivilegedAction;
 import java.util.Objects;
 import java.util.Properties;
 
+import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.JavaLangReflectAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.VM;
@@ -462,12 +463,8 @@ public class ReflectionFactory {
                                                      Constructor<?> constructorToCall) {
 
 
-        ConstructorAccessor acc = new MethodAccessorGenerator().
-            generateSerializationConstructor(cl,
-                                             constructorToCall.getParameterTypes(),
-                                             constructorToCall.getExceptionTypes(),
-                                             constructorToCall.getModifiers(),
-                                             constructorToCall.getDeclaringClass());
+        ConstructorAccessor acc = new MethodHandleConstructorAccessor(
+                SharedSecrets.getJavaLangInvokeAccess().createConstructorForSerialization(constructorToCall, cl));
         Constructor<?> c = newConstructor(constructorToCall.getDeclaringClass(),
                                           constructorToCall.getParameterTypes(),
                                           constructorToCall.getExceptionTypes(),

--- a/test/langtools/jdk/jshell/ExceptionsTest.java
+++ b/test/langtools/jdk/jshell/ExceptionsTest.java
@@ -227,7 +227,7 @@ public class ExceptionsTest extends KullaTesting {
         assertExceptionMatch(se,
                 new ExceptionInfo(IllegalStateException.class, message,
                         newStackTraceElement("", "lambda$do_it$$0", se.snippet(), 1),
-                        new StackTraceElement("jdk.proxy1.$Proxy0", "hashCode", null, -1),
+                        // new StackTraceElement("jdk.proxy1.$Proxy0", "hashCode", null, -1),
                         newStackTraceElement("", "", se.snippet(), 1)));
     }
 


### PR DESCRIPTION
This is a prototype to implement [JDK-8242888](https://bugs.openjdk.java.net/browse/JDK-8242888).

This could be split into 2 parts:
* Changes to `java.lang.invoke.*`, `jdk.internal.reflect.*` and `jdk.internal.access.*` change the implementation of the constructor for serialization implementation from spinning bytecode to use `MethodHandle`s.
* Changes to `java.lang.reflect.*` change the proxy implementation to use hidden classes.

The second change has a dependency on the first - otherwise serialization for dynamic proxies would break.

There is also one test change - the test breaks because hidden classes don't appear in stack traces.  
And the test did expect the dynamic proxy to appear in a stack trace.

Moving forward, extracting the first part and assign it it's own issue in the JBS might be the right move.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issues
 * [JDK-8242888](https://bugs.openjdk.java.net/browse/JDK-8242888): Convert dynamic proxy to hidden classes
 * [JDK-8229959](https://bugs.openjdk.java.net/browse/JDK-8229959): Convert proxy class to use constant dynamic


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1830/head:pull/1830`
`$ git checkout pull/1830`
