### PR TITLE
8257414: Drag n Drop target area is wrong on high DPI systems

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XDnDDropTargetProtocol.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XDnDDropTargetProtocol.java
@@ -37,6 +37,12 @@ import sun.util.logging.PlatformLogger;
 
 import jdk.internal.misc.Unsafe;
 
+import java.awt.GraphicsDevice;
+
+import java.awt.GraphicsEnvironment;
+
+import sun.awt.X11GraphicsDevice;
+
 /**
  * XDropTargetProtocol implementation for XDnD protocol.
  *
@@ -597,7 +603,42 @@ class XDnDDropTargetProtocol extends XDropTargetProtocol {
         x = (int)(xclient.get_data(2) >> 16);
         y = (int)(xclient.get_data(2) & 0xFFFF);
 
-        if (xwindow == null) {
+        if (xwindow != null) {
+            x = xwindow.scaleDown(x);
+            y = xwindow.scaleDown(y);
+        } else {
+            long display = xclient.get_display();
+            GraphicsEnvironment ge = GraphicsEnvironment.
+                    getLocalGraphicsEnvironment();
+            GraphicsDevice[] gds = ge.getScreenDevices();
+            int gdslen = gds.length;
+            XToolkit.awtLock();
+            try {
+                for (int i = 0; i < gdslen; i++) {
+                    long screenRoot = XlibWrapper.RootWindow(display, i);
+                    boolean pointerFound = XlibWrapper.XQueryPointer(
+                            display, screenRoot,
+                            XlibWrapper.larg1,  // root_return
+                            XlibWrapper.larg2,  // child_return
+                            XlibWrapper.larg3,  // xr_return
+                            XlibWrapper.larg4,  // yr_return
+                            XlibWrapper.larg5,  // xw_return
+                            XlibWrapper.larg6,  // yw_return
+                            XlibWrapper.larg7); // mask_return
+                    if (pointerFound) {
+                        GraphicsDevice device = gds[i];
+                        if (device instanceof X11GraphicsDevice) {
+                            int scale = ((X11GraphicsDevice) device).getScaleFactor();
+                            x = XlibUtil.scaleDown(x, scale);
+                            y = XlibUtil.scaleDown(y, scale);
+                        }
+                        break;
+                    }
+                }
+            } finally {
+                XToolkit.awtUnlock();
+            }
+
             long receiver =
                 XDropTargetRegistry.getRegistry().getEmbeddedDropSite(
                     xclient.get_window(), x, y);
@@ -613,7 +654,7 @@ class XDnDDropTargetProtocol extends XDropTargetProtocol {
         if (xwindow != null) {
             /* Translate mouse position from root coordinates
                to the target window coordinates. */
-            Point p = xwindow.toLocal(xwindow.scaleDown(x), xwindow.scaleDown(y));
+            Point p = xwindow.toLocal(x, y);
             x = p.x;
             y = p.y;
         }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XDnDDropTargetProtocol.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XDnDDropTargetProtocol.java
@@ -613,7 +613,7 @@ class XDnDDropTargetProtocol extends XDropTargetProtocol {
         if (xwindow != null) {
             /* Translate mouse position from root coordinates
                to the target window coordinates. */
-            Point p = xwindow.toLocal(x, y);
+            Point p = xwindow.toLocal(xwindow.scaleDown(x), xwindow.scaleDown(y));
             x = p.x;
             y = p.y;
         }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XDragSourceContextPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XDragSourceContextPeer.java
@@ -524,8 +524,8 @@ public final class XDragSourceContextPeer
         updateTargetWindow(xmotion);
 
         if (dragProtocol != null) {
-            dragProtocol.sendMoveMessage(scaleDown(xmotion.get_x_root()),
-                                         scaleDown(xmotion.get_y_root()),
+            dragProtocol.sendMoveMessage(xmotion.get_x_root(),
+                                         xmotion.get_y_root(),
                                          sourceAction, sourceActions,
                                          xmotion.get_time());
         }
@@ -533,8 +533,8 @@ public final class XDragSourceContextPeer
 
     private void processDrop(XButtonEvent xbutton) {
         try {
-            dragProtocol.initiateDrop(scaleDown(xbutton.get_x_root()),
-                                      scaleDown(xbutton.get_y_root()),
+            dragProtocol.initiateDrop(xbutton.get_x_root(),
+                                      xbutton.get_y_root(),
                                       sourceAction, sourceActions,
                                       xbutton.get_time());
         } catch (XException e) {


### PR DESCRIPTION
Please, review this small fix for drag-n-drop on Linux with HiDPI turned on!

This bug is due to the following reason: while scaling Java recalculates resolution (W x H) according to sun.java2d.uiScale (W/SCALE x H/SCALE) and works inside these new coordinates but at the same time the events, that come from the system, continue reporting positions in the old coordinates (W x H).

The idea of the suggested fix is in division of coordinates on the scale when they come from the system to Java and multiplying them on the scale when they go back from Java to the system. It is similar to processing events from mouse and buttons. 

Testing is quite complicated because for reproducing this bug the following conditions should be met:
1.	HiDPI is turned on
2.	sun.java2d.uiScale.enabled = true and sun.java2d.uiScale != 100%
3.	the source of drag-n-drop is non-java application

The step-by-step guide how to reproduce this bug is added to https://bugs.openjdk.java.net/browse/JDK-8257414.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257414](https://bugs.openjdk.java.net/browse/JDK-8257414): Drag n Drop target area is wrong on high DPI systems 


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1907/head:pull/1907`
`$ git checkout pull/1907`
