### PR TITLE
8258736: No break in the loop

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -532,6 +532,7 @@ enum SSLCipher {
             for (ProtocolVersion pv : me.getValue()) {
                 if (protocolVersion == pv) {
                     rcg = me.getKey();
+                    break;
                 }
             }
         }
@@ -557,6 +558,7 @@ enum SSLCipher {
             for (ProtocolVersion pv : me.getValue()) {
                 if (protocolVersion == pv) {
                     wcg = me.getKey();
+                    break;
                 }
             }
         }


### PR DESCRIPTION
It looks like the break is missed in the loop of the SSLCipher.createReadCipher() and createWriteCipher() methods.  See the change set.

Code cleanup, no new regression test.

Bug: https://bugs.openjdk.java.net/browse/JDK-8258736

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258736](https://bugs.openjdk.java.net/browse/JDK-8258736): No break in the loop 


### Reviewers
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**) ⚠️ Review applies to 3dd9fb3edf54dc40a4bbd005dd0880736dbd05fa


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1848/head:pull/1848`
`$ git checkout pull/1848`
