### PR TITLE
8250523: Remove abortOnException diagnostic option from TestHumongousNonArrayAllocation.java

### DIFF
--- a/test/hotspot/jtreg/gc/g1/humongousObjects/TestHumongousNonArrayAllocation.java
+++ b/test/hotspot/jtreg/gc/g1/humongousObjects/TestHumongousNonArrayAllocation.java
@@ -45,23 +45,23 @@ import java.nio.file.Paths;
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *
  * @run main/othervm -Xms128M -Xmx128M -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *                   -XX:G1HeapRegionSize=1M -XX:AbortVMOnException=java.lang.StackOverflowError
+ *                   -XX:G1HeapRegionSize=1M
  *                   gc.g1.humongousObjects.TestHumongousNonArrayAllocation LARGEST_NON_HUMONGOUS
  *
  * @run main/othervm -Xms128M -Xmx128M -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *                   -XX:G1HeapRegionSize=1M -XX:AbortVMOnException=java.lang.StackOverflowError
+ *                   -XX:G1HeapRegionSize=1M
  *                   gc.g1.humongousObjects.TestHumongousNonArrayAllocation SMALLEST_HUMONGOUS
  *
  * @run main/othervm -Xms128M -Xmx128M -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *                   -XX:G1HeapRegionSize=1M -XX:AbortVMOnException=java.lang.StackOverflowError
+ *                   -XX:G1HeapRegionSize=1M
  *                   gc.g1.humongousObjects.TestHumongousNonArrayAllocation ONE_REGION_HUMONGOUS
  *
  * @run main/othervm -Xms128M -Xmx128M -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *                   -XX:G1HeapRegionSize=1M -XX:AbortVMOnException=java.lang.StackOverflowError
+ *                   -XX:G1HeapRegionSize=1M
  *                   gc.g1.humongousObjects.TestHumongousNonArrayAllocation TWO_REGION_HUMONGOUS
  *
  * @run main/othervm -Xms128M -Xmx128M -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *                   -XX:G1HeapRegionSize=1M -XX:AbortVMOnException=java.lang.StackOverflowError
+ *                   -XX:G1HeapRegionSize=1M
  *                   gc.g1.humongousObjects.TestHumongousNonArrayAllocation MORE_THAN_TWO_REGION_HUMONGOUS
  *
  */


### PR DESCRIPTION
Test cleanup to remove a command line option used to gather more information about a previous failure.
The option is no longer needed.

The original test issue was:     8249217: Unexpected StackOverflowError in "process reaper" thread still happens

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250523](https://bugs.openjdk.java.net/browse/JDK-8250523): Remove abortOnException diagnostic option from TestHumongousNonArrayAllocation.java


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1841/head:pull/1841`
`$ git checkout pull/1841`
