### PR TITLE
8231627: ThreadsListHandleInErrorHandlingTest.java fails in printing all threads

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
@@ -93,8 +93,10 @@ public class NestedThreadsListHandleInErrorHandlingTest {
         Pattern.compile("Current thread .* _threads_hazard_ptr=0x[0-9A-Fa-f][0-9A-Fa-f]*, _nested_threads_hazard_ptr_cnt=1, _nested_threads_hazard_ptr=0x[0-9A-Fa-f][0-9A-Fa-f]*.*"),
         // We should have a section of Threads class SMR info:
         Pattern.compile("Threads class SMR info:"),
-        // We should have one nested ThreadsListHandle:
-        Pattern.compile(".*, _nested_thread_list_max=1"),
+        // We should have had a double nested ThreadsListHandle since
+        // ThreadsSMRSupport::print_info_on() now protects itself with
+        // a ThreadsListHandle in addition to what the test creates:
+        Pattern.compile(".*, _nested_thread_list_max=2"),
         // The current thread (marked with '=>') in the threads list
         // should show a hazard ptr and a nested hazard ptr:
         Pattern.compile("=>.* JavaThread \"main\" .* _threads_hazard_ptr=0x[0-9A-Fa-f][0-9A-Fa-f]*, _nested_threads_hazard_ptr_cnt=1, _nested_threads_hazard_ptr=0x[0-9A-Fa-f][0-9A-Fa-f]*.*"),

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
@@ -93,6 +93,10 @@ public class ThreadsListHandleInErrorHandlingTest {
         Pattern.compile("Current thread .* _threads_hazard_ptr=0x[0-9A-Fa-f][0-9A-Fa-f]*, _nested_threads_hazard_ptr_cnt=0.*"),
         // We should have a section of Threads class SMR info:
         Pattern.compile("Threads class SMR info:"),
+        // We should have had a single nested ThreadsListHandle since
+        // ThreadsSMRSupport::print_info_on() now protects itself with
+        // a ThreadsListHandle:
+        Pattern.compile(".*, _nested_thread_list_max=1"),
         // The current thread (marked with '=>') in the threads list
         // should show a hazard ptr and no nested hazard ptrs:
         Pattern.compile("=>.* JavaThread \"main\" .* _threads_hazard_ptr=0x[0-9A-Fa-f][0-9A-Fa-f]*, _nested_threads_hazard_ptr_cnt=0.*"),


### PR DESCRIPTION
A small robustness fix in ThreadsSMRSupport::print_info_on() to reduce the
likelihood of crashes during error reporting. Uses Threads_lock->try_lock()
for safety and restricts some reporting to when the Threads_lock has been
acquired (depends on JDK-8256383). Uses a ThreadsListHandle to make
the current ThreadsList safe for reporting (depends on JDK-8258284). Also
detects when the system ThreadsList (_java_thread_list) has changed and
will warn that some of the reported info may now be stale.

Two existing tests have been updated to reflect the use of a ThreadsListHandle
in ThreadsSMRSupport::print_info_on(). Mach5 Tier[1-6] testing has no regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8231627](https://bugs.openjdk.java.net/browse/JDK-8231627): ThreadsListHandleInErrorHandlingTest.java fails in printing all threads


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to 334bdd2aecdc77324a090e0b5086a2ba071da48c
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer) ⚠️ Review applies to 334bdd2aecdc77324a090e0b5086a2ba071da48c
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1891/head:pull/1891`
`$ git checkout pull/1891`
