### PR TITLE
8258792: LogCompilation: remove redundant check fixed by 8257518

### DIFF
--- a/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogCompilation.java
+++ b/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogCompilation.java
@@ -482,9 +482,6 @@ public class LogCompilation extends DefaultHandler implements ErrorHandler {
                 BasicLogEvent ble = (BasicLogEvent) e;
                 Compilation c = ble.getCompilation();
                 if (c == null) {
-                    if (!(ble instanceof NMethod)) {
-                        throw new InternalError("only nmethods should have a null compilation; here's a " + ble.getClass());
-                    }
                     continue;
                 }
                 String name = c.getMethod().getFullName();


### PR DESCRIPTION
There is no need to do the same check again doing -U processing, it is already done during XML parsing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258792](https://bugs.openjdk.java.net/browse/JDK-8258792): LogCompilation: remove redundant check fixed by 8257518


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1860/head:pull/1860`
`$ git checkout pull/1860`
