### PR TITLE
8255729: com.sun.tools.javac.processing.JavacFiler.FilerOutputStream is inefficient

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacFiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacFiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacFiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacFiler.java
@@ -275,6 +275,14 @@ public class JavacFiler implements Filer, Closeable {
             this.fileObject = fileObject;
         }
 
+        @Override
+        public void write(byte b[], int off, int len) throws IOException {
+            if ((off | len | (b.length - (len + off)) | (off + len)) < 0)
+                throw new IndexOutOfBoundsException();
+            out.write(b, off, len);
+        }
+
+        @Override
         public synchronized void close() throws IOException {
             if (!closed) {
                 closed = true;
@@ -312,6 +320,7 @@ public class JavacFiler implements Filer, Closeable {
             this.fileObject = fileObject;
         }
 
+        @Override
         public synchronized void close() throws IOException {
             if (!closed) {
                 closed = true;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacFiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacFiler.java
@@ -277,8 +277,7 @@ public class JavacFiler implements Filer, Closeable {
 
         @Override
         public void write(byte b[], int off, int len) throws IOException {
-            if ((off | len | (b.length - (len + off)) | (off + len)) < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkFromIndexSize(off, len, b.length);
             out.write(b, off, len);
         }
 


### PR DESCRIPTION
Hi all,

`FilerOutputStream` extends `FilterOutputStream` without overwriting the method `write(byte b[], int off, int len)` which would suffer from the performance problem.
This patch fixes it and adds some `@Override` to polish the code. But I can't find a good way to write a corresponding test case. Maybe it doesn't need a test case. And all existing tests in `test/langtools/tools/javac` passed locally.

Thank you for taking the time to review.

Best Regards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255729](https://bugs.openjdk.java.net/browse/JDK-8255729): com.sun.tools.javac.processing.JavacFiler.FilerOutputStream  is inefficient


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to 02a3fd1e1bc9c16268f8f9c7561b209b7cfe7987


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1854/head:pull/1854`
`$ git checkout pull/1854`
