### PR TITLE
8169086: DTLS tests fail intermittently with too much loops or timeout

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLEngineImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLEngineImpl.java
@@ -300,7 +300,7 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
         ByteBuffer[] srcs, int srcsOffset, int srcsLength,
         ByteBuffer[] dsts, int dstsOffset, int dstsLength) throws IOException {
 
-        Ciphertext ciphertext = null;
+        Ciphertext ciphertext;
         try {
             ciphertext = conContext.outputRecord.encode(
                 srcs, srcsOffset, srcsLength, dsts, dstsOffset, dstsLength);
@@ -570,7 +570,7 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
         }
 
         if (hsStatus == SSLEngineResult.HandshakeStatus.NEED_UNWRAP_AGAIN) {
-            Plaintext plainText = null;
+            Plaintext plainText;
             try {
                 plainText = decode(null, 0, 0,
                         dsts, dstsOffset, dstsLength);
@@ -607,7 +607,7 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
          * Check the packet to make sure enough is here.
          * This will also indirectly check for 0 len packets.
          */
-        int packetLen = 0;
+        int packetLen;
         try {
             packetLen = conContext.inputRecord.bytesInCompletePacket(
                     srcs, srcsOffset, srcsLength);
@@ -619,16 +619,16 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
                 }
 
                 // invalid, discard the entire data [section 4.1.2.7, RFC 6347]
-                int deltaNet = 0;
-                // int deltaNet = netData.remaining();
-                // netData.position(netData.limit());
+                for (int i = srcsOffset; i < srcsOffset + srcsLength; i++) {
+                    srcs[i].position(srcs[i].limit());
+                }
 
                 Status status = (isInboundDone() ? Status.CLOSED : Status.OK);
                 if (hsStatus == null) {
                     hsStatus = getHandshakeStatus();
                 }
 
-                return new SSLEngineResult(status, hsStatus, deltaNet, 0, -1L);
+                return new SSLEngineResult(status, hsStatus, srcsRemains, 0, -1L);
             } else {
                 throw ssle;
             }
@@ -686,7 +686,7 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
         /*
          * We're now ready to actually do the read.
          */
-        Plaintext plainText = null;
+        Plaintext plainText;
         try {
             plainText = decode(srcs, srcsOffset, srcsLength,
                             dsts, dstsOffset, dstsLength);

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -667,8 +667,6 @@ sun/security/tools/keytool/ListKeychainStore.sh                 8156889 macosx-a
 sun/security/tools/jarsigner/warnings/BadKeyUsageTest.java      8026393 generic-all
 
 javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java       8212096 generic-all
-javax/net/ssl/DTLS/PacketLossRetransmission.java                8169086 macosx-x64
-javax/net/ssl/DTLS/RespondToRetransmit.java                     8169086 macosx-x64
 javax/net/ssl/DTLS/CipherSuite.java                             8202059 macosx-x64
 
 sun/security/provider/KeyStore/DKSTest.sh                       8180266 windows-all


### PR DESCRIPTION
There are a few intermittent timeout in the DTLS regression test in JDK.  In the DTLS implementation, invalid record is not discarded in the ByteBuffers.  So, the next unwrap() will repeat the reading and thus there is a potential dead loop.  The DTLS test failure cannot reproduced, and I'm not very sure if this is the root cause.  Let see if the intermittent failure could be fixed or not with this update.

No new regression, the existing javax/net/ssl/DTLS/PacketLossRetransmission.java test will be used instead.

Bug: https://bugs.openjdk.java.net/browse/JDK-8169086

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8169086](https://bugs.openjdk.java.net/browse/JDK-8169086): DTLS tests fail intermittently with too much loops or timeout


### Reviewers
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1832/head:pull/1832`
`$ git checkout pull/1832`
