### PR TITLE
8258828: The method local variable is not really used

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SignatureAlgorithmsExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureAlgorithmsExtension.java
@@ -462,16 +462,10 @@ final class SignatureAlgorithmsExtension {
             // Parse the extension.
             SignatureSchemesSpec spec = new SignatureSchemesSpec(chc, buffer);
 
-            List<SignatureScheme> knownSignatureSchemes = new LinkedList<>();
-            for (int id : spec.signatureSchemes) {
-                SignatureScheme ss = SignatureScheme.valueOf(id);
-                if (ss != null) {
-                    knownSignatureSchemes.add(ss);
-                }
-            }
-
             // Update the context.
-            // chc.peerRequestedSignatureSchemes = knownSignatureSchemes;
+            //
+            // Note: the chc.peerRequestedSignatureSchemes will be updated
+            // in the CRSignatureSchemesUpdate.consume() implementation.
             chc.handshakeExtensions.put(
                     SSLExtension.CR_SIGNATURE_ALGORITHMS, spec);
 


### PR DESCRIPTION
The local variable "knownSignatureSchemes" in the CRSignatureSchemesConsumer.consume() method is assigned, but it is not really queried. It is safe to remove the local variable and the related code.

Code cleanup, no new regression test.

Bug: https://bugs.openjdk.java.net/browse/JDK-8258828

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258828](https://bugs.openjdk.java.net/browse/JDK-8258828): The method local variable is not really used


### Reviewers
 * [Jamil Nimeh](https://openjdk.java.net/census#jnimeh) (@jnimeh - **Reviewer**)
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1867/head:pull/1867`
`$ git checkout pull/1867`
