### PR TITLE
8255757: Javac emits duplicate pool entries on array::clone

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,9 @@
 
 package com.sun.tools.javac.jvm;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.sun.tools.javac.jvm.PoolConstant.LoadableConstant;
 import com.sun.tools.javac.tree.TreeInfo.PosKind;
 import com.sun.tools.javac.util.*;
@@ -43,9 +46,6 @@ import com.sun.tools.javac.jvm.Items.*;
 import com.sun.tools.javac.resources.CompilerProperties.Errors;
 import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree.*;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import static com.sun.tools.javac.code.Flags.*;
 import static com.sun.tools.javac.code.Kinds.Kind.*;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -2430,6 +2430,7 @@ public class Gen extends JCTree.Visitor {
             toplevel = null;
             endPosTable = null;
             nerrs = 0;
+            qualifiedSymbolCache = null;
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -240,9 +240,6 @@ public class Gen extends JCTree.Visitor {
                 sym.owner != syms.arrayClass)
                 return sym;
             // array clone can be qualified by the array type in later targets
-            if (qualifiedSymbolCache == null) {
-                qualifiedSymbolCache = new HashMap<>();
-            }
             Symbol qualifier;
             if ((qualifier = qualifiedSymbolCache.get(site)) == null) {
                 qualifier = new ClassSymbol(Flags.PUBLIC, site.tsym.name, site, syms.noSymbol);
@@ -2430,7 +2427,7 @@ public class Gen extends JCTree.Visitor {
             toplevel = null;
             endPosTable = null;
             nerrs = 0;
-            qualifiedSymbolCache = null;
+            qualifiedSymbolCache.clear();
         }
     }
 

--- a/test/langtools/tools/javac/classfiles/T8255757/T8255757.java
+++ b/test/langtools/tools/javac/classfiles/T8255757/T8255757.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,8 @@ public class T8255757 extends TestRunner {
             }
         }
         if (num != 1) {
-            throw new AssertionError("The number of the pool entries on array::clone is not right.");
+            throw new AssertionError("The number of the pool entries on array::clone is not right. " +
+                    "Expected number: 1, actual number: " + num);
         }
     }
 }

--- a/test/langtools/tools/javac/classfiles/T8255757/T8255757.java
+++ b/test/langtools/tools/javac/classfiles/T8255757/T8255757.java
@@ -73,8 +73,7 @@ public class T8255757 extends TestRunner {
         new JavacTask(tb)
                 .sources(code)
                 .outdir(curPath)
-                .run()
-                .writeAll();
+                .run();
 
         ClassFile cf = ClassFile.read(curPath.resolve("Test.class"));
         ConstantPool cp = cf.constant_pool;

--- a/test/langtools/tools/javac/classfiles/T8255757/T8255757.java
+++ b/test/langtools/tools/javac/classfiles/T8255757/T8255757.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8255757
+ * @summary Javac shouldn't emit duplicate pool entries on array::clone
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.jdeps/com.sun.tools.classfile
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main T8255757
+ */
+
+import java.nio.file.Path;
+
+import com.sun.tools.classfile.ClassFile;
+import com.sun.tools.classfile.ConstantPool;
+import com.sun.tools.classfile.ConstantPool.*;
+
+import toolbox.JavacTask;
+import toolbox.ToolBox;
+import toolbox.TestRunner;
+
+public class T8255757 extends TestRunner {
+    ToolBox tb;
+
+    T8255757() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        T8255757 t = new T8255757();
+        t.runTests();
+    }
+
+    @Test
+    public void testDuplicatePoolEntries() throws Exception {
+        String code = """
+                public class Test {
+                    void test(Object[] o) {
+                        o.clone();
+                        o.clone();
+                    }
+                    void test2(Object[] o) {
+                        o.clone();
+                        o.clone();
+                    }
+                }""";
+        Path curPath = Path.of(".");
+        new JavacTask(tb)
+                .sources(code)
+                .outdir(curPath)
+                .run()
+                .writeAll();
+
+        ClassFile cf = ClassFile.read(curPath.resolve("Test.class"));
+        ConstantPool cp = cf.constant_pool;
+        int num = 0;
+        for (CPInfo cpInfo : cp.entries()) {
+            if (cpInfo instanceof CONSTANT_Methodref_info) {
+                int class_index = ((CONSTANT_Methodref_info) cpInfo).class_index;
+                int name_and_type_index = ((CONSTANT_Methodref_info) cpInfo).name_and_type_index;
+                int class_name_index = ((CONSTANT_Class_info)
+                        cp.getClassInfo(class_index)).name_index;
+                int method_name_index = ((CONSTANT_NameAndType_info)
+                        cp.getNameAndTypeInfo(name_and_type_index)).name_index;
+                int method_type_name_index = ((CONSTANT_NameAndType_info)
+                        cp.getNameAndTypeInfo(name_and_type_index)).type_index;
+                if ("[Ljava/lang/Object;".equals(cp.getUTF8Value(class_name_index)) &&
+                        "clone".equals(cp.getUTF8Value(method_name_index)) &&
+                        "()Ljava/lang/Object;".equals(cp.getUTF8Value(method_type_name_index))) {
+                    ++num;
+                }
+            }
+        }
+        if (num != 1) {
+            throw new AssertionError("The number of the pool entries on array::clone is not right.");
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

Currently, javac would emit duplicate pool entries when compiling array::clone.
This patch fixes it by using a cached field `Map<Type, Symbol> qualifiedSymbolCache;` and adds a corresponding test case.

Thank you for taking the time to review.

Best Regards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255757](https://bugs.openjdk.java.net/browse/JDK-8255757): Javac emits duplicate pool entries on array::clone


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to d59ed82ff02609550fde0e61afaf76104efa675a


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1912/head:pull/1912`
`$ git checkout pull/1912`
