### PR TITLE
8258553 Limit number of fields in instance to be considered for scalar replacement

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -536,6 +536,10 @@
           "Array size (number of elements) limit for scalar replacement")   \
           range(0, max_jint)                                                \
                                                                             \
+  product(intx, EliminateAllocationFieldsLimit, 512, DIAGNOSTIC,            \
+          "Number of fields in instance limit for scalar replacement")      \
+          range(0, max_jint)                                                \
+                                                                            \
   product(bool, OptimizePtrCompare, true,                                   \
           "Use escape analysis to optimize pointers compare")               \
                                                                             \

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -906,6 +906,12 @@ void ConnectionGraph::add_call_node(CallNode* call) {
          !cik->as_instance_klass()->can_be_instantiated() ||
           cik->as_instance_klass()->has_finalizer()) {
         es = PointsToNode::GlobalEscape;
+      } else {
+        int nfields = cik->as_instance_klass()->nof_nonstatic_fields();
+        if (nfields > EliminateAllocationFieldsLimit) {
+          // Not scalar replaceable if there are too many fields.
+          scalar_replaceable = false;
+        }
       }
     }
     add_java_object(call, es);


### PR DESCRIPTION
I stumbled upon a test that we have (gc/TestBigObj.java) that has an object with 64k fields and that is scalar replaceable. Doing so puts a lot of strain on the compiler. I ran a few test and benchmarks and the maximum number of fields in scalar-replaced object that I've seen was 59. I think it should be reasonable to set a limit on the number of fields to 512.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258553](https://bugs.openjdk.java.net/browse/JDK-8258553): Limit number of fields in instance to be considered for scalar replacement


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1837/head:pull/1837`
`$ git checkout pull/1837`
