### PR TITLE
8258010: Debug build failure with clang-10 due to -Wdeprecated-copy

### DIFF
--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1455,8 +1455,6 @@ class DUIterator_Last : private DUIterator_Fast {
   DUIterator_Last() { }
   // initialize to garbage
 
-  DUIterator_Last (const DUIterator_Last& that) : DUIterator_Fast(that) {}
-
   void operator--()
     { _outp--;              VDUI_ONLY(verify_step(1));  }
 
@@ -1468,9 +1466,6 @@ class DUIterator_Last : private DUIterator_Fast {
     I_VDUI_ONLY(limit, limit.verify_limit());
     return _outp >= limit._outp;
   }
-
-  void operator=(const DUIterator_Last& that)
-    { DUIterator_Fast::operator=(that); }
 };
 
 DUIterator_Last Node::last_outs(DUIterator_Last& imin) const {

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1458,7 +1458,7 @@ class DUIterator_Last : private DUIterator_Fast {
   DUIterator_Last() { }
   // initialize to garbage
 
-  DUIterator_Last (const DUIterator_Last& that) = default;
+  DUIterator_Last(const DUIterator_Last& that) = default;
 
   void operator--()
     { _outp--;              VDUI_ONLY(verify_step(1));  }
@@ -1472,8 +1472,7 @@ class DUIterator_Last : private DUIterator_Fast {
     return _outp >= limit._outp;
   }
 
-  void operator=(const DUIterator_Last& that)
-    { DUIterator_Fast::operator=(that); }
+  DUIterator_Last& operator=(const DUIterator_Last& that) = default;
 };
 
 DUIterator_Last Node::last_outs(DUIterator_Last& imin) const {

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1330,6 +1330,9 @@ class DUIterator : public DUIterator_Common {
   DUIterator()
     { /*initialize to garbage*/         debug_only(_vdui = false); }
 
+  DUIterator(const DUIterator& that)
+    { _idx = that._idx;                 debug_only(_vdui = false; reset(that)); }
+
   void operator++(int dummy_to_specify_postfix_op)
     { _idx++;                           VDUI_ONLY(verify_increment()); }
 
@@ -1393,7 +1396,7 @@ class DUIterator_Fast : public DUIterator_Common {
     { /*initialize to garbage*/         debug_only(_vdui = false); }
 
   DUIterator_Fast(const DUIterator_Fast& that)
-    { _outp = that._outp;               debug_only(reset(that)); }
+    { _outp = that._outp;               debug_only(_vdui = false; reset(that)); }
 
   void operator++(int dummy_to_specify_postfix_op)
     { _outp++;                          VDUI_ONLY(verify(_node, true)); }
@@ -1455,6 +1458,8 @@ class DUIterator_Last : private DUIterator_Fast {
   DUIterator_Last() { }
   // initialize to garbage
 
+  DUIterator_Last (const DUIterator_Last& that) = default;
+
   void operator--()
     { _outp--;              VDUI_ONLY(verify_step(1));  }
 
@@ -1466,6 +1471,9 @@ class DUIterator_Last : private DUIterator_Fast {
     I_VDUI_ONLY(limit, limit.verify_limit());
     return _outp >= limit._outp;
   }
+
+  void operator=(const DUIterator_Last& that)
+    { DUIterator_Fast::operator=(that); }
 };
 
 DUIterator_Last Node::last_outs(DUIterator_Last& imin) const {

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1392,6 +1392,9 @@ class DUIterator_Fast : public DUIterator_Common {
   DUIterator_Fast()
     { /*initialize to garbage*/         debug_only(_vdui = false); }
 
+  DUIterator_Fast(const DUIterator_Fast& that)
+    { _outp = that._outp;               debug_only(reset(that)); }
+
   void operator++(int dummy_to_specify_postfix_op)
     { _outp++;                          VDUI_ONLY(verify(_node, true)); }
 
@@ -1451,6 +1454,8 @@ class DUIterator_Last : private DUIterator_Fast {
  public:
   DUIterator_Last() { }
   // initialize to garbage
+
+  DUIterator_Last (const DUIterator_Last& that) : DUIterator_Fast(that) {}
 
   void operator--()
     { _outp--;              VDUI_ONLY(verify_step(1));  }

--- a/src/hotspot/share/runtime/threadHeapSampler.cpp
+++ b/src/hotspot/share/runtime/threadHeapSampler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, Google and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/share/runtime/threadHeapSampler.cpp
+++ b/src/hotspot/share/runtime/threadHeapSampler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, Google and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -394,7 +394,7 @@ void ThreadHeapSampler::pick_next_geometric_sample() {
   double log_val = (fast_log2(q) - 26);
   double result =
       (0.0 < log_val ? 0.0 : log_val) * (-log(2.0) * (get_sampling_interval())) + 1;
-  assert(result > 0 && result < (double) SIZE_MAX, "Result is not in an acceptable range.");
+  assert(result > 0 && result < SIZE_MAX, "Result is not in an acceptable range.");
   size_t interval = static_cast<size_t>(result);
   _bytes_until_sample = interval;
 }

--- a/src/hotspot/share/runtime/threadHeapSampler.cpp
+++ b/src/hotspot/share/runtime/threadHeapSampler.cpp
@@ -394,7 +394,7 @@ void ThreadHeapSampler::pick_next_geometric_sample() {
   double log_val = (fast_log2(q) - 26);
   double result =
       (0.0 < log_val ? 0.0 : log_val) * (-log(2.0) * (get_sampling_interval())) + 1;
-  assert(result > 0 && result < SIZE_MAX, "Result is not in an acceptable range.");
+  assert(result > 0 && result < (double) SIZE_MAX, "Result is not in an acceptable range.");
   size_t interval = static_cast<size_t>(result);
   _bytes_until_sample = interval;
 }


### PR DESCRIPTION
1. '-Wdeprecated-copy'
As specified in C++11 [1], "the generation of the implicitly-defined
copy constructor is deprecated if T has a user-defined destructor or
user-defined copy assignment operator". The rationale behind is the
well-known Rule of Three [2].

Introduced since gcc-9 [3] and clang-10 [4], flag '-Wdeprecated-copy'
warns about the C++11 deprecation of implicitly declared copy
constructor and assignment operator if one of them is user-provided.
Defining an explicit copy constructor would suppress this warning.

The main reason why debug build with gcc-9 or higher succeeds lies in
the inconsistent warning behaviors between gcc and clang. See the
reduced code example [5]. We suspect it might be return value
optimization/copy elision [6] that drives gcc not to declare implicit
copy constructor for this case.

Note that flag '-Wdeprecated' in clang-8 and clang-9 would also raise
warnings for deprecated defintions of copy constructors. However,
'-Wdeprecated' is not enabled by '-Wall' or '-Wextra'. Hence, clang-8
and clang-9 are not affected.

~~2. '-Wimplicit-int-float-conversion'~~
~~Making the conversion explicit would fix it.~~

~~Flag '-Wimplicit-int-float-conversion' is first introduced in clang-10.~~
~~Therefore clang-8 and clang-9 are not affected. The flag with similar~~
~~functionality in gcc is '-Wfloat-conversion', but it is not enabled by~~
~~'-Wall' or '-Wextra'. That's why this warning does not apprear when~~
~~building with gcc.~~

[1] https://en.cppreference.com/w/cpp/language/copy_constructor
[2] https://en.cppreference.com/w/cpp/language/rule_of_three
[3] https://www.gnu.org/software/gcc/gcc-9/changes.html
[4] https://releases.llvm.org/10.0.0/tools/clang/docs/ReleaseNotes.html
[5] https://godbolt.org/z/err4jM
[6] https://en.wikipedia.org/wiki/Copy_elision#Return_value_optimization


Note that we have tested with this patch, debug build succeeded with clang-10 on Linux X86-64/AArch64 machines.
Note that '--with-extra-cxxflags=-Wno-implicit-int-float-conversion' should be added when configuration. It's another issue (See JDK-8259288)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258010](https://bugs.openjdk.java.net/browse/JDK-8258010): Debug build failure with clang-10 due to -Wdeprecated-copy


### Reviewers
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - no project role) ⚠️ Review applies to 68679966d8df8729602d5fc9ca6421ec5abdc75c
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1874/head:pull/1874`
`$ git checkout pull/1874`
