### PR TITLE
8258924: javax/swing/JSplitPane/4201995/bug4201995.java fails in GTk L&F

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -735,7 +735,6 @@ javax/swing/JComboBox/6559152/bug6559152.java 8164484 linux-x64
 # The next test below is an intermittent failure
 javax/swing/JComboBox/8033069/bug8033069ScrollBar.java 8163367 generic-all
 javax/swing/JColorChooser/Test6827032.java 8197825 windows-all
-javax/swing/JSplitPane/4201995/bug4201995.java 8079127 generic-all
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all

--- a/test/jdk/javax/swing/JSplitPane/4201995/bug4201995.java
+++ b/test/jdk/javax/swing/JSplitPane/4201995/bug4201995.java
@@ -38,6 +38,7 @@ public class bug4201995 {
                 UIManager.setLookAndFeel(LF.getClassName());
             } catch (UnsupportedLookAndFeelException ignored) {
                 System.out.println("Unsupported L&F: " + LF.getClassName());
+                continue;
             } catch (ClassNotFoundException | InstantiationException
                      | IllegalAccessException e) {
                 throw new RuntimeException(e);
@@ -48,7 +49,7 @@ public class bug4201995 {
                 public void run() {
                     boolean expectedOpaqueValue =
                         !("Nimbus".equals(UIManager.getLookAndFeel().getName()) ||
-                          "GTK".equals(UIManager.getLookAndFeel().getName()));
+                          UIManager.getLookAndFeel().getName().contains("GTK"));
                     JSplitPane sp = new JSplitPane();
                     System.out.println("sp.isOpaque " + sp.isOpaque());
 

--- a/test/jdk/javax/swing/JSplitPane/4201995/bug4201995.java
+++ b/test/jdk/javax/swing/JSplitPane/4201995/bug4201995.java
@@ -32,16 +32,31 @@ import javax.swing.*;
 
 public class bug4201995 {
     public static void main(String[] args) throws Exception {
-        SwingUtilities.invokeAndWait(new Runnable() {
-            @Override
-            public void run() {
-                boolean expectedOpaqueValue = !"Nimbus".equals(UIManager.getLookAndFeel().getName());
-                JSplitPane sp = new JSplitPane();
-
-                if (sp.isOpaque() != expectedOpaqueValue) {
-                    throw new RuntimeException("JSplitPane has incorrect default opaque value");
-                }
+        for (UIManager.LookAndFeelInfo LF :
+                UIManager.getInstalledLookAndFeels()) {
+            try {
+                UIManager.setLookAndFeel(LF.getClassName());
+            } catch (UnsupportedLookAndFeelException ignored) {
+                System.out.println("Unsupported L&F: " + LF.getClassName());
+            } catch (ClassNotFoundException | InstantiationException
+                     | IllegalAccessException e) {
+                throw new RuntimeException(e);
             }
-        });
+            System.out.println("Testing L&F: " + LF.getClassName());
+            SwingUtilities.invokeAndWait(new Runnable() {
+                @Override
+                public void run() {
+                    boolean expectedOpaqueValue =
+                        !("Nimbus".equals(UIManager.getLookAndFeel().getName()) ||
+                          "GTK".equals(UIManager.getLookAndFeel().getName()));
+                    JSplitPane sp = new JSplitPane();
+                    System.out.println("sp.isOpaque " + sp.isOpaque());
+
+                    if (sp.isOpaque() != expectedOpaqueValue) {
+                        throw new RuntimeException("JSplitPane has incorrect default opaque value");
+                    }
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
This test tests whether SplitPane is opaque or not but in nimbus and subseqeuently in GTK L&F the opaque property is set to false [1]
As nimbus is already handled in the test, it is modified to handle GTK L&F too. Along with this modification, the test is also updated to test all installed L&Fs.
Mach5 job running for several iterations for all platform is ok. Link in JBS.

[1] https://raw.githubusercontent.com/openjdk/jdk/master/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
      uiComponent opaque="false" type="javax.swing.JSplitPane" name="SplitPane" ui="SplitPaneUI" subregion="false"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258924](https://bugs.openjdk.java.net/browse/JDK-8258924): javax/swing/JSplitPane/4201995/bug4201995.java fails in GTk L&F


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1888/head:pull/1888`
`$ git checkout pull/1888`
