### PR TITLE
8259354 Fix race condition in AbstractEventStream.nextThreadName

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
@@ -276,8 +276,7 @@ public abstract class AbstractEventStream implements EventStream {
     }
 
     private String nextThreadName() {
-        counter.incrementAndGet();
-        return "JFR Event Stream " + counter;
+        return "JFR Event Stream " + counter.incrementAndGet();
     }
 
     @Override


### PR DESCRIPTION
The result of `AtomicLong.incrementAndGet()` is used rather than
incrementing the long and reading its value separately. The
previous approach allowed for the static counter to be incremented
several times before any caller read the value, resulting in
several callers with the same value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259354](https://bugs.openjdk.java.net/browse/JDK-8259354): Fix race condition in AbstractEventStream.nextThreadName


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**) ⚠️ Review applies to f0b2c78b1c9c9a89f2cf79709684dcdbce1b5da9


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1871/head:pull/1871`
`$ git checkout pull/1871`
