### PR TITLE
8262161: Refactor manual I/O stream copying in java.desktop to use new convenience APIs

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/DLSSoundbank.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DLSSoundbank.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/com/sun/media/sound/DLSSoundbank.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DLSSoundbank.java
@@ -987,11 +987,7 @@ public final class DLSSoundbank implements Soundbank {
             RIFFWriter data_chunk = writer.writeChunk("data");
             AudioInputStream stream = AudioSystem.getAudioInputStream(
                     audioformat, (AudioInputStream)sample.getData());
-            byte[] buff = new byte[1024];
-            int ret;
-            while ((ret = stream.read(buff)) != -1) {
-                data_chunk.write(buff, 0, ret);
-            }
+            stream.transferTo(data_chunk);
         } else {
             RIFFWriter data_chunk = writer.writeChunk("data");
             ModelByteBuffer databuff = sample.getDataBuffer();

--- a/src/java.desktop/share/classes/com/sun/media/sound/JavaSoundAudioClip.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/JavaSoundAudioClip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/com/sun/media/sound/JavaSoundAudioClip.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/JavaSoundAudioClip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,8 +59,6 @@ import javax.sound.sampled.UnsupportedAudioFileException;
  */
 @SuppressWarnings("deprecation")
 public final class JavaSoundAudioClip implements AudioClip, MetaEventListener, LineListener {
-
-    private static final int BUFFER_SIZE = 16384; // number of bytes written each time to the source data line
 
     private long lastPlayCall = 0;
     private static final int MINIMUM_PLAY_DELAY = 30;
@@ -359,19 +357,9 @@ public final class JavaSoundAudioClip implements AudioClip, MetaEventListener, L
     private void readStream(AudioInputStream as) throws IOException {
 
         DirectBAOS baos = new DirectBAOS();
-        byte[] buffer = new byte[16384];
-        int bytesRead = 0;
-        int totalBytesRead = 0;
-
-        // this loop may throw an IOException
-        while( true ) {
-            bytesRead = as.read(buffer, 0, buffer.length);
-            if (bytesRead <= 0) {
-                as.close();
-                break;
-            }
-            totalBytesRead += bytesRead;
-            baos.write(buffer, 0, bytesRead);
+        int totalBytesRead;
+        try (as) {
+            totalBytesRead = (int) as.transferTo(baos);
         }
         loadedAudio = baos.getInternalBuffer();
         loadedAudioByteLength = totalBytesRead;

--- a/src/java.desktop/share/classes/com/sun/media/sound/ModelByteBuffer.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/ModelByteBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/com/sun/media/sound/ModelByteBuffer.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/ModelByteBuffer.java
@@ -201,11 +201,7 @@ public final class ModelByteBuffer {
     public void writeTo(OutputStream out) throws IOException {
         if (root.file != null && root.buffer == null) {
             try (InputStream is = getInputStream()) {
-                byte[] buff = new byte[1024];
-                int ret;
-                while ((ret = is.read(buff)) != -1) {
-                    out.write(buff, 0, ret);
-                }
+                is.transferTo(out);
             }
         } else
             out.write(array(), (int) arrayOffset(), (int) capacity());

--- a/src/java.desktop/share/classes/com/sun/media/sound/StandardMidiFileWriter.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/StandardMidiFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/com/sun/media/sound/StandardMidiFileWriter.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/StandardMidiFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,6 @@ public final class StandardMidiFileWriter extends MidiFileWriter {
     private static final int MIDI_TYPE_0 = 0;
     private static final int MIDI_TYPE_1 = 1;
 
-    private static final int bufferSize = 16384;  // buffersize for write
     private DataOutputStream tddos;               // data output stream for track writing
 
     /**
@@ -117,22 +116,12 @@ public final class StandardMidiFileWriter extends MidiFileWriter {
         if (!isFileTypeSupported(type, in)) {
             throw new IllegalArgumentException("Could not write MIDI file");
         }
-        byte [] buffer = null;
-
-        int bytesRead = 0;
-        long bytesWritten = 0;
-
         // First get the fileStream from this sequence
         InputStream fileStream = getFileStream(type,in);
         if (fileStream == null) {
             throw new IllegalArgumentException("Could not write MIDI file");
         }
-        buffer = new byte[bufferSize];
-
-        while( (bytesRead = fileStream.read( buffer )) >= 0 ) {
-            out.write( buffer, 0, bytesRead );
-            bytesWritten += bytesRead;
-        }
+        long bytesWritten = fileStream.transferTo(out);
         // Done....return bytesWritten
         return (int) bytesWritten;
     }

--- a/src/java.desktop/share/classes/com/sun/media/sound/WaveFloatFileWriter.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/WaveFloatFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/com/sun/media/sound/WaveFloatFileWriter.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/WaveFloatFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,11 +80,7 @@ public final class WaveFloatFileWriter extends AudioFileWriter {
             fmt_chunk.writeUnsignedShort(format.getSampleSizeInBits());
         }
         try (RIFFWriter data_chunk = writer.writeChunk("data")) {
-            byte[] buff = new byte[1024];
-            int len;
-            while ((len = stream.read(buff, 0, buff.length)) != -1) {
-                data_chunk.write(buff, 0, len);
-            }
+            stream.transferTo(data_chunk);
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
@@ -2080,19 +2080,9 @@ public abstract class BasicLookAndFeel extends LookAndFeel implements Serializab
                         if (resource == null) {
                             return null;
                         }
-                        BufferedInputStream in =
-                            new BufferedInputStream(resource);
-                        ByteArrayOutputStream out =
-                            new ByteArrayOutputStream(1024);
-                        byte[] buffer = new byte[1024];
-                        int n;
-                        while ((n = in.read(buffer)) > 0) {
-                            out.write(buffer, 0, n);
+                        try (BufferedInputStream in = new BufferedInputStream(resource)) {
+                            return in.readAllBytes();
                         }
-                        in.close();
-                        out.flush();
-                        buffer = out.toByteArray();
-                        return buffer;
                     } catch (IOException ioe) {
                         System.err.println(ioe.toString());
                         return null;

--- a/src/java.desktop/share/classes/javax/swing/text/rtf/AbstractFilter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/rtf/AbstractFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/text/rtf/AbstractFilter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/rtf/AbstractFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,18 +93,7 @@ abstract class AbstractFilter extends OutputStream
     public void readFromStream(InputStream in)
       throws IOException
     {
-        byte[] buf;
-        int count;
-
-        buf = new byte[16384];
-
-        while(true) {
-            count = in.read(buf);
-            if (count < 0)
-                break;
-
-            this.write(buf, 0, count);
-        }
+        in.transferTo(this);
     }
 
     public void readFromReader(Reader in)

--- a/src/java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java
+++ b/src/java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java
+++ b/src/java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1978,16 +1978,7 @@ search:
     protected static byte[] inputStreamToByteArray(InputStream str)
         throws IOException
     {
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            int len = 0;
-            byte[] buf = new byte[8192];
-
-            while ((len = str.read(buf)) != -1) {
-                baos.write(buf, 0, len);
-            }
-
-            return baos.toByteArray();
-        }
+        return str.readAllBytes();
     }
 
     /**

--- a/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,6 @@ import java.awt.geom.Rectangle2D;
 import java.awt.print.PrinterGraphics;
 import java.beans.PropertyChangeEvent;
 import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Modifier;
@@ -1754,18 +1753,9 @@ public class SwingUtilities2 {
                     continue;
                             }
 
-                try (BufferedInputStream in
-                        = new BufferedInputStream(resource);
-                        ByteArrayOutputStream out
-                        = new ByteArrayOutputStream(1024)) {
-                            byte[] buffer = new byte[1024];
-                            int n;
-                            while ((n = in.read(buffer)) > 0) {
-                                out.write(buffer, 0, n);
+                            try (BufferedInputStream in = new BufferedInputStream(resource)) {
+                                return in.readAllBytes();
                             }
-                            out.flush();
-                            return out.toByteArray();
-                }
                         } catch (IOException ioe) {
                             System.err.println(ioe.toString());
                         }

--- a/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
+++ b/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
+++ b/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
@@ -596,21 +596,12 @@ public class UnixPrintJob implements CancelablePrintJob {
                 }
             }
         } else if (instream != null) {
-            BufferedInputStream bin = new BufferedInputStream(instream);
-            BufferedOutputStream bout = new BufferedOutputStream(output);
-            byte[] buffer = new byte[1024];
-            int bread = 0;
-
-            try {
-                while ((bread = bin.read(buffer)) >= 0) {
-                    bout.write(buffer, 0, bread);
-                }
-                bin.close();
-                bout.flush();
-                bout.close();
+            try (BufferedInputStream bin = new BufferedInputStream(instream);
+                 BufferedOutputStream bout = new BufferedOutputStream(output)) {
+                bin.transferTo(bout);
             } catch (IOException e) {
                 notifyEvent(PrintJobEvent.JOB_FAILED);
-                throw new PrintException (e);
+                throw new PrintException(e);
             }
         }
         notifyEvent(PrintJobEvent.DATA_TRANSFER_COMPLETE);

--- a/src/java.desktop/windows/classes/sun/print/Win32PrintJob.java
+++ b/src/java.desktop/windows/classes/sun/print/Win32PrintJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.io.Reader;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Vector;
 
 import javax.print.CancelablePrintJob;
@@ -432,7 +433,7 @@ public class Win32PrintJob implements CancelablePrintJob {
 
             if (mDestination != null) { // if destination attribute is set
                 try {
-                    Files.copy(instream, Path.of(mDestination));
+                    Files.copy(instream, Path.of(mDestination), StandardCopyOption.REPLACE_EXISTING);
                 } catch (IOException ioe) {
                     notifyEvent(PrintJobEvent.JOB_FAILED);
                     throw new PrintException(ioe.toString());

--- a/src/java.desktop/windows/classes/sun/print/Win32PrintJob.java
+++ b/src/java.desktop/windows/classes/sun/print/Win32PrintJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,22 +27,18 @@ package sun.print;
 
 import java.net.URI;
 import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.InputStream;
 import java.io.IOException;
-import java.io.FileNotFoundException;
 import java.io.Reader;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Vector;
 
 import javax.print.CancelablePrintJob;
 import javax.print.Doc;
 import javax.print.DocFlavor;
-import javax.print.DocPrintJob;
 import javax.print.PrintService;
 import javax.print.PrintException;
 import javax.print.event.PrintJobEvent;
@@ -50,7 +46,6 @@ import javax.print.event.PrintJobListener;
 import javax.print.event.PrintJobAttributeListener;
 
 import javax.print.attribute.Attribute;
-import javax.print.attribute.AttributeSet;
 import javax.print.attribute.AttributeSetUtilities;
 import javax.print.attribute.DocAttributeSet;
 import javax.print.attribute.HashPrintJobAttributeSet;
@@ -437,18 +432,7 @@ public class Win32PrintJob implements CancelablePrintJob {
 
             if (mDestination != null) { // if destination attribute is set
                 try {
-                    FileOutputStream fos = new FileOutputStream(mDestination);
-                    byte []buffer = new byte[1024];
-                    int cread;
-
-                    while ((cread = instream.read(buffer, 0, buffer.length)) >=0) {
-                        fos.write(buffer, 0, cread);
-                    }
-                    fos.flush();
-                    fos.close();
-                } catch (FileNotFoundException fnfe) {
-                    notifyEvent(PrintJobEvent.JOB_FAILED);
-                    throw new PrintException(fnfe.toString());
+                    Files.copy(instream, Path.of(mDestination));
                 } catch (IOException ioe) {
                     notifyEvent(PrintJobEvent.JOB_FAILED);
                     throw new PrintException(ioe.toString());


### PR DESCRIPTION
Cleanup code to use new handy methods in `java.io.InputStream`/`java.nio.file.Files` instead of manual stream copy:
1. java.io.InputStream#readAllBytes
2. java.io.InputStream#transferTo
3. java.nio.file.Files#copy

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262161](https://bugs.openjdk.java.net/browse/JDK-8262161): Refactor manual I/O stream copying in java.desktop to use new convenience APIs


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1856/head:pull/1856`
`$ git checkout pull/1856`
