### PR TITLE
Make void.class.arrayType() and <255-demension-array>.class.arrayType() returns null instead of throwing (undocumented) IllegalArgumentException

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -4350,14 +4350,23 @@ public final class Class<T> implements java.io.Serializable,
 
     /**
      * Returns a {@code Class} for an array type whose component type
-     * is described by this {@linkplain Class}.
+     * is described by this {@linkplain Class} if this {@code Class} does
+     * not describe {@code void} or an array type whose number of demension
+     * is 255 (which is the maximum number of demension of an array in Java
+     * language), or {@code null} otherwise.
      *
-     * @return a {@code Class} describing the array type
+     * @return a {@code Class} describing the array type, or {@code null}
+     * if this {@code Class} describes {@code void} or an array type whose
+     * number of demension is 255.
      * @since 12
      */
     @Override
     public Class<?> arrayType() {
-        return Array.newInstance(this, 0).getClass();
+        try {
+            return Array.newInstance(this, 0).getClass();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/TypeDescriptor.java
+++ b/src/java.base/share/classes/java/lang/invoke/TypeDescriptor.java
@@ -76,17 +76,21 @@ public interface TypeDescriptor {
         boolean isPrimitive();
 
         /**
-         * If this field descriptor describes an array type, return
-         * a descriptor for its component type, otherwise return {@code null}.
+         * If this field descriptor describes an array type, returns
+         * a descriptor for its component type, otherwise returns {@code null}.
          * @return the component type, or {@code null} if this field descriptor does
          * not describe an array type
          */
         F componentType();
 
         /**
-         * Return a descriptor for the array type whose component type is described by this
-         * descriptor
-         * @return the descriptor for the array type
+         * Returns a descriptor for the array type whose component type is described by this
+         * descriptor if this descriptor does not describe {@code void} or an array type
+         * whose number of demension is 255 (which is the maximum number of demension of an array
+         * in Java language), otherwise returns {@code null}.
+         * 
+         * @return the descriptor for the array type, or {@code null} if this descriptor
+         * describes {@code void} or an array type whose number of demension is 255.
          */
         F arrayType();
     }


### PR DESCRIPTION
Originally, the implementation of `java.lang.Class.arrayType` returns `java.lang.reflect.Array.newInstance(this, 0).getClass()` to get the array type. However, for `void.class` (i.e. `java.lang.Void.TYPE`) and `int[][][]...[].class` (which is a 255-demension array), `Array.newInstance` throws `IllegalArgumentException` as documented in [java.lang.reflect.Array#newInstance(Class<?>, int)](https://docs.oracle.com/en/java/javase/15/docs/api/java.base/java/lang/reflect/Array.html#newInstance(java.lang.Class,int)), and the implementation of `java.lang.Class.arrayType` does not catch it, so it rethrows the exception (unexpectedly). So I reimplemented it and modified the document to make it returns `null` as well as other methods in class `Class`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1893/head:pull/1893`
`$ git checkout pull/1893`
