### PR TITLE
8259037: livenmethods cannot find hsdis library

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/asm/Disassembler.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/asm/Disassembler.java
@@ -64,10 +64,11 @@ public class Disassembler {
 
       // Lazily load hsdis
       if (decode_function == 0) {
-         // 1. <home>/lib/<vm>/libhsdis-<arch>.so
-         // 2. <home>/lib/<vm>/hsdis-<arch>.so
-         // 3. <home>/lib/hsdis-<arch>.so
-         // 4. hsdis-<arch>.so  (using LD_LIBRARY_PATH)
+         // Search for hsdis library in the following 4 locations:
+         //   1. <home>/lib/<vm>/libhsdis-<arch>.so
+         //   2. <home>/lib/<vm>/hsdis-<arch>.so
+         //   3. <home>/lib/hsdis-<arch>.so
+         //   4. hsdis-<arch>.so  (using LD_LIBRARY_PATH)
          Properties targetSysProps = VM.getVM().getSystemProperties();
          String os = targetSysProps.getProperty("os.name");
          String ext = ".so";
@@ -77,6 +78,7 @@ public class Disassembler {
             ext = ".dylib";
          }
 
+         // Find the full path to libjvm.so (jvm.dll and libjvm.dylib on Windows and OSX).
          String jvmPattern = "^(lib)?jvm\\" + ext + "$";
          Path jvmPath = VM.getVM()
                           .getDebugger()
@@ -87,6 +89,7 @@ public class Disassembler {
                           .filter(p -> p.getFileName().toString().matches(jvmPattern))
                           .findAny()
                           .get();
+
          String arch = targetSysProps.getProperty("os.arch");
          String libname = "hsdis-" + arch + ext;
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/asm/Disassembler.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/asm/Disassembler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,14 @@
 package sun.jvm.hotspot.asm;
 
 import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Iterator;
+import java.util.Properties;
 import sun.jvm.hotspot.code.CodeBlob;
 import sun.jvm.hotspot.code.NMethod;
 import sun.jvm.hotspot.debugger.Address;
+import sun.jvm.hotspot.debugger.DebuggerException;
 import sun.jvm.hotspot.runtime.VM;
 
 public class Disassembler {
@@ -59,44 +64,57 @@ public class Disassembler {
 
       // Lazily load hsdis
       if (decode_function == 0) {
-         StringBuilder path = new StringBuilder(System.getProperty("java.home"));
-         String sep = System.getProperty("file.separator");
-         String os = System.getProperty("os.name");
-         String libname = "hsdis";
-         String arch = System.getProperty("os.arch");
-         if (os.lastIndexOf("Windows", 0) != -1) {
-            if (arch.equals("x86")) {
-               libname +=  "-i386";
-            } else if (arch.equals("amd64")) {
-               libname +=  "-amd64";
-            } else {
-               libname +=  "-" + arch;
-            }
-            path.append(sep + "bin" + sep);
-            libname += ".dll";
-         } else if (os.lastIndexOf("Linux", 0) != -1) {
-            if (arch.equals("x86") || arch.equals("i386")) {
-               path.append(sep + "lib" + sep + "i386" + sep);
-               libname += "-i386.so";
-            } else if (arch.equals("amd64") || arch.equals("x86_64")) {
-               path.append(sep + "lib" + sep + "amd64" + sep);
-               libname +=  "-amd64.so";
-            } else {
-               path.append(sep + "lib" + sep + arch + sep);
-               libname +=  "-" + arch + ".so";
-            }
-         } else if (os.lastIndexOf("Mac OS X", 0) != -1) {
-            path.append(sep + "lib" + sep);
-            libname += "-amd64" + ".dylib";       // x86_64 => amd64
-         } else {
-            path.append(sep + "lib" + sep + "arch" + sep);
-            libname +=  "-" + arch + ".so";
+         // 1. <home>/lib/<vm>/libhsdis-<arch>.so
+         // 2. <home>/lib/<vm>/hsdis-<arch>.so
+         // 3. <home>/lib/hsdis-<arch>.so
+         // 4. hsdis-<arch>.so  (using LD_LIBRARY_PATH)
+         Properties targetSysProps = VM.getVM().getSystemProperties();
+         String os = targetSysProps.getProperty("os.name");
+         String ext = ".so";
+         if (os.contains("Windows")) {
+            ext = ".dll";
+         } else if (os.contains("Mac OS")) {
+            ext = ".dylib";
          }
-         decode_function = load_library(path.toString(), libname);
+
+         String jvmPattern = "^(lib)?jvm\\" + ext + "$";
+         Path jvmPath = VM.getVM()
+                          .getDebugger()
+                          .getCDebugger()
+                          .getLoadObjectList()
+                          .stream()
+                          .map(o -> Path.of(o.getName()))
+                          .filter(p -> p.getFileName().toString().matches(jvmPattern))
+                          .findAny()
+                          .get();
+         String arch = targetSysProps.getProperty("os.arch");
+         String libname = "hsdis-" + arch + ext;
+
+         List<String> libs = List.of(
+            // 1. <home>/lib/<vm>/libhsdis-<arch>.so
+            jvmPath.resolveSibling("lib" + libname).toString(),
+            // 2. <home>/lib/<vm>/hsdis-<arch>.so
+            jvmPath.resolveSibling(libname).toString(),
+            // 3. <home>/lib/hsdis-<arch>.so
+            jvmPath.getParent().resolveSibling(libname).toString(),
+            // 4. hsdis-<arch>.so  (using LD_LIBRARY_PATH)
+            libname
+         );
+
+         var itr = libs.iterator();
+         while (itr.hasNext() && (decode_function == 0L)) {
+            try {
+               decode_function = load_library(itr.next());
+            } catch (DebuggerException e) {
+               if (!itr.hasNext()) {
+                  throw e;
+               }
+            }
+         }
       }
    }
 
-   private static native long load_library(String installed_jrepath, String hsdis_library_name);
+   private static native long load_library(String hsdis_library_name);
 
    private native void decode(InstructionVisitor visitor, long pc, byte[] code,
                               String options, long decode_function);

--- a/src/jdk.hotspot.agent/share/native/libsaproc/sadis.c
+++ b/src/jdk.hotspot.agent/share/native/libsaproc/sadis.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,32 +110,24 @@ static int getLastErrorString(char *buf, size_t len)
 /*
  * Class:     sun_jvm_hotspot_asm_Disassembler
  * Method:    load_library
- * Signature: (Ljava/lang/String;)L
+ * Signature: (Ljava/lang/String;)J
  */
 JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_asm_Disassembler_load_1library(JNIEnv * env,
                                                                            jclass disclass,
-                                                                           jstring jrepath_s,
                                                                            jstring libname_s) {
   uintptr_t func = 0;
   const char *error_message = NULL;
-  const char *jrepath = NULL;
   const char *libname = NULL;
-  char buffer[JVM_MAXPATHLEN];
 
 #ifdef _WINDOWS
+  char buffer[JVM_MAXPATHLEN];
   HINSTANCE hsdis_handle = (HINSTANCE) NULL;
 #else
   void* hsdis_handle = NULL;
 #endif
 
-  jrepath = (*env)->GetStringUTFChars(env, jrepath_s, NULL); // like $JAVA_HOME/jre/lib/sparc/
-  if (jrepath == NULL || (*env)->ExceptionOccurred(env)) {
-    return 0;
-  }
-
   libname = (*env)->GetStringUTFChars(env, libname_s, NULL);
   if (libname == NULL || (*env)->ExceptionOccurred(env)) {
-    (*env)->ReleaseStringUTFChars(env, jrepath_s, jrepath);
     return 0;
   }
 
@@ -143,8 +135,7 @@ JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_asm_Disassembler_load_1library(JNIE
 #ifdef _WINDOWS
   hsdis_handle = LoadLibrary(libname);
   if (hsdis_handle == NULL) {
-    snprintf(buffer, sizeof(buffer), "%s%s", jrepath, libname);
-    hsdis_handle = LoadLibrary(buffer);
+    hsdis_handle = LoadLibrary(libname);
   }
   if (hsdis_handle != NULL) {
     func = (uintptr_t)GetProcAddress(hsdis_handle, "decode_instructions_virtual");
@@ -156,8 +147,7 @@ JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_asm_Disassembler_load_1library(JNIE
 #else
   hsdis_handle = dlopen(libname, RTLD_LAZY | RTLD_GLOBAL);
   if (hsdis_handle == NULL) {
-    snprintf(buffer, sizeof(buffer), "%s%s", jrepath, libname);
-    hsdis_handle = dlopen(buffer, RTLD_LAZY | RTLD_GLOBAL);
+    hsdis_handle = dlopen(libname, RTLD_LAZY | RTLD_GLOBAL);
   }
   if (hsdis_handle != NULL) {
     func = (uintptr_t)dlsym(hsdis_handle, "decode_instructions_virtual");
@@ -168,7 +158,6 @@ JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_asm_Disassembler_load_1library(JNIE
 #endif
 
   (*env)->ReleaseStringUTFChars(env, libname_s, libname);
-  (*env)->ReleaseStringUTFChars(env, jrepath_s, jrepath);
 
   if (func == 0) {
     /* Couldn't find entry point.  error_message should contain some

--- a/src/jdk.hotspot.agent/share/native/libsaproc/sadis.c
+++ b/src/jdk.hotspot.agent/share/native/libsaproc/sadis.c
@@ -134,9 +134,6 @@ JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_asm_Disassembler_load_1library(JNIE
   /* Load the hsdis library */
 #ifdef _WINDOWS
   hsdis_handle = LoadLibrary(libname);
-  if (hsdis_handle == NULL) {
-    hsdis_handle = LoadLibrary(libname);
-  }
   if (hsdis_handle != NULL) {
     func = (uintptr_t)GetProcAddress(hsdis_handle, "decode_instructions_virtual");
   }
@@ -146,9 +143,6 @@ JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_asm_Disassembler_load_1library(JNIE
   }
 #else
   hsdis_handle = dlopen(libname, RTLD_LAZY | RTLD_GLOBAL);
-  if (hsdis_handle == NULL) {
-    hsdis_handle = dlopen(libname, RTLD_LAZY | RTLD_GLOBAL);
-  }
   if (hsdis_handle != NULL) {
     func = (uintptr_t)dlsym(hsdis_handle, "decode_instructions_virtual");
   }


### PR DESCRIPTION
`livenmethods` CLHSDB command could not find hsdis library even though it deployed to `$JAVA_HOME/lib/server/`.

```
sun.jvm.hotspot.debugger.DebuggerException: /usr/local/jdk-15.0.1/lib/amd64/hsdis-amd64.so: cannot open shared object file: No such file or directory
        at jdk.hotspot.agent/sun.jvm.hotspot.asm.Disassembler.load_library(Native Method)
        at jdk.hotspot.agent/sun.jvm.hotspot.asm.Disassembler.<init>(Disassembler.java:95)
        at jdk.hotspot.agent/sun.jvm.hotspot.asm.Disassembler.decode(Disassembler.java:52)
        at jdk.hotspot.agent/sun.jvm.hotspot.asm.Disassembler.decode(Disassembler.java:43)
        at jdk.hotspot.agent/sun.jvm.hotspot.ui.classbrowser.HTMLGenerator.genHTML(HTMLGenerator.java:1435)
        at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor$45.doit(CommandProcessor.java:1651)
        at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.executeCommand(CommandProcessor.java:2051)
        at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.executeCommand(CommandProcessor.java:2021)
        at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.run(CommandProcessor.java:1901)
        at jdk.hotspot.agent/sun.jvm.hotspot.CLHSDB.run(CLHSDB.java:99)
        at jdk.hotspot.agent/sun.jvm.hotspot.CLHSDB.main(CLHSDB.java:40)
        at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.runCLHSDB(SALauncher.java:280)
        at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.main(SALauncher.java:483)
```

JDK directory layout has been changed since JDK 9, however `livenmethods` hasn't followed it yet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259037](https://bugs.openjdk.java.net/browse/JDK-8259037): livenmethods cannot find hsdis library


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk pull/1920/head:pull/1920`
`$ git checkout pull/1920`
