### PR TITLE
8173165: javac should reject references to enum constants from nested classes inside instance initializers

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4585,14 +4585,21 @@ public class Attr extends JCTree.Visitor {
             // is declared to the right of e."
             if (isStaticEnumField(v)) {
                 ClassSymbol enclClass = env.info.scope.owner.enclClass();
+                ClassSymbol outerEnclClass = null;
+                if (env.outer != null) {
+                    outerEnclClass = env.outer.info.scope.owner.enclClass();
+                }
 
                 if (enclClass == null || enclClass.owner == null)
                     return;
 
-                // See if the enclosing class is the enum (or a
-                // subclass thereof) declaring v.  If not, this
-                // reference is OK.
-                if (v.owner != enclClass && !types.isSubtype(enclClass.type, v.owner.type))
+                // See if the enclosing class or the outer enclosing class
+                // is the enum (or a subclass thereof) declaring v.
+                // If not, this reference is OK.
+                // See JDK-8173165 for more information.
+                if (v.owner != enclClass && !types.isSubtype(enclClass.type, v.owner.type) &&
+                        (Flags.isEnum(enclClass) || outerEnclClass == null ||
+                                (v.owner != outerEnclClass && !types.isSubtype(outerEnclClass.type, v.owner.type))))
                     return;
 
                 // If the reference isn't from an initializer, then

--- a/test/langtools/tools/javac/enum/forwardRef/T8173165.java
+++ b/test/langtools/tools/javac/enum/forwardRef/T8173165.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8173165
+ * @summary javac should reject references to enum constants from nested classes inside instance initializers
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main T8173165
+ */
+
+import java.util.Arrays;
+import java.util.List;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import toolbox.ToolBox;
+import toolbox.JavacTask;
+import toolbox.TestRunner;
+import toolbox.Task;
+
+public class T8173165 extends TestRunner {
+    ToolBox tb;
+
+    public T8173165() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    @Override
+    protected void runTests() throws Exception {
+        runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    public static void main(String[] args) throws Exception {
+        T8173165 t = new T8173165();
+        t.runTests();
+    }
+
+    @Test
+    public void testEnumConstantInInstanceVariableInitializer(Path base) throws Exception {
+        Path src = base.resolve("src");
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        String code = """
+                import java.util.HashSet;
+                public enum Test {
+                    FOO;
+                    public HashSet<Test> vals = new HashSet<Test>(){
+                        Test test = FOO;
+                        {
+                            add(FOO);
+                        }
+                    };
+                }""";
+        tb.writeJavaFiles(src, code);
+        List<String> output = new JavacTask(tb)
+                .files(tb.findJavaFiles(src))
+                .outdir(classes)
+                .options("-XDrawDiagnostics")
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        List<String> expected = Arrays.asList(
+                "Test.java:5:21: compiler.err.illegal.enum.static.ref",
+                "Test.java:7:17: compiler.err.illegal.enum.static.ref",
+                "2 errors");
+        tb.checkEqual(expected, output);
+    }
+
+    @Test
+    public void testEnumConstantInNestedEnum(Path base) throws Exception {
+        Path src = base.resolve("src");
+        Path classes = base.resolve("classes");
+        Files.createDirectories(classes);
+        String code = """
+                import java.util.HashSet;
+                public enum OuterTest {
+                    FOO;
+                    enum InnerTest {
+                        APPLE {
+                            OuterTest test1 = FOO;
+                        };
+                        public HashSet<OuterTest> vals = new HashSet<OuterTest>(){
+                            OuterTest test2 = FOO;
+                            {
+                                add(FOO);
+                            }
+                        };
+                        OuterTest test3 = FOO;
+                    }
+                }""";
+        tb.writeJavaFiles(src, code);
+        new JavacTask(tb)
+                .files(tb.findJavaFiles(src))
+                .outdir(classes)
+                .run()
+                .writeAll();
+    }
+}


### PR DESCRIPTION
Hi all,

The [JLS 8.9.2](https://docs.oracle.com/javase/specs/jls/se15/html/jls-8.html#jls-8.9.2) states it as bellow.

> It is a compile-time error to refer to a static field of an enum type from a constructor, instance initializer, or instance variable initializer of the enum type, unless the field is a constant variable (§4.12.4).

Currently, compiler doesn't generate the compile-time error when compiling the following code.

```
import java.util.HashSet;
public enum Test {
    FOO;
    public HashSet<Test> vals = new HashSet<Test>(){
        Test test = FOO;
        {
            add(FOO);
        }
    };
}
```

This patch fixes it and adds two corresponding tests. Thank you for taking the time to review.

Best Regards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8173165](https://bugs.openjdk.java.net/browse/JDK-8173165): javac should reject references to enum constants from nested classes inside instance initializers


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1905/head:pull/1905`
`$ git checkout pull/1905`
