### PR TITLE
8258914: javax/net/ssl/DTLS/RespondToRetransmit.java timed out

### DIFF
--- a/test/jdk/javax/net/ssl/DTLS/RespondToRetransmit.java
+++ b/test/jdk/javax/net/ssl/DTLS/RespondToRetransmit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,8 @@
 
 /*
  * @test
- * @bug 8161086
+ * @bug 8161086 8258914
+ * @key intermittent
  * @summary DTLS handshaking fails if some messages were lost
  * @modules java.base/sun.security.util
  * @library /test/lib


### PR DESCRIPTION
The test javax/net/ssl/DTLS/RespondToRetransmit.java timed out intermittently.  This is a request to add "intermittent" tag to the test.

Test update, no new regression test.

Bug: https://bugs.openjdk.java.net/browse/JDK-8258914

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258914](https://bugs.openjdk.java.net/browse/JDK-8258914): javax/net/ssl/DTLS/RespondToRetransmit.java timed out


### Reviewers
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1892/head:pull/1892`
`$ git checkout pull/1892`
