### PR TITLE
8258913: ProblemList javax/swing/JComboBox/6559152/bug6559152.java on Linux-X64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -731,6 +731,7 @@ javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedPerPixelTranslucentGradien
 javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentSwing.java 8194128 macosx-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/SetShapeAndClickSwing.java 8013450 macosx-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 8024627 macosx-all
+javax/swing/JComboBox/6559152/bug6559152.java 8164484 linux-x64
 # The next test below is an intermittent failure
 javax/swing/JComboBox/8033069/bug8033069ScrollBar.java 8163367 generic-all
 javax/swing/JColorChooser/Test6827032.java 8197825 windows-all


### PR DESCRIPTION
A trivial fix to ProblemList javax/swing/JComboBox/6559152/bug6559152.java on Linux-X64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258913](https://bugs.openjdk.java.net/browse/JDK-8258913): ProblemList javax/swing/JComboBox/6559152/bug6559152.java on Linux-X64


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1885/head:pull/1885`
`$ git checkout pull/1885`
