### PR TITLE
JDK-8258606: os::print_signal_handlers() should resolve the function name of the handlers

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -654,6 +654,15 @@ static void UserHandler(int sig, void *siginfo, void *context) {
   os::signal_notify(sig);
 }
 
+static void print_signal_handler_name(outputStream* os, address handler, char* buf, size_t buflen) {
+  // We demangle, but omit arguments - signal handlers should have always the same prototype.
+  os::print_function_and_library_name(os, handler, buf, buflen,
+                                       true, // shorten_path
+                                       true, // demangle
+                                       true  // omit arguments
+                                       );
+}
+
 // Writes one-line description of a combination of sigaction.sa_flags into a user
 // provided buffer. Returns that buffer.
 static const char* describe_sa_flags(int flags, char* buffer, size_t size) {
@@ -806,9 +815,9 @@ static void check_signal_handler(int sig) {
   if (thisHandler != jvmHandler) {
     tty->print("Warning: %s handler ", os::exception_name(sig, buf, O_BUFLEN));
     tty->print_raw("expected:");
-    os::print_function_and_library_name(tty, jvmHandler, buf, O_BUFLEN, true, true, true);
+    print_signal_handler_name(tty, jvmHandler, buf, O_BUFLEN);
     tty->print_raw("  found:");
-    os::print_function_and_library_name(tty, thisHandler, buf, O_BUFLEN, true, true, true);
+    print_signal_handler_name(tty, thisHandler, buf, O_BUFLEN);
     // No need to check this sig any longer
     sigaddset(&check_signal_done, sig);
     // Running under non-interactive shell, SHUTDOWN2_SIGNAL will be reassigned SIG_IGN
@@ -1358,11 +1367,7 @@ void PosixSignals::print_signal_handler(outputStream* st, int sig,
   } else if (handler == CAST_FROM_FN_PTR(address, SIG_IGN)) {
     st->print("SIG_IGN");
   } else {
-    os::print_function_and_library_name(st, handler, buf, buflen,
-                                        true, // shorten_path
-                                        true, // demangle
-                                        true  // omit arguments
-                                        );
+    print_signal_handler_name(st, handler, buf, O_BUFLEN);
   }
 
   st->print(", sa_mask[0]=");

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -806,9 +806,9 @@ static void check_signal_handler(int sig) {
   if (thisHandler != jvmHandler) {
     tty->print("Warning: %s handler ", os::exception_name(sig, buf, O_BUFLEN));
     tty->print_raw("expected:");
-    os::print_function_and_library_name(tty, jvmHandler, buf, O_BUFLEN);
+    os::print_function_and_library_name(tty, jvmHandler, buf, O_BUFLEN, true, true, true);
     tty->print_raw("  found:");
-    os::print_function_and_library_name(tty, thisHandler, buf, O_BUFLEN);
+    os::print_function_and_library_name(tty, thisHandler, buf, O_BUFLEN, true, true, true);
     // No need to check this sig any longer
     sigaddset(&check_signal_done, sig);
     // Running under non-interactive shell, SHUTDOWN2_SIGNAL will be reassigned SIG_IGN
@@ -1358,9 +1358,11 @@ void PosixSignals::print_signal_handler(outputStream* st, int sig,
   } else if (handler == CAST_FROM_FN_PTR(address, SIG_IGN)) {
     st->print("SIG_IGN");
   } else {
-    st->put('[');
-    os::print_function_and_library_name(st, handler, buf, buflen);
-    st->put(']');
+    os::print_function_and_library_name(st, handler, buf, buflen,
+                                        true, // shorten_path
+                                        true, // demangle
+                                        true  // omit arguments
+                                        );
   }
 
   st->print(", sa_mask[0]=");

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -654,31 +654,6 @@ static void UserHandler(int sig, void *siginfo, void *context) {
   os::signal_notify(sig);
 }
 
-static const char* get_signal_handler_name(address handler,
-                                           char* buf, int buflen) {
-  int offset = 0;
-  bool found = os::dll_address_to_library_name(handler, buf, buflen, &offset);
-  if (found) {
-    // skip directory names
-    const char *p1, *p2;
-    p1 = buf;
-    size_t len = strlen(os::file_separator());
-    while ((p2 = strstr(p1, os::file_separator())) != NULL) p1 = p2 + len;
-#if !defined(AIX)
-    jio_snprintf(buf, buflen, "%s+0x%x", p1, offset);
-#else
-    // The way os::dll_address_to_library_name is implemented on Aix
-    // right now, it always returns -1 for the offset which is not
-    // terribly informative.
-    // Will fix that. For now, omit the offset.
-    jio_snprintf(buf, buflen, "%s", p1);
-#endif
-  } else {
-    jio_snprintf(buf, buflen, PTR_FORMAT, handler);
-  }
-  return buf;
-}
-
 // Writes one-line description of a combination of sigaction.sa_flags into a user
 // provided buffer. Returns that buffer.
 static const char* describe_sa_flags(int flags, char* buffer, size_t size) {
@@ -830,8 +805,10 @@ static void check_signal_handler(int sig) {
 
   if (thisHandler != jvmHandler) {
     tty->print("Warning: %s handler ", os::exception_name(sig, buf, O_BUFLEN));
-    tty->print("expected:%s", get_signal_handler_name(jvmHandler, buf, O_BUFLEN));
-    tty->print_cr("  found:%s", get_signal_handler_name(thisHandler, buf, O_BUFLEN));
+    tty->print_raw("expected:");
+    os::print_function_and_library_name(tty, jvmHandler, buf, O_BUFLEN);
+    tty->print_raw("  found:");
+    os::print_function_and_library_name(tty, thisHandler, buf, O_BUFLEN);
     // No need to check this sig any longer
     sigaddset(&check_signal_done, sig);
     // Running under non-interactive shell, SHUTDOWN2_SIGNAL will be reassigned SIG_IGN
@@ -1372,7 +1349,7 @@ void PosixSignals::print_signal_handler(outputStream* st, int sig,
   // See comment for SA_RESTORER_FLAG_MASK
   LINUX_ONLY(sa.sa_flags &= SA_RESTORER_FLAG_MASK;)
 
-  st->print("%s: ", os::exception_name(sig, buf, buflen));
+  st->print("%10s: ", os::exception_name(sig, buf, buflen));
 
   address handler = get_signal_handler(&sa);
 
@@ -1381,7 +1358,9 @@ void PosixSignals::print_signal_handler(outputStream* st, int sig,
   } else if (handler == CAST_FROM_FN_PTR(address, SIG_IGN)) {
     st->print("SIG_IGN");
   } else {
-    st->print("[%s]", get_signal_handler_name(handler, buf, buflen));
+    st->put('[');
+    os::print_function_and_library_name(st, handler, buf, buflen);
+    st->put(']');
   }
 
   st->print(", sa_mask[0]=");

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -900,13 +900,20 @@ bool os::print_function_and_library_name(outputStream* st,
   const bool have_function_name = dll_address_to_function_name(addr, p, buflen,
                                                                &offset, demangle);
   if (have_function_name) {
+    // Print function name, optionally demangled
     if (demangle && strip_arguments) {
       char* args_start = strchr(p, '(');
       if (args_start != NULL) {
         *args_start = '\0';
       }
     }
-    st->print("%s+%d", p, offset);
+    // Print offset. Omit printing if offset is zero, which makes the output
+    // more readable if we print function pointers.
+    if (offset == 0) {
+      st->print("%s", p);
+    } else {
+      st->print("%s+%d", p, offset);
+    }
   } else {
     st->print(PTR_FORMAT, p2i(addr));
   }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -882,6 +882,53 @@ void os::abort(bool dump_core) {
 //---------------------------------------------------------------------------
 // Helper functions for fatal error handler
 
+// Given an address, attempt to locate both the symbol and the library it
+// resides in. If at least one of these steps was successful, prints information
+// and returns true.
+// On success prints either one of:
+// "<function name>+<offset> in <library>"
+// "<function name>+<offset>"
+// "<address> in <library>+<offset>"
+bool os::print_function_and_library_name(outputStream* st,
+                                         address addr,
+                                         char* buf, int buflen,
+                                         bool shorten_paths,
+                                         bool demangle) {
+  // If no scratch buffer given, allocate one here on stack.
+  // (used during error handling; its a coin toss, really, if on-stack allocation
+  //  is worse than (raw) C-heap allocation in that case).
+  char* p = buf;
+  if (p == NULL) {
+    p = (char*)::alloca(O_BUFLEN);
+    buflen = O_BUFLEN;
+  }
+  int offset = 0;
+  const bool have_function_name = dll_address_to_function_name(addr, p, buflen,
+                                                               &offset, demangle);
+  if (have_function_name) {
+    st->print("%s+%d", p, offset);
+  } else {
+    st->print(PTR_FORMAT, p2i(addr));
+  }
+  offset = 0;
+
+  const bool have_library_name = dll_address_to_library_name(addr, p, buflen, &offset);
+  if (have_library_name) {
+    // Cut path parts
+    if (shorten_paths) {
+      char* p2 = strrchr(p, os::file_separator()[0]);
+      if (p2 != NULL) {
+        p = p2 + 1;
+      }
+    }
+    st->print(" in %s", p);
+    if (!have_function_name) { // Omit offset if we already printed the function offset
+      st->print("+%d", offset);
+    }
+  }
+  return have_function_name || have_library_name;
+}
+
 void os::print_hex_dump(outputStream* st, address start, address end, int unitsize,
                         int bytes_per_line, address logical_start) {
   assert(unitsize == 1 || unitsize == 2 || unitsize == 4 || unitsize == 8, "just checking");

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -882,18 +882,12 @@ void os::abort(bool dump_core) {
 //---------------------------------------------------------------------------
 // Helper functions for fatal error handler
 
-// Given an address, attempt to locate both the symbol and the library it
-// resides in. If at least one of these steps was successful, prints information
-// and returns true.
-// On success prints either one of:
-// "<function name>+<offset> in <library>"
-// "<function name>+<offset>"
-// "<address> in <library>+<offset>"
 bool os::print_function_and_library_name(outputStream* st,
                                          address addr,
                                          char* buf, int buflen,
                                          bool shorten_paths,
-                                         bool demangle) {
+                                         bool demangle,
+                                         bool strip_arguments) {
   // If no scratch buffer given, allocate one here on stack.
   // (used during error handling; its a coin toss, really, if on-stack allocation
   //  is worse than (raw) C-heap allocation in that case).
@@ -906,6 +900,12 @@ bool os::print_function_and_library_name(outputStream* st,
   const bool have_function_name = dll_address_to_function_name(addr, p, buflen,
                                                                &offset, demangle);
   if (have_function_name) {
+    if (demangle && strip_arguments) {
+      char* args_start = strchr(p, '(');
+      if (args_start != NULL) {
+        *args_start = '\0';
+      }
+    }
     st->print("%s+%d", p, offset);
   } else {
     st->print(PTR_FORMAT, p2i(addr));

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -599,6 +599,19 @@ class os: AllStatic {
   static bool dll_address_to_library_name(address addr, char* buf,
                                           int buflen, int* offset);
 
+  // Given an address, attempt to locate both the symbol and the library it
+  // resides in. If at least one of these steps was successful, prints information
+  // and returns true.
+  // On success prints either one of:
+  // "<function name>+<offset> in <library>"
+  // "<function name>+<offset>"
+  // "<address> in <library>+<offset>"
+  static bool print_function_and_library_name(outputStream* st,
+                                              address addr,
+                                              char* buf = NULL, int buflen = 0,
+                                              bool shorten_paths = true,
+                                              bool demangle = true);
+
   // Find out whether the pc is in the static code for jvm.dll/libjvm.so.
   static bool address_is_in_vm(address addr);
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -602,6 +602,10 @@ class os: AllStatic {
   // Given an address, attempt to locate both the symbol and the library it
   // resides in. If at least one of these steps was successful, prints information
   // and returns true.
+  // - if no scratch buffer is given, stack is used
+  // - shorten_paths: path is omitted from library name
+  // - demangle: function name is demangled
+  // - strip_arguments: arguments are stripped (requires demangle=true)
   // On success prints either one of:
   // "<function name>+<offset> in <library>"
   // "<function name>+<offset>"
@@ -610,7 +614,8 @@ class os: AllStatic {
                                               address addr,
                                               char* buf = NULL, int buflen = 0,
                                               bool shorten_paths = true,
-                                              bool demangle = true);
+                                              bool demangle = true,
+                                              bool strip_arguments = false);
 
   // Find out whether the pc is in the static code for jvm.dll/libjvm.so.
   static bool address_is_in_vm(address addr);

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -736,6 +736,7 @@ TEST_VM(os, dll_address_to_function_and_library_name) {
     EXPECT_CONTAINS(output, "Threads");
     EXPECT_CONTAINS(output, "create_vm");
     EXPECT_CONTAINS(output, "jvm"); // "jvm.dll" or "libjvm.so" or similar
+#ifndef _WIN32 // Demangler gives us no arguments on Windows
     if (demangle) {
       if (strip_arguments) {
         EXPECT_DOES_NOT_CONTAIN(output, "(");
@@ -743,6 +744,7 @@ TEST_VM(os, dll_address_to_function_and_library_name) {
         EXPECT_CONTAINS(output, "(");
       }
     }
+#endif // _WIN32
     LOG("%s", output);
 
     // Test truncation on scratch buffer

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -707,7 +707,8 @@ TEST_VM(os, dll_address_to_function_and_library_name) {
   EXPECT_NE(::strstr(haystack, needle), (char*)NULL)
 #define EXPECT_DOES_NOT_CONTAIN(haystack, needle) \
   EXPECT_EQ(::strstr(haystack, needle), (char*)NULL)
-#define LOG(...) tty->print_cr(__VA_ARGS__);
+// #define LOG(...) tty->print_cr(__VA_ARGS__); // enable if needed
+#define LOG(...)
 
   // Invalid addresses
   address addr = (address)(intptr_t)-1;


### PR DESCRIPTION
This patch changes the printout for our signal handlers in hs-err files and in `jcmd VM.info` to show the function names of the handlers. This is also interesting for CheckJNI.

Before:
```
Signal Handlers:
SIGSEGV: [libjvm.so+0xbb8ff0], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
SIGBUS: [libjvm.so+0xbb8ff0], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
SIGFPE: [libjvm.so+0xbb8ff0], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
SIGPIPE: [libjvm.so+0xbb8ff0], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
SIGXFSZ: [libjvm.so+0xbb8ff0], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
SIGILL: [libjvm.so+0xbb8ff0], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
SIGUSR2: [libjvm.so+0xbb8e90], sa_mask[0]=00000000000000000000000000000000, sa_flags=SA_RESTART|SA_SIGINFO
SIGHUP: [libjvm.so+0xbb95b0], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
SIGINT: [libjvm.so+0xbb95b0], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
SIGTERM: [libjvm.so+0xbb95b0], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
SIGQUIT: [libjvm.so+0xbb95b0], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
```

Now:
```
Signal Handlers:
   SIGSEGV: [javaSignalHandler(int, siginfo_t*, void*)+0 in libjvm.so], sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
    SIGBUS: [javaSignalHandler(int, siginfo_t*, void*)+0 in libjvm.so], sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
    SIGFPE: [javaSignalHandler(int, siginfo_t*, void*)+0 in libjvm.so], sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
   SIGPIPE: [javaSignalHandler(int, siginfo_t*, void*)+0 in libjvm.so], sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
   SIGXFSZ: [javaSignalHandler(int, siginfo_t*, void*)+0 in libjvm.so], sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
    SIGILL: [javaSignalHandler(int, siginfo_t*, void*)+0 in libjvm.so], sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
   SIGUSR2: [SR_handler(int, siginfo_t*, ucontext*)+0 in libjvm.so], sa_mask[0]=00000000000000000000000000000000, sa_flags=SA_RESTART|SA_SIGINFO
    SIGHUP: [UserHandler(int, void*, void*)+0 in libjvm.so], sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
    SIGINT: [UserHandler(int, void*, void*)+0 in libjvm.so], sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
   SIGTERM: [UserHandler(int, void*, void*)+0 in libjvm.so], sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
   SIGQUIT: [UserHandler(int, void*, void*)+0 in libjvm.so], sa_mask[0]=11100100010111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
   SIGTRAP: SIG_DFL, sa_mask[0]=00000000000000000000000000000000, sa_flags=none
```

The patch introduces a new function, `os::print_function_and_library_name`, which prints a combined function and library name. 

It also introduces gtests for that function. 

I plan to use it in other places to, and unify similar coding, e.g. when printing stack traces (NMT, VMError) or pointer locations (os::print_location). But I leave that for a future RFE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258606](https://bugs.openjdk.java.net/browse/JDK-8258606): os::print_signal_handlers() should resolve the function name of the handlers


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 8318559665cf7e3c13eb3d54171c72172f955241
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to 16e9ff9c57bca39844f54e2eacca9dc7abea3aec
 * [Gerard Ziemski](https://openjdk.java.net/census#gziemski) (@gerard-ziemski - Committer) ⚠️ Review applies to 8318559665cf7e3c13eb3d54171c72172f955241


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1839/head:pull/1839`
`$ git checkout pull/1839`
