### PR TITLE
8258631: Remove sun.security.jgss.krb5.Krb5Util.getSubject()

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5Util.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,30 +98,6 @@ public class Krb5Util {
                     null, clientPrincipal, KerberosTicket.class);
         }
         return ticket;
-    }
-
-    /**
-     * Retrieves the caller's Subject, or Subject obtained by logging in
-     * via the specified caller.
-     *
-     * Caller must have permission to:
-     *    - access the Subject
-     *    - create LoginContext
-     *    - read the auth.login.defaultCallbackHandler security property
-     *
-     * NOTE: This method is used by JSSE Kerberos Cipher Suites
-     */
-    public static Subject getSubject(GSSCaller caller,
-        AccessControlContext acc) throws LoginException {
-
-        // Try to get the Subject from acc
-        Subject subject = Subject.getSubject(acc);
-
-        // Try to get Subject obtained from GSSUtil
-        if (subject == null && !GSSUtil.useSubjectCredsOnly(caller)) {
-            subject = GSSUtil.login(caller, GSSUtil.GSS_KRB5_MECH_OID);
-        }
-        return subject;
     }
 
     /**


### PR DESCRIPTION
The method is useless now since the related TLS cipher suite was removed long ago.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258631](https://bugs.openjdk.java.net/browse/JDK-8258631): Remove sun.security.jgss.krb5.Krb5Util.getSubject()


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1865/head:pull/1865`
`$ git checkout pull/1865`
