### PR TITLE
8258853: Support separate function declaration and definition with ENABLE_IF-based SFINAE

### DIFF
--- a/src/hotspot/share/metaprogramming/enableIf.hpp
+++ b/src/hotspot/share/metaprogramming/enableIf.hpp
@@ -35,9 +35,15 @@ template<bool cond, typename T = void>
 using EnableIf = std::enable_if<cond, T>;
 
 // ENABLE_IF(Condition...)
+// ENABLE_IF_PARAM(Condition...)
 //
-// This macro can be used in a function template parameter list to control
-// the presence of that overload via SFINAE.
+// The ENABLE_IF macro can be used in a function template parameter list to
+// control the presence of that overload via SFINAE.
+//
+// When the declaration and definition of a function template are separate,
+// only the declaration can use ENABLE_IF in the template parameter list.
+// The definition should instead use ENABLE_IF_PARAM with the same Condition
+// for the corresponding template parameter.
 //
 // Condition must be a constant expression whose value is convertible to
 // bool.  The Condition is captured as a variadic macro parameter so that it
@@ -101,8 +107,14 @@ using EnableIf = std::enable_if<cond, T>;
 // rare that no additional macro support is provided for it; just use the
 // underlying enable_if_t directly.  (There is an automatic macro-based
 // solution, but it involves the __COUNTER__ extension.)
+//
+// The expansion of ENABLE_IF doesn't use ENABLE_IF_PARAM because of issues
+// with the Visual Studio preprocessor's handling of variadic macros.
 
 #define ENABLE_IF(...) \
   std::enable_if_t<bool(__VA_ARGS__), int> = 0
+
+#define ENABLE_IF_PARAM(...) \
+  std::enable_if_t<bool(__VA_ARGS__), int>
 
 #endif // SHARE_METAPROGRAMMING_ENABLEIF_HPP

--- a/test/hotspot/gtest/metaprogramming/test_enableIf.cpp
+++ b/test/hotspot/gtest/metaprogramming/test_enableIf.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,13 @@
  */
 
 #include "precompiled.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "metaprogramming/enableIf.hpp"
 #include "utilities/debug.hpp"
+#include <type_traits>
+#include "unittest.hpp"
 
-class EnableIfTest {
+class EnableIfTest: AllStatic {
   class A: AllStatic {
   public:
     template <bool condition>
@@ -42,3 +44,20 @@ class EnableIfTest {
   static const bool A_test_false_is_long = sizeof(A::test<false>()) == sizeof(long);
   STATIC_ASSERT(A_test_false_is_long);
 };
+
+template<typename T, ENABLE_IF(std::is_integral<T>::value)>
+static T sub1(T x) { return x - 1; }
+
+template<typename T, ENABLE_IF(std::is_integral<T>::value)>
+static T sub2(T x);
+
+template<typename T, ENABLE_IF_PARAM(std::is_integral<T>::value)>
+T sub2(T x) { return x - 2; }
+
+TEST(TestEnableIfParam, one_decl_and_def) {
+  EXPECT_EQ(15, sub1(16));
+}
+
+TEST(TestEnableIfParam, separate_decl_and_def) {
+  EXPECT_EQ(14, sub2(16));
+}


### PR DESCRIPTION
Please review this change which adds the ENABLE_IF_PARAM macro.  This is
used in the definition of a function template when that definition is
separate from the declaration and the declaration uses ENABLE_IF.

For the separate definition to match the declaration, the non-type template
parameter for SFINAE in the two places must be "equivalent", where that's
defined in terms of tokens.  Rather than requiring a separate definition
match the ENABLE_IF expansion directly, the new macro is provided; it is
maintained in parallel with ENABLE_IF to ensure the needed consistency.

Alternative names for the new macro are possible.

(1) This gives the following usage:

```
template<typename T, ENABLE_IF(std::is_integral<T>::value)>
void foo(T x) { ... }
```

and this for separate declaration and definition.  

```
template<typename T, ENABLE_IF(std::is_integral<T>::value)>
void foo(T x);

// later separate definition
template<typename T, ENABLE_IF_PARAM(std::is_integral<T>::value)>
void foo(T x) { ... }
```

(2) An alternative that isn't being proposed here, but which could be done
instead, would be to drop the ENABLE_IF macro and use a type alias, with
associated change of syntax. Suppose the name is EnableIfX (should probably
be EnableIf, but need to deal with name conflict). It would be defined as

```
template<bool cond> using EnableIfX = std::enable_if_t<cond, int>;
```

and used as

```
template<typename T, EnableIfX<std::is_integral<T>::value> = 0>
void foo(T x) { ... }
```

and this for separate declaration and definition. 

```
template<typename T, EnableIfX<std::is_integral<T>::value> = 0>
void foo(T x);

// later separate definition
template<typename T, EnableIfX<std::is_integral<T>::value>>
void foo(T x) { ... }
```

(3) Or we could not provide any syntactic help, and just write it all out everywhere:

```
template<typename T, std::enable_if_t<std::is_integral<T>::value, int> = 0>
void foo(T x) { ... }
```

and this for separate declaration and definition.  

```
template<typename T, std::enable_if_t<std::is_integral<T>::value, int> = 0>
void foo(T x);

// later separate definition
template<typename T, std::enable_if_t<std::is_integral<T>::value, int>> 
void foo(T x) { ... }
```

Testing:
mach5 tier1
This includes some new gtests for the macros.
There aren't any current non-test uses of ENABLE_IF_PARAM yet.

/label hotspot
/summary Add ENABLE_IF_PARAM, unit tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258853](https://bugs.openjdk.java.net/browse/JDK-8258853): Support separate function declaration and definition with ENABLE_IF-based SFINAE


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1873/head:pull/1873`
`$ git checkout pull/1873`
