### PR TITLE
8258481: gc.g1.plab.TestPLABPromotion fails on Linux x86

### DIFF
--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
@@ -222,7 +222,7 @@ public class TestPLABPromotion {
      * @return true if checkedValue is less than MEM_DIFFERENCE_PCT percent of controlValue
      */
     private static boolean checkRatio(long checkedValue, long controlValue) {
-        return ((double)Math.abs(checkedValue) / controlValue) * 100L < MEM_DIFFERENCE_PCT;
+        return Math.abs(checkedValue * 100.0 / controlValue) < MEM_DIFFERENCE_PCT;
     }
 
     /**
@@ -235,7 +235,7 @@ public class TestPLABPromotion {
      * MEM_DIFFERENCE_PCT percent of controlValue
      */
     private static boolean checkDifferenceRatio(long checkedValue, long controlValue) {
-        return ((double)Math.abs(checkedValue - controlValue) / controlValue) * 100L < MEM_DIFFERENCE_PCT;
+        return Math.abs((checkedValue - controlValue) * 100.0 / controlValue) < MEM_DIFFERENCE_PCT;
     }
 
     /**

--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
@@ -72,7 +72,7 @@ public class TestPLABPromotion {
     private static final int PLAB_SIZE_HIGH = 65536;
     private static final int OBJECT_SIZE_SMALL = 10;
     private static final int OBJECT_SIZE_MEDIUM = 100;
-    private static final int OBJECT_SIZE_HIGH = 3500;
+    private static final int OBJECT_SIZE_HIGH = 3250;
     private static final int GC_NUM_SMALL = 1;
     private static final int GC_NUM_MEDIUM = 3;
     private static final int GC_NUM_HIGH = 7;
@@ -222,7 +222,7 @@ public class TestPLABPromotion {
      * @return true if checkedValue is less than MEM_DIFFERENCE_PCT percent of controlValue
      */
     private static boolean checkRatio(long checkedValue, long controlValue) {
-        return (Math.abs(checkedValue) / controlValue) * 100L < MEM_DIFFERENCE_PCT;
+        return ((double)Math.abs(checkedValue) / controlValue) * 100L < MEM_DIFFERENCE_PCT;
     }
 
     /**
@@ -235,7 +235,7 @@ public class TestPLABPromotion {
      * MEM_DIFFERENCE_PCT percent of controlValue
      */
     private static boolean checkDifferenceRatio(long checkedValue, long controlValue) {
-        return (Math.abs(checkedValue - controlValue) / controlValue) * 100L < MEM_DIFFERENCE_PCT;
+        return ((double)Math.abs(checkedValue - controlValue) / controlValue) * 100L < MEM_DIFFERENCE_PCT;
     }
 
     /**
@@ -304,6 +304,7 @@ public class TestPLABPromotion {
         public List<String> toOptions() {
             return Arrays.asList("-XX:ParallelGCThreads=" + parGCThreads,
                     "-XX:ParallelGCBufferWastePct=" + wastePct,
+                    "-XX:ParallelGCThreads=1", // Avoid dynamic sizing of threads.
                     "-XX:OldPLABSize=" + plabSize,
                     "-XX:YoungPLABSize=" + plabSize,
                     "-XX:" + (plabIsFixed ? "-" : "+") + "ResizePLAB",


### PR DESCRIPTION
Hi all,

  can I have reviews for this test bug fix on x86 (but it did not do the correct thing on 64 bit platforms either)?

There are sone test cases that allocates byte arrays of ~3500 bytes, and expect that almost all allocations occur in the PLABs given a PLAB waste threshold of some percentage, in this case 20%.

On x64 this is good, as the PLAB size is 4096 *words*, i.e. 32kb, and 20% of that is ~6.5kb. So all objects are allocated in PLABs as expected

On x86 the PLAB size of 4096 words is only 16kb, and 20% of that is ~3.2kb. This threshold is less than these 3500 bytes, so the test fails.

It does not fail always (but very often) because of the broken calculation for meeting the threshold: unless really *all* objects copied are of that 3500 byte size (and hence directly allocated), the current checking using integer calculation results in 0% waste, which is below the expected 20%.

The suggested fix is to lower the size of that array to 3250 bytes, which meets the criteria on both 32 and 64 bit platforms (and fix the broken calculations).

Note that we should not change this array size to much lower, because there is another test that fails otherwise.

Testing:
100 successful test runs on x86 and x64 linux each

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258481](https://bugs.openjdk.java.net/browse/JDK-8258481): gc.g1.plab.TestPLABPromotion fails on Linux x86


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to b328d337107576282d11a00a9f02a8d384b30953
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1842/head:pull/1842`
`$ git checkout pull/1842`
