### PR TITLE
8256156: JFR: Allow 'jfr' tool to show metadata without a recording

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Command.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Command.java
@@ -236,7 +236,7 @@ abstract class Command {
         }
     }
 
-    private void ensureAccess(Path path) throws UserDataException {
+    final protected void ensureAccess(Path path) throws UserDataException {
         try (RandomAccessFile rad = new RandomAccessFile(path.toFile(), "r")) {
             if (rad.length() == 0) {
                 throw new UserDataException("file is empty '" + path + "'");
@@ -303,4 +303,10 @@ abstract class Command {
         names.addAll(getAliases());
         return names;
     }
+
+    public static void checkCommonError(Deque<String> options, String typo, String correct) throws UserSyntaxException {
+        if (typo.equals(options.peek())) {
+            throw new UserSyntaxException("unknown option " + typo + ", did you mean " + correct + "?");
+        }
+     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Main.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Main.java
@@ -75,6 +75,8 @@ public final class Main {
             System.out.println();
             System.out.println(" jfr metadata recording.jfr");
             System.out.println();
+            System.out.println(" jfr metadata --categories GC,Detailed");
+            System.out.println();
             System.out.println("For more information about available commands, use 'jfr help'");
             System.exit(EXIT_OK);
         }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Print.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Print.java
@@ -171,12 +171,6 @@ final class Print extends Command {
         pw.flush();
     }
 
-    private void checkCommonError(Deque<String> options, String typo, String correct) throws UserSyntaxException {
-       if (typo.equals(options.peek())) {
-           throw new UserSyntaxException("unknown option " + typo + ", did you mean " + correct + "?");
-       }
-    }
-
     private static boolean acceptFormatterOption(Deque<String> options, EventPrintWriter eventWriter, String expected) throws UserSyntaxException {
         if (expected.equals(options.peek())) {
             if (eventWriter != null) {


### PR DESCRIPTION
Hi all,

May I please have a review for this minor patch?

It simplifies the use of subcommand `metadata` of jfr tool. Recording 
file is no longer mandatory, users can directly use `jfr metadata` to 
output JDK builtin meta information. As JDK-8256156 mentioned, it also 
supports events and categories filters:
```
$ jfr metadata # compatible
$ jfr metadata recording.jfr
$ jfr metadata --events jdk.ThreadStart,jdk.ThreadEnd
$ jfr metadata --events jdk.ThreadStart,jdk.ThreadEnd recording.jfr
$ jfr metadata --categories GC,Detailed
$ jfr metadata --categories GC,Detailed recording.jfr
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8256156](https://bugs.openjdk.java.net/browse/JDK-8256156): JFR: Allow 'jfr' tool to show metadata without a recording


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1903/head:pull/1903`
`$ git checkout pull/1903`
