### PR TITLE
8258661: Inner class ResponseCacheEntry could be static

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/StatusResponseManager.java
+++ b/src/java.base/share/classes/sun/security/ssl/StatusResponseManager.java
@@ -527,7 +527,7 @@ final class StatusResponseManager {
     /**
      * Static nested class used as the data kept in the response cache.
      */
-    class ResponseCacheEntry {
+    static class ResponseCacheEntry {
         final OCSPResponse.ResponseStatus status;
         final byte[] ocspBytes;
         final Date nextUpdate;


### PR DESCRIPTION
The inner class StatusResponseManager#ResponseCacheEntry could be static, for better performance.

Code cleanup, no new regression test.

Bug: https://bugs.openjdk.java.net/browse/JDK-8258661

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258661](https://bugs.openjdk.java.net/browse/JDK-8258661): Inner class ResponseCacheEntry could be static


### Reviewers
 * [Jamil Nimeh](https://openjdk.java.net/census#jnimeh) (@jnimeh - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1838/head:pull/1838`
`$ git checkout pull/1838`
