### PR TITLE
8258857: Zero: non-PCH release build fails after JDK-8258074

### DIFF
--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 #define SHARE_COMPILER_COMPILER_GLOBALS_HPP
 
 #include "compiler/compiler_globals_pd.hpp"
+#include "runtime/globals_shared.hpp"
 #ifdef COMPILER1
 #include "c1/c1_globals.hpp"
 #endif // COMPILER1

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_COMPILER_COMPILER_GLOBALS_HPP
 #define SHARE_COMPILER_COMPILER_GLOBALS_HPP
 
-#include "runtime/globals_shared.hpp"
+#include "compiler/compiler_globals_pd.hpp"
 #ifdef COMPILER1
 #include "c1/c1_globals.hpp"
 #endif // COMPILER1


### PR DESCRIPTION
From the error log we can see the root cause is that, develop_pd flag
'pd_CICompileOSR' is undeclared in zero build.

Where this flag is used?
Flag 'pd_CICompileOSR' is assigned to flag 'CICompileOSR'. See line 77
of 'compiler_globals.hpp' and further line 86 of 'globals_shared.hpp'.

Where this flag can be declared?
Header files 'c1_globals.hpp' or 'c2_globals.hpp' would be included if
VM is built with compiler1 or compiler2. See lines 30 to 38 of
'complier_globals.hpp'. And further, flag 'pd_CICompileOSR' may get
declared in the header files for specific arch, e.g.,
'c1_globals_aarch64.hpp', 'c2_globals_aarch64.hpp'.
However, regarding zero build (without compiler1 and compiler2 and
jvmci) , this flag is undelcared. Hence, this patch gets header file
'compiler/compiler_globals_pd.hpp' included where this flag is declared
for the case when neither COMPILER1 nor COMPILER2 are defined and
INCLUDE_JVMCI is inactive.

Note that 'compiler/compiler_globals_pd.hpp' already includes
'runtime/globals_shared.hpp'.

Note that zero build with PCH succeeds because 'runtime/globals.hpp' is
included in 'precompiled.hpp', and further 'compiler_globals_pd.hpp' is
included in 'runtime/globals.hpp'.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258857](https://bugs.openjdk.java.net/browse/JDK-8258857): Zero: non-PCH release build fails after JDK-8258074


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1894/head:pull/1894`
`$ git checkout pull/1894`
