### PR TITLE
8259035: Comments for load order of hsdis should be updated

### DIFF
--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -800,25 +800,25 @@ bool Disassembler::load_library(outputStream* st) {
 
   // Find the disassembler shared library.
   // Search for several paths derived from libjvm, in this order:
-  // 1. <home>/jre/lib/<arch>/<vm>/libhsdis-<arch>.so  (for compatibility)
-  // 2. <home>/jre/lib/<arch>/<vm>/hsdis-<arch>.so
-  // 3. <home>/jre/lib/<arch>/hsdis-<arch>.so
+  // 1. <home>/lib/<vm>/libhsdis-<arch>.so  (for compatibility)
+  // 2. <home>/lib/<vm>/hsdis-<arch>.so
+  // 3. <home>/lib/hsdis-<arch>.so
   // 4. hsdis-<arch>.so  (using LD_LIBRARY_PATH)
   if (jvm_offset >= 0) {
-    // 1. <home>/jre/lib/<arch>/<vm>/libhsdis-<arch>.so
+    // 1. <home>/lib/<vm>/libhsdis-<arch>.so
     strcpy(&buf[jvm_offset], hsdis_library_name);
     strcat(&buf[jvm_offset], os::dll_file_extension());
     if (Verbose) st->print_cr("Trying to load: %s", buf);
     _library = os::dll_load(buf, ebuf, sizeof ebuf);
     if (_library == NULL && lib_offset >= 0) {
-      // 2. <home>/jre/lib/<arch>/<vm>/hsdis-<arch>.so
+      // 2. <home>/lib/<vm>/hsdis-<arch>.so
       strcpy(&buf[lib_offset], hsdis_library_name);
       strcat(&buf[lib_offset], os::dll_file_extension());
       if (Verbose) st->print_cr("Trying to load: %s", buf);
       _library = os::dll_load(buf, ebuf, sizeof ebuf);
     }
     if (_library == NULL && lib_offset > 0) {
-      // 3. <home>/jre/lib/<arch>/hsdis-<arch>.so
+      // 3. <home>/lib/hsdis-<arch>.so
       buf[lib_offset - 1] = '\0';
       const char* p = strrchr(buf, *os::file_separator());
       if (p != NULL) {


### PR DESCRIPTION
Load order for hsdis is described in both src/utils/hsdis/README and src/hotspot/share/compiler/disassembler.cpp. README has been updated in [JDK-8215977](https://bugs.openjdk.java.net/browse/JDK-8215977), however disassembler.cpp has not been updated yet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259035](https://bugs.openjdk.java.net/browse/JDK-8259035): Comments for load order of hsdis should be updated


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1919/head:pull/1919`
`$ git checkout pull/1919`
