### PR TITLE
8258751: Improve ExceptionHandlerTable dump

### DIFF
--- a/src/hotspot/share/code/exceptionHandlerTable.cpp
+++ b/src/hotspot/share/code/exceptionHandlerTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/code/exceptionHandlerTable.cpp
+++ b/src/hotspot/share/code/exceptionHandlerTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,22 +120,32 @@ HandlerTableEntry* ExceptionHandlerTable::entry_for(int catch_pco, int handler_b
 }
 
 
-void ExceptionHandlerTable::print_subtable(HandlerTableEntry* t) const {
+void ExceptionHandlerTable::print_subtable(HandlerTableEntry* t, address base) const {
   int l = t->len();
-  tty->print_cr("catch_pco = %d (%d entries)", t->pco(), l);
+  bool have_base_addr = (base != NULL);
+  if (have_base_addr) {
+    tty->print_cr("catch_pco = %d (pc=" INTPTR_FORMAT ", %d entries)", t->pco(), p2i(base + t->pco()), l);
+  } else {
+    tty->print_cr("catch_pco = %d (%d entries)", t->pco(), l);
+  }
   while (l-- > 0) {
     t++;
-    tty->print_cr("  bci %d at scope depth %d -> pco %d", t->bci(), t->scope_depth(), t->pco());
+    if (have_base_addr) {
+      tty->print_cr("  bci %d at scope depth %d -> pco %d (pc=" INTPTR_FORMAT ")",
+                    t->bci(), t->scope_depth(), t->pco(), p2i(base + t->pco()));
+    } else {
+      tty->print_cr("  bci %d at scope depth %d -> pco %d", t->bci(), t->scope_depth(), t->pco());
+    }
   }
 }
 
 
-void ExceptionHandlerTable::print() const {
+void ExceptionHandlerTable::print(address base) const {
   tty->print_cr("ExceptionHandlerTable (size = %d bytes)", size_in_bytes());
   int i = 0;
   while (i < _length) {
     HandlerTableEntry* t = _table + i;
-    print_subtable(t);
+    print_subtable(t, base);
     // advance to next subtable
     i += t->len() + 1; // +1 for header
   }

--- a/src/hotspot/share/code/exceptionHandlerTable.hpp
+++ b/src/hotspot/share/code/exceptionHandlerTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/code/exceptionHandlerTable.hpp
+++ b/src/hotspot/share/code/exceptionHandlerTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,8 +123,8 @@ class ExceptionHandlerTable {
   HandlerTableEntry* entry_for(int catch_pco, int handler_bci, int scope_depth) const;
 
   // debugging
-  void print_subtable(HandlerTableEntry* t) const;
-  void print() const;
+  void print_subtable(HandlerTableEntry* t, address base = NULL) const;
+  void print(address base = NULL) const;
   void print_subtable_for(int catch_pco) const;
 };
 

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2700,7 +2700,7 @@ void nmethod::print_native_invokers() {
 }
 
 void nmethod::print_handler_table() {
-  ExceptionHandlerTable(this).print();
+  ExceptionHandlerTable(this).print(code_begin());
 }
 
 void nmethod::print_nul_chk_table() {


### PR DESCRIPTION
In addition to PC offset, print the real PC as well if available when
dumping the ExceptionHandlerTable, as it's more convenient and readable
for debugging or other activities.

Note that compilers might dump the ExceptionHandlerTable before method
registered. See functions emit_code_body() and fill_buffer(). However,
real PC is not ready yet during these phases since the generated code is
not installed. In such scenarios, the real PC is not printed.

The example below shows how the dump information would be changed after
applying this patch.
  BEFORE:
    ExceptionHandlerTable (size = 40 bytes)
    catch_pco = 392 (2 entries)
      bci 8 at scope depth 0 -> pco 184
      bci 19 at scope depth 0 -> pco 124
  AFTER:
    ExceptionHandlerTable (size = 40 bytes)
    catch_pco = 392 (pc=0x0000ffff818f13c8, 2 entries)
      bci 8 at scope depth 0 -> pco 184 (pc=0x0000ffff818f12f8)
      bci 19 at scope depth 0 -> pco 124 (pc=0x0000ffff818f12bc)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258751](https://bugs.openjdk.java.net/browse/JDK-8258751):  Improve ExceptionHandlerTable dump


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 018252b586407d06fbd9f954eff4d3a9b4ff54bb
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Ningsheng Jian](https://openjdk.java.net/census#njian) (@nsjian - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1877/head:pull/1877`
`$ git checkout pull/1877`
