### PR TITLE
8258715: [JVMCI] separate JVMCI code install timers for CompileBroker and hosted compilations

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2721,13 +2721,6 @@ void CompileBroker::print_times(bool per_compiler, bool aggregate) {
     }
   }
 
-#if INCLUDE_JVMCI
-  // In hosted mode, print the JVMCI compiler specific counters manually.
-  if (EnableJVMCI && !UseJVMCICompiler) {
-    JVMCICompiler::print_compilation_timers();
-  }
-#endif
-
   if (!aggregate) {
     return;
   }
@@ -2777,6 +2770,13 @@ void CompileBroker::print_times(bool per_compiler, bool aggregate) {
     tty->cr();
     comp->print_timers();
   }
+#if INCLUDE_JVMCI
+  if (EnableJVMCI) {
+    tty->cr();
+    JVMCICompiler::print_hosted_timers();
+  }
+#endif
+
   tty->cr();
   tty->print_cr("  Total compiled methods    : %8d methods", total_compile_count);
   tty->print_cr("    Standard compilation    : %8d methods", standard_compile_count);

--- a/src/hotspot/share/jvmci/jvmciCompiler.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompiler.cpp
@@ -33,6 +33,7 @@
 
 JVMCICompiler* JVMCICompiler::_instance = NULL;
 elapsedTimer JVMCICompiler::_codeInstallTimer;
+elapsedTimer JVMCICompiler::_hostedCodeInstallTimer;
 
 JVMCICompiler::JVMCICompiler() : AbstractCompiler(compiler_jvmci) {
   _bootstrapping = false;
@@ -152,19 +153,19 @@ void JVMCICompiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, 
   ShouldNotReachHere();
 }
 
-// Print compilation timers and statistics
+// Print CompileBroker compilation timers
 void JVMCICompiler::print_timers() {
-  tty->print_cr("    JVMCI Compile Time:      %7.3f s", stats()->total_time());
-  print_compilation_timers();
+  double code_install_time = _codeInstallTimer.seconds();
+  tty->print_cr("    JVMCI CompileBroker Time:");
+  tty->print_cr("       Compile:        %7.3f s", stats()->total_time());
+  tty->print_cr("       Install Code:   %7.3f s", code_install_time);
 }
 
-// Print compilation timers and statistics
-void JVMCICompiler::print_compilation_timers() {
-  double code_install_time = _codeInstallTimer.seconds();
-  if (code_install_time != 0.0) {
-    tty->cr();
-    tty->print_cr("    JVMCI code install time:        %6.3f s", code_install_time);
-  }
+// Print non-CompileBroker compilation timers
+void JVMCICompiler::print_hosted_timers() {
+  double code_install_time = _hostedCodeInstallTimer.seconds();
+  tty->print_cr("    JVMCI Hosted Time:");
+  tty->print_cr("       Install Code:   %7.3f s", code_install_time);
 }
 
 void JVMCICompiler::inc_methods_compiled() {

--- a/src/hotspot/share/jvmci/jvmciCompiler.hpp
+++ b/src/hotspot/share/jvmci/jvmciCompiler.hpp
@@ -49,7 +49,11 @@ private:
 
   static JVMCICompiler* _instance;
 
+  // Code installation timer for CompileBroker compilations
   static elapsedTimer _codeInstallTimer;
+
+  // Code installation timer for non-CompileBroker compilations
+  static elapsedTimer _hostedCodeInstallTimer;
 
   /**
    * Exits the VM due to an unexpected exception.
@@ -107,10 +111,16 @@ public:
   int global_compilation_ticks() const { return _global_compilation_ticks; }
   void inc_global_compilation_ticks();
 
-  // Print compilation timers and statistics
-  static void print_compilation_timers();
+  // Print timers related to non-CompileBroker compilations
+  static void print_hosted_timers();
 
-  static elapsedTimer* codeInstallTimer() { return &_codeInstallTimer; }
+  static elapsedTimer* codeInstallTimer(bool hosted) {
+    if (!hosted) {
+      return &_codeInstallTimer;
+    } else {
+      return &_hostedCodeInstallTimer;
+    }
+  }
 };
 
 #endif // SHARE_JVMCI_JVMCICOMPILER_HPP

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -838,7 +838,7 @@ C2V_VMENTRY_0(jint, installCode, (JNIEnv *env, jobject, jobject target, jobject 
 
   JVMCICompiler* compiler = JVMCICompiler::instance(true, CHECK_JNI_ERR);
 
-  TraceTime install_time("installCode", JVMCICompiler::codeInstallTimer());
+  TraceTime install_time("installCode", JVMCICompiler::codeInstallTimer(!thread->is_Compiler_thread()));
   bool is_immutable_PIC = JVMCIENV->get_HotSpotCompiledCode_isImmutablePIC(compiled_code_handle) > 0;
 
   CodeInstaller installer(JVMCIENV, is_immutable_PIC);


### PR DESCRIPTION
Currently, a single timer is used for timing JVMCI based installation of code into the code cache. This makes it impossible to work out how much time is for compilations requested by the CompileBroker and how much is for "hosted" compilations (i.e. requested from the JVMCI Java API). This PR separates out timers for each of these compilation types.

Here's an example of how the JVMCI section in the output for `-XX:+CITime` now looks:
```
    JVMCI CompileBroker Time:
       Compile:         15.794 s
       Install Code:     0.182 s

    JVMCI Hosted Time:
       Install Code:     0.035 s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258715](https://bugs.openjdk.java.net/browse/JDK-8258715): [JVMCI] separate JVMCI code install timers for CompileBroker and hosted compilations


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1847/head:pull/1847`
`$ git checkout pull/1847`
