### PR TITLE
8258911: ProblemList serviceability/attach/RemovingUnixDomainSocketTest.java on Linux-X64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -100,6 +100,8 @@ serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatIntervalTest.java 8214
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java 8224150 generic-all
 serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 windows-all
 
+serviceability/attach/RemovingUnixDomainSocketTest.java 8248162 linux-x64
+
 #############################################################################
 
 # :hotspot_misc


### PR DESCRIPTION
This is a trivial fix to ProblemList serviceability/attach/RemovingUnixDomainSocketTest.java
on Linux-X64.

The test has been failing fairly frequently in the JDK17 CI when it is run with the
"-XX:NativeMemoryTracking=detail" option. We currently only specify that configuration
on linux-x64 so I'm going to ProblemList the test only on Linux-X64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258911](https://bugs.openjdk.java.net/browse/JDK-8258911): ProblemList serviceability/attach/RemovingUnixDomainSocketTest.java on Linux-X64


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1884/head:pull/1884`
`$ git checkout pull/1884`
