### PR TITLE
8258186: Replace use of JNI_COMMIT mode with mode 0

### DIFF
--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_crypt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_crypt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -173,7 +173,7 @@ cleanup:
         (*env)->ReleasePrimitiveArrayCritical(env, jIn, inBufP, JNI_ABORT);
     }
     if (directOut == 0 && outBufP != NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, jOut, outBufP, JNI_COMMIT);
+        (*env)->ReleasePrimitiveArrayCritical(env, jOut, outBufP, 0);
     }
     return ckEncryptedLen;
 }
@@ -239,7 +239,7 @@ cleanup:
         (*env)->ReleasePrimitiveArrayCritical(env, jIn, inBufP, JNI_ABORT);
     }
     if (directOut == 0 && outBufP != NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, jOut, outBufP, JNI_COMMIT);
+        (*env)->ReleasePrimitiveArrayCritical(env, jOut, outBufP, 0);
     }
     return ckEncryptedPartLen;
 }
@@ -284,7 +284,7 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1EncryptFinal
                                          &ckLastEncryptedPartLen);
 
     if (directOut == 0) {
-        (*env)->ReleasePrimitiveArrayCritical(env, jOut, outBufP, JNI_COMMIT);
+        (*env)->ReleasePrimitiveArrayCritical(env, jOut, outBufP, 0);
     }
 
     ckAssertReturnValueOK(env, rv);
@@ -408,7 +408,7 @@ cleanup:
         (*env)->ReleasePrimitiveArrayCritical(env, jIn, inBufP, JNI_ABORT);
     }
     if (directOut == 0 && outBufP != NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, jOut, outBufP, JNI_COMMIT);
+        (*env)->ReleasePrimitiveArrayCritical(env, jOut, outBufP, 0);
     }
     return ckOutLen;
 }
@@ -472,7 +472,7 @@ cleanup:
         (*env)->ReleasePrimitiveArrayCritical(env, jIn, inBufP, JNI_ABORT);
     }
     if (directOut == 0 && outBufP != NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, jOut, outBufP, JNI_COMMIT);
+        (*env)->ReleasePrimitiveArrayCritical(env, jOut, outBufP, 0);
     }
     return ckDecryptedPartLen;
 }
@@ -518,7 +518,7 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1DecryptFinal
                                          &ckLastPartLen);
 
     if (directOut == 0) {
-        (*env)->ReleasePrimitiveArrayCritical(env, jOut, outBufP, JNI_COMMIT);
+        (*env)->ReleasePrimitiveArrayCritical(env, jOut, outBufP, 0);
 
     }
 


### PR DESCRIPTION
Could someone please help review this trivial change - just replace JNI_COMMIT with 0 for all ReleasePrimitiveArrayCritical calls.

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258186](https://bugs.openjdk.java.net/browse/JDK-8258186): Replace use of JNI_COMMIT mode with mode 0


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1875/head:pull/1875`
`$ git checkout pull/1875`
