### PR TITLE
8265474: Dubious 'null' assignment in CompactByteArray.expand

### DIFF
--- a/src/java.base/share/classes/sun/text/CompactByteArray.java
+++ b/src/java.base/share/classes/sun/text/CompactByteArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/text/CompactByteArray.java
+++ b/src/java.base/share/classes/sun/text/CompactByteArray.java
@@ -129,7 +129,7 @@ public final class CompactByteArray implements Cloneable {
     {
         if (isCompact)
             expand();
-        values[(int)index] = value;
+        values[index] = value;
         touchBlock(index >> BLOCKSHIFT, value);
     }
 
@@ -326,15 +326,9 @@ public final class CompactByteArray implements Cloneable {
             for (i = 0; i < INDEXCOUNT; ++i) {
                 indices[i] = (short)(i<<BLOCKSHIFT);
             }
-            values = null;
             values = tempArray;
             isCompact = false;
         }
-    }
-
-    private byte[] getArray()
-    {
-        return values;
     }
 
     private static  final int BLOCKSHIFT =7;
@@ -347,4 +341,4 @@ public final class CompactByteArray implements Cloneable {
     private short indices[];
     private boolean isCompact;
     private int[] hashes;
-};
+}


### PR DESCRIPTION
I propose to remove 'null' assignment of field CompactByteArray.values in `expand` method. In the next statement this field is overridden with another value - `tempArray`.
This code was there from initial load of OpenJDK sources. I believe it was just leftovers from development phase of this class. There is no practical reason to assign `null` to non-volatile field and then overwrite it with another value.
Also I've removed unused method `getArray`. I hope it's ok to cleanup such unused stuff in the same PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265474](https://bugs.openjdk.java.net/browse/JDK-8265474): Dubious 'null' assignment in CompactByteArray.expand


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/1880/head:pull/1880` \
`$ git checkout pull/1880`

Update a local copy of the PR: \
`$ git checkout pull/1880` \
`$ git pull https://git.openjdk.java.net/jdk pull/1880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1880`

View PR using the GUI difftool: \
`$ git pr show -t 1880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/1880.diff">https://git.openjdk.java.net/jdk/pull/1880.diff</a>

</details>
