### PR TITLE
8066694: Strange code in JavacParser.java

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -2391,7 +2391,7 @@ public class JavacParser implements Parser {
                 List<JCAnnotation> maybeDimAnnos = typeAnnotationsOpt();
                 int pos = token.pos;
                 nextToken();
-                if (token.kind == RBRACKET) {
+                if (token.kind == RBRACKET) { // no dimension
                     elemtype = bracketsOptCont(elemtype, pos, maybeDimAnnos);
                 } else {
                     dimAnnotations.append(maybeDimAnnos);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -2394,13 +2394,9 @@ public class JavacParser implements Parser {
                 if (token.kind == RBRACKET) {
                     elemtype = bracketsOptCont(elemtype, pos, maybeDimAnnos);
                 } else {
-                    if (token.kind == RBRACKET) { // no dimension
-                        elemtype = bracketsOptCont(elemtype, pos, maybeDimAnnos);
-                    } else {
-                        dimAnnotations.append(maybeDimAnnos);
-                        dims.append(parseExpression());
-                        accept(RBRACKET);
-                    }
+                    dimAnnotations.append(maybeDimAnnos);
+                    dims.append(parseExpression());
+                    accept(RBRACKET);
                 }
             }
 


### PR DESCRIPTION
This code was introduced in main repository under https://bugs.openjdk.java.net/browse/JDK-8006775
I checked original commit in `type-annotations/langtools` repository: https://hg.openjdk.java.net/type-annotations/type-annotations/langtools/rev/71f35e4b93a5
Looks like it's not a merge problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8066694](https://bugs.openjdk.java.net/browse/JDK-8066694): Strange code in JavacParser.java


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/1852/head:pull/1852` \
`$ git checkout pull/1852`

Update a local copy of the PR: \
`$ git checkout pull/1852` \
`$ git pull https://git.openjdk.java.net/jdk pull/1852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1852`

View PR using the GUI difftool: \
`$ git pr show -t 1852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/1852.diff">https://git.openjdk.java.net/jdk/pull/1852.diff</a>

</details>
