### PR TITLE
8258833: Cancel multi-part cipher operations in SunPKCS11 after failures

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -350,6 +350,13 @@ final class P11AEADCipher extends CipherSpi {
                         0, buffer, 0, bufLen);
             }
         } catch (PKCS11Exception e) {
+            if (e.getErrorCode() == CKR_OPERATION_NOT_INITIALIZED) {
+                // Cancel Operation may be invoked after an error on a PKCS#11
+                // call. If the operation inside the token was already cancelled,
+                // do not fail here. This is part of a defensive mechanism for
+                // PKCS#11 libraries that do not strictly follow the standard.
+                return;
+            }
             if (encrypt) {
                 throw new ProviderException("Cancel failed", e);
             }
@@ -616,6 +623,12 @@ final class P11AEADCipher extends CipherSpi {
             }
             return k;
         } catch (PKCS11Exception e) {
+            // As per the PKCS#11 standard, C_Encrypt and C_Decrypt may only
+            // keep the operation active on CKR_BUFFER_TOO_SMALL errors or
+            // successful calls to determine the output length. However,
+            // these cases are not expected here because the output length
+            // is checked in the OpenJDK side before making the PKCS#11 call.
+            // Thus, doCancel can safely be 'false'.
             doCancel = false;
             handleException(e);
             throw new ProviderException("doFinal() failed", e);
@@ -702,6 +715,12 @@ final class P11AEADCipher extends CipherSpi {
             outBuffer.position(outBuffer.position() + k);
             return k;
         } catch (PKCS11Exception e) {
+            // As per the PKCS#11 standard, C_Encrypt and C_Decrypt may only
+            // keep the operation active on CKR_BUFFER_TOO_SMALL errors or
+            // successful calls to determine the output length. However,
+            // these cases are not expected here because the output length
+            // is checked in the OpenJDK side before making the PKCS#11 call.
+            // Thus, doCancel can safely be 'false'.
             doCancel = false;
             handleException(e);
             throw new ProviderException("doFinal() failed", e);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -439,6 +439,13 @@ final class P11Cipher extends CipherSpi {
                 token.p11.C_DecryptFinal(session.id(), 0, buffer, 0, bufLen);
             }
         } catch (PKCS11Exception e) {
+            if (e.getErrorCode() == CKR_OPERATION_NOT_INITIALIZED) {
+                // Cancel Operation may be invoked after an error on a PKCS#11
+                // call. If the operation inside the token was already cancelled,
+                // do not fail here. This is part of a defensive mechanism for
+                // PKCS#11 libraries that do not strictly follow the standard.
+                return;
+            }
             if (encrypt) {
                 throw new ProviderException("Cancel failed", e);
             }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -851,9 +851,9 @@ final class P11Cipher extends CipherSpi {
                             0, padBuffer, 0, actualPadLen,
                             outAddr, outArray, outOfs, outLen);
                 }
+                doCancel = false;
                 k += token.p11.C_EncryptFinal(session.id(),
                         outAddr, outArray, (outOfs + k), (outLen - k));
-                doCancel = false;
             } else {
                 // Special handling to match SunJCE provider behavior
                 if (bytesBuffered == 0 && padBufferLen == 0) {
@@ -867,18 +867,18 @@ final class P11Cipher extends CipherSpi {
                                 0, padBuffer, 0, padBuffer.length);
                         padBufferLen = 0;
                     }
+                    doCancel = false;
                     k += token.p11.C_DecryptFinal(session.id(),
                             0, padBuffer, k, padBuffer.length - k);
-                    doCancel = false;
 
                     int actualPadLen = paddingObj.unpad(padBuffer, k);
                     k -= actualPadLen;
                     outArray = padBuffer;
                     outOfs = 0;
                 } else {
+                    doCancel = false;
                     k = token.p11.C_DecryptFinal(session.id(),
                             outAddr, outArray, outOfs, outLen);
-                    doCancel = false;
                 }
             }
             if ((!encrypt && paddingObj != null) ||

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -628,7 +628,7 @@ final class P11Cipher extends CipherSpi {
                 throw (ShortBufferException)
                         (new ShortBufferException().initCause(e));
             }
-            reset(false);
+            reset(true);
             throw new ProviderException("update() failed", e);
         }
     }
@@ -746,7 +746,7 @@ final class P11Cipher extends CipherSpi {
                 throw (ShortBufferException)
                         (new ShortBufferException().initCause(e));
             }
-            reset(false);
+            reset(true);
             throw new ProviderException("update() failed", e);
         }
     }
@@ -799,7 +799,6 @@ final class P11Cipher extends CipherSpi {
             }
             return k;
         } catch (PKCS11Exception e) {
-            doCancel = false;
             handleException(e);
             throw new ProviderException("doFinal() failed", e);
         } finally {
@@ -884,7 +883,6 @@ final class P11Cipher extends CipherSpi {
             }
             return k;
         } catch (PKCS11Exception e) {
-            doCancel = false;
             handleException(e);
             throw new ProviderException("doFinal() failed", e);
         } finally {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -220,6 +220,11 @@ final class P11Mac extends MacSpi {
             ensureInitialized();
             return token.p11.C_SignFinal(session.id(), 0);
         } catch (PKCS11Exception e) {
+            // As per the PKCS#11 standard, C_SignFinal may only
+            // keep the operation active on CKR_BUFFER_TOO_SMALL errors or
+            // successful calls to determine the output length. However,
+            // these cases are handled at OpenJDK's libj2pkcs11 native
+            // library. Thus, doCancel can safely be 'false' here.
             throw new ProviderException("doFinal() failed", e);
         } finally {
             reset(false);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -224,7 +224,8 @@ final class P11Mac extends MacSpi {
             // keep the operation active on CKR_BUFFER_TOO_SMALL errors or
             // successful calls to determine the output length. However,
             // these cases are handled at OpenJDK's libj2pkcs11 native
-            // library. Thus, doCancel can safely be 'false' here.
+            // library. Thus, P11Mac::reset can be called with a 'false'
+            // doCancel argument from here.
             throw new ProviderException("doFinal() failed", e);
         } finally {
             reset(false);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -151,6 +151,13 @@ final class P11Mac extends MacSpi {
         try {
             token.p11.C_SignFinal(session.id(), 0);
         } catch (PKCS11Exception e) {
+            if (e.getErrorCode() == CKR_OPERATION_NOT_INITIALIZED) {
+                // Cancel Operation may be invoked after an error on a PKCS#11
+                // call. If the operation inside the token was already cancelled,
+                // do not fail here. This is part of a defensive mechanism for
+                // PKCS#11 libraries that do not strictly follow the standard.
+                return;
+            }
             throw new ProviderException("Cancel failed", e);
         }
     }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
@@ -662,6 +662,11 @@ final class P11PSSSignature extends SignatureSpi {
             doCancel = false;
             return signature;
         } catch (PKCS11Exception pe) {
+            // As per the PKCS#11 standard, C_Sign and C_SignFinal may only
+            // keep the operation active on CKR_BUFFER_TOO_SMALL errors.
+            // However, this type of error is prevented from reaching this
+            // point at OpenJDK's libj2pkcs11 native library. Thus, doCancel
+            // can safely be 'false' here.
             doCancel = false;
             throw new ProviderException(pe);
         } catch (ProviderException e) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
@@ -298,6 +298,13 @@ final class P11PSSSignature extends SignatureSpi {
                 }
             }
         } catch (PKCS11Exception e) {
+            if (e.getErrorCode() == CKR_OPERATION_NOT_INITIALIZED) {
+                // Cancel Operation may be invoked after an error on a PKCS#11
+                // call. If the operation inside the token was already cancelled,
+                // do not fail here. This is part of a defensive mechanism for
+                // PKCS#11 libraries that do not strictly follow the standard.
+                return;
+            }
             if (mode == M_SIGN) {
                 throw new ProviderException("cancel failed", e);
             }
@@ -663,10 +670,10 @@ final class P11PSSSignature extends SignatureSpi {
             return signature;
         } catch (PKCS11Exception pe) {
             // As per the PKCS#11 standard, C_Sign and C_SignFinal may only
-            // keep the operation active on CKR_BUFFER_TOO_SMALL errors.
-            // However, this type of error is prevented from reaching this
-            // point at OpenJDK's libj2pkcs11 native library. Thus, doCancel
-            // can safely be 'false' here.
+            // keep the operation active on CKR_BUFFER_TOO_SMALL errors or
+            // successful calls to determine the output length. However,
+            // these cases are handled at OpenJDK's libj2pkcs11 native
+            // library. Thus, doCancel can safely be 'false' here.
             doCancel = false;
             throw new ProviderException(pe);
         } catch (ProviderException e) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -314,6 +314,13 @@ final class P11Signature extends SignatureSpi {
                 }
             }
         } catch (PKCS11Exception e) {
+            if (e.getErrorCode() == CKR_OPERATION_NOT_INITIALIZED) {
+                // Cancel Operation may be invoked after an error on a PKCS#11
+                // call. If the operation inside the token was already cancelled,
+                // do not fail here. This is part of a defensive mechanism for
+                // PKCS#11 libraries that do not strictly follow the standard.
+                return;
+            }
             if (mode == M_VERIFY) {
                 long errorCode = e.getErrorCode();
                 if ((errorCode == CKR_SIGNATURE_INVALID) ||

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -654,6 +654,11 @@ final class P11Signature extends SignatureSpi {
                 }
             }
         } catch (PKCS11Exception pe) {
+            // As per the PKCS#11 standard, C_Sign and C_SignFinal may only
+            // keep the operation active on CKR_BUFFER_TOO_SMALL errors.
+            // However, this type of error is prevented from reaching this
+            // point at OpenJDK's libj2pkcs11 native library. Thus, doCancel
+            // can safely be 'false' here.
             doCancel = false;
             throw new ProviderException(pe);
         } catch (SignatureException | ProviderException e) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -662,10 +662,10 @@ final class P11Signature extends SignatureSpi {
             }
         } catch (PKCS11Exception pe) {
             // As per the PKCS#11 standard, C_Sign and C_SignFinal may only
-            // keep the operation active on CKR_BUFFER_TOO_SMALL errors.
-            // However, this type of error is prevented from reaching this
-            // point at OpenJDK's libj2pkcs11 native library. Thus, doCancel
-            // can safely be 'false' here.
+            // keep the operation active on CKR_BUFFER_TOO_SMALL errors or
+            // successful calls to determine the output length. However,
+            // these cases are handled at OpenJDK's libj2pkcs11 native
+            // library. Thus, doCancel can safely be 'false' here.
             doCancel = false;
             throw new ProviderException(pe);
         } catch (SignatureException | ProviderException e) {

--- a/test/jdk/sun/security/pkcs11/Cipher/CancelMultipart.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/CancelMultipart.java
@@ -191,10 +191,19 @@ public class CancelMultipart extends PKCS11Test {
 
     private static void tryCipherInit() throws Exception {
         Cipher cipher = Cipher.getInstance("AES/ECB/NoPadding", provider);
+
+        // A CKR_OPERATION_ACTIVE error may be thrown if a session was
+        // returned to the Session Manager with an active operation, and
+        // we try to initialize the Cipher using it.
+        //
+        // Given that the maximum number of sessions was forced to 2, we know
+        // that the session to be used here was already used in a previous
+        // (failed) operation. Thus, the test asserts that the operation was
+        // properly cancelled.
         cipher.init(Cipher.ENCRYPT_MODE, key);
 
         // If initialization passes, finish gracefully so other paths can
-        // be tested under the current max number of sessions.
+        // be tested under the current maximum number of sessions.
         cipher.doFinal(new byte[16], 0, 0);
     }
 }

--- a/test/jdk/sun/security/pkcs11/Cipher/CancelMultipart.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/CancelMultipart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat, Inc.
+ * Copyright (c) 2021, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/pkcs11/Cipher/CancelMultipart.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/CancelMultipart.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8258833
+ * @library /test/lib ..
+ * @modules jdk.crypto.cryptoki/sun.security.pkcs11:open
+ * @run main/othervm CancelMultipart
+ */
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.security.Key;
+import java.security.Provider;
+import java.security.ProviderException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.spec.SecretKeySpec;
+
+public class CancelMultipart extends PKCS11Test {
+
+    private static Provider provider;
+    private static Key key;
+
+    static {
+        key = new SecretKeySpec(new byte[16], "AES");
+    }
+
+    private static class SessionLeaker {
+        private LeakOperation op;
+        private LeakInputType type;
+
+        SessionLeaker(LeakOperation op, LeakInputType type) {
+            this.op = op;
+            this.type = type;
+        }
+
+        private void leakAndTry() throws Exception {
+            Cipher cipher = op.getCipher();
+            try {
+                type.doOperation(cipher,
+                        (op instanceof LeakDecrypt ?
+                                LeakInputType.DECRYPT_MODE :
+                                LeakInputType.ENCRYPT_MODE));
+                throw new Exception("PKCS11Exception expected, invalid block"
+                        + "size");
+            } catch (ProviderException | IllegalBlockSizeException e) {
+                // Exception expected - session returned to the SessionManager
+                // should be cancelled. That's what will be tested now.
+            }
+
+            tryCipherInit();
+        }
+    }
+
+    private static interface LeakOperation {
+        Cipher getCipher() throws Exception;
+    }
+
+    private static interface LeakInputType {
+        static int ENCRYPT_MODE = 1;
+        static int DECRYPT_MODE = 2;
+        void doOperation(Cipher cipher, int mode) throws Exception;
+    }
+
+    private static class LeakDecrypt implements LeakOperation {
+        public Cipher getCipher() throws Exception {
+            Cipher cipher = Cipher.getInstance(
+                    "AES/ECB/PKCS5Padding", provider);
+            cipher.init(Cipher.DECRYPT_MODE, key);
+            return cipher;
+        }
+    }
+
+    private static class LeakEncrypt implements LeakOperation {
+        public Cipher getCipher() throws Exception {
+            Cipher cipher = Cipher.getInstance(
+                    "AES/ECB/NoPadding", provider);
+            cipher.init(Cipher.ENCRYPT_MODE, key);
+            return cipher;
+        }
+    }
+
+    private static class LeakByteBuffer implements LeakInputType {
+        public void doOperation(Cipher cipher, int mode) throws Exception {
+            if (mode == DECRYPT_MODE) {
+                cipher.update(ByteBuffer.allocate(1), ByteBuffer.allocate(1));
+                cipher.doFinal(ByteBuffer.allocate(0), ByteBuffer.allocate(1));
+            } else {
+                cipher.update(ByteBuffer.allocate(1), ByteBuffer.allocate(2));
+            }
+        }
+    }
+
+    private static class LeakByteArray implements LeakInputType {
+        public void doOperation(Cipher cipher, int mode) throws Exception {
+            if (mode == DECRYPT_MODE) {
+                cipher.update(new byte[1]);
+                cipher.doFinal(new byte[1], 0, 0);
+            } else {
+                cipher.update(new byte[1]);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        main(new CancelMultipart(), args);
+    }
+
+    @Override
+    public void main(Provider p) throws Exception {
+        init(p);
+
+        // Try multiple paths:
+
+        executeTest(new SessionLeaker(new LeakEncrypt(), new LeakByteArray()),
+                "P11Cipher::implUpdate(byte[], int, int, byte[], int, int)");
+
+        executeTest(new SessionLeaker(new LeakEncrypt(), new LeakByteBuffer()),
+                "P11Cipher::implUpdate(ByteBuffer, ByteBuffer)");
+
+        executeTest(new SessionLeaker(new LeakDecrypt(), new LeakByteArray()),
+                "P11Cipher::implDoFinal(byte[], int, int)");
+
+        executeTest(new SessionLeaker(new LeakDecrypt(), new LeakByteBuffer()),
+                "P11Cipher::implDoFinal(ByteBuffer)");
+
+        System.out.println("TEST PASS - OK");
+    }
+
+    private static void executeTest(SessionLeaker sl, String testName)
+            throws Exception {
+        try {
+            sl.leakAndTry();
+            System.out.println(testName +  ": OK");
+        } catch (Exception e) {
+            System.out.println(testName +  ": FAILED");
+            throw e;
+        }
+    }
+
+    private static void init(Provider p) throws Exception {
+        provider = p;
+
+        // The max number of sessions is 2 because, in addition to the
+        // operation (i.e. PKCS11::getNativeKeyInfo), a session to hold
+        // the P11Key object is needed.
+        setMaxSessions(2);
+    }
+
+    /*
+     * This method is intended to generate pression on the number of sessions
+     * to be used from the NSS Software Token, so sessions with (potentially)
+     * active operations are reused.
+     */
+    private static void setMaxSessions(int maxSessions) throws Exception {
+        Field tokenField = Class.forName("sun.security.pkcs11.SunPKCS11")
+                .getDeclaredField("token");
+        tokenField.setAccessible(true);
+        Field sessionManagerField = Class.forName("sun.security.pkcs11.Token")
+                .getDeclaredField("sessionManager");
+        sessionManagerField.setAccessible(true);
+        Field maxSessionsField = Class.forName("sun.security.pkcs11.SessionManager")
+                .getDeclaredField("maxSessions");
+        maxSessionsField.setAccessible(true);
+        Object sessionManagerObj = sessionManagerField.get(
+                tokenField.get(provider));
+        maxSessionsField.setInt(sessionManagerObj, maxSessions);
+    }
+
+    private static void tryCipherInit() throws Exception {
+        Cipher cipher = Cipher.getInstance("AES/ECB/NoPadding", provider);
+        cipher.init(Cipher.ENCRYPT_MODE, key);
+
+        // If initialization passes, finish gracefully so other paths can
+        // be tested under the current max number of sessions.
+        cipher.doFinal(new byte[16], 0, 0);
+    }
+}


### PR DESCRIPTION
When a multi-part cipher operation fails in SunPKCS11 (i.e. because of an invalid block size), we now cancel the operation before returning the underlying Session to the Session Manager. This allows to use the returned Session for a different purpose. Otherwise, an CKR_OPERATION_ACTIVE error would be raised from the PKCS#11 library.

The jdk/sun/security/pkcs11/Cipher/CancelMultipart.java regression test is introduced as part of this PR.

No regressions found in jdk/sun/security/pkcs11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258833](https://bugs.openjdk.java.net/browse/JDK-8258833): Cancel multi-part cipher operations in SunPKCS11 after failures


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1901/head:pull/1901`
`$ git checkout pull/1901`
