### PR TITLE
JDK-8258655: remove <-- NewPage --> comment from generated pages

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Contents.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Contents.java
@@ -140,7 +140,6 @@ public class Contents {
     public final Content navProperty;
     public final Content navServices;
     public final Content nestedClassSummary;
-    public final Content newPage;
     public final Content noScriptMessage;
     public final Content openModuleLabel;
     public final Content openedTo;
@@ -274,7 +273,6 @@ public class Contents {
         navProperty = getContent("doclet.navProperty");
         navServices = getContent("doclet.navServices");
         nestedClassSummary = getContent("doclet.Nested_Class_Summary");
-        newPage = new Comment(resources.getText("doclet.New_Page"));
         noScriptMessage = getContent("doclet.No_Script_Message");
         openedTo = getContent("doclet.OpenedTo");
         openModuleLabel = getContent("doclet.Open_Module");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -454,7 +454,6 @@ public class HtmlDocletWriter {
                                   List<DocPath> localStylesheets,
                                   Content body)
             throws DocFileIOException {
-        Content htmlComment = contents.newPage;
         List<DocPath> additionalStylesheets = configuration.getAdditionalStylesheets();
         additionalStylesheets.addAll(localStylesheets);
         Head head = new Head(path, configuration.getDocletVersion(), configuration.startTime)
@@ -468,8 +467,8 @@ public class HtmlDocletWriter {
                 .setIndex(options.createIndex(), mainBodyScript)
                 .addContent(extraHeadContent);
 
-        Content htmlTree = HtmlTree.HTML(configuration.getLocale().getLanguage(), head, body);
-        HtmlDocument htmlDocument = new HtmlDocument(htmlComment, htmlTree);
+        HtmlDocument htmlDocument = new HtmlDocument(
+                HtmlTree.HTML(configuration.getLocale().getLanguage(), head, body));
         htmlDocument.write(DocFile.createFileForOutput(configuration, path));
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexRedirectWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexRedirectWriter.java
@@ -74,7 +74,6 @@ public class IndexRedirectWriter extends HtmlDocletWriter {
      * @throws DocFileIOException if there is a problem generating the file
      */
     private void generateIndexFile() throws DocFileIOException {
-        Content htmlComment = contents.newPage;
         Head head = new Head(path, configuration.getDocletVersion(), configuration.startTime)
                 .setTimestamp(!options.noTimestamp())
                 .setDescription("index redirect")
@@ -109,8 +108,8 @@ public class IndexRedirectWriter extends HtmlDocletWriter {
         HtmlTree main = HtmlTree.MAIN(bodyContent);
         body.add(main);
 
-        Content htmlTree = HtmlTree.HTML(configuration.getLocale().getLanguage(), head, body);
-        HtmlDocument htmlDocument = new HtmlDocument(htmlComment, htmlTree);
+        HtmlDocument htmlDocument = new HtmlDocument(
+                HtmlTree.HTML(configuration.getLocale().getLanguage(), head, body));
         htmlDocument.write(DocFile.createFileForOutput(configuration, path));
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlDocument.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlDocument.java
@@ -45,17 +45,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocletConstants;
  */
 public class HtmlDocument {
     private final DocType docType = DocType.HTML5;
-    private final List<Content> docContent;
-
-    /**
-     * Constructor to construct an HTML document.
-     *
-     * @param docComment comment for the document
-     * @param htmlTree HTML tree of the document
-     */
-    public HtmlDocument(Content docComment, Content htmlTree) {
-        docContent = Arrays.asList(docComment, htmlTree);
-    }
+    private final Content docContent;
 
     /**
      * Constructor to construct an HTML document.
@@ -63,7 +53,7 @@ public class HtmlDocument {
      * @param htmlTree HTML tree of the document
      */
     public HtmlDocument(Content htmlTree) {
-        docContent = Collections.singletonList(htmlTree);
+        docContent = htmlTree;
     }
 
     /**
@@ -93,9 +83,6 @@ public class HtmlDocument {
     private void write(Writer writer) throws IOException {
         writer.write(docType.text);
         writer.write(DocletConstants.NL);
-        boolean atNewline = true;
-        for (Content c : docContent) {
-            atNewline = c.write(writer, atNewline);
-        }
+        docContent.write(writer, true);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -69,7 +69,6 @@ doclet.Window_Split_Index={0}-Index
 doclet.Help=Help
 doclet.Skip_navigation_links=Skip navigation links
 doclet.Navigation=Navigation
-doclet.New_Page=NewPage
 doclet.navDeprecated=Deprecated
 doclet.Window_Deprecated_List=Deprecated List
 doclet.Overrides=Overrides:


### PR DESCRIPTION
Small change to remove an unnecessary comment from the beginning of generated files.  I'm guessing the comment dates from way back when the doc pages were used to generate paper books.  For those that want to identify that point in the file, either the DOCTYPE or start of the HTML elements t should be enough.

No test: it's somewhat silly to rigorously test that the comment will always be missing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258655](https://bugs.openjdk.java.net/browse/JDK-8258655): remove <-- NewPage --> comment from generated pages


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1833/head:pull/1833`
`$ git checkout pull/1833`
