### PR TITLE
8258851: Mismatch in SunPKCS11 provider registration properties and actual implementation

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -508,12 +508,13 @@ public final class SunPKCS11 extends AuthProvider {
         // names of all the implementation classes
         // use local variables, only used here
         String P11Digest           = "sun.security.pkcs11.P11Digest";
-        String P11MAC              = "sun.security.pkcs11.P11MAC";
+        String P11Mac              = "sun.security.pkcs11.P11Mac";
         String P11KeyPairGenerator = "sun.security.pkcs11.P11KeyPairGenerator";
         String P11KeyGenerator     = "sun.security.pkcs11.P11KeyGenerator";
         String P11RSAKeyFactory    = "sun.security.pkcs11.P11RSAKeyFactory";
         String P11DSAKeyFactory    = "sun.security.pkcs11.P11DSAKeyFactory";
         String P11DHKeyFactory     = "sun.security.pkcs11.P11DHKeyFactory";
+        String P11ECKeyFactory     = "sun.security.pkcs11.P11ECKeyFactory";
         String P11KeyAgreement     = "sun.security.pkcs11.P11KeyAgreement";
         String P11SecretKeyFactory = "sun.security.pkcs11.P11SecretKeyFactory";
         String P11Cipher           = "sun.security.pkcs11.P11Cipher";
@@ -552,33 +553,33 @@ public final class SunPKCS11 extends AuthProvider {
         dA(MD, "SHA3-512",        P11Digest,
                 m(CKM_SHA3_512));
 
-        d(MAC, "HmacMD5",       P11MAC,
+        d(MAC, "HmacMD5",       P11Mac,
                 m(CKM_MD5_HMAC));
-        dA(MAC, "HmacSHA1",      P11MAC,
+        dA(MAC, "HmacSHA1",      P11Mac,
                 m(CKM_SHA_1_HMAC));
-        dA(MAC, "HmacSHA224",    P11MAC,
+        dA(MAC, "HmacSHA224",    P11Mac,
                 m(CKM_SHA224_HMAC));
-        dA(MAC, "HmacSHA256",    P11MAC,
+        dA(MAC, "HmacSHA256",    P11Mac,
                 m(CKM_SHA256_HMAC));
-        dA(MAC, "HmacSHA384",    P11MAC,
+        dA(MAC, "HmacSHA384",    P11Mac,
                 m(CKM_SHA384_HMAC));
-        dA(MAC, "HmacSHA512",    P11MAC,
+        dA(MAC, "HmacSHA512",    P11Mac,
                 m(CKM_SHA512_HMAC));
-        dA(MAC, "HmacSHA512/224",    P11MAC,
+        dA(MAC, "HmacSHA512/224",    P11Mac,
                 m(CKM_SHA512_224_HMAC));
-        dA(MAC, "HmacSHA512/256",    P11MAC,
+        dA(MAC, "HmacSHA512/256",    P11Mac,
                 m(CKM_SHA512_256_HMAC));
-        dA(MAC, "HmacSHA3-224",    P11MAC,
+        dA(MAC, "HmacSHA3-224",    P11Mac,
                 m(CKM_SHA3_224_HMAC));
-        dA(MAC, "HmacSHA3-256",    P11MAC,
+        dA(MAC, "HmacSHA3-256",    P11Mac,
                 m(CKM_SHA3_256_HMAC));
-        dA(MAC, "HmacSHA3-384",    P11MAC,
+        dA(MAC, "HmacSHA3-384",    P11Mac,
                 m(CKM_SHA3_384_HMAC));
-        dA(MAC, "HmacSHA3-512",    P11MAC,
+        dA(MAC, "HmacSHA3-512",    P11Mac,
                 m(CKM_SHA3_512_HMAC));
-        d(MAC, "SslMacMD5",     P11MAC,
+        d(MAC, "SslMacMD5",     P11Mac,
                 m(CKM_SSL3_MD5_MAC));
-        d(MAC, "SslMacSHA1",    P11MAC,
+        d(MAC, "SslMacSHA1",    P11Mac,
                 m(CKM_SSL3_SHA1_MAC));
 
         d(KPG, "RSA",           P11KeyPairGenerator,
@@ -640,7 +641,7 @@ public final class SunPKCS11 extends AuthProvider {
         d(KF, "DH",             P11DHKeyFactory,
                 dhAlias,
                 m(CKM_DH_PKCS_KEY_PAIR_GEN, CKM_DH_PKCS_DERIVE));
-        d(KF, "EC",             P11DHKeyFactory,
+        d(KF, "EC",             P11ECKeyFactory,
                 m(CKM_EC_KEY_PAIR_GEN, CKM_ECDH1_DERIVE,
                     CKM_ECDSA, CKM_ECDSA_SHA1));
 
@@ -1133,6 +1134,7 @@ public final class SunPKCS11 extends AuthProvider {
             this.mechanism = mechanism & 0xFFFFFFFFL;
         }
 
+        @Override
         public Object newInstance(Object param)
                 throws NoSuchAlgorithmException {
             if (token.isValid() == false) {

--- a/test/jdk/sun/security/pkcs11/Provider/CheckRegistration.java
+++ b/test/jdk/sun/security/pkcs11/Provider/CheckRegistration.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8258851
+ * @library /test/lib ..
+ * @modules jdk.crypto.cryptoki
+ * @run main CheckRegistration
+ * @summary Ensure SunPKCS11 provider service registration matches the actual
+ *     impl class
+ */
+
+import java.security.Provider;
+import java.util.Set;
+
+public class CheckRegistration extends PKCS11Test {
+
+    public static void main(String[] args) throws Exception {
+        main(new CheckRegistration(), args);
+    }
+
+    @Override
+    public void main(Provider p) throws Exception {
+        Set<Provider.Service> services = p.getServices();
+
+        for (Provider.Service s : services) {
+            String key = s.getType() + "." + s.getAlgorithm();
+            Object val = p.get(key);
+            System.out.println("Checking " + key + " : " + s.getClassName());
+            if (val == null) {
+                throw new RuntimeException("Missing mapping");
+            }
+            if (!s.getClassName().equals(val)) {
+                System.out.println("Mapping value: " + val);
+                throw new RuntimeException("Mapping mismatches");
+            }
+            Object o = s.newInstance(null);
+            if (!s.getClassName().equals(o.getClass().getName())) {
+                System.out.println("Actual impl: " + o.getClass().getName());
+                throw new RuntimeException("Impl class mismatches");
+            }
+        }
+        System.out.println("Test Passed");
+    }
+}


### PR DESCRIPTION
Max, can you help taking a look? This trivial change fixes the inconsistent registration properties to match the actual implementation.

In addition to the DH->EC KeyFactory inconsistency, the new test finds another MAC->Mac typo.
Mach5 run is clean.
Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258851](https://bugs.openjdk.java.net/browse/JDK-8258851): Mismatch in SunPKCS11 provider registration properties and actual implementation


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1883/head:pull/1883`
`$ git checkout pull/1883`
