### PR TITLE
8258696: Temporarily revert use of pattern match instanceof until docs-reference is fixed

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -158,7 +158,8 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         }
 
         private void shutdown() {
-            if (delegate instanceof ExecutorService service) {
+            if (delegate instanceof ExecutorService) {
+                ExecutorService service = (ExecutorService)delegate;
                 PrivilegedAction<?> action = () -> {
                     service.shutdown();
                     return null;


### PR DESCRIPTION
Temporarily revert use of pattern match instanceof construct until docs-reference is fixed, see JDK-8258657. 

... 
Generating REFERENCE_API javadoc for 21 modules 
/Users/chhegar/git/open/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java:161: error: pattern matching in instanceof is a preview feature and is disabled by default. 
            if (delegate instanceof ExecutorService service) { 
                                                    ^ 
  (use --enable-preview to enable pattern matching in instanceof) 
1 error 
make[3]: *** [/Users/chhegar/git/open/build/macosx-x64/support/docs/_javadoc_REFERENCE_API_exec.marker] Error 1 
Docs.gmk:472: recipe for target '/Users/chhegar/git/open/build/macosx-x64/support/docs/_javadoc_REFERENCE_API_exec.marker' failed 
make/Main.gmk:485: recipe for target 'docs-reference-api-javadoc' failed 
make[2]: *** [docs-reference-api-javadoc] Error 2 
make[2]: *** Waiting for unfinished jobs....

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258696](https://bugs.openjdk.java.net/browse/JDK-8258696): Temporarily revert use of pattern match instanceof until docs-reference is fixed


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1843/head:pull/1843`
`$ git checkout pull/1843`
