### PR TITLE
8258989: JVM is failed to inline in jdk.internal.vm.vector.VectorSupport::convert

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1436,7 +1436,7 @@ bool LibraryCallKit::inline_vector_convert() {
     } else if (num_elem_from > num_elem_to) {
       // Since number elements from input is larger than output, simply reduce size of input (we are supposed to
       // drop top elements anyway).
-      int num_elem_for_resize = MAX2(num_elem_to, Matcher::min_vector_size(elem_bt_to));
+      int num_elem_for_resize = MAX2(num_elem_to, Matcher::min_vector_size(elem_bt_from));
 
       // It is possible that arch does not support this intermediate vector size
       // TODO More complex logic required here to handle this corner case for the sizes.


### PR DESCRIPTION
```
$java --add-modules=jdk.incubator.vector -Xcomp -XX:CompileCommand=compileonly,TestCast16BTo2D::* -XX:+UnlockDiagnosticVMOptions -XX:+PrintIntrinsics TestCast16BTo2D
before fixing:
  ** not supported: arity=1 op=cast/5 vlen2=2 etype1=byte ismask=0
                                    @ 3 jdk.internal.util.Preconditions::checkIndex (18 bytes) (intrinsic)
                                      @ 101 java.lang.Object::getClass (0 bytes) (intrinsic)
                                      @ 109 java.lang.Object::getClass (0 bytes) (intrinsic)
                                    @ 3 jdk.internal.util.Preconditions::checkIndex (18 bytes) (intrinsic)
                                    @ 31 jdk.internal.vm.vector.VectorSupport::load (38 bytes) (intrinsic)
                                      @ 128 jdk.internal.vm.vector.VectorSupport::convert (39 bytes) failed to inline (intrinsic)
                                @ 42 jdk.internal.vm.vector.VectorSupport::store (38 bytes) (intrinsic)
Expect:
                                    @ 3 jdk.internal.util.Preconditions::checkIndex (18 bytes) (intrinsic)
                                      @ 101 java.lang.Object::getClass (0 bytes) (intrinsic)
                                      @ 109 java.lang.Object::getClass (0 bytes) (intrinsic)
                                    @ 3 jdk.internal.util.Preconditions::checkIndex (18 bytes) (intrinsic)
                                    @ 31 jdk.internal.vm.vector.VectorSupport::load (38 bytes) (intrinsic)
                                      @ 128 jdk.internal.vm.vector.VectorSupport::convert (39 bytes) (intrinsic)
                                @ 42 jdk.internal.vm.vector.VectorSupport::store (38 bytes) (intrinsic)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258989](https://bugs.openjdk.java.net/browse/JDK-8258989): JVM is failed to inline in jdk.internal.vm.vector.VectorSupport::convert  


### Contributors
 * He Xuejin `<hexuejin2@huawei.com>`

### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1909/head:pull/1909`
`$ git checkout pull/1909`
