### PR TITLE
8258804: Collection.toArray() should use empty array

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
@@ -851,7 +851,7 @@ public abstract class SSLContextImpl extends SSLContextSpi {
             } else {
                 // Use the customized TLS protocols.
                 candidates =
-                    refactored.toArray(new ProtocolVersion[refactored.size()]);
+                    refactored.toArray(new ProtocolVersion[0]);
             }
 
             return getAvailableProtocols(candidates);

--- a/src/java.base/share/classes/sun/security/ssl/SunX509KeyManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SunX509KeyManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -424,6 +424,6 @@ final class SunX509KeyManagerImpl extends X509ExtendedKeyManager {
                 }
             }
         }
-        return list.toArray(new X500Principal[list.size()]);
+        return list.toArray(new X500Principal[0]);
     }
 }


### PR DESCRIPTION
Comparing to Collection.toArray(new T[size)), the Collection.toArray(new T[0]) seems faster, safer and contractually cleaner.  In the update, the use of Collection.toArray(new T[size)) in the SunJSSE provider implementation is replaced with Collection.toArray(new T[0]).

Bug: https://bugs.openjdk.java.net/browse/JDK-8258804

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258804](https://bugs.openjdk.java.net/browse/JDK-8258804): Collection.toArray() should use empty array


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1861/head:pull/1861`
`$ git checkout pull/1861`
