### PR TITLE
8258652: Assert in JvmtiThreadState::cur_stack_depth() can noticeably slow down debugging single stepping

### DIFF
--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -259,14 +259,6 @@ void JvmtiThreadState::incr_cur_stack_depth() {
   }
   if (_cur_stack_depth != UNKNOWN_STACK_DEPTH) {
     ++_cur_stack_depth;
-#ifdef ASSERT
-    if (EnableJVMTIStackDepthAsserts) {
-      // heavy weight assert
-      jint num_frames = count_frames();
-      assert(_cur_stack_depth == num_frames, "cur_stack_depth out of sync _cur_stack_depth: %d num_frames: %d",
-             _cur_stack_depth, num_frames);
-    }
-#endif
   }
 }
 
@@ -277,14 +269,6 @@ void JvmtiThreadState::decr_cur_stack_depth() {
     _cur_stack_depth = UNKNOWN_STACK_DEPTH;
   }
   if (_cur_stack_depth != UNKNOWN_STACK_DEPTH) {
-#ifdef ASSERT
-    if (EnableJVMTIStackDepthAsserts) {
-      // heavy weight assert
-      jint num_frames = count_frames();
-      assert(_cur_stack_depth == num_frames, "cur_stack_depth out of sync _cur_stack_depth: %d num_frames: %d",
-             _cur_stack_depth, num_frames);
-    }
-#endif
     --_cur_stack_depth;
     assert(_cur_stack_depth >= 0, "incr/decr_cur_stack_depth mismatch");
   }

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -259,6 +259,14 @@ void JvmtiThreadState::incr_cur_stack_depth() {
   }
   if (_cur_stack_depth != UNKNOWN_STACK_DEPTH) {
     ++_cur_stack_depth;
+#ifdef ASSERT
+    if (EnableJVMTIStackDepthAsserts) {
+      // heavy weight assert
+      jint num_frames = count_frames();
+      assert(_cur_stack_depth == num_frames, "cur_stack_depth out of sync _cur_stack_depth: %d num_frames: %d",
+             _cur_stack_depth, num_frames);
+    }
+#endif
   }
 }
 
@@ -269,6 +277,14 @@ void JvmtiThreadState::decr_cur_stack_depth() {
     _cur_stack_depth = UNKNOWN_STACK_DEPTH;
   }
   if (_cur_stack_depth != UNKNOWN_STACK_DEPTH) {
+#ifdef ASSERT
+    if (EnableJVMTIStackDepthAsserts) {
+      // heavy weight assert
+      jint num_frames = count_frames();
+      assert(_cur_stack_depth == num_frames, "cur_stack_depth out of sync _cur_stack_depth: %d num_frames: %d",
+             _cur_stack_depth, num_frames);
+    }
+#endif
     --_cur_stack_depth;
     assert(_cur_stack_depth >= 0, "incr/decr_cur_stack_depth mismatch");
   }
@@ -282,9 +298,14 @@ int JvmtiThreadState::cur_stack_depth() {
   if (!is_interp_only_mode() || _cur_stack_depth == UNKNOWN_STACK_DEPTH) {
     _cur_stack_depth = count_frames();
   } else {
-    // heavy weight assert
-    assert(_cur_stack_depth == count_frames(),
-           "cur_stack_depth out of sync");
+#ifdef ASSERT
+    if (EnableJVMTIStackDepthAsserts) {
+      // heavy weight assert
+      jint num_frames = count_frames();
+      assert(_cur_stack_depth == num_frames, "cur_stack_depth out of sync _cur_stack_depth: %d num_frames: %d",
+             _cur_stack_depth, num_frames);
+    }
+#endif
   }
   return _cur_stack_depth;
 }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1845,6 +1845,9 @@ const intx ObjectAlignmentInBytes = 8;
   notproduct(bool, UseDebuggerErgo2, false,                                 \
           "Debugging Only: Limit the number of spawned JVM threads")        \
                                                                             \
+  notproduct(bool, EnableJVMTIStackDepthAsserts, true,                      \
+          "Enable JVMTI asserts related to stack depth checks")             \
+                                                                            \
   /* flags for performance data collection */                               \
                                                                             \
   product(bool, UsePerfData, true,                                          \


### PR DESCRIPTION
There is an assert in `JvmtiThreadState::cur_stack_depth()` that tends to slow down single stepping a lot when running the debuggee with a debug jvm. See CR for details. The fix is to allow disabling of this assert using the new EnableJVMTIStackDepthAsserts global, which defaults to true.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258652](https://bugs.openjdk.java.net/browse/JDK-8258652): Assert in JvmtiThreadState::cur_stack_depth() can noticeably slow down debugging single stepping


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1835/head:pull/1835`
`$ git checkout pull/1835`
